### PR TITLE
feat: add dynamo-miles-grpo-self-hosted-inference skill

### DIFF
--- a/plugins/tooling/skills-registry-commands/commands/advise.md
+++ b/plugins/tooling/skills-registry-commands/commands/advise.md
@@ -1,5 +1,5 @@
 ---
-description: Search team knowledge before starting work
+description: Search team knowledge before starting work. Use when starting experiments, debugging unfamiliar errors, or before implementing features with unknowns.
 ---
 
 # /advise
@@ -9,9 +9,10 @@ Search the skills registry for relevant prior learnings before starting work.
 ## Target Repository
 
 **Repository**: `HomericIntelligence/ProjectMnemosyne`
-**Cache location**: `$HOME/.agent-brain/ProjectMnemosyne/` (persistent read-only cache)
+**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
 
-Automatically updated before searches. Skipped if already running in the ProjectMnemosyne repository.
+Single shared clone in user's home directory. Automatically updated before searches.
+Automatically skipped if already running in the ProjectMnemosyne repository.
 
 ## Instructions
 
@@ -52,9 +53,46 @@ When the user invokes this command:
    - Select top 5 most relevant matches
 5. **Read skill `.md` files** for top matches only (from flat `skills/<name>.md` files)
    - Focus on: `## Failed Attempts`, `## When to Use`, `## Results & Parameters`
-6. **Present findings**:
-   - What worked (verified approaches)
+
+6. **CRITICAL — Credibility assessment** for each matched skill:
+
+   Check the `verification` field in YAML frontmatter. If absent, treat as `unverified`.
+
+   Score each skill:
+   - `verified-ci` = HIGH confidence — the approach was validated end-to-end in CI
+   - `verified-local` = MEDIUM confidence — works locally but CI may differ
+   - `verified-precommit` = LOW confidence — only formatting/linting checked, not execution
+   - `unverified` or missing = TREAT WITH SKEPTICISM — approach is theoretical
+
+   **Flag contradictions**: If two skills give conflicting advice for the same topic, highlight
+   both and explain which is newer/better verified. Example: "Skill A says retry JIT crashes,
+   but newer Skill B (verified-ci) says they were actually compile errors."
+
+7. **CRITICAL — Check for history files**:
+
+   For each matched skill, check if a `.history` file exists:
+   ```bash
+   ls "$MNEMOSYNE_DIR/skills/<name>.history" 2>/dev/null
+   ```
+
+   If a history file exists, check the version and read the changelog headers to understand
+   how the skill has evolved. A skill at v3.0.0 with a rich history has been battle-tested
+   and amended multiple times — it's more trustworthy than a v1.0.0 skill.
+
+   When presenting findings, note the version:
+   - `v1.0.0` = initial version, may not have been refined
+   - `v2.0.0+` = amended at least once, has a history log showing what changed and why
+   - Skills with history files that show prior approaches were wrong are especially valuable —
+     they document the evolution from wrong to right
+
+   If a history file shows the skill contradicts its own earlier version, highlight this:
+   "> **Evolution note:** This skill was amended from v1.0.0 (which recommended X) to v2.0.0
+   > (which recommends Y instead). The history log explains why X didn't work."
+
+8. **Present findings** with credibility markers:
+   - What worked (verified approaches) — with verification level and version
    - What failed (critical — prevents wasted effort)
+   - Evolution notes from history files (if any)
    - Recommended parameters (copy-paste ready)
 
 ### Phase 2: Follow-Up (If Needed)
@@ -62,34 +100,49 @@ When the user invokes this command:
 After presenting findings, ask:
 "Would you like me to dig deeper into any of these skills, or are you ready to proceed?"
 
-If the user wants more detail, read the full skill `.md` file for the most relevant matches.
+If the user wants more detail, read the full skill `.md` file and its `.history` file
+for the most relevant matches.
 
