### PR TITLE
feat: amend python-version-alignment skill (v2.0.0)

### DIFF
--- a/skills/python-version-alignment.history
+++ b/skills/python-version-alignment.history
@@ -1,0 +1,176 @@
+# python-version-alignment — History
+
+## v2.0.0 (2026-03-25)
+
+**Changed by:** Issue #44 — Expand CI test matrix to cover Python 3.10+ (ProjectHephaestus PR #75)
+**Verification:** verified-local
+
+### What changed
+- Added "CI Test Matrix Expansion" workflow section for expanding Python version coverage in GitHub Actions
+- Added key learning: pixi ignores setup-python and manages its own Python, so multi-version CI requires setup-python + pip
+- Added "When to Use" trigger for CI test matrix not covering all claimed Python versions
+- Added Failed Attempts entry documenting the pixi vs setup-python subtlety
+- Bumped version from 1.0.0 to 2.0.0
+- Added verification field to frontmatter
+
+### Why
+Previous version (v1.0.0) only covered Dockerfile alignment. The same root problem — claimed Python versions not matching tested versions — also manifests in CI test matrices. ProjectHephaestus claimed 3.10+ but only tested 3.12 in CI. The non-obvious part is that pixi-based workflows can't simply add versions to the matrix because pixi installs its own Python, ignoring setup-python.
+
+### Previous version (v1.0.0) snapshot
+---
+name: python-version-alignment
+description: Align Python version across pyproject.toml classifiers, pixi.toml, and
+  Dockerfile when drift is detected
+category: tooling
+date: 2026-02-27
+version: 1.0.0
+user-invocable: false
+---
+# Python Version Alignment
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-02-27 |
+| **Issue** | #1118 - [Docs] Standardize Python version specification across configs |
+| **Objective** | Align Python version in `docker/Dockerfile`, `pyproject.toml`, and `pixi.toml` |
+| **Outcome** | ✅ Dockerfile updated from `python:3.14.2-slim` to `python:3.12-slim` (pinned SHA256) |
+| **Root Cause** | Accidental drift — Dockerfile was manually updated to 3.14 without updating classifiers |
+| **Key Learning** | Use `docker pull` to get a fresh pinned SHA256 digest before updating `FROM` lines |
+
+## When to Use
+
+Use this workflow when:
+
+- A quality audit flags version mismatch across config files
+- `pyproject.toml` classifiers don't match the Dockerfile base image Python version
+- `pixi.toml` resolves a different Python than the Dockerfile uses
+- PR review mentions "Python version drift" or "config inconsistency"
+
+Trigger symptoms:
+- Dockerfile `FROM python:X.Y.Z-slim` doesn't match `pyproject.toml` classifier max version
+- CI/CD runs on a different Python than local `pixi` environment
+- `requires-python = ">=3.10"` but Dockerfile uses `3.14.x` (bleeding edge)
+
+## Verified Workflow
+
+### Step 1: Audit all three files
+
+```bash
+# Check pyproject.toml classifiers and requires-python
+grep -n "python\|Python\|3\.[0-9]" pyproject.toml
+
+# Check pixi.toml constraint
+grep -n "python" pixi.toml
+
+# Check Dockerfile FROM lines
+grep -n "FROM python\|python3\." docker/Dockerfile
+```
+
+### Step 2: Determine the canonical version
+
+The canonical version is the **highest version listed in `pyproject.toml` classifiers**.
+`requires-python = ">=3.10"` sets the minimum; the Dockerfile should use the *tested* maximum.
+
+Example:
+```toml
+# pyproject.toml classifiers → canonical max = 3.12
+"Programming Language :: Python :: 3.10",
+"Programming Language :: Python :: 3.11",
+"Programming Language :: Python :: 3.12",
+```
+
+### Step 3: Pull the target image and get its SHA256 digest
+
+```bash
+# Pull the target image (use -slim variant for smaller size)
+docker pull python:3.12-slim
+
+# Get the pinned digest
+docker inspect python:3.12-slim --format='{{index .RepoDigests 0}}'
+# Output: python@sha256:<digest>
+```
+
+### Step 4: Update the Dockerfile
+
+Replace all `FROM` lines and any `python3.X` path references:
+
+```dockerfile
+# Before (drifted):
+FROM python:3.14.2-slim@sha256:<old-digest> AS builder
+...
+COPY --from=builder /root/.local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+
+# After (aligned):
+# Python 3.12 aligns with pyproject.toml classifiers (3.10-3.12); requires-python = ">=3.10"
+FROM python:3.12-slim@sha256:<new-digest> AS builder
+...
+COPY --from=builder /root/.local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+```
+
+**Important**: In multi-stage Dockerfiles, update **both** stages (builder + runtime) and the `COPY` path.
+
+### Step 5: Verify no remaining old-version references
+
+```bash
+grep -rn "3\.14\|python3\.14" docker/ pyproject.toml pixi.toml
+# Should produce no output
+```
+
+### Step 6: Run tests and commit
+
+```bash
+pixi run python -m pytest tests/unit/ -v --tb=short -q
+
+git add docker/Dockerfile
+git commit -m "docs(docker): align Dockerfile Python version with pyproject.toml classifiers"
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| N/A | Direct approach worked | N/A | Solution was straightforward |
+## Results & Parameters
+
+### Files Changed (Issue #1118)
+
+| File | Change |
+|------|--------|
+| `docker/Dockerfile` line 15 | `python:3.14.2-slim@sha256:1a3c6...` → `python:3.12-slim@sha256:f3fa41d7...` |
+| `docker/Dockerfile` line 44 | Same update for runtime stage |
+| `docker/Dockerfile` line 53 | `python3.14/site-packages` → `python3.12/site-packages` |
+
+### Final State After Fix
+
+```
+pyproject.toml:  requires-python = ">=3.10", classifiers 3.10-3.12  (unchanged)
+pixi.toml:       python = ">=3.10"                                   (unchanged)
+docker/Dockerfile: FROM python:3.12-slim@sha256:f3fa41d7...          (updated)
+```
+
+### Docker SHA256 Digest (as of 2026-02-27)
+
+```
+python:3.12-slim → sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
+```
+
+Note: SHA256 digests change when Docker Hub publishes security patches. Re-pull before updating.
+
+### Test Results
+
+- 3185 tests passed, 78.36% coverage (above 75% threshold)
+- Pre-push coverage hook validated and passed
+
+## References
+
+- PR #1166: https://github.com/HomericIntelligence/ProjectScylla/pull/1166
+- Issue #1118: Discovered during February 2026 quality audit (P2)
+- See `references/notes.md` for raw session details
+
+## Tags
+
+`python`, `dockerfile`, `version-drift`, `pyproject`, `pixi`, `configuration`, `quality-audit`
+
+---

--- a/skills/python-version-alignment.md
+++ b/skills/python-version-alignment.md
@@ -1,24 +1,33 @@
 ---
 name: python-version-alignment
-description: Align Python version across pyproject.toml classifiers, pixi.toml, and
-  Dockerfile when drift is detected
+description: "Align Python version across pyproject.toml, pixi.toml, Dockerfile, and CI test matrix. Use when: (1) classifiers don't match CI matrix, (2) Dockerfile uses wrong Python, (3) pixi ignores setup-python in multi-version CI."
 category: tooling
-date: 2026-02-27
-version: 1.0.0
+date: 2026-03-25
+version: "2.0.0"
 user-invocable: false
+verification: verified-local
+history: python-version-alignment.history
+tags:
+- python
+- ci-cd
+- test-matrix
+- pixi
+- setup-python
+- version-drift
+- github-actions
 ---
+
 # Python Version Alignment
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-02-27 |
-| **Issue** | #1118 - [Docs] Standardize Python version specification across configs |
-| **Objective** | Align Python version in `docker/Dockerfile`, `pyproject.toml`, and `pixi.toml` |
-| **Outcome** | ✅ Dockerfile updated from `python:3.14.2-slim` to `python:3.12-slim` (pinned SHA256) |
-| **Root Cause** | Accidental drift — Dockerfile was manually updated to 3.14 without updating classifiers |
-| **Key Learning** | Use `docker pull` to get a fresh pinned SHA256 digest before updating `FROM` lines |
+| **Date** | 2026-03-25 |
+| **Objective** | Align Python version across pyproject.toml, pixi.toml, Dockerfile, and CI test matrix |
+| **Outcome** | v1: Dockerfile aligned. v2: CI test matrix expanded to cover all claimed Python versions |
+| **Verification** | verified-local |
+| **History** | [changelog](./python-version-alignment.history) |
 
 ## When to Use
 
@@ -28,128 +37,104 @@ Use this workflow when:
 - `pyproject.toml` classifiers don't match the Dockerfile base image Python version
 - `pixi.toml` resolves a different Python than the Dockerfile uses
 - PR review mentions "Python version drift" or "config inconsistency"
+- **CI test matrix only tests one Python version but `pyproject.toml` claims multiple** (e.g., `requires-python = ">=3.10"` with 3.10/3.11/3.12 classifiers but CI only tests 3.12)
+- **Pixi-based CI workflow needs multi-version Python testing** (pixi ignores `setup-python`)
 
 Trigger symptoms:
 - Dockerfile `FROM python:X.Y.Z-slim` doesn't match `pyproject.toml` classifier max version
 - CI/CD runs on a different Python than local `pixi` environment
 - `requires-python = ">=3.10"` but Dockerfile uses `3.14.x` (bleeding edge)
+- CI matrix has `python-version: ["3.12"]` but classifiers list 3.10, 3.11, 3.12
 
 ## Verified Workflow
 
-### Step 1: Audit all three files
+### Quick Reference
 
 ```bash
