### PR TITLE
feat: amend versioning-consistency-release-workflow skill (v2.0.0)

### DIFF
--- a/skills/tooling-justfile-pixi-ecosystem-wrapping.history
+++ b/skills/tooling-justfile-pixi-ecosystem-wrapping.history
@@ -1,0 +1,29 @@
+# tooling-justfile-pixi-ecosystem-wrapping — History
+
+## v2.0.0 (2026-03-25)
+
+**Changed by:** ProjectHephaestus issue #35 — add justfile for ecosystem convention
+**Verification:** verified-local
+
+### What changed
+- Added Python library repo template (Template A) alongside existing CI-heavy template (Template B)
+- Added `*ARGS` parameterization pattern for `test` and `lint` recipes
+- Added "When to Use" trigger for Python library repos without CI recipes
+- Added ProjectHephaestus to "Verified On" table
+- Updated description to cover Python library repos, not just CI-heavy projects
+
+### Why
+v1.0.0 only documented the pattern for ProjectScylla which has CI container recipes
+(ci-build, ci-test, ci-lint, ci-all) and BATS sync tests. Python library repos like
+ProjectHephaestus have a simpler justfile — just test/lint/format/typecheck/audit/pre-commit
+with `*ARGS` forwarding. The simpler template is the more common case across the ecosystem.
+
+### Previous version (v1.0.0) snapshot
+
+See git history for full v1.0.0 content (commit `42ae0b14`).
+
+---
+
+## v1.0.0 (2026-03-25)
+
+**Initial version.**

--- a/skills/tooling-justfile-pixi-ecosystem-wrapping.md
+++ b/skills/tooling-justfile-pixi-ecosystem-wrapping.md
@@ -1,10 +1,12 @@
 ---
 name: tooling-justfile-pixi-ecosystem-wrapping
-description: "Add justfile wrapping pixi tasks for ecosystem convention alignment. Use when: (1) a project uses pixi.toml but lacks a justfile, (2) cross-repo task invocation needs just scylla-* convention, (3) adding BATS tests to verify justfile-pixi sync."
+description: "Add justfile wrapping pixi tasks for ecosystem convention alignment. Use when: (1) a project uses pixi.toml but lacks a justfile, (2) Python library repo needs consistent CLI, (3) cross-repo task invocation needs just <project>-<task> convention, (4) adding BATS tests to verify justfile-pixi sync."
 category: tooling
 date: 2026-03-25
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
+verification: verified-local
+history: tooling-justfile-pixi-ecosystem-wrapping.history
 tags:
   - justfile
   - pixi
@@ -20,12 +22,15 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-03-25 |
-| **Objective** | Add a justfile to a pixi-managed project so that cross-repo orchestration (e.g., Odysseus invoking `just scylla-*`) works via the HomericIntelligence ecosystem convention |
-| **Outcome** | Successful — justfile created with 12 recipes, BATS sync test, all CI hooks passing |
+| **Objective** | Add a justfile to a pixi-managed project so that cross-repo orchestration and developer CLI is consistent via the HomericIntelligence ecosystem convention |
+| **Outcome** | Successful — verified on both CI-heavy (Scylla, 12 recipes) and library (Hephaestus, 7 recipes) repos |
+| **Verification** | verified-local |
+| **History** | [changelog](./tooling-justfile-pixi-ecosystem-wrapping.history) |
 
 ## When to Use
 
 - A project has `pixi.toml` tasks but no `justfile`
+- A Python library repo needs a consistent developer CLI (test, lint, format, typecheck, audit)
 - Cross-repo orchestrators (e.g., Odysseus) need to invoke tasks via `just <project>-<task>`
 - You need to verify justfile recipes stay in sync with pixi tasks
 - Adding `just` as a conda-forge dev dependency in pixi.toml
