### PR TITLE
feat: amend judge-empty-response-file-path-bug skill (v3.0.0)

### DIFF
--- a/skills/judge-empty-response-file-path-bug.history
+++ b/skills/judge-empty-response-file-path-bug.history
@@ -1,0 +1,50 @@
+# judge-empty-response-file-path-bug — History
+
+## v3.0.0 (2026-03-25)
+
+**Changed by:** PR #1558 — stream-json workaround for Claude CLI v2.1.83 empty result bug
+**Verification:** verified-local
+
+### What changed
+- Added new failure mode: Claude CLI v2.1.83 `--print` returns empty `result` field despite model generating tokens
+- Updated Verified Workflow to use `--output-format stream-json --verbose` and parse `type:assistant` events
+- Added `_extract_response_from_stream()` helper function reference
+- Added 2 new Failed Attempts rows (text output format, json output format)
+- Updated CLI Patterns table with stream-json approach
+- Filed upstream bug: anthropics/claude-code#39028
+
+### Why
+After fixing the variadic --allowedTools issue (v2.0.0), stdin piping worked correctly.
+However, Claude CLI v2.1.83 introduced a regression where the `result` field in --print mode
+is always empty. The model generates tokens (confirmed via stream events, cost charged),
+but the output is discarded before reaching stdout. Workaround: parse stream-json events
+instead of relying on the result field.
+
+### Previous version (v2.0.0) snapshot
+---
+name: judge-empty-response-file-path-bug
+description: "Fix judge producing empty responses when prompt consumed by variadic --allowedTools flag. Use when: (1) all judges return empty responses across all models, (2) CLI positional arg placed after variadic flag like --allowedTools, (3) checkpoint has invalid zero-score judge results needing reset."
+category: debugging
+date: 2026-03-25
+version: "2.0.0"
+user-invocable: false
+tags: []
+---
+
+# Judge Empty Response — Variadic Flag Consuming Prompt
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Fix LLM judge returning empty responses causing "Judge response does not contain valid JSON" across all models |
+| **Outcome** | Root cause: --allowedTools variadic flag consumed positional prompt arg. Fixed in PR #1543 + #1544. Checkpoint reset procedure for invalidated results. |
+
+(full content preserved in git history)
+
+---
+
+## v2.0.0 (2026-03-25)
+
+**Initial version** (created as v2.0.0 due to prior iteration history).

--- a/skills/judge-empty-response-file-path-bug.md
+++ b/skills/judge-empty-response-file-path-bug.md
@@ -1,101 +1,128 @@
 ---
 name: judge-empty-response-file-path-bug
-description: "Fix judge producing empty responses when prompt consumed by variadic --allowedTools flag. Use when: (1) all judges return empty responses across all models, (2) CLI positional arg placed after variadic flag like --allowedTools, (3) checkpoint has invalid zero-score judge results needing reset."
+description: "Fix judge producing empty responses — variadic --allowedTools flag issue AND Claude CLI v2.1.83 empty result field bug. Use when: (1) all judges return empty responses across all models, (2) stdout_len=1 (single newline) from judge CLI calls, (3) --print mode returns empty result despite model generating tokens."
 category: debugging
 date: 2026-03-25
-version: "2.0.0"
+version: "3.0.0"
 user-invocable: false
-tags: []
+verification: verified-local
+history: judge-empty-response-file-path-bug.history
+tags:
+  - judge
+  - cli-bug
+  - stream-json
+  - empty-response
 ---
 
-# Judge Empty Response — Variadic Flag Consuming Prompt
+# Judge Empty Response — CLI Bugs and Workarounds
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-03-25 |
-| **Objective** | Fix LLM judge returning empty responses causing "Judge response does not contain valid JSON" across all models |
-| **Outcome** | Root cause: --allowedTools variadic flag consumed positional prompt arg. Fixed in PR #1543 + #1544. Checkpoint reset procedure for invalidated results. |
+| **Objective** | Fix LLM judge returning empty responses — two distinct root causes |
+| **Outcome** | v2: stdin piping fixes variadic flag issue. v3: stream-json parsing works around CLI v2.1.83 result field bug. |
+| **Verification** | verified-local (4901 tests pass, manual stream-json extraction confirmed) |
+| **History** | [changelog](./judge-empty-response-file-path-bug.history) |
 
 ## When to Use
 
 - All judge models (Opus, Sonnet, Haiku) return empty responses simultaneously
