### PR TITLE
feat: amend tooling-justfile-pixi-ecosystem-wrapping skill (v3.0.0)

### DIFF
--- a/skills/tooling-justfile-pixi-ecosystem-wrapping.history
+++ b/skills/tooling-justfile-pixi-ecosystem-wrapping.history
@@ -1,5 +1,32 @@
 # tooling-justfile-pixi-ecosystem-wrapping — History
 
+## v3.0.0 (2026-03-25)
+
+**Changed by:** ProjectHephaestus issue #48 — one-command bootstrap and dev workflows
+**Verification:** verified-local
+
+### What changed
+- Added `bootstrap` recipe pattern (`pixi install` + `pixi run pre-commit install`)
+- Added `check` composite recipe (`just lint && just typecheck && just test`)
+- Added configurable variables at top of justfile (`src_dirs`, `test_dir`) to avoid path duplication
+- Updated Template A to include all 9 recipes (was 7)
+- Added documentation update workflow (Step 5): how to update README.md and CLAUDE.md to reference `just` recipes
+- Added "DRY violation" trigger to "When to Use" section
+- Added failed attempt: `pre-commit install` in git worktrees with `core.hooksPath` set
+- Added ProjectHephaestus PR #77 to "Verified On" table
+
+### Why
+v2.0.0 Template A was minimal — no `bootstrap` or `check` recipe, no configurable variables,
+and no guidance on updating project docs. The actual Hephaestus justfile (PR #77) evolved beyond
+the template with these patterns, and the docs update (README.md + CLAUDE.md) is a key part of
+the DX improvement that should be documented.
+
+### Previous version (v2.0.0) snapshot
+
+See git diff for full v2.0.0 content.
+
+---
+
 ## v2.0.0 (2026-03-25)
 
 **Changed by:** ProjectHephaestus issue #35 — add justfile for ecosystem convention

--- a/skills/tooling-justfile-pixi-ecosystem-wrapping.md
+++ b/skills/tooling-justfile-pixi-ecosystem-wrapping.md
@@ -1,9 +1,9 @@
 ---
 name: tooling-justfile-pixi-ecosystem-wrapping
-description: "Add justfile wrapping pixi tasks for ecosystem convention alignment. Use when: (1) a project uses pixi.toml but lacks a justfile, (2) Python library repo needs consistent CLI, (3) cross-repo task invocation needs just <project>-<task> convention, (4) adding BATS tests to verify justfile-pixi sync."
+description: "Add justfile wrapping pixi tasks for ecosystem convention alignment. Use when: (1) a project uses pixi.toml but lacks a justfile, (2) Python library repo needs consistent CLI, (3) cross-repo task invocation needs just <project>-<task> convention, (4) adding BATS tests to verify justfile-pixi sync, (5) docs reference individual pixi run commands instead of just recipes."
 category: tooling
 date: 2026-03-25
-version: "2.0.0"
+version: "3.0.0"
 user-invocable: false
 verification: verified-local
 history: tooling-justfile-pixi-ecosystem-wrapping.history
@@ -23,7 +23,7 @@ tags:
 |-------|-------|
 | **Date** | 2026-03-25 |
 | **Objective** | Add a justfile to a pixi-managed project so that cross-repo orchestration and developer CLI is consistent via the HomericIntelligence ecosystem convention |
-| **Outcome** | Successful — verified on both CI-heavy (Scylla, 12 recipes) and library (Hephaestus, 7 recipes) repos |
+| **Outcome** | Successful — verified on both CI-heavy (Scylla, 12 recipes) and library (Hephaestus, 9 recipes) repos |
 | **Verification** | verified-local |
 | **History** | [changelog](./tooling-justfile-pixi-ecosystem-wrapping.history) |
 
@@ -34,6 +34,7 @@ tags:
 - Cross-repo orchestrators (e.g., Odysseus) need to invoke tasks via `just <project>-<task>`
 - You need to verify justfile recipes stay in sync with pixi tasks
 - Adding `just` as a conda-forge dev dependency in pixi.toml
+- README.md and CLAUDE.md document individual `pixi run` commands instead of `just` recipes (DRY violation)
 
 ## Verified Workflow
 
@@ -63,57 +64,79 @@ pixi run test-shell
    - Add a comment above each recipe describing what it does
    - **Never use heredocs** in justfile recipes (known `just` pitfall — use `printf` instead)
    - For tasks without a pixi equivalent (e.g., `typecheck`), call the tool directly via `pixi run mypy ...`
-   - Use `*ARGS` forwarding for recipes where users commonly pass extra flags (test, lint)
+   - Use `*ARGS` forwarding for recipes where users commonly pass extra flags (test)
+   - Use configurable variables at top of file (`src_dirs`, `test_dir`) to avoid path duplication
+   - Include a `bootstrap` recipe for one-command setup and a `check` composite recipe for full CI
 
 3. **Choose the right template** based on project type:
 
 ### Template A: Python Library Repo (e.g., Hephaestus)
 
 ```just
-# ProjectName task runner
-# Convention: justfile delegates to pixi tasks
+# ProjectName justfile
+# One-command developer experience for the HomericIntelligence ecosystem
 
+# Configurable paths
+src_dirs := "<package> scripts tests"
+test_dir := "tests/unit"
+
+# List available recipes
 default:
     @just --list
 
+# === Setup ===
+
+# Install dependencies and configure pre-commit hooks
+bootstrap:
+    pixi install
+    pixi run pre-commit install
+
 # === Test ===
 
-# Run tests (accepts optional args, e.g. `just test tests/unit/`)
+# Run unit tests (pass extra args: just test -v, just test -k test_slugify)
 test *ARGS:
-    pixi run pytest {{ ARGS }}
+    pixi run pytest {{ test_dir }} {{ ARGS }}
 
 # === Code Quality ===
 
-# Run linter
-lint *ARGS:
-    pixi run lint {{ ARGS }}
+# Check code with ruff linter
+lint:
+    pixi run ruff check {{ src_dirs }}
 
-# Run formatter
+# Format code with ruff formatter
 format:
-    pixi run format
+    pixi run ruff format {{ src_dirs }}
 
-# Run type checker
+# Run mypy type checking
 typecheck:
     pixi run mypy <package>/
-
-# === Security ===
-
-# Run dependency audit
-audit:
-    pixi run audit
-
-# === Checks ===
 
 # Run pre-commit hooks on all files
 pre-commit:
     pixi run pre-commit run --all-files
+
+# === Security ===
+
+# Run pip-audit dependency audit
+audit:
+    pixi run --environment lint pip-audit
+
+# === CI ===
+
+# Run lint, typecheck, and tests (full CI check)
+check:
+    just lint
+    just typecheck
+    just test
 ```
 
 Key decisions for library repos:
-- `test *ARGS` forwards to pytest (e.g., `just test tests/unit/ -v`)
-- `lint *ARGS` forwards to ruff check (e.g., `just lint --fix`)
-- `format` has no args — ruff format targets are fixed in pixi.toml
+- **Configurable variables at top** (`src_dirs`, `test_dir`) avoid path duplication across recipes
+- `bootstrap` combines `pixi install` + `pixi run pre-commit install` for one-command setup
+- `test *ARGS` forwards to pytest with a default test directory (e.g., `just test -v`, `just test -k test_slugify`)
+- `lint` and `format` use the `src_dirs` variable for consistent path targeting
 - `typecheck` calls `pixi run mypy` directly since there's typically no pixi task for it
+- `check` is a composite recipe that runs lint + typecheck + test for a single "is everything green?" command
 - No CI recipes needed — CI runs pixi tasks directly
 
 ### Template B: CI-Heavy Repo (e.g., Scylla)
@@ -178,14 +201,20 @@ test-shell:
    - Regression guard: no heredocs in justfile (`grep -cE '<<\s*[A-Z_]'`)
    - **Sync test**: parse `[tasks]` from `pixi.toml` and verify each has a matching just recipe
 
-5. **Verify** — run `just --list` to confirm no parse errors and all recipes show descriptions.
+5. **Update documentation** to reference `just` recipes instead of individual `pixi run` commands:
+   - **README.md**: Replace "Getting Started with Pixi" with "Getting Started", use `just bootstrap`/`just test`/`just lint`/`just format` as primary commands, add a fallback note for `pixi run`
+   - **CLAUDE.md**: Update Environment Setup, Common Commands, Testing Strategy, Pre-commit Hooks, and Troubleshooting sections to use `just` recipes
+   - Add `justfile` to the directory structure listing in both files
+
+6. **Verify** — run `just --list` to confirm no parse errors and all recipes show descriptions.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | N/A — clean implementation (Scylla) | Direct pixi run delegation | Did not fail | Following the ecosystem convention from prior skills avoided all known pitfalls |
-| N/A — clean implementation (Hephaestus) | Direct pixi run delegation with `*ARGS` | Did not fail | Pattern is now well-established; `*ARGS` forwarding works cleanly for test and lint |
+| N/A — clean implementation (Hephaestus v1) | Direct pixi run delegation with `*ARGS` | Did not fail | Pattern is now well-established; `*ARGS` forwarding works cleanly for test and lint |
+| bootstrap in git worktree | `pixi run pre-commit install` in a worktree with `core.hooksPath` set | pre-commit refuses to install when `core.hooksPath` is set | `just bootstrap` works in normal clones; in worktrees with custom hook paths, pre-commit install may fail — this is a git config issue, not a justfile issue |
 
 ## Results & Parameters
 
@@ -201,12 +230,14 @@ just = ">=1.25.0,<2"
 | Recipe | Delegates To | Notes |
 |--------|-------------|-------|
 | `default` | `@just --list` | Ecosystem standard |
-| `test *ARGS` | `pixi run pytest {{ ARGS }}` | Forwards args to pytest |
-| `lint *ARGS` | `pixi run lint {{ ARGS }}` | Forwards args to ruff check |
-| `format` | `pixi run format` | ruff format |
+| `bootstrap` | `pixi install` + `pixi run pre-commit install` | One-command setup |
+| `test *ARGS` | `pixi run pytest {{ test_dir }} {{ ARGS }}` | Forwards args to pytest |
+| `lint` | `pixi run ruff check {{ src_dirs }}` | Uses configurable variable |
+| `format` | `pixi run ruff format {{ src_dirs }}` | Uses configurable variable |
 | `typecheck` | `pixi run mypy hephaestus/` | No pixi task; calls mypy directly |
-| `audit` | `pixi run audit` | pip-audit scan |
+| `audit` | `pixi run --environment lint pip-audit` | pip-audit in lint env |
 | `pre-commit` | `pixi run pre-commit run --all-files` | All hooks |
+| `check` | `just lint && just typecheck && just test` | Composite CI recipe |
 
 ### Recipe-to-Pixi Mapping (CI-Heavy Repo — Scylla)
 
@@ -231,3 +262,4 @@ just = ">=1.25.0,<2"
 |---------|---------|---------|
 | ProjectScylla | Issue #1506 — ecosystem convention alignment | PR #1550 |
 | ProjectHephaestus | Issue #35 — add justfile for ecosystem convention | PR #72 |
+| ProjectHephaestus | Issue #48 — bootstrap, check, variables, docs update | PR #77 |


### PR DESCRIPTION
## Summary

Amends existing skill from v2.0.0 to v3.0.0.

Documents patterns learned from ProjectHephaestus issue #48 (PR #77): bootstrap recipe, check composite recipe, configurable justfile variables, and documentation update workflow.

- Added `bootstrap` recipe pattern for one-command setup
- Added `check` composite recipe for full CI check
- Added configurable variables (`src_dirs`, `test_dir`) to avoid path duplication
- Added docs update workflow (README.md + CLAUDE.md)
- Added worktree `core.hooksPath` gotcha to Failed Attempts

## Verification Level

**verified-local**

All just recipes verified locally: 384 tests pass, lint clean, typecheck clean, 21 pre-commit hooks pass.

## Key Findings

**What Worked**:
- Configurable variables at top of justfile avoid repeating paths across recipes
- `check` composite recipe (`just lint && just typecheck && just test`) provides single "is everything green?" command
- `bootstrap` recipe (`pixi install` + `pixi run pre-commit install`) provides one-command setup

**What Failed**:
- `pixi run pre-commit install` in git worktrees with `core.hooksPath` set -> pre-commit refuses to install (git config issue, not justfile)

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1053/1053 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>