### PR TITLE
feat: add ci-cd-promote-subgroups-to-matrix skill

### DIFF
--- a/skills/ci-cd-promote-subgroups-to-matrix.md
+++ b/skills/ci-cd-promote-subgroups-to-matrix.md
@@ -1,0 +1,155 @@
+---
+name: ci-cd-promote-subgroups-to-matrix
+description: "Promote subdirectory-scoped test patterns into separate CI matrix entries with leaf-level wildcards for auto-discovery. Use when: (1) a single matrix group uses multi-pattern strings covering subdirectories, (2) new test files are silently missed because they're not in the explicit pattern list, (3) you want each subdirectory to be its own CI job with test_*.mojo auto-discovery."
+category: ci-cd
+date: 2026-03-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-precommit
+supersedes: []
+tags:
+  - ci-cd
+  - github-actions
+  - test-matrix
+  - auto-discovery
+  - wildcard-patterns
+---
+
+# Promote Sub-Groups to CI Matrix Entries
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Replace a single monolithic CI matrix group that uses explicit multi-pattern strings with separate per-subdirectory matrix entries using leaf-level `test_*.mojo` wildcards |
+| **Outcome** | Successful — 1 group split into 6, all 52 files covered, zero overlap, `validate_test_coverage.py` passes |
+| **Verification** | verified-precommit |
+
+## When to Use
+
+- A CI matrix group covers multiple subdirectories via a compound pattern like `test_*.mojo datasets/test_*.mojo samplers/test_*.mojo`
+- New test files added to subdirectories are silently missed because they aren't in the explicit pattern list
+- You want each subdirectory to auto-discover new files via simple `test_*.mojo` wildcards
+- The inverse of `consolidate-ci-matrix` — splitting for auto-discovery rather than merging for job reduction
+
+## Verified Workflow
+
+> **Note:** Verified through pre-commit hooks and local coverage validation. CI validation pending on PR #5116.
+
+### Quick Reference
+
+```bash
+# 1. Identify the monolithic group in comprehensive-tests.yml
+grep -A 3 'name: "Data"' .github/workflows/comprehensive-tests.yml
+
+# 2. List subdirectories to promote
+ls tests/shared/data/
+
+# 3. Count files per subdirectory (verify coverage)
+python3 -c "
+from pathlib import Path
+for d in ['tests/shared/data'] + sorted([str(p) for p in Path('tests/shared/data').iterdir() if p.is_dir()]):
+    files = list(Path('.').glob(f'{d}/test_*.mojo'))
+    print(f'{d}: {len(files)} files')
+"
+
+# 4. After editing YAML, validate coverage
+python3 scripts/validate_test_coverage.py
+
+# 5. Verify no overlap between groups
+python3 -c "
+from pathlib import Path
+groups = {
+    'Parent': ('tests/shared/data', 'test_*.mojo'),
+    'Sub1': ('tests/shared/data/datasets', 'test_*.mojo'),
+    # ... add all subdirectories
+}
+all_files = set()
+for name, (path, pat) in groups.items():
+    for f in Path('.').glob(f'{path}/{pat}'):
+        assert str(f) not in all_files, f'OVERLAP: {f}'
+        all_files.add(str(f))
+print(f'Total: {len(all_files)} files, no overlaps')
+"
+```
+
+### Detailed Steps
+
+1. **Read the current matrix entry** — identify the compound pattern covering subdirectories
+2. **List all subdirectories** under the parent path that contain test files
+3. **Create one matrix entry per subdirectory** — each with `path:` pointing to the leaf directory and `pattern: "test_*.mojo"`
+4. **Create a "Core" entry** for top-level files — the parent path with `test_*.mojo` (non-recursive glob means no overlap with subdirectory entries)
+5. **Preserve flags** — copy `continue-on-error: true` or other flags from the original entry to all new entries
+6. **Validate coverage** — run `python3 scripts/validate_test_coverage.py` (must exit 0)
+7. **Verify no overlap** — `Path.glob("dir/test_*.mojo")` is non-recursive, so parent and subdirectory entries never match the same files
+8. **Run pre-commit hooks** — `just pre-commit-all` to validate YAML, coverage, and formatting
+
+### Key Insight: Non-Recursive Glob Prevents Overlap
+
+`Path.glob("tests/shared/data/test_*.mojo")` only matches files directly in `tests/shared/data/`, NOT files in `tests/shared/data/datasets/`. This is because `test_*.mojo` has no `**` component, so the glob is non-recursive. This means a parent "Core" entry and subdirectory entries will never overlap — each file is matched by exactly one group.
+
+The same behavior applies to the justfile's bash glob (`$TEST_PATH/$pattern`), which is also non-recursive without `**`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A — first approach succeeded | Replaced single group with 6 leaf-level entries | Did not fail | Verify glob non-recursiveness before assuming zero overlap; always run `validate_test_coverage.py` |
+
+## Results & Parameters
+
+### Before (1 group)
+
+```yaml
+- name: "Data"
+  path: "tests/shared/data"
+  pattern: "test_*.mojo datasets/test_*.mojo samplers/test_*.mojo transforms/test_*.mojo loaders/test_*.mojo formats/test_*.mojo"
+```
+
+### After (6 groups)
+
+```yaml
+- name: "Data Core"
+  path: "tests/shared/data"
+  pattern: "test_*.mojo"
+  continue-on-error: true
+- name: "Data Datasets"
+  path: "tests/shared/data/datasets"
+  pattern: "test_*.mojo"
+  continue-on-error: true
+- name: "Data Loaders"
+  path: "tests/shared/data/loaders"
+  pattern: "test_*.mojo"
+  continue-on-error: true
+- name: "Data Transforms"
+  path: "tests/shared/data/transforms"
+  pattern: "test_*.mojo"
+  continue-on-error: true
+- name: "Data Samplers"
+  path: "tests/shared/data/samplers"
+  pattern: "test_*.mojo"
+  continue-on-error: true
+- name: "Data Formats"
+  path: "tests/shared/data/formats"
+  pattern: "test_*.mojo"
+  continue-on-error: true
+```
+
+### File Coverage
+
+| Group | Path | Files |
+|-------|------|-------|
+| Data Core | `tests/shared/data` | 13 |
+| Data Datasets | `tests/shared/data/datasets` | 8 |
+| Data Loaders | `tests/shared/data/loaders` | 5 |
+| Data Transforms | `tests/shared/data/transforms` | 18 |
+| Data Samplers | `tests/shared/data/samplers` | 6 |
+| Data Formats | `tests/shared/data/formats` | 2 |
+| **Total** | | **52** |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | Issue #4458, PR #5116 | Split monolithic Data CI group into 6 sub-groups for auto-discovery |