-- Error: `Judge response does not contain valid JSON.\nResponse:` (nothing after "Response:")
+- `stdout_len=1` (single newline byte `0x0a`) from judge subprocess calls
+- `--output-format json` shows `"result": ""` but `"output_tokens" > 0`
+- Error: "Judge returned empty response. This may indicate the prompt was not delivered to the model."
 - CLI returns exit 1: `Error: Input must be provided either through stdin or as a prompt argument`
 - Positional prompt arg placed after a variadic CLI flag (--allowedTools, --tools, etc.)
-- Checkpoint has zero-score is_valid=False judge results that need re-running
 
 ## Verified Workflow
 
 ### Quick Reference
 
-```bash
-# DIAGNOSTIC: Test if CLI receives prompt (run OUTSIDE Claude Code)
-# Test stdin (correct approach):
-echo 'Return JSON: {"test": true}' | \
-  claude --print --output-format text --model claude-haiku-4-5 \
-  --dangerously-skip-permissions --allowedTools ""
-# Expected: non-empty response
-
-# Test positional arg AFTER --allowedTools (broken):
-claude --print --output-format text --model claude-haiku-4-5 \
-  --dangerously-skip-permissions --allowedTools "" \
-  'Return JSON: {"test": true}' < /dev/null
-# Expected: exit 1 "Input must be provided"
-```
-
-### Detailed Steps
-
-#### 1. Root Cause: Variadic --allowedTools Consumes Positional Args
-
-The Claude Code CLI flag `--allowedTools <tools...>` is variadic -- it consumes all subsequent non-flag arguments as tool names. When the evaluation context was placed as a positional arg after `--allowedTools ""`, the CLI parser consumed it as a tool argument, leaving no prompt for the model.
-
 ```python
-# BROKEN: positional arg consumed by variadic --allowedTools
+# CURRENT FIX (v3.0.0): Use stream-json and parse assistant events
 cmd = [
-    "claude", "--print", "--output-format", "text",
-    "--allowedTools", "",          # variadic: consumes everything after
-    evaluation_context,            # eaten as a tool name, not the prompt!
-]
-# CLI error: "Input must be provided either through stdin or as a prompt argument"
-```
-
-User-confirmed tests:
-- Test 1 (positional arg after --allowedTools): EXIT 1, 0 bytes stdout
-- Test 2 (file path after --allowedTools): EXIT 1, 0 bytes stdout
-- Test 3 (stdin pipe): EXIT 0, response received
-
-#### 2. The Fix: Always Pipe Via Stdin (PR #1544)
-
-```python
-# FIXED: pipe via stdin, avoids variadic flag issue AND ARG_MAX limits
-cmd = [
-    "claude", "--print", "--output-format", "text",
+    "claude", "--model", model, "--print",
+    "--output-format", "stream-json", "--verbose",
     "--dangerously-skip-permissions",
     "--allowedTools", "",
     "--system-prompt-file", str(JUDGE_SYSTEM_PROMPT_FILE),
 ]
-
-result = subprocess.run(
-    cmd, capture_output=True, text=True, timeout=1200,
-    env={k: v for k, v in os.environ.items() if k != "CLAUDECODE"},
-    input=evaluation_context,  # stdin pipe -- always works
-)
+result = subprocess.run(cmd, capture_output=True, text=True, timeout=1200,
+                        env={k: v for k, v in os.environ.items() if k != "CLAUDECODE"},
+                        input=evaluation_context)
+response_text = _extract_response_from_stream(result.stdout)
 ```
 
-#### 3. Reset Checkpoint for Invalid Judge Results
+```python
+def _extract_response_from_stream(stream_output: str) -> str:
+    """Extract assistant response text from stream-json output."""
+    text_parts: list[str] = []
+    result_text = ""
+    for line in stream_output.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "assistant":
+            message = event.get("message", {})
+            for block in message.get("content", []):
+                if block.get("type") == "text":
+                    text_parts.append(block["text"])
+        elif event.get("type") == "result":
+            result_text = event.get("result", "")
+    # Prefer result field if populated (CLI bug is fixed)
+    if result_text.strip():
+        return result_text
+    return "".join(text_parts)
+```
 
