### PR TITLE
feat: add mojo-thread-safety-spinlock-atomic-stats skill

### DIFF
--- a/skills/ci-coverage-threshold-single-source.history
+++ b/skills/ci-coverage-threshold-single-source.history
@@ -1,0 +1,73 @@
+# ci-coverage-threshold-single-source — History
+
+## v2.0.0 (2026-03-25)
+
+**Changed by:** Issue #1511, PR #1554 — raise combined coverage floor from 9% to 75%
+**Verification:** verified-local
+
+### What changed
+- Extended skill to cover removing `--cov-fail-under` from pyproject.toml addopts (not just CI workflows)
+- Added dual-threshold design pattern (combined floor in pyproject.toml + per-step floors in CI)
+- Added guidance on updating consistency check scripts that validate addopts
+- Added `pixi run test-unit` local task pattern for CI parity
+- Added 2 new Failed Attempts entries
+- Updated Results & Parameters with new data points
+
+### Why
+v1.0.0 only covered removing `--cov-fail-under` from CI workflows to let pyproject.toml be the single source.
+Issue #1511 revealed the reverse case: `--cov-fail-under=9` in pyproject.toml addopts was redundant with
+`[tool.coverage.report].fail_under = 9`, and the 9% floor was cosmetically low. The fix removed the addopts
+flag entirely and raised `fail_under` to 75%, making `[tool.coverage.report]` the true single source of truth
+for local runs, while CI continues to use `--override-ini="addopts="` with its own per-step floors.
+
+### Previous version (v1.0.0) snapshot
+---
+name: ci-coverage-threshold-single-source
+description: Remove explicit --cov-fail-under from CI workflows and rely on pyproject.toml
+  as the single source of truth for coverage threshold.
+category: ci-cd
+date: 2026-02-20
+version: 1.0.0
+user-invocable: false
+---
+# Skill: ci-coverage-threshold-single-source
+
+## Overview
+
+| Field     | Value |
+|-----------|-------|
+| Date      | 2026-02-20 |
+| Issue     | #754 |
+| PR        | #868 |
+| Objective | Align coverage threshold between CI and local by removing explicit --cov-fail-under from CI |
+| Outcome   | Success — single source of truth established in pyproject.toml; CI now enforces 73% matching local |
+
+## When to Use
+
+- CI passes with a lower coverage threshold than local development enforces
+- --cov-fail-under=N appears in a GitHub Actions workflow AND fail_under = M exists in pyproject.toml with N != M
+- You want a single source of truth for the coverage threshold
+- A PR introduces a coverage regression that CI doesn't catch but local runs do
+
+## Verified Workflow
+
+1. Diagnose: grep for cov-fail-under in CI and pyproject.toml
+2. Remove --cov-fail-under from CI pytest invocations
+3. Verify trailing whitespace
+4. Commit and PR
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | Direct approach worked | N/A | Solution was straightforward |
+
+## Results & Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Threshold removed from CI | --cov-fail-under=72 |
+| Authoritative threshold | fail_under = 73 |
+| Files changed | .github/workflows/test.yml |
+
+---

--- a/skills/ci-coverage-threshold-single-source.md
+++ b/skills/ci-coverage-threshold-single-source.md
@@ -1,113 +1,190 @@
 ---
 name: ci-coverage-threshold-single-source
-description: Remove explicit --cov-fail-under from CI workflows and rely on pyproject.toml
-  as the single source of truth for coverage threshold.
+description: "Establish [tool.coverage.report].fail_under as the single source of truth for
+  coverage thresholds by removing redundant --cov-fail-under from both CI workflows and
+  pyproject.toml addopts. Use when: (1) --cov-fail-under appears in addopts or CI alongside
+  fail_under in pyproject.toml, (2) coverage floor is cosmetically low, (3) local and CI
+  thresholds diverge."
 category: ci-cd
-date: 2026-02-20
-version: 1.0.0
+date: 2026-03-25
+version: "2.0.0"
 user-invocable: false
+verification: verified-local
+history: ci-coverage-threshold-single-source.history
+tags:
+  - coverage
+  - pytest
+  - single-source-of-truth
+  - pyproject-toml
+  - ci-cd
 ---
+
 # Skill: ci-coverage-threshold-single-source
 
 ## Overview
 
