### PR TITLE
feat: amend gradient-checking-test-setup-fixes skill (v2.0.0)

### DIFF
--- a/skills/gradient-checking-test-setup-fixes.history
+++ b/skills/gradient-checking-test-setup-fixes.history
@@ -1,0 +1,62 @@
+# gradient-checking-test-setup-fixes — History
+
+## v2.0.0 (2026-03-25)
+
+**Changed by:** PR #5107 second commit — CI showed v1.0.0 approach still failed for conv2d/depthwise
+**Verification:** verified-local
+
+### What changed
+
+- Conv2d and depthwise conv2d: switched from `check_gradients()` to `check_gradient()` (the real fix)
+- v1.0.0 only changed epsilon from 1e-4 to default 3e-4 — this reduced diff from 0.134 to 0.046 but still failed absolute tolerance of 0.01
+- Root cause was `check_gradients()` using pure absolute tolerance `|diff| >= 0.01`, not epsilon
+- `check_gradient()` uses combined tolerance: `|diff| <= atol + rtol * max_magnitude`
+- Updated decision tree: ALL gradient checking should use `check_gradient()`, not just normalization layers
+- Added 2 new Failed Attempts entries documenting the v1.0.0 approach failing
+
+### Why
+
+v1.0.0 correctly identified the batch norm cancellation issue but misdiagnosed the conv2d/depthwise
+failures as an epsilon problem. The actual root cause was the tolerance MODEL — `check_gradients()`
+applies pure absolute tolerance (`|diff| >= 0.01`) which is too tight when gradient magnitudes
+reach 32-126. Even with the correct epsilon=3e-4, the diff of 0.046 at magnitude 32.4 still exceeds
+the absolute threshold.
+
+`check_gradient()` uses `assert_gradients_close()` with `|diff| <= atol + rtol * max_magnitude`:
+- Conv2d multi-channel: 0.046 < (0.01 + 0.01*32.4) = 0.334
+- Depthwise conv2d: 0.010 < (0.01 + 0.01*126.4) = 1.274
+
+### Previous version (v1.0.0) snapshot
+
+---
+name: gradient-checking-test-setup-fixes
+description: 'Fix gradient checking test failures caused by pathological test setup
+  (uniform inputs, wrong epsilon, degenerate cases). Use when: (1) gradient checking
+  tests fail with analytical~0 vs numerical~nonzero for normalization layers, (2)
+  multi-channel conv2d gradient checks exceed tolerance due to accumulated float32
+  precision, (3) depthwise conv2d tests fail with uniform inputs.'
+category: testing
+date: 2026-03-25
+version: 1.0.0
+user-invocable: false
+tags:
+  - gradient-checking
+  - batch-norm
+  - conv2d
+  - depthwise-conv2d
+  - float32-precision
+  - test-setup
+---
+
+[Full v1.0.0 content preserved in git history — see commit that created this skill]
+
+Key differences from v2.0.0:
+- Recommended `check_gradients()` with adjusted epsilon for conv2d (FAILED in CI)
+- Decision tree said "NO normalization → use check_gradients()" (WRONG — should always use check_gradient())
+- Did not identify absolute vs relative tolerance as the root cause
+
+---
+
+## v1.0.0 (2026-03-25)
+
+**Initial version.**

--- a/skills/gradient-checking-test-setup-fixes.md
+++ b/skills/gradient-checking-test-setup-fixes.md
@@ -1,14 +1,15 @@
 ---
 name: gradient-checking-test-setup-fixes
-description: 'Fix gradient checking test failures caused by pathological test setup
-  (uniform inputs, wrong epsilon, degenerate cases). Use when: (1) gradient checking
-  tests fail with analytical~0 vs numerical~nonzero for normalization layers, (2)
-  multi-channel conv2d gradient checks exceed tolerance due to accumulated float32
-  precision, (3) depthwise conv2d tests fail with uniform inputs.'
+description: 'Fix gradient checking test failures caused by pathological test setup.
+  Use when: (1) gradient checks fail with analytical~0 vs numerical~nonzero for normalization
+  layers, (2) any gradient check exceeds tolerance due to large-magnitude gradients,
+  (3) tests use check_gradients() instead of check_gradient().'
 category: testing
 date: 2026-03-25