-# Check pyproject.toml classifiers and requires-python
-grep -n "python\|Python\|3\.[0-9]" pyproject.toml
+# Audit Python version references across all config files
+grep -n "python\|Python\|3\.[0-9]" pyproject.toml pixi.toml .github/workflows/test.yml
 
-# Check pixi.toml constraint
-grep -n "python" pixi.toml
+# Validate workflow YAML after editing
+python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml')); print('OK')"
 
-# Check Dockerfile FROM lines
-grep -n "FROM python\|python3\." docker/Dockerfile
+# Run tests locally to verify nothing breaks
+pytest tests/unit -v
 ```
 
-### Step 2: Determine the canonical version
+### Detailed Steps
 
-The canonical version is the **highest version listed in `pyproject.toml` classifiers**.
-`requires-python = ">=3.10"` sets the minimum; the Dockerfile should use the *tested* maximum.
+#### Part A: Dockerfile Alignment (v1.0.0 workflow)
 
-Example:
-```toml
-# pyproject.toml classifiers → canonical max = 3.12
-"Programming Language :: Python :: 3.10",
-"Programming Language :: Python :: 3.11",
-"Programming Language :: Python :: 3.12",
-```
+1. **Audit all config files** for Python version references
+2. **Determine canonical version** from `pyproject.toml` classifiers (highest listed = Dockerfile target)
+3. **Pull target image** and get SHA256 digest: `docker pull python:3.12-slim`
+4. **Update Dockerfile** — both `FROM` lines and `python3.X` path references in multi-stage builds
+5. **Verify** no remaining old-version references: `grep -rn "3\.14\|python3\.14" docker/`
 
-### Step 3: Pull the target image and get its SHA256 digest
+#### Part B: CI Test Matrix Expansion (v2.0.0 workflow)
 
-```bash
-# Pull the target image (use -slim variant for smaller size)
-docker pull python:3.12-slim
+1. **Identify the gap**: Compare `pyproject.toml` classifiers against `.github/workflows/test.yml` matrix
+2. **Expand the matrix**: Change `python-version: ["3.12"]` to `python-version: ["3.10", "3.11", "3.12"]`
+3. **Replace pixi with setup-python + pip** (see critical note below):
+   - Remove `Install pixi` step (e.g., `prefix-dev/setup-pixi@v0.9.4`)
+   - Change `pixi run pip install -e .` to `pip install -e ".[dev]"`
+   - Change all `pixi run pytest` to `pytest`, `pixi run python` to `python`
+   - Update cache from pixi paths to `~/.cache/pip`
+4. **Restrict coverage upload** to one Python version to avoid duplicate reports:
+   ```yaml
+   if: matrix.test-type == 'unit' && matrix.python-version == '3.12'
+   ```
+5. **Validate YAML** and run tests locally
+6. **Verify CI** spawns N×M jobs (N Python versions × M test types)
 