-> **Note**: If the user's goal involves **creating or fixing skills**, remind them to run `/retrospective` which captures session learnings and creates a new flat-format skill file.
+> **Note**: If the user's goal involves **creating or fixing skills**, remind them to run
+> `/retrospective` which captures session learnings and creates or amends a skill file.
 
 ## Output Format
 
 ```markdown
 ### Related Skills Found
 
-| Skill | Category | Relevance |
-|-------|----------|-----------|
-| skill-name | category | Why relevant |
+| Skill | Version | Verification | Relevance |
+|-------|---------|-------------|-----------|
+| skill-name | v2.0.0 | verified-ci | Why relevant |
+| skill-name | v1.0.0 | unverified | Why relevant (TREAT WITH SKEPTICISM) |
+
+### Evolution Notes
+
+> **skill-name** was amended from v1.0.0 → v2.0.0 on YYYY-MM-DD.
+> v1.0.0 recommended using `check_gradients()` with absolute tolerance.
+> v2.0.0 switched to `check_gradient()` with relative+absolute tolerance
+> because absolute tolerance fails for large-magnitude gradients.
+> [Full history](skills/skill-name.history)
 
 ### Key Findings
 
-**What Worked**:
-- Verified approach 1
-- Verified approach 2
+**What Worked** (high confidence):
+- Verified approach 1 [verified-ci, v2.0.0]
+- Verified approach 2 [verified-local, v1.0.0]
+
+**What Worked** (low confidence — verify before using):
+- Approach 3 [verified-precommit only, v1.0.0]
 
 **What Failed** (Critical!):
 - Failed approach 1: Why it failed
+- Failed approach 2: Why it failed (documented in v1.0.0 → v2.0.0 amendment)
 
 **Recommended Parameters**:
 \`\`\`yaml
 param1: value1
 \`\`\`
 
-**Need more detail?** Ask me to read the full SKILL.md for any skill above.
+**Need more detail?** Ask me to read the full SKILL.md or its .history for any skill above.
 ```
 
 ## Example Workflow
@@ -105,22 +158,27 @@ param1: value1
 ```markdown
 ### Related Skills Found
 
-| Skill | Category | Relevance |
-|-------|----------|-----------|
-| grpo-external-vllm | training | Uses external vLLM server for GRPO training |
-| grpo-batch-tuning | optimization | Optimal batch sizes for GRPO |
+| Skill | Version | Verification | Relevance |
+|-------|---------|-------------|-----------|
+| grpo-external-vllm | v2.0.0 | verified-ci | Uses external vLLM server for GRPO training |
+| grpo-batch-tuning | v1.0.0 | verified-local | Optimal batch sizes for GRPO |
+
+### Evolution Notes
+
+> **grpo-external-vllm** was amended from v1.0.0 → v2.0.0 on 2026-02-15.
+> v1.0.0 used same-GPU vLLM which caused OOM. v2.0.0 uses separate GPU.
+> [Full history](skills/grpo-external-vllm.history)
 
 ### Key Findings
 
-**What Worked**:
-- External vLLM server prevents memory issues
-- batch_size=4 with learning_rate=1e-5 for 7B models
-- Separate GPU setup for vLLM server
+**What Worked** (high confidence):
+- External vLLM server prevents memory issues [verified-ci, v2.0.0]
+- batch_size=4 with learning_rate=1e-5 for 7B models [verified-ci]
 
 **What Failed** (Critical!):
-- vllm_skip_weight_sync errors when vLLM on same GPU
+- vllm_skip_weight_sync errors when vLLM on same GPU (fixed in v2.0.0)
 - batch_size > 8 causes OOM on 24GB GPUs
 - learning_rate > 5e-5 causes training instability
 
-**Need more detail?** Ask me to read the full SKILL.md for any skill above.
+**Need more detail?** Ask me to read the full SKILL.md or its .history for any skill above.
 ```

--- a/plugins/tooling/skills-registry-commands/commands/retrospective.md
+++ b/plugins/tooling/skills-registry-commands/commands/retrospective.md
@@ -1,23 +1,19 @@
 ---
-description: Save session learnings as a new skill plugin
+description: Save session learnings as a new skill plugin. Use after experiments, debugging sessions, or when you want to preserve team knowledge.
 ---
 
 # /retrospective
 