-| Field     | Value |
-|-----------|-------|
-| Date      | 2026-02-20 |
-| Issue     | #754 |
-| PR        | #868 |
-| Objective | Align coverage threshold between CI (`.github/workflows/test.yml`) and local (`pyproject.toml`) by removing the explicit `--cov-fail-under` flag from CI and letting pytest-cov read `fail_under` from `pyproject.toml` |
-| Outcome   | Success — single source of truth established in `pyproject.toml`; CI now enforces 73% matching local |
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Establish `[tool.coverage.report].fail_under` as the single source of truth for coverage thresholds — remove redundant `--cov-fail-under` from both CI and pyproject.toml addopts |
+| **Outcome** | Success — threshold raised from 9% to 75%, addopts flag removed, consistency checks updated |
+| **Verification** | verified-local |
+| **History** | [changelog](./ci-coverage-threshold-single-source.history) |
 
 ## When to Use
 
-- CI passes with a lower coverage threshold than local development enforces
-- `--cov-fail-under=<N>` appears in a GitHub Actions workflow AND `fail_under = <M>` exists in `[tool.coverage.report]` in `pyproject.toml` with `N != M`
-- You want a single source of truth for the coverage threshold
-- A PR introduces a coverage regression that CI doesn't catch but local runs do
+- `--cov-fail-under=<N>` appears in `[tool.pytest.ini_options].addopts` AND `fail_under = <M>` exists in `[tool.coverage.report]` — redundant, remove the addopts flag
+- `--cov-fail-under=<N>` appears in a CI workflow AND `fail_under = <M>` exists in `pyproject.toml` with `N != M` — inconsistent, remove the CI flag
+- Coverage floor is cosmetically low (e.g., 9%) and provides no regression protection
+- Local `pytest` runs don't catch coverage regressions that CI would catch
+- You want developers to get the same coverage feedback locally as CI provides
 
 ## Root Cause Pattern
 
 pytest-cov supports two ways to set a minimum coverage threshold:
 
-1. **CLI flag**: `--cov-fail-under=72` in the pytest command
+1. **CLI flag**: `--cov-fail-under=72` in the pytest command (or in `addopts`)
 2. **Config file**: `fail_under = 73` under `[tool.coverage.report]` in `pyproject.toml`
 
-When both are present, the **CLI flag wins** — it overrides the config file value. This means a lower threshold in CI silently overrides the higher threshold defined in `pyproject.toml`, creating a false sense of confidence: CI passes builds that would fail locally.
+When both are present, the **CLI flag wins** — it overrides the config file value.
+
+**Three places this flag can hide:**
+
+| Location | Precedence | Scope |
+|----------|-----------|-------|
+| `addopts` in `[tool.pytest.ini_options]` | Highest (local runs) | All local `pytest` invocations |
+| `--cov-fail-under=N` in CI workflow | Highest (CI runs) | CI pytest invocations only |
+| `fail_under` in `[tool.coverage.report]` | Lowest (fallback) | Any run without CLI override |
+
+**The fix**: Remove the flag from addopts and CI, making `[tool.coverage.report].fail_under` the single source of truth. CI can use `--override-ini="addopts="` to bypass pyproject.toml addopts and apply its own per-step floors.
 
 ## Verified Workflow
 
-### 1. Diagnose the mismatch
+### Quick Reference
 
 ```bash
-# Find all --cov-fail-under flags in CI workflows
-grep -rn "cov-fail-under" .github/workflows/
+# 1. Find all --cov-fail-under flags
+grep -rn "cov-fail-under" pyproject.toml .github/workflows/
+grep -n "fail_under" pyproject.toml
 
-# Find the authoritative threshold in pyproject.toml
-grep -n "fail_under\|cov-fail-under" pyproject.toml
+# 2. Measure actual coverage
+pixi run pytest tests/ -v --tb=no -q 2>&1 | tail -5
+
+# 3. Remove --cov-fail-under from addopts, raise fail_under
+# Edit pyproject.toml: remove "--cov-fail-under=N" from addopts list
+# Edit pyproject.toml: set fail_under = <actual - 2%>
+
+# 4. Update any consistency check scripts
+# If scripts validate addopts contains --cov-fail-under, update them
+
+# 5. Add local test-unit task for CI parity
+# pixi.toml: test-unit = "pytest tests/unit --override-ini='addopts=' ..."
 ```
 