--- a/skills/cli-json-report-format-implementation.md
+++ b/skills/cli-json-report-format-implementation.md
@@ -1,0 +1,104 @@
+---
+name: cli-json-report-format-implementation
+description: "Implement JSON output format for CLI report commands using dataclasses.asdict() with NaN/Inf sanitization. Use when: (1) adding JSON output to a CLI that already has a dataclass-based report model, (2) serializing dataclasses containing IEEE 754 special floats to JSON."
+category: tooling
+date: 2026-03-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+supersedes: []
+tags: [json, cli, dataclasses, serialization, nan-sanitization, click]
+---
+
+# CLI JSON Report Format Implementation
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Add `--format json` to a Click CLI report command that already has a dataclass-based `ReportData` model and a working Markdown generator |
+| **Outcome** | Successful — JSON report generator created, CLI wired, HTML stub removed, 20 new tests, PR merged |
+| **Verification** | verified-local — all 46 targeted tests pass, pre-commit clean, CI pending |
+
+## When to Use
+
+- Adding a JSON output format to a CLI command that already has structured dataclass models
+- Serializing Python dataclasses to JSON when fields may contain `float("inf")`, `float("-inf")`, or `float("nan")`
+- Removing unimplemented CLI format stubs to avoid misleading `sys.exit(1)` on valid-looking options
+- Following the "parallel generator class" pattern for multi-format report output
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# 1. Sanitize special floats before json.dumps
+import math
+from dataclasses import asdict
+from typing import Any
+
+def _sanitize_for_json(obj: Any) -> Any:
+    if isinstance(obj, float):
+        if math.isinf(obj) or math.isnan(obj):
+            return None
+        return obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_json(item) for item in obj]
+    return obj
+
+# 2. Generate JSON from dataclass
+raw = asdict(report_data)
+sanitized = _sanitize_for_json(raw)
+json_str = json.dumps(sanitized, indent=2)
+
+# 3. Wire into Click CLI (local import pattern)
+elif output_format == "json":
+    from module.json_report import JsonReportGenerator
+    generator = JsonReportGenerator(report_dir)
+    path = generator.write_report(data)
+```
+
+### Detailed Steps
+
+1. **Create a parallel generator class** following the existing generator pattern (same `__init__(base_dir)`, same `write_report(data) -> Path` signature, same `get_report_dir(test_id)` helper)
+2. **Add `_sanitize_for_json()` helper** — recursively walks `dataclasses.asdict()` output, replaces `float("inf")`, `float("-inf")`, `float("nan")` with `None`. Standard `json.dumps` raises `ValueError` on these values
+3. **Wire into CLI dispatch** — add `elif output_format == "json":` branch with a local import (follows existing CLI pattern of importing inside branches)
+4. **Remove unimplemented formats** from `click.Choice` — if a format raises `sys.exit(1)` with "not yet implemented", remove it from the choices so Click rejects it cleanly
+5. **Update `__init__.py` exports** — add to imports and `__all__` (keep `__all__` sorted for ruff RUF022)
+6. **Write tests** — sanitization helper tests (normal values, inf, -inf, nan, nested), generator tests (basic, with tiers, with sensitivity, with transitions, write to file, parametrized special floats), CLI integration tests (json with mock data, html rejection)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Adding comments to `__all__` | Added section comments (`# JSON`, `# Markdown`, etc.) between entries in `__all__` | ruff RUF022 requires isort-style sorting which doesn't support interleaved comments | Keep `__all__` as a flat sorted list without comments when RUF022 is enabled |
+| N/A — direct approach worked | First implementation attempt succeeded | N/A | When the dataclass model is already structured for serialization, `dataclasses.asdict()` + sanitization is minimal work |
+
+## Results & Parameters
+
+**Key pattern**: `dataclasses.asdict()` + recursive sanitize + `json.dumps(indent=2)`
+
+**NaN/Inf sanitization is required because**:
+- `json.dumps(float("inf"))` raises `ValueError: Out of range float values are not JSON compliant`
+- `json.dumps(float("nan"))` produces `NaN` which is not valid JSON per RFC 7159
+- Using `json.dumps(allow_nan=True)` produces JavaScript-compatible but not JSON-standard output
+
+**Test coverage**: 18 unit tests for the generator (100% module coverage) + 2 CLI integration tests
+
+**Files created**:
+- `scylla/reporting/json_report.py` — `JsonReportGenerator` class + `_sanitize_for_json` helper
+- `tests/unit/reporting/test_json_report.py` — 18 tests
+
+**Files modified**:
+- `scylla/cli/main.py` — removed `"html"` from `click.Choice`, added `elif output_format == "json":` branch
+- `scylla/reporting/__init__.py` — added `JsonReportGenerator` to imports and `__all__`
+- `tests/unit/cli/test_cli.py` — added 2 new tests
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #1510 — CLI report JSON format | PR #1553, all tests pass locally |