@@ -35,90 +40,175 @@ tags:
 ### Quick Reference
 
 ```bash
-# 1. Add just as dev dependency in pixi.toml
+# 1. (Optional) Add just as dev dependency in pixi.toml
 # [feature.dev.dependencies]
 # just = ">=1.25.0,<2"
 
-# 2. Regenerate lock file
-pixi install
+# 2. Create justfile (see templates below)
 
-# 3. Create justfile (see template below)
+# 3. Verify
+just --list
 
-# 4. Verify
-pixi run just --list
-
-# 5. Run BATS sync test
+# 4. (Optional) Run BATS sync test if available
 pixi run test-shell
 ```
 
 ### Detailed Steps
 
-1. **Add `just` to `pixi.toml`** under `[feature.dev.dependencies]` — it's a dev-only tool, not needed in CI lint or production environments.
+1. **Decide if `just` needs to be a pixi dependency.** If `just` is already installed system-wide or via another mechanism, skip adding it to pixi.toml. For repos where `just` is the only way to discover it, add it under `[feature.dev.dependencies]`.
 
-2. **Run `pixi install`** to regenerate `pixi.lock`. Always commit the updated lock file.
-
-3. **Create `justfile`** at project root with these conventions:
+2. **Create `justfile`** at project root with these conventions:
    - `default` recipe: `@just --list` (ecosystem standard)
    - Each recipe delegates to `pixi run <task>` (single source of truth stays in pixi.toml)
    - Add a comment above each recipe describing what it does
    - **Never use heredocs** in justfile recipes (known `just` pitfall — use `printf` instead)
    - For tasks without a pixi equivalent (e.g., `typecheck`), call the tool directly via `pixi run mypy ...`
+   - Use `*ARGS` forwarding for recipes where users commonly pass extra flags (test, lint)
 
-4. **Justfile template**:
-   ```just
-   # Project task runner — delegates to pixi run
-   # Ecosystem convention: justfile + pixi
+3. **Choose the right template** based on project type:
 
-   # List all available recipes
-   default:
-       @just --list
+### Template A: Python Library Repo (e.g., Hephaestus)
 
-   # Run pytest
-   test:
-       pixi run test
+```just
+# ProjectName task runner
+# Convention: justfile delegates to pixi tasks
 
-   # Run ruff check
-   lint:
-       pixi run lint
+default:
+    @just --list
 
-   # Run ruff format
-   format:
-       pixi run format
+# === Test ===
 
-   # Run mypy type checker
-   typecheck:
-       pixi run mypy scylla scripts tests
+# Run tests (accepts optional args, e.g. `just test tests/unit/`)
+test *ARGS:
+    pixi run pytest {{ ARGS }}
 
-   # Run all pre-commit hooks
-   pre-commit:
-       pixi run pre-commit run --all-files
-   ```
+# === Code Quality ===
 
-5. **Create BATS sync test** at `tests/shell/justfile/test_justfile.bats`:
+# Run linter
+lint *ARGS:
+    pixi run lint {{ ARGS }}
+
+# Run formatter
+format:
+    pixi run format
+
+# Run type checker
+typecheck:
+    pixi run mypy <package>/
+
+# === Security ===
+
+# Run dependency audit
+audit:
+    pixi run audit
+
+# === Checks ===
+
+# Run pre-commit hooks on all files
+pre-commit:
+    pixi run pre-commit run --all-files
+```
+
+Key decisions for library repos:
+- `test *ARGS` forwards to pytest (e.g., `just test tests/unit/ -v`)
+- `lint *ARGS` forwards to ruff check (e.g., `just lint --fix`)
+- `format` has no args — ruff format targets are fixed in pixi.toml
+- `typecheck` calls `pixi run mypy` directly since there's typically no pixi task for it
+- No CI recipes needed — CI runs pixi tasks directly
+
+### Template B: CI-Heavy Repo (e.g., Scylla)
+
+```just
+# Project task runner — delegates to pixi run
+# Ecosystem convention: justfile + pixi
+
+# List all available recipes
+default:
+    @just --list
+
+# Run pytest
+test:
+    pixi run test
+
+# Run ruff check
+lint:
+    pixi run lint
+
+# Run ruff format
+format:
+    pixi run format
+
+# Run mypy type checker
+typecheck:
+    pixi run mypy scylla scripts tests
+
+# Run all pre-commit hooks
+pre-commit:
+    pixi run pre-commit run --all-files
+
+# Run CI build
+ci-build:
+    pixi run ci-build
+
+# Run CI lint
+ci-lint:
+    pixi run ci-lint
+
+# Run CI tests
+ci-test:
+    pixi run ci-test
+
+# Run full CI suite
+ci-all:
+    pixi run ci-all
+
+# Run dependency audit
+audit:
+    pixi run audit
+
+# Run BATS shell tests
+test-shell:
+    pixi run test-shell
+```
+
+4. **(Optional) Create BATS sync test** at `tests/shell/justfile/test_justfile.bats`:
    - Verify `justfile` exists at project root
    - Verify `just --list` succeeds
