### PR TITLE
refactor: rename /retrospective command to /learn

### DIFF
--- a/plugins/tooling/skills-registry-commands/commands/advise.md
+++ b/plugins/tooling/skills-registry-commands/commands/advise.md
@@ -104,7 +104,7 @@ If the user wants more detail, read the full skill `.md` file and its `.history`
 for the most relevant matches.
 
 > **Note**: If the user's goal involves **creating or fixing skills**, remind them to run
-> `/retrospective` which captures session learnings and creates or amends a skill file.
+> `/learn` which captures session learnings and creates or amends a skill file.
 
 ## Output Format
 
@@ -150,7 +150,7 @@ param1: value1
 ### Invocation
 
 ```bash
-/skills-registry-commands:advise training a model with GRPO
+/mnemosyne:advise training a model with GRPO
 ```
 
 ### Output

--- a/plugins/tooling/skills-registry-commands/commands/learn.md
+++ b/plugins/tooling/skills-registry-commands/commands/learn.md
@@ -2,7 +2,7 @@
 description: Save session learnings as a new skill plugin. Use after experiments, debugging sessions, or when you want to preserve team knowledge.
 ---
 
-# /retrospective
+# /learn
 
 Capture session learnings and create or amend a skill file in the ProjectMnemosyne marketplace.
 
@@ -396,7 +396,7 @@ git push origin skill/<name>
 
 **Cause**: Shared clone at `$HOME/.agent-brain/ProjectMnemosyne` takes up disk space.
 
-**Solution**: Safe to delete anytime — re-clones automatically on next `/advise` or `/retrospective`:
+**Solution**: Safe to delete anytime — re-clones automatically on next `/advise` or `/learn`:
 ```bash
 rm -rf $HOME/.agent-brain/ProjectMnemosyne
 ```
@@ -415,7 +415,7 @@ rm -rf $HOME/.agent-brain/ProjectMnemosyne
 ## Example
 
 ```
-/skills-registry-commands:retrospective
+/mnemosyne:learn
 ```
 
 Claude will analyze the session, check for existing skills to amend, and either update an existing skill (with history) or create a new one.


### PR DESCRIPTION
## Summary

- Renames `retrospective.md` to `learn.md` in the skills-registry-commands plugin
- Updates the command heading from `# /retrospective` to `# /learn`
- Updates all command invocation examples to use the `mnemosyne:` prefix (`/mnemosyne:learn`, `/mnemosyne:advise`)
- Updates the cross-reference in `advise.md` from `/retrospective` to `/learn`

The retrospective workflow logic is unchanged — only the command name and invocation references are updated.

## Test plan

- [ ] Verify `learn.md` exists at `plugins/tooling/skills-registry-commands/commands/learn.md`
- [ ] Verify `retrospective.md` no longer exists at that path
- [ ] Verify heading in `learn.md` reads `# /learn`
- [ ] Verify example invocation in `learn.md` reads `/mnemosyne:learn`
- [ ] Verify `advise.md` references `/learn` and `/mnemosyne:advise`

🤖 Generated with [Claude Code](https://claude.com/claude-code)