### PR TITLE
feat: add tooling-shared-scripts-pypi-centralization skill

### DIFF
--- a/skills/documentation-strict-audit-remediation-workflow.md
+++ b/skills/documentation-strict-audit-remediation-workflow.md
@@ -1,0 +1,107 @@
+---
+name: documentation-strict-audit-remediation-workflow
+description: "Workflow for running strict repo audits and fixing documentation findings. Use when: (1) performing comprehensive repository quality audits, (2) remediating documentation issues found in audits."
+category: documentation
+date: 2026-03-22
+version: "1.0.0"
+user-invocable: false
+tags: [audit, documentation, quality, strict-grading, remediation]
+---
+
+# Strict Repository Audit: Documentation Remediation Workflow
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-22 |
+| **Objective** | Run a strict 15-section repository audit on ProjectHephaestus and fix identified documentation issues |
+| **Outcome** | Successful. Audit scored B+ (87%) overall. Three documentation issues identified and fixed: stale SECURITY.md, misleading code comment, missing COMPATIBILITY.md |
+
+## When to Use
+
+- Running `/repo-analyze-strict` on a Python library and need to act on findings
+- Fixing documentation issues identified during quality audits
+- Creating missing policy documents (COMPATIBILITY.md, SECURITY.md updates)
+- Prioritizing audit remediation items (documentation vs CI vs code quality)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Run the strict audit
+/repo-analyze-strict
+
+# 2. Common documentation fixes:
+
+# Fix stale SECURITY.md version table
+# Edit the supported versions table to match current release
+
+# Fix misleading comments in source code
+# Remove or update comments that don't match the function's role
+
+# Create missing policy docs referenced in CHANGELOG
+# Check CHANGELOG for references to files that don't exist
+grep -r "COMPATIBILITY\|SECURITY\|MIGRATION" CHANGELOG.md
+```
+
+### Detailed Steps
+
+1. **Run the strict audit** using `/repo-analyze-strict` — this launches 3 parallel Explore agents to read source files, tests, and CI configs, then produces a 15-section graded report
+
+2. **Identify documentation findings** across all sections — documentation issues appear not just in Section 2 (Documentation) but also in:
+   - Section 8 (Security) — stale SECURITY.md
+   - Section 4 (Source Code Quality) — misleading comments
+   - Section 12 (Packaging) — missing COMPATIBILITY.md
+   - Section 14 (API Design) — misleading function comments
+
+3. **Fix stale version tables** — SECURITY.md supported versions must match the current release. When the project is at v0.4.0, the table should list 0.4.x as supported
+
+4. **Fix misleading code comments** — comments like "Example usage function" on public API functions (`get_config_value`) confuse both humans and AI agents. Remove or rewrite to accurately describe the function's role
+
+5. **Create missing referenced documents** — search CHANGELOG.md for references to files that were "added" but don't exist in the repo. Create them with appropriate content for the project's maturity level (e.g., v0.x compatibility policy differs from v1.0+)
+
+6. **Verify changes** — run linters on modified source files to ensure no regressions:
+   ```bash
+   pixi run ruff check <modified-files>
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Initial plan proposed CI matrix expansion | Proposed expanding Python test matrix as top priority fix from audit | User preferred documentation fixes over CI changes | Ask the user which audit findings to prioritize rather than assuming the highest-severity finding should be fixed first |
+
+## Results & Parameters
+
+### Common Documentation Audit Findings (Python Libraries)
+
+| Finding | Typical Section | Severity | Fix |
+|---------|----------------|----------|-----|
+| Stale SECURITY.md versions | Section 8 | MINOR | Update version table to include current release |
+| Misleading code comments | Section 4 | NITPICK | Remove or rewrite comments that don't match function purpose |
+| Missing referenced docs | Section 12 | MINOR | Create the document with appropriate content |
+| No ADRs | Section 2 | MINOR | Usually deferred — design decisions live in CHANGELOG |
+| No API auto-generation | Section 2 | MINOR | Add Sphinx/MkDocs if project warrants it |
+
+### COMPATIBILITY.md Template for v0.x Projects
+
+Key sections for a pre-1.0 library compatibility policy:
+- v0.x stability expectations (minor releases may break API)
+- Definition of breaking vs non-breaking changes
+- Deprecation policy (warn for at least one minor release)
+- Planned v1.0 stability guarantee
+
+### Audit Score Distribution (ProjectHephaestus Baseline)
+
+- **A- range (90-92%)**: Structure, Documentation, Developer Experience, Dependencies
+- **B+ range (87-89%)**: Architecture, Code Quality, Testing, CI/CD, Security, AI Tooling, Packaging
+- **B range (83-86%)**: Planning, API Design, Compliance
+- **C+ range (77-79%)**: Safety & Reliability
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Strict audit + documentation remediation | [notes.md](./skills/documentation-strict-audit-remediation-workflow.notes.md) |

