### PR TITLE
feat: add testing-cli-entrypoint-help-smoke skill

### DIFF
--- a/skills/testing-cli-entrypoint-help-smoke.md
+++ b/skills/testing-cli-entrypoint-help-smoke.md
@@ -1,0 +1,174 @@
+---
+name: testing-cli-entrypoint-help-smoke
+description: "Smoke-test Python CLI entry points with --help subprocess calls and import verification. Use when: (1) a package declares [project.scripts] entry points, (2) entry points need regression protection, (3) an issue asks for CLI importability tests."
+category: testing
+date: 2026-03-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - python
+  - cli
+  - integration-testing
+  - entry-points
+  - smoke-tests
+---
+
+# Testing CLI Entry Points with --help Smoke Tests
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Verify all `[project.scripts]` entry points are importable and respond to `--help` without crashing |
+| **Outcome** | Success — 8 tests (4 import + 4 subprocess) all pass in 0.39s |
+| **Verification** | verified-local |
+
+## When to Use
+
+- A Python package declares `[project.scripts]` entry points in `pyproject.toml`
+- Entry points need smoke tests to catch import errors, missing dependencies, or broken `main()` signatures
+- An issue explicitly asks for CLI entry point integration tests
+- The existing integration tests only cover module imports, not the `main()` functions that serve as entry points
+
+Do NOT use when:
+- Entry points require real credentials or network access just for `--help` (check first)
+- The package doesn't use argparse/click (custom CLI parsing may not support `--help`)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Run CLI entry point tests
+pixi run pytest tests/integration/test_cli_entry_points.py -v --no-cov
+
+# Verify a single entry point manually
+python -m hephaestus.git.changelog --help
+```
+
+### Detailed Steps
+
+#### 1. Read `pyproject.toml` to find entry points
+
+```bash
+grep -A10 '\[project.scripts\]' pyproject.toml
+```
+
+Example output:
+```toml
+[project.scripts]
+hephaestus-changelog = "hephaestus.git.changelog:main"
+hephaestus-merge-prs = "hephaestus.github.pr_merge:main"
+hephaestus-system-info = "hephaestus.system.info:main"
+hephaestus-download-dataset = "hephaestus.datasets.downloader:main"
+```
+
+#### 2. Verify each module has a `main()` function and `__main__` block
+
+```bash
+grep -n "def main\|if __name__" hephaestus/git/changelog.py
+```
+
+Confirm: each module has `def main()` and `if __name__ == "__main__": main()`.
+
+#### 3. Check for side effects before `--help`
+
+Read each `main()` function to verify `--help` exits cleanly:
+- argparse handles `--help` **before** any business logic runs — `sys.exit(0)` is called by argparse
+- This is safe as long as there are no module-level side effects (network calls, file writes) at import time
+
+#### 4. Create the test file
+
+Key design decisions:
+- **Use `sys.executable -m module.path`** instead of installed script names — avoids depending on pip-installed entry points
+- **Parametrize with ids** matching the script names from `pyproject.toml` for readable test output
+- **Two test classes**: import verification (fast, in-process) + subprocess `--help` (realistic, out-of-process)
+- **Assert usage text** in stdout to confirm argparse actually ran (not just a silent exit 0)
+
+```python
+import importlib
+import subprocess
+import sys
+import pytest
+
+ENTRY_POINTS = [
+    ("hephaestus.git.changelog", "main"),
+    ("hephaestus.github.pr_merge", "main"),
+    ("hephaestus.system.info", "main"),
+    ("hephaestus.datasets.downloader", "main"),
+]
+
+class TestCLIEntryPointImports:
+    @pytest.mark.parametrize(
+        "module_path,func_name",
+        ENTRY_POINTS,
+        ids=["hephaestus-changelog", "hephaestus-merge-prs",
+             "hephaestus-system-info", "hephaestus-download-dataset"],
+    )
+    def test_main_importable_and_callable(self, module_path: str, func_name: str) -> None:
+        mod = importlib.import_module(module_path)
+        main_func = getattr(mod, func_name, None)
+        assert main_func is not None, f"{module_path}.{func_name} not found"
+        assert callable(main_func), f"{module_path}.{func_name} is not callable"
+
+class TestCLIEntryPointHelp:
+    @pytest.mark.parametrize(
+        "module_path",
+        [ep[0] for ep in ENTRY_POINTS],
+        ids=["hephaestus-changelog", "hephaestus-merge-prs",
+             "hephaestus-system-info", "hephaestus-download-dataset"],
+    )
+    def test_help_exits_cleanly(self, module_path: str) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", module_path, "--help"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"{module_path} --help exited with code {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "usage:" in result.stdout.lower(), (
+            f"{module_path} --help did not produce usage text"
+        )
+```
+
+#### 5. Run and verify
+
+```bash
+pixi run pytest tests/integration/test_cli_entry_points.py -v --no-cov
+pixi run ruff check tests/integration/test_cli_entry_points.py
+pixi run ruff format --check tests/integration/test_cli_entry_points.py
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Using installed script names | Tried `subprocess.run(["hephaestus-changelog", "--help"])` | Requires package to be pip-installed with entry points registered; fails in pixi/dev environments | Use `sys.executable -m module.path` — tests the same `main()` code path via `__main__` block without needing pip install |
+| N/A — direct approach worked | Import + subprocess two-pronged strategy succeeded on first try | N/A | For argparse-based CLIs, `--help` is always safe — argparse calls `sys.exit(0)` before any business logic |
+
+## Results & Parameters
+
+**Test file**: `tests/integration/test_cli_entry_points.py`
+
+**Test count**: 8 (4 import + 4 subprocess)
+
+**Execution time**: ~0.39s total
+
+**Pattern for adding new entry points**: Add a tuple to `ENTRY_POINTS` list and a corresponding id string to both `ids=` lists.
+
+**Key assertion**: Always check for `"usage:"` in stdout — this confirms argparse actually ran, not just a silent exit 0 from some other code path.
+
+**Pre-flight check for new entry points**: Before adding to tests, verify:
+1. Module has `def main()` function
+2. Module has `if __name__ == "__main__": main()` block
+3. `main()` uses argparse (or click) with `--help` support
+4. No module-level side effects that would crash on import
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #52, PR #95 | 4 CLI entry points: changelog, merge-prs, system-info, download-dataset |

--- a/skills/testing-package-module-mock-coverage.md
+++ b/skills/testing-package-module-mock-coverage.md
@@ -1,0 +1,171 @@
+---
+name: testing-package-module-mock-coverage
+description: "Add comprehensive mock-based unit tests for installed Python package modules
+  with subprocess/shutil calls. Use when: (1) a hephaestus/ module has no tests or
+  low coverage, (2) the module uses subprocess.run or shutil.which, (3) you need >85%
+  coverage without real command execution."
+category: testing
+date: 2026-03-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - mock
+  - subprocess
+  - coverage
+  - hephaestus
+  - package-module
+---
+
+# Testing Package Modules with Mock Coverage
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Add comprehensive unit tests for installed Python package modules that use subprocess/shutil, achieving >85% coverage |
+| **Outcome** | 99% coverage of `readme_commands.py` with 65 tests, all mocked |
+| **Verification** | verified-local |
+
+## When to Use
+
+- A module under `hephaestus/` (installed package, not scripts/) has no or low test coverage
+- The module calls `subprocess.run`, `shutil.which`, or other external process functions
+- You need to mock at the module import path (not stdlib level) to prevent real execution
+- An issue or audit identifies coverage gaps in validation/utility modules
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Run module-specific tests with coverage
+pixi run python -m pytest tests/unit/validation/test_readme_commands.py -v \
+  --cov=hephaestus.validation.readme_commands --cov-report=term-missing --no-cov-on-fail
+
+# Run full suite to verify no regressions
+pixi run pytest tests/unit -v
+```
+
+### Detailed Steps
+
+1. **Read the source module** to understand all public methods, subprocess calls, and error handling paths
+2. **Read the existing test file** (if any) to avoid duplicating tests
+3. **Organize tests into one class per public method/concept**:
+   - `TestCodeBlock` for dataclass methods
+   - `TestExtractCodeBlocks` for file parsing
+   - `TestCommandClassification` for is_blocked/is_allowed/is_safe
+   - `TestValidateSyntax` for mocked subprocess syntax checks
+   - `TestValidateExecution` for mocked subprocess execution
+   - `TestGenerateReport` for output formatting
+4. **Mock at the module import path**, not at stdlib:
+   ```python
+   # CORRECT - mocks the module's reference
+   @patch("hephaestus.validation.readme_commands.subprocess.run")
+
+   # WRONG - mocks globally, may miss the target
+   @patch("subprocess.run")
+   ```
+5. **Mock all external dependencies per method**:
+   - `subprocess.run` for validate_syntax, validate_execution
+   - `shutil.which` for validate_availability
+   - `get_repo_root` for validate_execution (returns Path)
+6. **Use `@pytest.mark.parametrize`** for exhaustive pattern lists (e.g., all BLOCKED_PATTERNS)
+7. **Cover all error paths**: TimeoutExpired, OSError, non-zero return codes
+8. **Python 3.14 compatibility**: Construct `subprocess.TimeoutExpired` with positional `cmd` and `timeout` only:
+   ```python
+   exc = subprocess.TimeoutExpired(cmd="bash", timeout=5)
+   mock_run.side_effect = exc
+   ```
+9. **Run module-specific coverage** with `--no-cov-on-fail` to see line coverage even when project threshold isn't met
+10. **Run ruff check + format** before committing
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Importing unused constants | Imported `BLOCKED_PATTERNS`, `EXECUTE_LANGUAGES`, `SKIP_MARKERS` for documentation purposes | ruff F401 auto-removed them in pre-commit | Only import symbols actually used in assertions |
+| Running coverage without `--no-cov-on-fail` | Used default `--cov=hephaestus` from pyproject.toml | Coverage fails at 12% overall since only one module's tests ran | Use `--cov=hephaestus.validation.readme_commands --no-cov-on-fail` to see module-specific coverage |
+| Writing multi-line strings in test fixture | Used multi-line string with explicit newlines for markdown content | ruff format collapsed them to single-line concatenation | Let ruff format handle it; the single-line version is equivalent and passes formatting |
+
+## Results & Parameters
+
+### Mock Pattern Templates
+
+**Mocking subprocess.run (success)**:
+```python
+@patch("hephaestus.validation.readme_commands.subprocess.run")
+def test_valid_syntax(self, mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+    result = ReadmeValidator().validate_syntax("echo hello")
+    assert result.passed is True
+    mock_run.assert_called_once()
+```
+
+**Mocking subprocess.run (failure)**:
+```python
+@patch("hephaestus.validation.readme_commands.subprocess.run")
+def test_invalid_syntax(self, mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=2, stderr="syntax error", stdout="")
+    result = ReadmeValidator().validate_syntax("echo 'unterminated")
+    assert result.passed is False
+    assert result.error_message == "syntax error"
+```
+
+**Mocking subprocess.run (timeout)**:
+```python
+@patch("hephaestus.validation.readme_commands.subprocess.run")
+def test_timeout(self, mock_run: MagicMock) -> None:
+    exc = subprocess.TimeoutExpired(cmd="bash", timeout=5)
+    mock_run.side_effect = exc
+    result = ReadmeValidator().validate_syntax("echo hang")
+    assert result.passed is False
+    assert "timed out" in (result.error_message or "").lower()
+```
+
+**Mocking shutil.which**:
+```python
+@patch("hephaestus.validation.readme_commands.shutil.which")
+def test_binary_found(self, mock_which: MagicMock) -> None:
+    mock_which.return_value = "/usr/bin/echo"
+    result = ReadmeValidator().validate_availability("echo test")
+    assert result.passed is True
+    mock_which.assert_called_once_with("echo")
+```
+
+**Stacking multiple mocks (validate_execution needs both subprocess.run and get_repo_root)**:
+```python
+@patch("hephaestus.validation.readme_commands.get_repo_root")
+@patch("hephaestus.validation.readme_commands.subprocess.run")
+def test_execution(self, mock_run: MagicMock, mock_root: MagicMock) -> None:
+    mock_root.return_value = Path("/repo")
+    mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+    result = ReadmeValidator().validate_execution("echo hello")
+    assert result.passed is True
+```
+
+### Coverage Results
+
+| Module | Before | After | Tests |
+|--------|--------|-------|-------|
+| `hephaestus/validation/readme_commands.py` | ~0% | 99% | 65 |
+
+### Key pyproject.toml Settings
+
+```toml
+[tool.pytest.ini_options]
+addopts = ["--cov=hephaestus", "--cov-report=term-missing", "--cov-fail-under=80"]
+```
+
+Override for module-specific runs:
+```bash
+pixi run python -m pytest tests/unit/validation/test_readme_commands.py \
+  --cov=hephaestus.validation.readme_commands --cov-report=term-missing --no-cov-on-fail
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #51: Add test coverage for readme_commands.py | 65 tests, 99% coverage, PR #94 |


### PR DESCRIPTION
## Summary

New skill documenting the pattern for smoke-testing Python CLI entry points declared in `[project.scripts]`.

- Two-pronged test strategy: import verification + `--help` subprocess smoke tests
- Uses `sys.executable -m module.path` to avoid pip-install dependency
- Includes pre-flight checklist for safely adding new entry points

## Verification Level

**verified-local**

Tests pass locally (8/8 in 0.39s). CI validation pending on ProjectHephaestus PR #95.

## Key Findings

**What Worked**:
- argparse handles `--help` before business logic, making subprocess tests safe for all argparse-based CLIs
- Asserting `"usage:"` in stdout catches silent exit-0 false positives
- Parametrized tests with `ids=` matching script names give readable output

**What Failed**:
- Using installed script names (`hephaestus-changelog`) instead of `python -m` requires pip install

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1056/1056 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>