-version: 1.0.0
+version: 2.0.0
 user-invocable: false
+verification: verified-local
+history: gradient-checking-test-setup-fixes.history
 tags:
   - gradient-checking
   - batch-norm
@@ -16,6 +17,7 @@ tags:
   - depthwise-conv2d
   - float32-precision
   - test-setup
+  - tolerance
 ---
 
 ## Overview
@@ -23,16 +25,17 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-03-25 |
-| **Objective** | Root-cause and fix 3 gradient checking test failures on main branch (batch norm, conv2d multi-channel, depthwise conv2d) |
-| **Outcome** | All 3 failures identified as test setup issues (not backward pass bugs). Fixed via non-uniform inputs/grad_output, correct epsilon, and explicit tolerances. PR #5107. |
+| **Objective** | Root-cause and fix 3 gradient checking test failures on main (batch norm, conv2d, depthwise conv2d) |
+| **Outcome** | Batch norm fixed in v1.0.0. Conv2d/depthwise required v2.0.0 — switching to `check_gradient()` for relative tolerance. PR #5107. |
+| **Verification** | verified-local (batch norm confirmed passing in CI; conv2d/depthwise CI pending) |
+| **History** | [changelog](./gradient-checking-test-setup-fixes.history) |
 
 ## When to Use
 
 - CI "Core Gradient" test group fails with gradient checking mismatches
 - Batch norm backward gradient check shows analytical~0 vs numerical~0.09 (cancellation gotcha)
-- Conv2d multi-channel gradient check exceeds tolerance with large-magnitude gradients (~44.5)
-- Depthwise conv2d gradient check fails with uniform (ones) inputs
-- Any normalization layer gradient check uses `check_gradients()` (which hardcodes `ones_like` grad_output)
+- Any gradient check exceeds tolerance when gradient magnitudes are large (>10)
+- `check_gradients()` is used anywhere — it has a fundamentally broken tolerance model
 - Accumulated float32 precision error exceeds absolute tolerance in multi-element output sums
 
 ## Verified Workflow
@@ -41,41 +44,46 @@ tags:
 
 ```bash
 # Diagnose: extract failure lines from CI
-gh run view <run_id> --log-failed 2>&1 | grep -E "(FAILED|❌|Gradient check FAILED|Analytical:|Numerical:|Tolerance:)"
+gh run view <run_id> --log-failed 2>&1 | grep -E "(FAILED|Gradient check FAILED|Analytical:|Numerical:|Tolerance:)"
 
-# Check if check_gradients() is using uniform grad_output (always does)
-grep "check_gradients" tests/shared/core/test_gradient_checking_*.mojo
-
-# Check if tests use uniform inputs
-grep "ones(" tests/shared/core/test_gradient_checking_*.mojo
+# Find tests still using check_gradients() (should be migrated to check_gradient())
+grep -r "check_gradients" tests/shared/core/test_gradient_checking_*.mojo
 ```
 
 ### Detailed Steps
 
-1. **Identify the failure pattern** from CI logs:
+1. **Always use `check_gradient()` (no trailing 's')** for ALL gradient checking tests:
 
-   | Pattern | Root Cause | Fix |
-   |---------|-----------|-----|
-   | Analytical: ~0, Numerical: ~0.09 | Batch norm cancellation with uniform grad_output | Use `check_gradient()` with non-uniform grad_output |
-   | Max diff 0.134, values ~44.5, tolerance 0.01 | Float32 precision error with epsilon=1e-4 | Use default epsilon=3e-4 |
-   | Kernel gradient check failed with ones() inputs | Degenerate gradient patterns from uniform input | Use non-uniform inputs |
+   The critical difference is the tolerance model:
 