-   - Verify expected recipes are present (test, lint, format, typecheck, etc.)
+   - Verify expected recipes are present
    - Regression guard: no heredocs in justfile (`grep -cE '<<\s*[A-Z_]'`)
-   - **Sync test**: parse `[tasks]` from `pixi.toml` and verify each has a matching just recipe (skip utility-only tasks like `plan-issues`)
+   - **Sync test**: parse `[tasks]` from `pixi.toml` and verify each has a matching just recipe
 
-6. **Update project docs** (e.g., CLAUDE.md) with a Quick Start section showing justfile commands.
+5. **Verify** — run `just --list` to confirm no parse errors and all recipes show descriptions.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| N/A — clean implementation | Direct pixi run delegation | Did not fail | Following the ecosystem convention from prior skills (flesh-out-scaffolded-repo, just-recipe-heredoc-fix) avoided all known pitfalls |
+| N/A — clean implementation (Scylla) | Direct pixi run delegation | Did not fail | Following the ecosystem convention from prior skills avoided all known pitfalls |
+| N/A — clean implementation (Hephaestus) | Direct pixi run delegation with `*ARGS` | Did not fail | Pattern is now well-established; `*ARGS` forwarding works cleanly for test and lint |
 
 ## Results & Parameters
 
-### Pixi.toml Addition
+### Pixi.toml Addition (optional)
 
 ```toml
 [feature.dev.dependencies]
 just = ">=1.25.0,<2"
 ```
 
-### Recipe-to-Pixi Mapping
+### Recipe-to-Pixi Mapping (Library Repo — Hephaestus)
+
+| Recipe | Delegates To | Notes |
+|--------|-------------|-------|
+| `default` | `@just --list` | Ecosystem standard |
+| `test *ARGS` | `pixi run pytest {{ ARGS }}` | Forwards args to pytest |
+| `lint *ARGS` | `pixi run lint {{ ARGS }}` | Forwards args to ruff check |
+| `format` | `pixi run format` | ruff format |
+| `typecheck` | `pixi run mypy hephaestus/` | No pixi task; calls mypy directly |
+| `audit` | `pixi run audit` | pip-audit scan |
+| `pre-commit` | `pixi run pre-commit run --all-files` | All hooks |
+
+### Recipe-to-Pixi Mapping (CI-Heavy Repo — Scylla)
 
 | Recipe | Delegates To | Notes |
 |--------|-------------|-------|
@@ -135,13 +225,9 @@ just = ">=1.25.0,<2"
 | `audit` | `pixi run audit` | pip-audit scan |
 | `pre-commit` | `pixi run pre-commit run --all-files` | All hooks |
 
-### BATS Test Coverage
-
-- 11 tests: existence, list, 7 recipe checks, no-heredoc guard, pixi sync test
-- All pass in < 100ms total
-
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectScylla | Issue #1506 — ecosystem convention alignment | PR #1550 |
+| ProjectHephaestus | Issue #35 — add justfile for ecosystem convention | PR #72 |