-# Get the pinned digest
-docker inspect python:3.12-slim --format='{{index .RepoDigests 0}}'
-# Output: python@sha256:<digest>
-```
-
-### Step 4: Update the Dockerfile
-
-Replace all `FROM` lines and any `python3.X` path references:
-
-```dockerfile
-# Before (drifted):
-FROM python:3.14.2-slim@sha256:<old-digest> AS builder
-...
-COPY --from=builder /root/.local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
-
-# After (aligned):
-# Python 3.12 aligns with pyproject.toml classifiers (3.10-3.12); requires-python = ">=3.10"
-FROM python:3.12-slim@sha256:<new-digest> AS builder
-...
-COPY --from=builder /root/.local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-```
-
-**Important**: In multi-stage Dockerfiles, update **both** stages (builder + runtime) and the `COPY` path.
-
-### Step 5: Verify no remaining old-version references
-
-```bash
-grep -rn "3\.14\|python3\.14" docker/ pyproject.toml pixi.toml
-# Should produce no output
-```
-
-### Step 6: Run tests and commit
-
-```bash
-pixi run python -m pytest tests/unit/ -v --tb=short -q
-
-git add docker/Dockerfile
-git commit -m "docs(docker): align Dockerfile Python version with pyproject.toml classifiers"
-```
+**CRITICAL — Pixi vs setup-python**:
+> Pixi manages its own Python installation from conda-forge and **ignores** the Python provided by `actions/setup-python`. If your workflow uses pixi, adding versions to the matrix has NO EFFECT — pixi will install whatever version its solver chooses. To genuinely test multiple Python versions, you must use `setup-python` + `pip install -e ".[dev]"` instead of pixi in the test workflow.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| N/A | Direct approach worked | N/A | Solution was straightforward |
+| Keep pixi + expand matrix | Attempted to add 3.10/3.11 to matrix while keeping pixi | Pixi ignores setup-python and installs its own Python from conda-forge. Matrix expansion alone has no effect. | For multi-version Python CI, must use setup-python + pip, not pixi |
+| Pixi --override to pin Python | Considered using pixi's override mechanism to force specific Python versions | Fragile and non-standard — fighting the tool rather than working with it | Standard CI patterns (setup-python + pip) are more reliable than tool-specific workarounds |
+| v1.0.0: Dockerfile only | Direct approach worked for Dockerfile alignment | N/A — successful | Straightforward when scope is limited to Dockerfile |
+
 ## Results & Parameters
 
-### Files Changed (Issue #1118)
+### v2.0.0: CI Test Matrix (ProjectHephaestus Issue #44)
+
+**Before:**
+```yaml
+python-version: ["3.12"]  # 2 CI jobs (1 version × 2 test types)
+```
+
+**After:**
+```yaml
+python-version: ["3.10", "3.11", "3.12"]  # 6 CI jobs (3 versions × 2 test types)
+```
+
+**Files Changed:**
+| File | Change |
+|------|--------|
+| `.github/workflows/test.yml` line 16 | `["3.12"]` → `["3.10", "3.11", "3.12"]` |
+| `.github/workflows/test.yml` lines 27-43 | Replaced pixi install/cache with pip install/cache |
+| `.github/workflows/test.yml` lines 47-64 | Removed `pixi run` prefix from all commands |
+| `.github/workflows/test.yml` line 61 | Added `&& matrix.python-version == '3.12'` to coverage upload condition |
+
+**Test Results:**
+- 384 unit tests passed locally on Python 3.12
+- CI validation pending (PR #75)
+
+### v1.0.0: Dockerfile Alignment (ProjectScylla Issue #1118)
 
 | File | Change |
 |------|--------|
-| `docker/Dockerfile` line 15 | `python:3.14.2-slim@sha256:1a3c6...` → `python:3.12-slim@sha256:f3fa41d7...` |
+| `docker/Dockerfile` line 15 | `python:3.14.2-slim` → `python:3.12-slim` (pinned SHA256) |
 | `docker/Dockerfile` line 44 | Same update for runtime stage |
 | `docker/Dockerfile` line 53 | `python3.14/site-packages` → `python3.12/site-packages` |
 
-### Final State After Fix
+## Verified On
 
-```
-pyproject.toml:  requires-python = ">=3.10", classifiers 3.10-3.12  (unchanged)
-pixi.toml:       python = ">=3.10"                                   (unchanged)
-docker/Dockerfile: FROM python:3.12-slim@sha256:f3fa41d7...          (updated)
-```
-
-### Docker SHA256 Digest (as of 2026-02-27)
-
-```
-python:3.12-slim → sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
-```
-
-Note: SHA256 digests change when Docker Hub publishes security patches. Re-pull before updating.
-
-### Test Results
-
-- 3185 tests passed, 78.36% coverage (above 75% threshold)
-- Pre-push coverage hook validated and passed
-
-## References
-
-- PR #1166: https://github.com/HomericIntelligence/ProjectScylla/pull/1166
-- Issue #1118: Discovered during February 2026 quality audit (P2)
-- See `references/notes.md` for raw session details
-
-## Tags
-
-`python`, `dockerfile`, `version-drift`, `pyproject`, `pixi`, `configuration`, `quality-audit`
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #44, PR #75 — Expand CI test matrix to 3.10/3.11/3.12 | Replaced pixi with setup-python + pip for multi-version CI |
+| ProjectScylla | Issue #1118, PR #1166 — Dockerfile Python version alignment | Dockerfile updated from 3.14.2 to 3.12 with pinned SHA256 |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.0.0 to v2.0.0.

Documents how to expand CI test matrices for multi-version Python testing, specifically the critical subtlety that pixi ignores `setup-python` and requires switching to `pip install` for genuine multi-version coverage.

- Adds CI test matrix expansion workflow (Part B of the skill)
- Documents pixi vs setup-python incompatibility
- Archives v1.0.0 in history file

## Verification Level

**verified-local**

All 384 unit tests pass locally. CI validation pending on ProjectHephaestus PR #75.

## Key Findings

**What Worked**:
- Replacing pixi with `setup-python` + `pip install -e ".[dev]"` for reliable multi-version CI
- Restricting coverage upload to single Python version to avoid duplicate Codecov reports

**What Failed**:
- Keeping pixi + expanding matrix → pixi ignores setup-python and installs its own Python
- Pixi `--override` to pin Python → fragile, non-standard workaround

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1049/1049 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>