### PR DESCRIPTION
## Summary

Documents the pattern of promoting subdirectory-scoped test patterns into separate CI matrix entries with leaf-level wildcards for auto-discovery.

- Replace monolithic CI matrix groups (compound multi-pattern strings) with per-subdirectory entries
- Each sub-group uses `test_*.mojo` wildcard at leaf path for automatic file discovery
- `Path.glob` non-recursive behavior ensures zero overlap between parent and subdirectory entries

## Deduplication

Searched 7 existing CI matrix skills for overlap (`ci-matrix-*`, `consolidate-ci-matrix`, `adr009-ci-group-split`). Found none — existing skills cover consolidating groups (opposite direction), disabling flaky tests, and ADR-009 file splitting. This skill covers promoting subdirectories to matrix entries for auto-discovery.

## Verification Level

**verified-precommit**

Pre-commit hooks and `validate_test_coverage.py` pass locally. CI validation pending on ProjectOdyssey PR #5116.

## Key Findings

**What Worked**:
- Simple `test_*.mojo` wildcards at leaf paths auto-discover new files
- `Path.glob("dir/test_*.mojo")` is non-recursive — parent and subdirectory entries never overlap
- No changes needed to `validate_test_coverage.py` or `justfile` when splitting groups

**What Failed**:
- N/A — first approach succeeded

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>