--- a/skills/versioning-consistency-release-workflow.history
+++ b/skills/versioning-consistency-release-workflow.history
@@ -1,0 +1,164 @@
+# versioning-consistency-release-workflow — History
+
+## v2.0.0 (2026-03-25)
+
+**Changed by:** Issue #1535 — Reconcile version 0.1.0 with CHANGELOG aspirational refs (PR #1562)
+**Verification:** verified-local
+
+### What changed
+- Added `importlib.metadata.version()` as the recommended approach for `__init__.py` (replaces hardcoded string)
+- Replaced regex-based TOML parsing with `tomllib` for the consistency check script
+- Added CHANGELOG aspirational version detection to the pre-commit hook
+- Added skill template remediation as a root-cause fix (update templates that generate phantom versions)
+- Added `PackageNotFoundError` fallback pattern for dev installs
+- Added new failed attempt: regex TOML parsing vs tomllib
+
+### Why
+v1.0.0 recommended hardcoded `__version__ = "0.1.0"` in `__init__.py` and regex-based TOML parsing.
+Issue #1535 proved that `importlib.metadata` is the proper single-source-of-truth pattern (pyproject.toml
+is authoritative, runtime reads from installed metadata). The regex TOML parser is fragile and unnecessary
+since Python 3.11+ includes `tomllib`. The pre-commit hook also needed CHANGELOG scanning to catch the
+exact aspirational version problem that triggered the issue.
+
+### Previous version (v1.0.0) snapshot
+
+---
+name: versioning-consistency-release-workflow
+description: "Establish single-source-of-truth version management with CI consistency checks, release workflow, and CHANGELOG fixes. Use when: (1) project has version declared in multiple files that can drift, (2) need to add automated release workflow triggered by git tags, (3) CHANGELOG references phantom version numbers."
+category: ci-cd
+date: '2026-03-25'
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - versioning
+  - release
+  - ci
+  - changelog
+  - DRY
+---
+
+# Version Consistency and Release Workflow
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Establish a single-source-of-truth version management system: eliminate hardcoded versions, add CI consistency checks, create a release workflow, fix aspirational CHANGELOG references, and document the versioning strategy. |
+| **Outcome** | Successful — PR created with all tests passing and pre-commit hooks green. |
+| **Verification** | verified-local |
+
+## When to Use
+
+- Project declares version in multiple files (e.g., `pyproject.toml`, `pixi.toml`, `__init__.py`, CLI) that can drift
+- CLI hardcodes a version string instead of importing from a canonical source
+- CHANGELOG references phantom future versions (e.g., "deprecated in v1.5.0, removed in v2.0.0") when no releases exist
+- Need to add a GitHub Actions release workflow triggered by version tags
+- Want CI to catch version drift before it reaches production
+- Audit finding: no git tags, no GitHub releases, no documented versioning strategy
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Replace hardcoded CLI version with dynamic import
+# In cli/main.py:
+#   from mypackage import __version__
+#   @click.version_option(version=__version__, prog_name="mypackage")
+
+# 2. Create version consistency script
+python3 scripts/check_version_consistency.py
+
+# 3. Run tests
+pixi run pytest tests/unit/scripts/test_check_version_consistency.py -v
+
+# 4. After PR merges, tag the release
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+### Detailed Steps
+
+1. **Eliminate hardcoded CLI version**: Import `__version__` from the package's `__init__.py` instead of hardcoding a version string in the CLI decorator.
+
+2. **Create a version consistency checker script**: A lightweight Python script that reads version strings from all declaration sites using regex.
+
+3. **Add CI step**: Add the consistency check to the test workflow.
+
+4. **Fix CHANGELOG phantom versions**: Replace references to non-existent versions with relative timeline language.
+
+5. **Create release workflow**: A GitHub Actions workflow triggered by `v*` tags.
+
+6. **Document versioning strategy**: Add a "Versioning and Releases" section to CONTRIBUTING.md.
+
+7. **Update tests**: Replace hardcoded version assertions in CLI tests with dynamic `__version__` imports.
+
+8. **Respect test structure conventions**: Place version consistency tests in `tests/unit/scripts/` to match the script being tested.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Test file at `tests/unit/test_version_consistency.py` | Placed test directly under `tests/unit/` | Pre-commit hook `check-unit-test-structure` requires tests in sub-packages | Always check project's test structure conventions before placing new test files |
+
+## Results & Parameters
+
+### Version Declaration Sites Pattern
+
+```python
+# pyproject.toml — canonical source
+[project]
+version = "0.1.0"
+
+# pixi.toml — workspace version
+[workspace]
+version = "0.1.0"
+
+# package/__init__.py — runtime access
+__version__ = "0.1.0"
+
+# CLI — derived (imports __version__)
+from mypackage import __version__
+
+@click.version_option(version=__version__, prog_name="mypackage")
+```
+
+### Consistency Script Pattern (no TOML library needed)
+
+```python
+def _read_toml_version(path: Path, table_key: str) -> str | None:
+    text = path.read_text()
+    in_table = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_table = stripped == f"[{table_key}]"
+            continue
+        if in_table:
+            match = re.match(r'^version\s*=\s*"([^"]+)"', stripped)
+            if match:
+                return match.group(1)
+    return None
+```
+
+### Release Workflow Key Points
+
+- Trigger on `push.tags: ["v*"]` — not on PR merge
+- Validate tag version matches `pyproject.toml` version before creating release
+- Use `gh release create` with `--generate-notes` for auto-generated release notes
+- Pass `github.ref_name` via `env:` variable (not `${{ }}` interpolation in `run:`) for GH Actions security
+
+### CHANGELOG Fix Pattern
+
+Replace phantom version references:
+- Before: "deprecated as of v1.5.0. It will be removed in v2.0.0."
+- After: "deprecated. It will be removed in a future major release."
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | Issue #1527 — Audit S10 versioning remediation | PR #1557: 8 files changed, 35 tests passing, all pre-commit hooks green |
+
+---