-### 2. Apply the fix
+### Detailed Steps
 
-Remove `--cov-fail-under=<N>` from every `pytest` invocation in the workflow file.
-Do NOT add it back with the correct value — removing it is preferred so `pyproject.toml` remains the single source of truth.
+#### Scenario A: Remove `--cov-fail-under` from pyproject.toml addopts
 
-```yaml
-# BEFORE (test.yml) — duplicated, inconsistent
-pixi run pytest "$TEST_PATH" -v --cov=<package> --cov-report=term-missing --cov-report=xml --cov-fail-under=72
+1. **Measure actual coverage** to determine the right `fail_under` value:
+   ```bash
+   pixi run pytest tests/ -v --tb=no -q 2>&1 | tail -5
+   # Look for: "Required test coverage of X% reached. Total coverage: Y%"
+   ```
 
-# AFTER (test.yml) — pyproject.toml controls the threshold
-pixi run pytest "$TEST_PATH" -v --cov=<package> --cov-report=term-missing --cov-report=xml
-```
+2. **Remove the flag from addopts** and raise `fail_under`:
+   ```toml
+   # BEFORE
+   [tool.pytest.ini_options]
+   addopts = [
+       "--cov=scylla",
+       "--cov-report=term-missing",
+       "--cov-fail-under=9",   # ← Remove this line
+   ]
 
-```toml
-# pyproject.toml — unchanged, stays as single source of truth
-[tool.coverage.report]
-fail_under = 73
-```
+   [tool.coverage.report]
+   fail_under = 9   # ← Raise to actual - 2% (e.g., 75 if actual is 77.42%)
+   ```
 
-### 3. Verify trailing whitespace is clean
+   ```toml
+   # AFTER
+   [tool.pytest.ini_options]
+   addopts = [
+       "--cov=scylla",
+       "--cov-report=term-missing",
+   ]
 
-`sed` removal of the flag can leave a trailing space on the line. Always check:
+   [tool.coverage.report]
+   fail_under = 75   # Single source of truth
+   ```
 
-```bash
-grep -n " $" .github/workflows/test.yml
-# If any lines appear, strip them:
-sed -i 's/ *$//' .github/workflows/test.yml
-```
+3. **Update consistency check scripts** that validate addopts:
+   ```python
+   # BEFORE: script errors when --cov-fail-under absent from addopts
+   if addopts_threshold is None:
+       return ["No --cov-fail-under=N flag found in addopts"]
 
-### 4. Commit and PR
+   # AFTER: absent is fine — fail_under is the single source of truth
+   if addopts_threshold is None:
+       return []
+   ```
 
-```bash
-git add .github/workflows/test.yml
-git commit -m "fix(ci): Remove --cov-fail-under=<N> from CI, rely on pyproject.toml (<M>%)"
-git push -u origin <branch>
-gh pr create --title "fix(ci): Align coverage threshold between CI and pyproject.toml" \
-  --body "Closes #<issue>"
-gh pr merge --auto --rebase
-```
+4. **Add a `test-unit` pixi task** for local CI parity:
+   ```toml
+   # pixi.toml
+   test-unit = "pytest tests/unit --override-ini='addopts=' -v --strict-markers --cov=scylla --cov-report=term-missing --cov-fail-under=75"
+   ```
+   This gives developers the same per-module floor as CI without relying on pyproject.toml addopts.
+
+5. **Update documentation** (CLAUDE.md, CONTRIBUTING.md) referencing the old floor value.
+
+#### Scenario B: Remove `--cov-fail-under` from CI workflow
+
+1. Remove `--cov-fail-under=<N>` from every `pytest` invocation in `.github/workflows/test.yml`
+2. The CI will now inherit `fail_under` from `[tool.coverage.report]`
+
+**Note**: If CI uses `--override-ini="addopts="` (which clears all addopts), CI must specify its own `--cov-fail-under` — it won't read `addopts` from pyproject.toml. In this case, CI manages its own thresholds independently, and pyproject.toml only governs local runs.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| N/A | Direct approach worked | N/A | Solution was straightforward |
+| Removing flag only | Removed `--cov-fail-under=9` from addopts without raising `fail_under` | Pre-commit consistency check failed: script expected the flag in addopts | Always check for consistency-check scripts that validate addopts contents |
+| Raising floor without measuring | Would have set `fail_under=50` per issue suggestion | Would have left 27% gap below actual (77.42%) — too loose for regression protection | Always measure actual coverage first, then set floor 2% below baseline |
+
 ## Results & Parameters