-2. **For batch norm tests** — switch from `check_gradients()` to `check_gradient()`:
+   | API | Tolerance | Formula |
+   | --- | --- | --- |
+   | `check_gradients()` | Pure absolute | `abs(diff) >= tolerance` (BROKEN for large gradients) |
+   | `check_gradient()` | Combined relative+absolute | `abs(diff) > atol + rtol * max_magnitude` (CORRECT) |
 
-   `check_gradients()` (line 95 in gradient_checker.mojo) hardcodes `grad_output = ones_like(output)`.
-   `check_gradient()` (line 727) accepts a custom `grad_output` parameter.
+   For a gradient of magnitude 32.4 with diff 0.046:
+   - `check_gradients(tolerance=0.01)`: 0.046 >= 0.01 → FAIL
+   - `check_gradient(rtol=1e-2, atol=1e-2)`: 0.046 > (0.01 + 0.01*32.4) = 0.334 → PASS
+
+2. **For ALL tests** — use this pattern:
 
    ```mojo
-   # BEFORE: uses check_gradients() which hardcodes ones grad_output
-   var passed = check_gradients(forward, backward, input)
+   from shared.testing.gradient_checker import check_gradient
+   from shared.tensor.any_tensor import AnyTensor, zeros, zeros_like
 
-   # AFTER: use check_gradient() with non-uniform grad_output
+   fn _make_ones_grad_output(output: AnyTensor) raises -> AnyTensor:
+       var grad_output = zeros_like(output)
+       for i in range(output.numel()):
+           grad_output._set_float64(i, 1.0)
+       return grad_output^
+
+   # In each test:
    var output = forward(input)
-   var grad_output = _make_non_uniform_grad_output(output)
+   var grad_output = _make_ones_grad_output(output)
    check_gradient(forward, backward, input, grad_output, rtol=1e-2, atol=1e-2)
    ```
 
-   Non-uniform grad_output pattern (proven, from team KB):
+3. **For normalization layers (batch norm, layer norm)** — use non-uniform grad_output:
 
    ```mojo
    fn _make_non_uniform_grad_output(output: AnyTensor) raises -> AnyTensor:
@@ -86,112 +94,67 @@ grep "ones(" tests/shared/core/test_gradient_checking_*.mojo
        return grad_output^
    ```
 