--- a/skills/documentation-strict-audit-remediation-workflow.notes.md
+++ b/skills/documentation-strict-audit-remediation-workflow.notes.md
@@ -1,0 +1,74 @@
+# Session Notes: Strict Audit + Documentation Remediation
+
+## Session Context
+
+- **Project**: ProjectHephaestus (HomericIntelligence-Hephaestus)
+- **Date**: 2026-03-22
+- **Trigger**: User ran `/repo-analyze-strict`
+
+## Audit Execution Details
+
+### Agent Strategy
+- 3 parallel Explore agents launched:
+  1. Repo structure, configs, documentation files
+  2. All 36 Python source files in hephaestus/
+  3. All 22 test files, 4 CI workflows, scripts
+
+### Files Examined
+- 55+ files total
+- 26 source files (10 random + 5 largest + 5 smallest + 6 key files)
+- 22 test files
+- 12 config files
+- 8 documentation files
+
+### Key Metrics Discovered
+- 36 Python source files, ~5,223 LOC
+- 38 test files, ~4,156 LOC (test:source ratio ~0.8)
+- 11 scripts, 796 LOC
+- ~490 test cases across 22 test modules
+- 80% coverage threshold enforced
+- 1 runtime dependency (PyYAML)
+- 4 CI workflows (test, pre-commit, release, security)
+
+## Documentation Fixes Applied
+
+### 1. SECURITY.md (SECURITY.md:5-8)
+**Before:**
+```markdown
+| Version | Supported |
+|---------|-----------|
+| 0.3.x   | Yes       |
+| < 0.3   | No        |
+```
+
+**After:**
+```markdown
+| Version | Supported |
+|---------|-----------|
+| 0.4.x   | Yes       |
+| 0.3.x   | Yes       |
+| < 0.3   | No        |
+```
+
+### 2. config/utils.py (line 193)
+**Before:**
+```python
+# Example usage function
+def get_config_value(
+```
+
+**After:**
+```python
+def get_config_value(
+```
+
+### 3. COMPATIBILITY.md (new file)
+Created backwards compatibility policy with sections:
+- v0.x Stability (minor releases may break API)
+- What Constitutes a Breaking Change (with examples)
+- Deprecation Policy (warn for 1 minor release)
+- Planned v1.0 Stability
+
+## User Preference Noted
+
+User chose to fix documentation issues rather than expand CI test matrix (Python 3.10/3.11 coverage). This suggests documentation completeness is valued over CI thoroughness for this project's current stage.