+
+### v2.0.0 — Issue #1511, PR #1554
+
+| Parameter | Value |
+|-----------|-------|
+| Previous combined floor | `fail_under = 9` + `--cov-fail-under=9` in addopts |
+| New combined floor | `fail_under = 75` (single source of truth) |
+| Actual combined coverage | 77.42% (2.42% buffer) |
+| Actual scylla/ unit coverage | 81.69% |
+| Files changed | `pyproject.toml`, `pixi.toml`, `CONTRIBUTING.md`, `CLAUDE.md`, `scripts/check_doc_config_consistency.py`, tests |
+| New pixi task | `test-unit` — mirrors CI 75% scylla/ enforcement |
+
+### v1.0.0 — Issue #754, PR #868
 
 | Parameter | Value |
 |-----------|-------|
 | Threshold removed from CI | `--cov-fail-under=72` |
-| Authoritative threshold | `fail_under = 73` in `[tool.coverage.report]` in `pyproject.toml` |
+| Authoritative threshold | `fail_under = 73` in `[tool.coverage.report]` |
 | Files changed | `.github/workflows/test.yml` |
-| Lines changed | 2 (one per pytest invocation branch in if/else) |
-| Commit type | `fix(ci):` |
 
-## Key Insight
+## Key Insights
 
-pytest-cov reads `fail_under` from `[tool.coverage.report]` in `pyproject.toml` automatically when no CLI `--cov-fail-under` flag is provided. Removing the CLI flag (rather than updating it) enforces the single source of truth principle: coverage policy lives in `pyproject.toml` and CI inherits it automatically.
+1. **`[tool.coverage.report].fail_under` is sufficient** — pytest-cov reads it automatically when no CLI `--cov-fail-under` flag is provided. Removing the CLI flag enforces the single source of truth.
+
+2. **CI with `--override-ini="addopts="` bypasses all addopts** — this means pyproject.toml addopts changes only affect local runs. CI must specify its own thresholds explicitly.
+
+3. **Consistency check scripts are a hidden dependency** — if your project has scripts that validate `--cov-fail-under` exists in addopts, removing the flag will break them. Update these scripts to accept the absent flag.
+
+4. **Dual-threshold design**: Use `fail_under` in pyproject.toml for local combined coverage, and explicit `--cov-fail-under` in CI for per-step enforcement (unit at 75%, integration at 5%).
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectScylla | Issue #754, PR #868 | [notes.md](../../references/notes.md) |
+| ProjectScylla | Issue #1511, PR #1554 | Raised floor 9%→75%, added test-unit task |
+| ProjectScylla | Issue #754, PR #868 | Removed CI --cov-fail-under, aligned to pyproject.toml |


### PR DESCRIPTION
## Summary

New skill documenting how to implement thread-safe data structures in Mojo 0.26.1 using `os.atomic.Atomic` for spinlocks and atomic counters.

- SpinLock implementation using `fetch_add`/`fetch_sub` test-and-set pattern
- Atomic counter struct for lock-free statistics
- Per-bucket locking pattern for pool-style data structures
- Workarounds for Mojo 0.26.1 limitations (Atomic not Movable, comptime format crashes)

## Verification Level

**verified-local**

Tests pass locally (19 tests: 13 existing + 6 concurrent stress tests across 5 consecutive runs with zero flakes). CI validation pending on ProjectOdyssey PR #5118.

## Key Findings

**What Worked**:
- `os.atomic.Atomic[DType.int64]` with `fetch_add`/`fetch_sub`/`load`/`max` for lock-free operations
- Heap-allocated `UnsafePointer[UInt8]` with `bitcast[Atomic[...]]()` to work around Atomic not being Movable
- Per-bucket spinlocks minimize contention across different size classes
- `parallelize[worker](N)` for concurrent stress testing

**What Failed**:
- `Atomic` as struct field → breaks synthesized move/copy constructors
- `comptime` inside structs/fns → crashes `mojo format` parser
- `int()` → not available in Mojo 0.26.1, use `Int()` instead
- `store(value)` → not available as expected on Atomic

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1019/1019 pass)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>