-   Also use non-uniform input (not all `ones`):
+   Uniform grad_output (ones) causes pathological cancellation: `sum(x_norm) = 0` makes
+   analytical gradient exactly 0, while numerical gradient picks up float32 noise ~0.094.
+
+4. **Always use non-uniform inputs**:
 
    ```mojo
-   fn _make_non_uniform_input(shape: List[Int]) raises -> AnyTensor:
-       var input = zeros(shape, DType.float32)
-       for i in range(input.numel()):
-           input._data.bitcast[Float32]()[i] = Float32(i) * Float32(0.1) + Float32(0.1)
-       return input^
-   ```
-
-3. **For conv2d tests** — remove explicit `epsilon=1e-4`:
-
-   The `GRADIENT_CHECK_EPSILON_FLOAT32 = 3e-4` constant exists for a reason (issue #2704).
-   With epsilon=1e-4 and multi-channel output (75 elements at magnitude ~44.5), accumulated
-   float32 error is 0.134 which exceeds the 0.01 tolerance.
-
-   ```mojo
-   # BEFORE: explicit epsilon=1e-4 causes precision issues
-   var passed = check_gradients(forward, backward_fn, x, epsilon=1e-4, tolerance=1e-2)
-
-   # AFTER: use default epsilon=3e-4
-   var passed = check_gradients(forward, backward_fn, x, tolerance=1e-2)
-   ```
-
-4. **For depthwise conv2d tests** — use non-uniform inputs:
-
-   ```mojo
-   # BEFORE: uniform inputs
-   var input = ones(shape, DType.float32)
-   var kernel = ones(kernel_shape, DType.float32)
-
-   # AFTER: non-uniform inputs
    var input = zeros(shape, DType.float32)
    for i in range(input.numel()):
        input._data.bitcast[Float32]()[i] = Float32(i) * Float32(0.1)
-
-   var kernel = zeros(kernel_shape, DType.float32)
-   for i in range(kernel.numel()):
-       kernel._data.bitcast[Float32]()[i] = Float32(i) * Float32(0.05) + Float32(0.1)
-   ```
-
-5. **Import the right function**:
-
-   ```mojo
-   # For custom grad_output: use check_gradient (no 's')
-   from shared.testing.gradient_checker import check_gradient
-
-   # For default ones grad_output: use check_gradients (with 's')
-   from shared.testing.gradient_checker import check_gradients
    ```
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Increasing tolerance to hide batch norm mismatch | Raise tolerance from 1e-2 to 1e-1 | Masks the real issue — doesn't validate the backward pass correctly | Fix the test setup (non-uniform grad_output) instead of loosening tolerance |
-| Fixing the batch norm backward formula | Suspected formula bug since analytical=0 but numerical=0.09 | The formula IS correct — zero is the mathematically right answer for uniform grad_output | Always verify the math before assuming the implementation is wrong |
-| Using epsilon=1e-5 for conv2d | Smaller epsilon for more accurate finite differences | Float32 rounding error gets WORSE with smaller epsilon (~56% precision loss at 1e-5) | Smaller epsilon != more accurate in float32; use 3e-4 (sqrt of machine epsilon) |
-| Keeping uniform ones() inputs for depthwise conv2d | Assumed uniform inputs would be fine since depthwise conv doesn't normalize | Uniform inputs create degenerate patterns where many gradient contributions cancel | Always use non-uniform inputs for gradient checking — avoid symmetry artifacts |
+| Increasing tolerance to hide batch norm mismatch | Raise tolerance from 1e-2 to 1e-1 | Masks the real issue — doesn't validate the backward pass correctly | Fix the test setup, not the threshold |
+| Fixing the batch norm backward formula | Suspected formula bug since analytical=0 but numerical=0.09 | The formula IS correct — zero is the right answer for uniform grad_output | Verify the math before assuming the implementation is wrong |
+| Using epsilon=1e-5 for conv2d | Smaller epsilon for more accurate finite differences | Float32 rounding error gets WORSE with smaller epsilon (~56% precision loss) | Smaller epsilon != more accurate in float32; use 3e-4 |
+| Keeping uniform ones() inputs for depthwise conv2d | Assumed uniform inputs would be fine since depthwise conv doesn't normalize | Uniform inputs create degenerate patterns where many gradient contributions cancel | Always use non-uniform inputs for gradient checking |
+| v1.0.0: Removing epsilon=1e-4 for conv2d (keeping check_gradients) | Changed from epsilon=1e-4 to default 3e-4, keeping check_gradients() | Diff dropped from 0.134 to 0.046 but STILL failed absolute tolerance of 0.01 | The problem was the tolerance MODEL (absolute vs relative), not the epsilon |
+| v1.0.0: Using check_gradients() with non-uniform inputs for depthwise | Added non-uniform inputs but kept check_gradients() | Diff was 0.0103 at magnitude 126.4 — barely exceeded absolute tolerance 0.01 | Large-magnitude gradients need relative tolerance; absolute tolerance can't scale |
 
 ## Results & Parameters
 
-### Tolerance Settings by Layer Type
+### Tolerance Settings (v2.0.0 — ALL layers)
 
 ```yaml
-# Batch norm (with non-uniform grad_output)
-rtol: 1e-2
-atol: 1e-2
-
-# Conv2d (any configuration)
-epsilon: 3e-4  # default GRADIENT_CHECK_EPSILON_FLOAT32
-tolerance: 1e-2
-
-# Depthwise conv2d
-epsilon: 3e-4  # default
-tolerance: 1e-2
+# Use check_gradient() for everything
+rtol: 1e-2   # 1% relative tolerance
+atol: 1e-2   # absolute floor for near-zero gradients
+# epsilon: auto-selected by check_gradient() based on dtype
 ```
 
-### Key API Difference
+### The Key Insight (v1.0.0 → v2.0.0)
 
 ```text
-check_gradients(forward, backward, input, epsilon, tolerance) -> Bool
-  - Hardcodes grad_output = ones_like(output)
-  - Returns True/False
-  - Use for: activations, arithmetic, non-normalization layers
+v1.0.0 thought the problem was epsilon (step size for finite differences).
+v2.0.0 discovered the problem was the tolerance model itself.
 
-check_gradient(forward, backward, x, grad_output, epsilon, rtol, atol) -> None
-  - Accepts custom grad_output
-  - Raises on failure (no return value)
-  - Use for: normalization layers (batch norm, layer norm, group norm)
+check_gradients() asks: "Is the absolute difference < 0.01?"
+  → For gradient=32.4, diff=0.046: 0.046 >= 0.01 → FAIL (0.14% error, should pass)
+
+check_gradient() asks: "Is the absolute difference < atol + rtol * magnitude?"
+  → For gradient=32.4, diff=0.046: 0.046 < 0.01 + 0.01*32.4 = 0.334 → PASS
 ```
 
-### Decision Tree
+### Decision Tree (v2.0.0 — UPDATED from v1.0.0)
 
 ```text
-Is the layer a normalization layer (batch norm, layer norm, group norm)?
-├─ YES → Use check_gradient() with non-uniform grad_output
-│        Pattern: Float32(i % 4) * 0.25 - 0.3
-│
-└─ NO → Use check_gradients() with default epsilon=3e-4
-         ├─ Multi-channel output (>25 elements)? → Keep tolerance ≥ 1e-2
-         └─ Use non-uniform inputs (Float32(i) * 0.1)
+Writing a gradient checking test?
+└─ Use check_gradient() (no trailing 's') with:
+    ├─ Normalization layer? → Non-uniform grad_output (Float32(i%4)*0.25 - 0.3)
+    └─ All other layers → ones grad_output via _make_ones_grad_output()
+    Always: rtol=1e-2, atol=1e-2, non-uniform inputs
 ```
+
+**v1.0.0 decision tree was WRONG** — it recommended `check_gradients()` for non-normalization
+layers. This fails for any test where gradient magnitudes exceed ~1.0.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | PR #5107, CI Core Gradient group | [notes.md](./gradient-checking-test-setup-fixes.notes.md) |
+| ProjectOdyssey | PR #5107 (2 commits), CI Core Gradient group | [notes.md](./gradient-checking-test-setup-fixes.notes.md) |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.0.0 to v2.0.0. Previous version archived in `.history` file.

v1.0.0 correctly fixed batch norm but misdiagnosed conv2d/depthwise as epsilon problem.
v2.0.0 identifies the real root cause: `check_gradients()` uses pure absolute tolerance
which fails for large-magnitude gradients. `check_gradient()` uses combined relative+absolute.

## Verification Level

**verified-local** — batch norm confirmed passing in CI; conv2d/depthwise CI pending

## Key Findings

**What Worked**:
- `check_gradient()` with `rtol=1e-2, atol=1e-2` for ALL gradient tests
- Non-uniform grad_output for normalization layers

**What Failed**:
- v1.0.0: changing epsilon from 1e-4 to 3e-4 still failed absolute tolerance
- v1.0.0: recommending `check_gradients()` for non-normalization layers

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1019/1019 valid)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>