-Capture session learnings and create a new flat-format skill file in the ProjectMnemosyne marketplace.
+Capture session learnings and create or amend a skill file in the ProjectMnemosyne marketplace.
 
 ## Target Repository
 
 **Repository**: `HomericIntelligence/ProjectMnemosyne`
 **Base branch**: `main`
-**Work isolation**: Git worktrees (auto-created per branch, cleaned up after PR creation)
+**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
 
-All skill creation work MUST be done in an isolated git worktree. The base repository
-(either the current directory or a persistent cache at `$HOME/.agent-brain/ProjectMnemosyne/`)
-is used only to spawn worktrees — never work directly in it.
-
-> **Important**: Always use `git worktree add` for branch isolation and `git worktree remove`
-> for cleanup. Never use `rm -rf` on repository directories.
+Single shared clone in user's home directory. Automatically cleaned after PR creation.
+Automatically skipped if already running in the ProjectMnemosyne repository.
 
 ## Instructions
 
@@ -36,39 +32,126 @@ When the user invokes this command:
    - Filename: `<topic>-<subtopic>-<short-4-word-summary>` (kebab-case)
    - Auto-detect category from conversation context (training, evaluation, optimization, debugging, architecture, tooling, ci-cd, testing, documentation)
 
-3. **Setup repository and create worktree**:
+3. **CRITICAL — Search for existing skills to amend**:
+
+   Before creating a new file, search the registry for skills covering the same topic:
+
+   ```bash
+   MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
+   # Search by keywords from the skill name
+   ls "$MNEMOSYNE_DIR/skills/" | grep -i "<keyword1>\|<keyword2>\|<keyword3>" | grep -v ".notes.md" | grep -v ".history"
+   # Also search descriptions in frontmatter
+   grep -l "<keyword>" "$MNEMOSYNE_DIR/skills/"*.md 2>/dev/null | head -20
+   ```
+
+   **If an existing skill covers the same topic → AMEND it** (don't create a new file):
+
+   a. Read the existing skill to understand its current state
+   b. Archive the current version to the history log (see Step 4)
+   c. Update the skill `.md` in-place with new learnings:
+      - Add new Failed Attempts rows to the table
+      - Update the Verified Workflow if the approach changed
+      - Update Results & Parameters with new data
+      - Bump the `version` in frontmatter (e.g., `1.0.0` → `2.0.0`)
+      - Update the `date` to today
+   d. Update the changelog in the history file
+
+   **If no existing skill matches → Create a new skill** (proceed to Step 5)
+
+4. **History log management** (for amendments):
+
+   When amending an existing skill, preserve the previous version in `skills/<name>.history`:
+
+   **File: `skills/<name>.history`**
+
+   This is an append-only log. Each entry records what changed and why. Format:
+
+   ```markdown
+   # <skill-name> — History
+
+   ## v2.0.0 (YYYY-MM-DD)
+
+   **Changed by:** Session context (e.g., "PR #5107 gradient checking fixes")
+   **Verification:** verified-ci | verified-local | verified-precommit | unverified
+
+   ### What changed
+   - Updated tolerance from 1e-2 absolute to rtol=1e-2 + atol=1e-2 combined
+   - Added check_gradient() as preferred API over check_gradients()
+   - Added 2 new Failed Attempts entries
+
+   ### Why
+   Previous approach (v1.0.0) used check_gradients() with absolute tolerance.
+   CI showed this fails for multi-channel conv2d where gradient magnitudes reach ~32-126.
+   Relative tolerance via check_gradient() handles large magnitudes correctly.
+
+   ### Previous version (v1.0.0) snapshot
+   <paste the full previous skill content here as a reference>
+
+   ---
+
+   ## v1.0.0 (YYYY-MM-DD)
+
+   **Initial version.**
+   ```
+
+   **Rules for history files:**
+   - Append new entries at the TOP (newest first)
+   - Always include: version, date, what changed, why, previous snapshot
+   - The snapshot preserves the exact previous content for auditability
+   - Add a reference from the main skill file: `**History:** [changelog](./skills/<name>.history)`
+
+5. **CRITICAL — Honesty gate for "Verified Workflow"**:
+
+   Before writing the "Verified Workflow" section, answer these questions honestly:
+   - Was the workflow actually executed end-to-end? (Not just pre-commit hooks — the actual tests/code)
+   - Did CI pass with these changes? If not, the section MUST be titled "Proposed Workflow" not "Verified Workflow"
+   - Were the results observed in CI, or only locally? If only locally, state: "Verified locally only — CI validation pending"
+
+   **Verification levels** (must be stated in the skill):
+   - `verified-ci`: Tests pass in CI (highest confidence)
+   - `verified-local`: Tests pass locally but not confirmed in CI
+   - `verified-precommit`: Only pre-commit hooks pass (formatting, linting)
+   - `unverified`: Approach is theoretically sound but never executed
+
+   Add this as a frontmatter field:
+   ```yaml
+   verification: verified-ci | verified-local | verified-precommit | unverified
+   ```
+
+6. **Setup repository**:
    ```bash
    # Detect if already in ProjectMnemosyne
    CURRENT_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
    if [[ "$CURRENT_REMOTE" == *"ProjectMnemosyne"* ]] && [[ "$CURRENT_REMOTE" != *"ProjectMnemosyne-"* ]]; then
-     # Already in ProjectMnemosyne - use current repo as base
-     MNEMOSYNE_BASE="$(git rev-parse --show-toplevel)"
+     # Already in ProjectMnemosyne - work in current directory
+     MNEMOSYNE_DIR="."
+     NEED_CLEANUP=false
    else
-     # Use persistent cache as base repo for worktree creation
-     MNEMOSYNE_BASE="$HOME/.agent-brain/ProjectMnemosyne"
+     # Use shared home directory location
+     MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
+     NEED_CLEANUP=true
 
-     if [ ! -d "$MNEMOSYNE_BASE" ]; then
+     if [ ! -d "$MNEMOSYNE_DIR" ]; then
        # Clone fresh
        mkdir -p "$HOME/.agent-brain"
-       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_BASE"
+       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
      fi
+
+     # Always update to latest main before starting
+     git -C "$MNEMOSYNE_DIR" fetch origin
+     git -C "$MNEMOSYNE_DIR" checkout main
+     git -C "$MNEMOSYNE_DIR" pull --ff-only origin main
+
+     cd "$MNEMOSYNE_DIR"
    fi
 
-   # Ensure we have latest main
-   git -C "$MNEMOSYNE_BASE" fetch origin
-   git -C "$MNEMOSYNE_BASE" checkout main 2>/dev/null || true
-   git -C "$MNEMOSYNE_BASE" pull --ff-only origin main 2>/dev/null || true
-
-   # Create an isolated worktree for the new skill branch
-   WORKTREE_DIR="/tmp/mnemosyne-skill-<name>"
-   git -C "$MNEMOSYNE_BASE" worktree add "$WORKTREE_DIR" -b skill/<name> origin/main
-
-   cd "$WORKTREE_DIR"
+   # Create branch from origin/main (clean state)
+   git checkout -b skill/<name> origin/main
    ```
 
-4. **Generate skill file** as flat `skills/<name>.md`:
+7. **Generate or amend skill file** as flat `skills/<name>.md`:
 
-   > ✅ New flat format: Single `.md` file in `skills/` root (not nested directories or plugin.json)
+   > New flat format: Single `.md` file in `skills/` root (not nested directories or plugin.json)
 
    **File 1: `skills/<name>.md`** with **YAML frontmatter + markdown body**:
 
@@ -80,6 +163,8 @@ When the user invokes this command:
    date: YYYY-MM-DD
    version: "1.0.0"
    user-invocable: false
+   verification: <verified-ci|verified-local|verified-precommit|unverified>
+   history: <name>.history  # Only present if skill has been amended
    tags: []
    ---
 
@@ -92,6 +177,8 @@ When the user invokes this command:
    | **Date** | YYYY-MM-DD |
    | **Objective** | What was this skill developed to accomplish? |
    | **Outcome** | Was it successful? Operational? |
+   | **Verification** | verified-ci / verified-local / verified-precommit / unverified |
+   | **History** | [changelog](./<name>.history) |
 
    ## When to Use
 
@@ -126,21 +213,27 @@ When the user invokes this command:
 
    | Project | Context | Details |
    |---------|---------|---------|
-   | ProjectMnemosyne | Session context | [notes.md](./skills/<name>.notes.md) |
+   | ProjectName | Session context | [notes.md](./skills/<name>.notes.md) |
    ```
 
    Rules:
    - Filename: lowercase kebab-case (`^[a-z0-9-]+$`) — e.g., `training-grpo-external-vllm-setup.md`
    - `category`: one of 9 valid categories (no "refactoring" — use "architecture")
-   - All required fields in frontmatter: name, description, category, date, version
+   - All required fields in frontmatter: name, description, category, date, version, verification
    - All required markdown sections: Overview, When to Use, Verified Workflow, Failed Attempts, Results & Parameters
+   - **If verification is `unverified` or `verified-precommit`**: rename the section to "Proposed Workflow" instead of "Verified Workflow" and add a warning: "> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms."
 
    **File 2: `skills/<name>.notes.md`** (optional):
    - Raw session details, code snippets, debugging logs
    - Human-readable reference material
    - Only create if additional context needed beyond main skill file
 
-5. **Validate skill** (MUST pass before committing):
+   **File 3: `skills/<name>.history`** (created on first amendment):
+   - Append-only changelog with version snapshots
+   - Referenced from main skill file via `history` frontmatter field
+   - See Step 4 for format
+
+8. **Validate skill** (MUST pass before committing):
 
    ### Pre-Commit Validation Checklist
 
@@ -161,12 +254,15 @@ When the user invokes this command:
    ```
    If validation fails, fix errors and re-run. Do NOT commit until it passes.
 
-6. **Commit and push**:
+9. **Commit and push**:
    ```bash
+   # For new skills:
    git add skills/<name>.md skills/<name>.notes.md 2>/dev/null || true
    git commit -m "feat: add <name> skill
 
 Documents <brief description of what was learned>.
+
+Verification: <verified-ci|verified-local|verified-precommit|unverified>
 
 Key learnings:
 - <bullet 1>
@@ -175,20 +271,43 @@ Key learnings:
 
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 
+   # For amendments:
+   git add skills/<name>.md skills/<name>.history skills/<name>.notes.md 2>/dev/null || true
+   git commit -m "feat: amend <name> skill (v<X.0.0>)
+
+<Brief description of what changed and why>.
+
+Verification: <level>
+Previous version archived in <name>.history
+
+Key changes:
+- <change 1>
+- <change 2>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
    git push -u origin skill/<name>
    ```
 
-7. **Create PR** (only if push succeeded):
-   ```bash
-   gh pr create --repo HomericIntelligence/ProjectMnemosyne --base main \
-     --title "feat: add <name> skill" \
-     --body "## Summary
+10. **Create PR** (only if push succeeded):
+    ```bash
+    gh pr create --repo HomericIntelligence/ProjectMnemosyne --base main \
+      --title "feat: <add|amend> <name> skill" \
+      --body "## Summary
+
+<New skill | Amends existing skill from v<old> to v<new>>.
 
 Documents <brief description of what was learned>.
 
 - <Key point 1>
 - <Key point 2>
 - <Key point 3>
+
+## Verification Level
+
+**<verified-ci|verified-local|verified-precommit|unverified>**
+
+<If not verified-ci, explain what is pending>
 
 ## Key Findings
 
@@ -206,17 +325,36 @@ Documents <brief description of what was learned>.
 - [ ] Test skill discovery with relevant keywords
 
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
-   ```
 
-8. **Clean up worktree** (REQUIRED after PR creation):
-   ```bash
-   # Return to the base repo directory first
-   cd "$MNEMOSYNE_BASE" 2>/dev/null || cd -
+    # Enable auto-merge so the PR merges automatically once CI passes
+    gh pr merge --auto --rebase --repo HomericIntelligence/ProjectMnemosyne
+    ```
 
-   # Remove the worktree
-   git -C "$MNEMOSYNE_BASE" worktree remove "$WORKTREE_DIR"
-   git -C "$MNEMOSYNE_BASE" worktree prune
-   ```
+11. **Cleanup** (if cloned to $HOME/.agent-brain):
+    ```bash
+    if [ "$NEED_CLEANUP" = true ]; then
+      # After PR created, remove the worktree clone
+      rm -rf "$HOME/.agent-brain/ProjectMnemosyne"
+    fi
+    ```
+
+## Amendment Workflow Summary
+
+```text
+Existing skill found?
+├─ YES → Amend workflow:
+│   1. Read existing skill
+│   2. Create/append to <name>.history with previous version snapshot
+│   3. Update <name>.md in-place (new data, bump version, update date)
+│   4. Add history frontmatter field if first amendment
+│   5. Commit both files
+│
+└─ NO → New skill workflow:
+    1. Create <name>.md with full template
+    2. Optionally create <name>.notes.md
+    3. No history file needed yet
+    4. Commit
+```
 
 ## Common Issues & Solutions
 
@@ -232,17 +370,6 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 | "Quick Reference should use ###" | Using `## Quick Reference` instead of `###` | Demote to `### Quick Reference` (subsection of Verified Workflow) |
 | Skill not in marketplace | File not committed or in wrong location | Verify in `skills/<name>.md` (root of skills dir, not nested) |
 
-### Issue: Stale worktree
-
-**Cause**: Worktree from a previous failed `/retrospective` was not cleaned up.
-
-**Solution**: List and remove stale worktrees:
-```bash
-git worktree list
-git worktree remove /tmp/mnemosyne-skill-<name>
-git worktree prune
-```
-
 ### Issue: PR already exists
 
 **Cause**: Branch was already pushed in previous attempt.
@@ -257,12 +384,21 @@ git push -u origin skill/<name>
 git push origin skill/<name>
 ```
 
+### Issue: Cleanup directory
+
+**Cause**: Shared clone at `$HOME/.agent-brain/ProjectMnemosyne` takes up disk space.
+
+**Solution**: Safe to delete anytime — re-clones automatically on next `/advise` or `/retrospective`:
+```bash
+rm -rf $HOME/.agent-brain/ProjectMnemosyne
+```
+
 ## Required Sections
 
 | Section | Format | Purpose |
 |---------|--------|---------|
-| **YAML frontmatter** | Starts with `---`, includes name/description/category/date/version | Metadata for marketplace |
-| **Overview** | `## Overview` with table (date, objective, outcome) | Quick context |
+| **YAML frontmatter** | Starts with `---`, includes name/description/category/date/version/verification | Metadata for marketplace |
+| **Overview** | `## Overview` with table (date, objective, outcome, verification) | Quick context |
 | **When to Use** | Bullet points with trigger conditions | Discoverability |
 | **Verified Workflow** | Steps that worked + `### Quick Reference` subsection | The actual solution |
 | **Failed Attempts** | Table: Attempt, What Was Tried, Why Failed, Lesson | Prevent wasted effort |
@@ -274,4 +410,4 @@ git push origin skill/<name>
 /skills-registry-commands:retrospective
 ```
 
-Claude will analyze the session, auto-generate the skill filename, and guide you through creating a new flat-format skill file.
+Claude will analyze the session, check for existing skills to amend, and either update an existing skill (with history) or create a new one.

--- a/skills/architecture-hierarchical-agent-command-creation.md
+++ b/skills/architecture-hierarchical-agent-command-creation.md
@@ -1,0 +1,174 @@
+---
+name: architecture-hierarchical-agent-command-creation
+description: "Create a Claude Code custom command that orchestrates hierarchical multi-agent
+  workflows with model tier assignments. Use when: (1) building a reusable /command
+  that spawns sub-agents at different model tiers (Opus/Sonnet/Haiku), (2) integrating
+  ProjectOdyssey's 6-level agent hierarchy into a portable command, (3) implementing
+  wave-based parallel agent execution with approval gates."
+category: architecture
+date: 2026-03-25
+version: 1.0.0
+user-invocable: false
+verification: verified-local
+tags:
+  - claude-code
+  - agent-hierarchy
+  - model-tiers
+  - custom-command
+  - orchestration
+---
+
+# Hierarchical Agent Command Creation
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Create a reusable Claude Code custom command (`/myrmidon-swarm`) that decomposes complex tasks into hierarchical agent trees with automatic model tier assignment (Opus for orchestrators, Sonnet for specialists, Haiku for executors) |
+| **Outcome** | Success - 387-line command file installed at `~/.claude/commands/myrmidon-swarm.md`, immediately discoverable in Claude Code autocomplete |
+| **Verification** | verified-local |
+
+## When to Use
+
+- Building a Claude Code custom command that spawns sub-agents at different model tiers
+- Porting ProjectOdyssey's 6-level agent hierarchy (L0-L5) into a portable, repo-agnostic command
+- Implementing wave-based parallel agent execution with mandatory user approval gates
+- Integrating ProjectMnemosyne `/advise` auto-invocation into a workflow command
+- Creating commands that follow the XML-structured prompt pattern from `repo-analyze.md`
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Command file location
+~/.claude/commands/<command-name>.md
+
+# YAML frontmatter (only description field needed)
+---
+description: Brief description of what the command does
+---
+
+# Invocation
+/<command-name> <arguments>
+```
+
+### Detailed Steps
+
+1. **Study the existing command pattern** — Read `~/.claude/commands/repo-analyze.md` for the established structure: YAML frontmatter with `description` field, then markdown body with XML-structured sections (`<system>`, `<task>`, etc.)
+
+2. **Study the agent hierarchy pattern** — Read ProjectOdyssey's agent configs at `.claude/agents/`:
+   - `chief-architect.md` (L0, Opus) — strategic decisions, delegation
+   - `foundation-orchestrator.md` (L1, Sonnet) — section coordination
+   - `implementation-specialist.md` (L3, Sonnet) — component expertise
+   - `implementation-engineer.md` (L4, Haiku) — execution
+
+3. **Define model tier assignments** — Map agent levels to Claude models:
+
+   | Tier | Levels | Model | Role |
+   |------|--------|-------|------|
+   | Orchestrator | L0, L1 | `model: "opus"` | Strategic decisions, coordination |
+   | Specialist | L2, L3 | `model: "sonnet"` | Design, analysis, code review |
+   | Executor | L4, L5 | `model: "haiku"` | Implementation, boilerplate |
+
+4. **Structure the command file** with XML sections (~300-400 lines):
+   - `<system>` — Orchestrator identity and behavior
+   - `<agent_tiers>` — Tier definitions with decision flowchart
+   - `<workflow>` — 5-phase workflow (Plan, Test, Implementation, Package, Cleanup)
+   - `<delegation_rules>` — Agent spawning, wave execution, escalation
+   - `<integrations>` — Mnemosyne, AI Maestro, Scylla
+   - `<constraints>` — Safety rules, scope control
+   - `<agent_prompt_template>` — Template for sub-agent prompts
+   - `<output_format>` — Status reporting format
+
+5. **Implement the approval gate** — Phase 1 (Plan) must present a decomposition table and WAIT for user approval before spawning any agents. Use explicit stop instruction: "STOP HERE. Ask the user."
+
+6. **Implement auto-invocation of /advise** — Use the Skill tool:
+   ```
+   Skill(skill: "skills-registry-commands:advise", args: "<task description>")
+   ```
+
+7. **Use Agent tool with model parameter** for spawning tiered sub-agents:
+   ```
+   Agent(
+     model: "sonnet",
+     isolation: "worktree",
+     description: "5-word summary",
+     prompt: "... full self-contained instructions ..."
+   )
+   ```
+
+8. **Write the file** to `~/.claude/commands/<name>.md` and verify it appears in autocomplete
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Initial model mapping from ProjectOdyssey | Used Odyssey's exact mapping (only L0=Opus, L1-L3=Sonnet, L4-L5=Haiku) | User wanted Orchestrators (L0+L1) on Opus, not just L0 | Always confirm model tier assignments with the user — the command owner's preferences may differ from the source project |
+| Generic command name | Proposed `/agentic-workflow` as the command name | User wanted `/myrmidon-swarm` to fit the Homeric theme | Ask about naming preferences — ecosystem naming conventions matter |
+| Skip approval gate | Considered autonomous execution for speed | User explicitly wanted mandatory approval before spawning agents | Default to requiring approval for commands that spawn multiple agents — the cost of misunderstood tasks is high |
+
+## Results & Parameters
+
+### Command File Structure
+
+```yaml
+# ~/.claude/commands/myrmidon-swarm.md
+---
+description: Summon the Myrmidon swarm — hierarchical agent delegation with Opus/Sonnet/Haiku model tiers
+---
+
+# Sections (XML-structured):
+# <system>            — L0 orchestrator identity (~30 lines)
+# <agent_tiers>       — 3 tiers with decision flowchart (~35 lines)
+# <workflow>          — 5-phase workflow with approval gate (~75 lines)
+# <delegation_rules>  — wave execution, escalation (~55 lines)
+# <integrations>      — Mnemosyne, AI Maestro, Scylla (~40 lines)
+# <constraints>       — safety rules, tooling preferences (~30 lines)
+# <agent_prompt_template> — reusable template for sub-agents (~40 lines)
+# <output_format>     — status reporting (~30 lines)
+# Total: ~387 lines, ~14KB
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| File location | `~/.claude/commands/` (user-level) | Works across all repos without per-repo setup |
+| Prompt structure | XML sections in markdown | Matches `repo-analyze.md` convention, gives Claude clear semantic boundaries |
+| Approval gate | Mandatory in Phase 1 | Prevents wasted compute on misunderstood tasks |
+| `/advise` invocation | Auto-invoke via Skill tool | Ensures prior learnings are always consulted |
+| Wave sizing | Max 5 agents per wave | Prevents resource exhaustion |
+| File conflict prevention | No two agents in same wave touch same file | Prevents merge conflicts |
+
+### Wave-Based Execution Pattern
+
+```
+Wave 1: [Independent sub-tasks with no dependencies]
+  ↓ wait for all to complete
+Wave 2: [Sub-tasks that depend on Wave 1 results]
+  ↓ wait for all to complete
+Wave N: [Final sub-tasks]
+```
+
+Key rules from `wave-based-bulk-issue-triage` skill:
+- Use `isolation: "worktree"` for file-modifying agents
+- Never `git add -A` — stage specific files
+- Never `--no-verify` — fix hook failures
+- Max 5 agents per wave
+
+### Integration Points
+
+| Integration | Required? | How |
+|-------------|-----------|-----|
+| ProjectMnemosyne `/advise` | Yes (auto) | Skill tool invocation in Phase 1 |
+| ProjectMnemosyne `/retrospective` | No (suggest) | User decides in Phase 5 |
+| AI Maestro | No (detect) | Check for `~/.aimaestro/` directory |
+| ProjectScylla T0-T6 | No (when relevant) | Only for agent evaluation tasks |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| HomericIntelligence ecosystem | Session creating /myrmidon-swarm command | Installed at ~/.claude/commands/myrmidon-swarm.md, 387 lines, appears in autocomplete |


### PR DESCRIPTION
## Summary

Documents NVIDIA Dynamo + Miles GRPO training integration using self-hosted multi-node SGLang inference on Slurm+Enroot clusters.

- Dynamo only exposes `/v1/chat/completions` (not SGLang `/generate`)
- Miles `--rollout-external` won't work with Dynamo — custom generate function needed
- Two-job Slurm pattern: inference cluster + training job
- Dynamo v1.0.1+ required (v1.0.0 logprobs bug)

## Verification Level

**unverified** — Based on proven Baseten pattern, not yet run on cluster.

## Key Findings

**What Worked**: Custom `dynamo_generate.py`, two-job Slurm pattern, FSDP+GRPO pipeline

**What Failed**: `--rollout-external` with Dynamo, Dynamo v1.0.0 logprobs, sbatch sourcing

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1019/1019 pass)
- [ ] Verify skill appears in marketplace

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>