--- a/skills/versioning-consistency-release-workflow.md
+++ b/skills/versioning-consistency-release-workflow.md
@@ -1,17 +1,20 @@
 ---
 name: versioning-consistency-release-workflow
-description: "Establish single-source-of-truth version management with CI consistency checks, release workflow, and CHANGELOG fixes. Use when: (1) project has version declared in multiple files that can drift, (2) need to add automated release workflow triggered by git tags, (3) CHANGELOG references phantom version numbers."
+description: "Establish single-source-of-truth version management with importlib.metadata, pre-commit consistency checks, and CHANGELOG fixes. Use when: (1) project has version declared in multiple files that can drift, (2) __init__.py hardcodes a version string instead of using importlib.metadata, (3) CHANGELOG references phantom version numbers, (4) skill templates generate aspirational version refs."
 category: ci-cd
 date: '2026-03-25'
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
 verification: verified-local
+history: versioning-consistency-release-workflow.history
 tags:
   - versioning
   - release
   - ci
   - changelog
   - DRY
+  - importlib-metadata
+  - pre-commit
 ---
 
 # Version Consistency and Release Workflow
@@ -21,102 +24,148 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-03-25 |
-| **Objective** | Establish a single-source-of-truth version management system: eliminate hardcoded versions, add CI consistency checks, create a release workflow, fix aspirational CHANGELOG references, and document the versioning strategy. |
-| **Outcome** | Successful — PR created with all tests passing and pre-commit hooks green. |
+| **Objective** | Establish a single-source-of-truth version management system: `pyproject.toml` is canonical, `importlib.metadata` reads it at runtime, pre-commit hook guards against drift, and CHANGELOG uses `[Unreleased]` convention. |
+| **Outcome** | Successful — two PRs (#1557, #1562) across two issues (#1527, #1535), 4808+ tests passing, all pre-commit hooks green. |
 | **Verification** | verified-local |
+| **History** | [changelog](./versioning-consistency-release-workflow.history) |
 
 ## When to Use
 
 - Project declares version in multiple files (e.g., `pyproject.toml`, `pixi.toml`, `__init__.py`, CLI) that can drift
+- `__init__.py` hardcodes `__version__ = "X.Y.Z"` instead of using `importlib.metadata.version()`
 - CLI hardcodes a version string instead of importing from a canonical source
 - CHANGELOG references phantom future versions (e.g., "deprecated in v1.5.0, removed in v2.0.0") when no releases exist
+- Skill templates or code generators produce aspirational version numbers in CHANGELOG entries
+- Want a pre-commit hook to catch version drift before it reaches production
 - Need to add a GitHub Actions release workflow triggered by version tags
-- Want CI to catch version drift before it reaches production
-- Audit finding: no git tags, no GitHub releases, no documented versioning strategy
 
 ## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# 1. Replace hardcoded CLI version with dynamic import
+# 1. Switch __init__.py to importlib.metadata (single source of truth)
+# In package/__init__.py:
+#   from importlib.metadata import PackageNotFoundError, version as _get_version
+#   try:
+#       __version__: str = _get_version("mypackage")
+#   except PackageNotFoundError:
+#       __version__ = "0.0.0"
+
+# 2. Replace hardcoded CLI version with dynamic import
 # In cli/main.py:
 #   from mypackage import __version__
 #   @click.version_option(version=__version__, prog_name="mypackage")
 
-# 2. Create version consistency script
-python3 scripts/check_version_consistency.py
+# 3. Create version consistency pre-commit hook
+python3 scripts/check_package_version_consistency.py --verbose
 
-# 3. Run tests
-pixi run pytest tests/unit/scripts/test_check_version_consistency.py -v
+# 4. Run tests
+pixi run pytest tests/unit/scripts/test_check_package_version_consistency.py -v
 
-# 4. After PR merges, tag the release
-git tag v0.1.0 && git push origin v0.1.0
+# 5. Verify
+python -c "import mypackage; print(mypackage.__version__)"
 ```
 
 ### Detailed Steps
 
-1. **Eliminate hardcoded CLI version**: Import `__version__` from the package's `__init__.py` instead of hardcoding a version string in the CLI decorator. This is the core DRY fix — one fewer place to update on version bumps.
+1. **Switch `__init__.py` to `importlib.metadata`**: Replace `__version__ = "0.1.0"` with `importlib.metadata.version("mypackage")`. Include a `PackageNotFoundError` fallback for editable/dev installs. This makes `pyproject.toml` the single authority — no more dual maintenance.
 
-2. **Create a version consistency checker script**: A lightweight Python script that reads version strings from all declaration sites (e.g., `pyproject.toml`, `pixi.toml`, `__init__.py`) using regex — no TOML library needed. Exits non-zero if they disagree. Designed to run in CI before expensive test steps.
+2. **Eliminate hardcoded CLI version**: Import `__version__` from the package's `__init__.py` instead of hardcoding a version string in the CLI decorator.
 
-3. **Add CI step**: Add the consistency check to the test workflow so version drift is caught on every PR, before Pixi setup (since it only needs Python stdlib).
+3. **Create a pre-commit consistency checker**: A Python script using `tomllib` (not regex) that validates:
+   - `pixi.toml` `[workspace].version` matches `pyproject.toml` `[project].version`
+   - `__init__.py` uses `importlib.metadata` (no hardcoded `__version__ = "..."` pattern)
+   - `CHANGELOG.md` has no version references higher than the canonical version
 
-4. **Fix CHANGELOG phantom versions**: Replace references to non-existent versions (e.g., "deprecated in v1.5.0") with relative timeline language ("deprecated in current release, removed in a future major release"). Add a proper release section for the current version.
+4. **Register as pre-commit hook**: Trigger on changes to `pyproject.toml`, `pixi.toml`, `__init__.py`, `CHANGELOG.md`. Use `pass_filenames: false`.
 
-5. **Create release workflow**: A GitHub Actions workflow triggered by `v*` tags that validates the tag matches the package version in `pyproject.toml` before creating a GitHub release with auto-generated notes.
+5. **Fix CHANGELOG phantom versions**: Replace aspirational version references with `[Unreleased]` per keepachangelog.com convention. If deprecated classes have already been removed, change the section from "Deprecated" to "Removed".
 
-6. **Document versioning strategy**: Add a "Versioning and Releases" section to CONTRIBUTING.md covering: where version is declared, how to bump it, how to create a release, and CHANGELOG maintenance expectations.
+6. **Fix root cause — skill templates**: If the phantom versions came from a code-generation skill template, update the template to use "a future major version" instead of hardcoded version numbers.
 
-7. **Update tests**: Replace hardcoded version assertions in CLI tests with dynamic `__version__` imports. Add parametrized tests for the consistency checker covering: all-match, single-mismatch, missing-file scenarios.
+7. **Update tests**: Replace hardcoded version assertions in CLI tests with dynamic `__version__` imports. Add comprehensive tests for the consistency checker.
 
-8. **Respect test structure conventions**: If the project enforces that test files must be in sub-packages (not directly under `tests/unit/`), place version consistency tests in `tests/unit/scripts/` to match the script being tested.
+8. **Respect test structure conventions**: Place version consistency tests in `tests/unit/scripts/` to match the script being tested.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Test file at `tests/unit/test_version_consistency.py` | Placed test directly under `tests/unit/` | Pre-commit hook `check-unit-test-structure` requires tests in sub-packages | Always check project's test structure conventions before placing new test files |
+| Regex-based TOML parsing | Used `re.match(r'^version\s*=\s*"([^"]+)"')` to read TOML values | Fragile: breaks on inline comments, multi-line strings, or non-standard formatting | Use `tomllib` (stdlib since 3.11) for reliable TOML parsing; fall back to `tomli` for 3.10 |
+| `if cond: return False; return True` pattern | Simple conditional in `check_init_uses_importlib()` | Ruff SIM103 requires direct condition return | Use `return not pattern.search(content)` for boolean-returning functions |
 
 ## Results & Parameters
 
-### Version Declaration Sites Pattern
+### importlib.metadata Pattern (recommended)
 
 ```python
-# pyproject.toml — canonical source
-[project]
-version = "0.1.0"
+# package/__init__.py — read version from installed metadata
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _get_version
 
-# pixi.toml — workspace version
-[workspace]
-version = "0.1.0"
-
-# package/__init__.py — runtime access
-__version__ = "0.1.0"
-
-# CLI — derived (imports __version__)
-from mypackage import __version__
-
-@click.version_option(version=__version__, prog_name="mypackage")
+try:
+    __version__: str = _get_version("mypackage")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # fallback when package is not installed
 ```
 
-### Consistency Script Pattern (no TOML library needed)
+### Consistency Script Pattern (with tomllib)
 
 ```python
-def _read_toml_version(path: Path, table_key: str) -> str | None:
-    text = path.read_text()
-    in_table = False
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            in_table = stripped == f"[{table_key}]"
-            continue
-        if in_table:
-            match = re.match(r'^version\s*=\s*"([^"]+)"', stripped)
-            if match:
-                return match.group(1)
-    return None
+import tomllib  # Python 3.11+; use tomli as fallback for 3.10
+
+def get_pyproject_version(path: Path) -> str:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    return data["project"]["version"]
+
+def get_pixi_version(path: Path) -> str:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    return data["workspace"]["version"]
+
+def check_init_uses_importlib(path: Path) -> bool:
+    content = path.read_text()
+    return not re.search(r'^__version__\s*=\s*["\'][\d.]+["\']', content, re.MULTILINE)
+
+def find_aspirational_versions(changelog_path: Path, canonical: str) -> list[str]:
+    content = changelog_path.read_text()
+    canonical_tuple = tuple(int(p) for p in canonical.split("."))
+    aspirational = []
+    for match in re.finditer(r"\bv(\d+\.\d+\.\d+)\b", content):
+        if tuple(int(p) for p in match.group(1).split(".")) > canonical_tuple:
+            ref = f"v{match.group(1)}"
+            if ref not in aspirational:
+                aspirational.append(ref)
+    return aspirational
 ```
+
+### Pre-commit Hook Configuration
+
+```yaml
+- id: check-package-version-consistency
+  name: Check Package Version Consistency
+  description: Fails if package version in pyproject.toml, pixi.toml, or CHANGELOG.md are inconsistent
+  entry: pixi run python scripts/check_package_version_consistency.py
+  language: system
+  files: ^(pyproject\.toml|pixi\.toml|package/__init__\.py|CHANGELOG\.md)$
+  pass_filenames: false
+```
+
+### CHANGELOG Fix Pattern
+
+Replace phantom version references:
+- Before: "deprecated as of v1.5.0. It will be removed in v2.0.0."
+- After (if still deprecated): "deprecated. It will be removed in a future major version."
+- After (if already removed): Section header changes from "Deprecated" to "Removed"
+
+### Skill Template Root-Cause Fix
+
+Update any code-generation templates that produce CHANGELOG entries:
+- Before: `"<Class> is deprecated and will be removed in v2.0.0."`
+- After: `"<Class> is deprecated and will be removed in a future major version."`
 
 ### Release Workflow Key Points
 
@@ -125,14 +174,9 @@ def _read_toml_version(path: Path, table_key: str) -> str | None:
 - Use `gh release create` with `--generate-notes` for auto-generated release notes
 - Pass `github.ref_name` via `env:` variable (not `${{ }}` interpolation in `run:`) for GH Actions security
 
-### CHANGELOG Fix Pattern
-
-Replace phantom version references:
-- Before: "deprecated as of v1.5.0. It will be removed in v2.0.0."
-- After: "deprecated. It will be removed in a future major release."
-
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectScylla | Issue #1527 — Audit S10 versioning remediation | PR #1557: 8 files changed, 35 tests passing, all pre-commit hooks green |
+| ProjectScylla | Issue #1535 — Reconcile version 0.1.0 with CHANGELOG refs | PR #1562: 8 files changed, 26 new tests, 4808 total passing, 77.50% coverage |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.0.0 to v2.0.0.

Documents learnings from ProjectScylla issue #1535 — reconciling version 0.1.0 with aspirational CHANGELOG references (v1.5.0/v2.0.0).

- `importlib.metadata.version()` is the proper single-source-of-truth pattern for `__init__.py`
- `tomllib` replaces fragile regex-based TOML parsing in consistency check scripts
- Pre-commit hook should scan CHANGELOG for aspirational version references
- Root cause: skill templates that generate phantom version numbers must be updated

## Verification Level

**verified-local**

All 4808 tests pass locally with 77.50% coverage. CI validation pending on ProjectScylla PR #1562.

## Key Findings

**What Worked**:
- `importlib.metadata.version("package")` with `PackageNotFoundError` fallback
- `tomllib` for TOML parsing (stdlib since 3.11, `tomli` fallback for 3.10)
- CHANGELOG version-ref scanning via regex `\bv(\d+\.\d+\.\d+)\b` with tuple comparison
- Fixing the skill template that generated the phantom versions in the first place

**What Failed**:
- Regex TOML parsing → fragile, breaks on comments/multiline
- `if cond: return False; return True` → Ruff SIM103 requires direct return

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1049/1049 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>