-After fixing the code, already-completed subtests have zero-score is_valid=False results baked into the checkpoint. Reset run states to re-run the judge stage. See Results section for the reset script.
+### Detailed Steps
+
+#### Bug 1: Variadic --allowedTools Consumes Positional Args (v2.0.0)
+
+The `--allowedTools <tools...>` flag is variadic — it consumes all subsequent non-flag arguments as tool names. When the evaluation context was placed as a positional arg after `--allowedTools ""`, the CLI parser consumed it as a tool argument, leaving no prompt.
+
+**Fix**: Always pipe via stdin (`subprocess.run(..., input=evaluation_context)`).
+
+#### Bug 2: CLI v2.1.83 Empty Result Field (v3.0.0)
+
+Claude CLI v2.1.83 `--print` mode has a regression where the `result` field is always empty, despite the model generating tokens. Confirmed via:
+
+```bash
+# JSON shows result="" but output_tokens=7
+claude -p "Say hello" --model claude-haiku-4-5 --output-format json < /dev/null
+# → {"result":"", "output_tokens":7, "total_cost_usd":0.02}
+
+# Stream-JSON proves the model IS responding
+claude -p "Say hello" --model claude-haiku-4-5 --output-format stream-json --verbose < /dev/null
+# → {"type":"assistant","message":{"content":[{"type":"text","text":"Hello!"}]}}
+# → {"type":"result","result":""}  ← EMPTY
+```
+
+**Fix**: Switch to `--output-format stream-json --verbose` and extract text from `type:assistant` message events. Forward-compatible: falls back to `result` field when the CLI bug is fixed.
+
+#### Reset Checkpoint After Failed Judges
+
+After fixing the code, run the cleanup script to reset judge artifacts:
+
+```bash
+python3 ~/fullruns/haiku-2/reset_judges.py --apply
+```
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Pass content as positional arg (PR #1543) | Replaced temp file path with prompt content as positional CLI arg | --allowedTools is variadic and consumed the positional arg | Variadic CLI flags consume all subsequent non-flag args; use stdin piping instead |
-| Test CLI from within Claude Code | Ran claude -p "hello" from bash tool | All invocations returned empty due to CLAUDECODE=1 env var | Never test Claude CLI invocations from within a Claude Code session |
+| Test CLI from within Claude Code | Ran claude -p "hello" from bash tool | All invocations returned empty due to CLI bug (not CLAUDECODE env) | Cannot distinguish env issues from CLI bugs when testing inside Claude Code |
 | Resume old checkpoint after code fix | Applied fix and resumed old experiment | Already-completed subtests had zero-score results baked in | Code fixes don't retroactively fix completed checkpoint states; must reset run states |
-| Diagnose as output-format text issue | Initially suspected text vs json output format mismatch | Testing was unreliable inside Claude Code; actual issue was argument parsing | Get user confirmation with external tests before committing to a theory |
+| Use --output-format text with stdin | Piped prompt via stdin with text output format | CLI v2.1.83 discards result content; stdout is just `\n` | Text output relies on the broken `result` field |
+| Use --output-format json with stdin | Tried JSON format hoping result field works differently | Same bug: `"result": ""` with `output_tokens > 0` | The `result` field is empty regardless of output format in v2.1.83 |
+| Initially blamed CLAUDECODE env var | Suspected nested Claude Code session caused empty output | Stripping CLAUDECODE didn't help; the bug is in the CLI itself | Verify with `--output-format stream-json --verbose` to see actual model output vs result field |
 
 ## Results & Parameters
 
@@ -105,26 +132,40 @@ After fixing the code, already-completed subtests have zero-score is_valid=False
 |----|--------|
 | #1543 | Pass prompt content instead of temp file path + diagnostics |
 | #1544 | Pipe via stdin instead of positional arg (fixes variadic flag) |
+| #1558 | Switch to stream-json parsing (works around CLI v2.1.83 result bug) |
+
+### Upstream Bug
+
+- anthropics/claude-code#39028: `--print` mode returns empty result in v2.1.83
 
 ### CLI Patterns
 
 | Pattern | Works? | Why |
 |---------|--------|-----|
 | `--allowedTools "" "prompt"` | No | Variadic flag consumes prompt as tool name |
-| `echo "prompt" \| claude --allowedTools ""` | Yes | Stdin not affected by variadic flags |
-| `subprocess.run(cmd, input=prompt)` | Yes | Python pipes via stdin |
+| `echo "prompt" \| claude --output-format text` | No (v2.1.83) | Result field empty despite model responding |
+| `echo "prompt" \| claude --output-format json` | No (v2.1.83) | Same empty result field |
+| `echo "prompt" \| claude --output-format stream-json --verbose` | Yes | Parse type:assistant events for actual content |
+| `subprocess.run(cmd, input=prompt)` + stream-json | Yes | Current recommended approach |
 
-### State Machine Reset Reference
+### Diagnostic Commands
 
-| Current State | Reset To | Effect |
-|---------------|----------|--------|
-| worktree_cleaned (run) | judge_prompt_built | Re-runs judge stage |
-| aggregated (subtest) | pending | Re-dispatches subtest |
-| complete (tier) | config_loaded | Re-dispatches tier |
-| complete (experiment) | tiers_dispatched | Resumes experiment |
+```bash
+# Quick test: does the CLI return content?
+echo "Say hello" | env -u CLAUDECODE claude -p --model claude-haiku-4-5 \
+  --output-format stream-json --verbose 2>/dev/null | \
+  grep '"type":"assistant"'
+# Should show content in message.content[].text
+
+# Check result field specifically:
+echo "Say hello" | env -u CLAUDECODE claude -p --model claude-haiku-4-5 \
+  --output-format json 2>/dev/null | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(f'result={repr(d[\"result\"][:80])}, tokens={d[\"usage\"][\"output_tokens\"]}')"
+# If result="" but tokens>0, the CLI bug is active
+```
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectScylla | haiku-2 fullrun T0 judge failures | 21/24 subtests failed; PRs #1543 + #1544; checkpoint reset for 15 subtests |
+| ProjectScylla | haiku-2 fullrun judge failures | v2: PRs #1543+#1544; v3: PR #1558; upstream bug anthropics/claude-code#39028 |

--- a/skills/logging-handler-registry-deduplication.md
+++ b/skills/logging-handler-registry-deduplication.md
@@ -1,0 +1,127 @@
+---
+name: logging-handler-registry-deduplication
+description: "Fix Python get_logger() adding duplicate handlers on repeated calls. Use when: (1) logger adds multiple StreamHandlers after repeated get_logger() calls, (2) file handler is silently skipped on second call, (3) parent logger propagation causes duplicate output."
+category: debugging
+date: 2026-03-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - python
+  - logging
+  - deduplication
+  - handlers
+---
+
+# Logging Handler Registry Deduplication
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Fix `get_logger()` adding duplicate handlers when called multiple times for the same logger name, and allow incremental handler addition (e.g., file handler on second call) |
+| **Outcome** | Successful — all three bugs fixed with a module-level registry pattern |
+| **Verification** | verified-local (389 unit tests pass, ruff/mypy clean) |
+
+## When to Use
+
+- `get_logger("name")` called multiple times produces duplicate log lines (one per call)
+- `if not logger.handlers` guard prevents adding a file handler on a subsequent call
+- Parent logger propagation causes double output (e.g., root logger + child logger both emit)
+- Need to track which specific handlers have been configured per logger name
+- Factory function wraps `logging.getLogger()` and needs idempotent handler setup
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# Module-level registry — tracks handler keys per logger name
+_configured_loggers: dict[str, set[str]] = {}
+
+def get_logger(name: str, log_file: str | None = None) -> logging.Logger:
+    logger = logging.getLogger(name)
+    configured = _configured_loggers.setdefault(name, set())
+
+    if "console" not in configured:
+        logger.addHandler(logging.StreamHandler(sys.stdout))
+        configured.add("console")
+
+    if log_file and log_file not in configured:
+        logger.addHandler(logging.FileHandler(log_file))
+        configured.add(log_file)
+
+    logger.propagate = False
+    return logger
+```
+
+### Detailed Steps
+
+1. **Add a module-level registry** — `_configured_loggers: dict[str, set[str]] = {}` mapping logger names to sets of handler keys (e.g., `{"console", "/path/to/file.log"}`)
+
+2. **Replace `if not logger.handlers` with registry checks** — The naive guard fails because:
+   - It's all-or-nothing: if handlers exist, no new ones can be added
+   - It doesn't distinguish handler types (console vs file)
+   - Python's logging hierarchy means `logger.handlers` can be empty while parent handles output
+
+3. **Check each handler type independently**:
+   - Console: `if "console" not in configured` — add StreamHandler once
+   - File: `if log_file and log_file not in configured` — add FileHandler per unique path
+
+4. **Set `logger.propagate = False`** — Prevents parent loggers (especially root) from duplicating messages that child loggers already handle
+
+5. **Always update level** — Call `logger.setLevel()` on every invocation so subsequent calls with a different level take effect
+
+6. **Write tests with cleanup** — Use an `autouse` pytest fixture that clears the registry and logger handlers after each test to prevent cross-test contamination
+
+### Test Cleanup Pattern
+
+```python
+@pytest.fixture(autouse=True)
+def _clean_logging_registry():
+    yield
+    for name in list(_configured_loggers):
+        if name.startswith("test."):
+            _configured_loggers.pop(name, None)
+            logging.getLogger(name).handlers.clear()
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `if not logger.handlers` guard | Check if logger already has any handlers before adding | All-or-nothing: blocks adding file handler on second call; doesn't prevent duplicates if handlers are removed and re-added | Track handler types individually, not just presence/absence |
+| Check handler types on logger | Inspect `type(h)` for existing handlers | Doesn't distinguish between two different file paths; would need to inspect `baseFilename` attribute | Use a string-keyed registry that tracks exact handler identity (console key + file path) |
+| Rely on `propagate=True` (default) | Let parent loggers handle output | Parent + child both emit when both have handlers, causing duplicate lines | Set `propagate=False` on any logger that has its own handlers |
+
+## Results & Parameters
+
+### Key behavior after fix
+
+```python
+# Repeated calls — no duplicate handlers
+logger1 = get_logger("app")           # 1 StreamHandler
+logger2 = get_logger("app")           # Still 1 StreamHandler
+
+# Incremental handler addition works
+logger3 = get_logger("app", log_file="app.log")  # 1 StreamHandler + 1 FileHandler
+
+# Same file path doesn't duplicate
+logger4 = get_logger("app", log_file="app.log")  # Still 1 StreamHandler + 1 FileHandler
+
+# Level updates take effect
+logger5 = get_logger("app", level=logging.DEBUG)  # Level changed to DEBUG
+```
+
+### Environment
+
+- Python 3.10+
+- Standard library `logging` module
+- Works with `LoggerAdapter` wrappers (e.g., `ContextLogger`)
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #32 — PR #70 | Fixed `hephaestus/logging/utils.py:get_logger()`, 389 tests pass |


### PR DESCRIPTION
## Summary

Amends existing skill from v2.0.0 to v3.0.0.

Documents Claude CLI v2.1.83 regression where `--print` mode returns empty `result` field despite the model generating tokens, and the stream-json parsing workaround.

- New failure mode: `result=""` with `output_tokens > 0` across all output formats
- Fix: `--output-format stream-json --verbose` + parse `type:assistant` events
- Upstream bug filed: anthropics/claude-code#39028
- Previous version (variadic --allowedTools fix) archived in history file

## Verification Level

**verified-local**

4901 tests pass locally. Manual verification confirms stream-json extraction works (1070-char response successfully extracted). CI validation pending on PR #1558.

## Key Findings

**What Worked**:
- `--output-format stream-json --verbose` contains actual model response in `type:assistant` events
- `_extract_response_from_stream()` with forward-compat fallback to `result` field
- Cleanup script (`reset_judges.py`) for resetting stale judge artifacts

**What Failed**:
- `--output-format text` -> single newline (result field empty)
- `--output-format json` -> `"result": ""` with tokens generated
- Stripping CLAUDECODE env var -> no effect (bug is in CLI itself)

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [x] Verify skill appears in marketplace
- [x] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>