--- a/skills/tooling-shared-scripts-pypi-centralization.md
+++ b/skills/tooling-shared-scripts-pypi-centralization.md
@@ -1,0 +1,155 @@
+---
+name: tooling-shared-scripts-pypi-centralization
+description: "Workflow for auditing cross-repo script duplication and centralizing shared Python validation scripts into a PyPI package with CLI entry points. Use when: (1) multiple repos have duplicated scripts/check_*.py or scripts/validate_*.py files, (2) planning to consolidate shared tooling into a library package, (3) porting standalone scripts to library modules with testable APIs."
+category: tooling
+date: 2026-03-22
+version: "1.0.0"
+user-invocable: false
+tags:
+  - pypi
+  - deduplication
+  - validation-scripts
+  - cli-entry-points
+  - cross-repo
+---
+
+# Centralizing Shared Python Scripts into a PyPI Package
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-22 |
+| **Objective** | Audit all HomericIntelligence repos for duplicated Python validation scripts and port them into ProjectHephaestus as first-class library modules with CLI entry points, published to PyPI |
+| **Outcome** | Successfully ported 9 validation modules from ProjectScylla/Hephaestus scripts/ into `hephaestus.validation.*`, added 9 CLI entry points, bumped to v0.5.0. Filed tracking issues against 2 repos with duplicated code. |
+
+## When to Use
+
+- Multiple repositories contain duplicated `scripts/check_*.py` or `scripts/validate_*.py` files
+- Standalone scripts need to become importable library modules with testable public APIs
+- A shared PyPI package needs new modules with optional dependency extras
+- Planning a cross-repo deduplication effort with tracking issues
+- Converting scripts that use `sys.exit()` directly into testable functions that return structured data
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Audit repos for duplicated scripts
+gh repo list <org> --limit 50 --json name,description
+# Clone each, compare scripts/ directories
+
+# 2. For each script, create a library module:
+#    - Testable function returning structured data (tuple/dict)
+#    - main() function that calls sys.exit() for CLI
+#    - argparse with --repo-root, --verbose
+
+# 3. Add CLI entry points to pyproject.toml:
+# [project.scripts]
+# hephaestus-check-foo = "hephaestus.validation.foo:main"
+
+# 4. Add optional dependency extras:
+# [project.optional-dependencies]
+# toml = ["tomli>=2.0,<3;python_version<'3.11'"]
+# schema = ["jsonschema>=4.0,<5"]
+
+# 5. File tracking issues against repos with duplicated code
+gh issue create --repo <org>/<repo> --title "chore: Replace duplicated scripts with <package>>=X.Y"
+```
+
+### Detailed Steps
+
+1. **Audit phase**: Clone all ecosystem repos, list all `scripts/*.py` files, identify duplicates by comparing functionality (not just filenames — implementations may differ)
+
+2. **Design module API**: Each script becomes a module with:
+   - Public functions returning structured results (tuples, dicts) — NOT calling `sys.exit()`
+   - A `main()` function that wraps the public API with argparse and `sys.exit()`
+   - Reuse existing package utilities (e.g., `get_repo_root()`) instead of inline helpers
+
+3. **Handle optional dependencies** with guarded imports:
+   ```python
+   try:
+       import tomllib
+   except ModuleNotFoundError:
+       try:
+           import tomli as tomllib
+       except ModuleNotFoundError:
+           tomllib = None
+   ```
+   Print clear install instructions when optional deps are missing.
+
+4. **Implementation order matters**: Build standalone modules first (no new deps), then dep-dependent modules, then enhance existing modules, then integration
+
+5. **Tests with `pytest.importorskip`**: For optional-dep-dependent tests, use `pytest.importorskip("jsonschema")` inside each test method rather than class-level decorators
+
+6. **File tracking issues** against repos with duplicated code before implementation — reference the planned version. Update issues after publishing.
+
+7. **Merge divergent implementations**: When two repos have different scripts for the same purpose, merge the best parts. E.g., Hephaestus checked pyproject.toml internal consistency (regex), Scylla checked pyproject.toml vs Dockerfile (tomllib). The merged module does both.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Class-level `@pytest.mark.skipif` with `pytest.importorskip` | Used `@pytest.mark.skipif(not pytest.importorskip(...))` on test class | `pytest.importorskip` raises `Skipped` exception at collection time, causing the entire module to be skipped (0 tests collected) | Use `pytest.importorskip()` inside individual test methods, not at class/module level |
+| Lazy import of argparse inside helper function | Deferred `import argparse` to `_build_parser()` while using `argparse.ArgumentParser` in the return type annotation | `from __future__ import annotations` makes annotations lazy but ruff F821 still flags undefined names in annotations when the import is deferred | Import modules at top level if they appear in type annotations, even with `from __future__ import annotations` |
+| Using `replace_all=false` with non-unique string | Tried to append code after `return issues` in markdown.py | String `return issues` appeared twice in the file | Provide more surrounding context to make the match unique, or use a different anchor point |
+
+## Results & Parameters
+
+### Module Structure Pattern
+
+```python
+"""Module docstring with Usage:: section."""
+
+from __future__ import annotations
+import argparse
+import sys
+from pathlib import Path
+from hephaestus.utils.helpers import get_repo_root
+
+def check_something(repo_root: Path, verbose: bool = False) -> tuple[bool, dict]:
+    """Testable public function — returns structured data, never calls sys.exit()."""
+    ...
+    return (passed, details)
+
+def main() -> int:
+    """CLI entry point — parses args, calls public function, returns exit code."""
+    parser = argparse.ArgumentParser(...)
+    parser.add_argument("--repo-root", type=Path, default=None)
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+    repo_root = args.repo_root or get_repo_root()
+    passed, details = check_something(repo_root, verbose=args.verbose)
+    return 0 if passed else 1
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### pyproject.toml Optional Extras Pattern
+
+```toml
+[project.optional-dependencies]
+toml = ["tomli>=2.0,<3;python_version<'3.11'"]
+xml = ["defusedxml>=0.7,<1"]
+schema = ["jsonschema>=4.0,<5"]
+all = ["MyPackage[github,toml,xml,schema]"]
+```
+
+### Final Stats
+
+- **9 new modules** in `hephaestus/validation/`
+- **9 CLI entry points** added
+- **3 optional dependency extras** (toml, xml, schema)
+- **557 tests passed**, 6 skipped (optional dep tests)
+- **Version bump**: 0.4.0 → 0.5.0
+- **2 GitHub issues filed** for cross-repo adoption
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Porting shared validation scripts to PyPI package v0.5.0 | [notes.md](./tooling-shared-scripts-pypi-centralization.notes.md) |
+| ProjectScylla | Source of 9 duplicated scripts, tracking issue #1537 | Scripts in scripts/ directory |
+| ProjectOdyssey | Source of duplicated utilities, tracking issue #5061 | common.py, validation.py |

--- a/skills/tooling-shared-scripts-pypi-centralization.notes.md
+++ b/skills/tooling-shared-scripts-pypi-centralization.notes.md
@@ -1,0 +1,57 @@
+# Session Notes: Centralizing Shared Scripts into ProjectHephaestus
+
+## Session Context
+
+- **Date**: 2026-03-22
+- **Repos explored**: ProjectHephaestus, ProjectScylla, ProjectOdyssey, ProjectTelemachy, ProjectHermes, ProjectArgus, AchaeanFleet, Myrmidons
+- **Tool**: Claude Code with `/advise` skill for prior art search
+
+## Modules Created
+
+### Phase 1 — Standalone (no new deps)
+1. `hephaestus/validation/type_aliases.py` — Type alias shadowing detection
+2. `hephaestus/validation/audit.py` — pip-audit CVSS severity filter
+3. `hephaestus/validation/test_structure.py` — Merged test directory mirror + loose file check
+
+### Phase 2 — TOML-dependent
+4. `hephaestus/validation/python_version.py` — Merged pyproject.toml + Dockerfile consistency
+5. `hephaestus/validation/coverage.py` — Coverage threshold gate with per-module config
+
+### Phase 3 — External tool dependent
+6. `hephaestus/validation/complexity.py` — Ruff C901 wrapper
+7. `hephaestus/validation/schema.py` — YAML-against-JSON-schema validation
+
+### Phase 4 — Enhancement
+8. `hephaestus/validation/markdown.py` — Added link validation pipeline (validate_all_links, validate_file_links, etc.)
+
+### Phase 5 — AST-based
+9. `hephaestus/validation/docstrings.py` — Docstring fragment detection
+
+## Key Duplication Findings
+
+### Identical scripts across repos
+- `check_python_version_consistency.py`: Hephaestus (regex-based, checks pyproject internal) vs Scylla (tomllib-based, checks pyproject vs Dockerfile)
+- `check_unit_test_structure.py`: Hephaestus (mirror check) vs Scylla (no-loose-files check)
+
+### Scylla-only scripts worth sharing
+- `check_coverage.py`, `check_max_complexity.py`, `filter_audit.py`, `validate_config_schemas.py`, `validate_links.py`, `check_type_alias_shadowing.py`, `check_docstring_fragments.py`
+
+### Utility duplication
+- `get_repo_root()` reimplemented in Odyssey's `scripts/common.py` and Scylla's `scylla/automation/git_utils.py`
+- Markdown validation utilities duplicated between Odyssey's `scripts/validation.py` and Hephaestus's `hephaestus/validation/markdown.py`
+- `Colors` ANSI class in Odyssey's `common.py` vs Hephaestus's `hephaestus/cli/colors.py`
+
+## GitHub Issues Filed
+
+- ProjectScylla #1537: https://github.com/HomericIntelligence/ProjectScylla/issues/1537
+- ProjectOdyssey #5061: https://github.com/HomericIntelligence/ProjectOdyssey/issues/5061
+
+## Implementation Decisions
+
+1. **Schema map is configurable**: Scylla's `validate_config_schemas.py` had a hardcoded `_SCHEMA_MAP`. The library version takes a `SchemaMapping` parameter and supports loading from a JSON file via `--schema-map`.
+
+2. **Dockerfile check is optional**: Not all repos have Dockerfiles, so `check_python_version_consistency()` has `check_dockerfile=False` by default.
+
+3. **Coverage graceful fallback**: If `defusedxml` is not installed, `parse_coverage_report()` returns None and `check_coverage()` passes gracefully rather than failing.
+
+4. **No Scylla-specific scope filters**: Scylla's `check_docstring_fragments.py` had `_is_scylla_file()` hardcoded. Replaced with configurable `--directory` argument.


### PR DESCRIPTION
## Summary

Documents the workflow for auditing cross-repo script duplication and centralizing shared Python validation scripts into a PyPI package (ProjectHephaestus v0.5.0) with CLI entry points.

- Ported 9 validation modules from standalone scripts into `hephaestus.validation.*`
- Added 9 CLI entry points and 3 optional dependency extras
- Filed tracking issues against ProjectScylla (#1537) and ProjectOdyssey (#5061)

## Key Findings

**What Worked**:
- Merging divergent implementations (e.g., two different python version checkers into one comprehensive module)
- Phased implementation order: standalone -> dep-dependent -> enhancement -> integration
- Structuring modules with testable public functions + main() CLI wrapper pattern
- Filing tracking issues before implementation to create accountability

**What Failed**:
- Class-level @pytest.mark.skipif with pytest.importorskip -> skipped entire module instead of individual tests
- Lazy import argparse inside helper function -> ruff F821 on type annotation despite from __future__ import annotations
- replace_all=false edit with non-unique anchor string -> had to provide more context

## Test Plan

- [x] Validate with python3 scripts/validate_plugins.py (988/988 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: pypi, centralize, shared scripts, deduplication

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>