### PR TITLE
refactor: update all remaining skills-registry-commands references to mnemosyne

### DIFF
--- a/ADVISE_RETROSPECTIVE_UPDATED.md
+++ b/ADVISE_RETROSPECTIVE_UPDATED.md
@@ -9,7 +9,7 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
 ## Changes Overview
 
 ### /advise Command
-**File**: `plugins/tooling/skills-registry-commands/commands/advise.md`
+**File**: `plugins/tooling/mnemosyne/commands/advise.md`
 
 #### Key Updates:
 1. **Clone Location**
@@ -30,7 +30,7 @@ Both `/advise` and `/retrospective` commands have been updated to work with the 
    - Focus sections: Failed Attempts, When to Use, Results & Parameters
 
 ### /retrospective Command
-**File**: `plugins/tooling/skills-registry-commands/commands/retrospective.md`
+**File**: `plugins/tooling/mnemosyne/commands/retrospective.md`
 
 #### Key Updates:
 1. **Auto-Generate Filename** (Major Change!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Removed legacy `build/$$` and `build/ProjectMnemosyne` directory references.
-- Corrected skills-registry-commands source path in marketplace.
+- Corrected mnemosyne source path in marketplace.
 - Resolved marketplace validation issues and missing frontmatter fields.
 - Enforced kebab-case names in skill frontmatter.
 - Migrated 29 remaining old-format skills to flat structure.
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skills are now single `.md` files with YAML frontmatter in the `skills/` directory.
 - Branch naming changed from `skill/<category>/<name>` to `skill/<name>`.
 - Skill filenames follow `<topic>-<subtopic>-<short-4-word-summary>.md` convention.
-- Updated `/advise` and `/retrospective` commands for flat file format.
+- Updated `/advise` and `/learn` commands for flat file format.
 - Updated validation scripts, marketplace generation, templates, docs, and CI.
 
 ### Added
@@ -50,8 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2025-12-29
 
 ### Added
-- `/advise` and `/retrospective` slash commands.
-- skills-registry-commands plugin infrastructure.
+- `/advise` and `/learn` slash commands.
+- mnemosyne plugin infrastructure.
 - Initial batch of skills: batch-pr-ci-fix, claude-plugin-format, retrospective-hook-integration.
 
 ### Fixed
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2025-12-28
 
 ### Added
-- Skills marketplace with `/advise` and `/retrospective` commands.
+- Skills marketplace with `/advise` and `/learn` commands.
 - `marketplace.json` for searchable skill index.
 - Plugin validation with `validate_plugins.py`.
 - CI pipeline for PR validation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Claude: Found 2 related skills...
   - Recommended: batch_size=4, learning_rate=1e-5
 ```
 
-### /retrospective
+### /learn
 
 Save learnings after a session (auto-creates PR).
 
@@ -77,7 +77,7 @@ skills/<name>.notes.md       # (Optional) Additional context from development se
 
 All skills are now flat files in the `skills/` directory. Metadata is stored as YAML frontmatter in each `.md` file.
 
-**Exception**: `plugins/tooling/skills-registry-commands/` stays in `plugins/` — it's the command infrastructure (advise, retrospective), not a skill.
+**Exception**: `plugins/tooling/mnemosyne/` stays in `plugins/` — it's the command infrastructure (advise, retrospective), not a skill.
 
 ### Required Fields
 
@@ -172,7 +172,7 @@ The project uses Claude Code hooks for automatic retrospective prompts.
 This project uses UserPromptSubmit hooks instead.
 
 **UserPromptSubmit Hook**: Triggers when user types session-ending keywords (exit, quit,
-clear, done, finished, etc.) to remind about `/retrospective`.
+clear, done, finished, etc.) to remind about `/learn`.
 
 **NEW in v2.1.0**: Hooks support `once: true` field to execute only once per session:
 ```json
@@ -186,15 +186,15 @@ clear, done, finished, etc.) to remind about `/retrospective`.
 ```
 
 See `.claude/settings.json` for configuration and
-`plugins/tooling/skills-registry-commands/hooks/settings.json.example` for reference.
+`plugins/tooling/mnemosyne/hooks/settings.json.example` for reference.
 
 **Skills location**: All skills live as flat files in `skills/` (e.g., `skills/skill-name.md`). The only exception is
-`plugins/tooling/skills-registry-commands/` which contains the /advise and /retrospective
+`plugins/tooling/mnemosyne/` which contains the /advise and /learn
 command infrastructure.
 
 ## Contributing a Skill
 
-1. Run `/retrospective` after a valuable session (preferred — auto-generates filename and structure)
+1. Run `/learn` after a valuable session (preferred — auto-generates filename and structure)
 2. Or manually create from `templates/skill-template.md`
    - Copy to `skills/<name>.md`
    - Fill YAML frontmatter (name, description, category, date, version)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,12 @@ PR process.
 
 ## How to Contribute a Skill
 
-### Option 1: Automatic via `/retrospective` (Recommended)
+### Option 1: Automatic via `/learn` (Recommended)
 
-The easiest way to contribute is using the `/retrospective` command after a valuable session:
+The easiest way to contribute is using the `/learn` command after a valuable session:
 
 1. Complete an experiment, debugging session, or development task.
-2. Run `/retrospective` in your Claude Code session.
+2. Run `/learn` in your Claude Code session.
 3. Claude automatically:
    - Reads your entire conversation history.
    - Extracts successes, failures, and parameters.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ claude plugin marketplace list
 
 ## Quick Start
 
-These commands work inside any Claude Code session after installation. All skill discovery and installation is handled automatically through the `/advise` and `/retrospective` commands.
+These commands work inside any Claude Code session after installation. All skill discovery and installation is handled automatically through the `/advise` and `/learn` commands.
 
 ### Search for Knowledge
 
@@ -80,7 +80,7 @@ Claude will search the marketplace for relevant prior learnings and return:
 ### Save Your Learnings
 
 ```text
-/retrospective
+/learn
 ```
 
 After an experiment or debugging session, capture your learnings as a new skill.
@@ -102,7 +102,7 @@ skills/
 
 plugins/
 └── tooling/
-    └── skills-registry-commands/   # /advise and /retrospective commands
+    └── mnemosyne/   # /advise and /learn commands
 ```
 
 Each skill is a flat markdown file with YAML frontmatter:
@@ -121,7 +121,7 @@ See `marketplace.json` for the complete searchable index of available skills. Th
 ### Option 1: Automatic (Recommended)
 
 1. Complete an experiment or debugging session
-2. Run `/retrospective`
+2. Run `/learn`
 3. Follow the prompts to categorize and name the skill
 4. PR is created automatically
 
@@ -192,7 +192,7 @@ python3 scripts/validate_plugins.py
 | [ProjectOdyssey](https://github.com/HomericIntelligence/ProjectOdyssey) | Training framework written in Mojo |
 | [ProjectScylla](https://github.com/HomericIntelligence/ProjectScylla) | Testing, optimization, and resilience evaluation |
 
-> **Note**: Skills produced by any of the above repositories can be contributed to ProjectMnemosyne via `/retrospective` so that learnings are shared across the ecosystem.
+> **Note**: Skills produced by any of the above repositories can be contributed to ProjectMnemosyne via `/learn` so that learnings are shared across the ecosystem.
 
 ## Why Mnemosyne?
 

--- a/plugins/tooling/mnemosyne/references/notes.md
+++ b/plugins/tooling/mnemosyne/references/notes.md
@@ -5,10 +5,10 @@ A complete skills registry system for Claude agents, including commands, hooks, 
 ## What's Included
 
 ```
-skills-registry-commands/
+mnemosyne/
 ├── skills/
 │   ├── advise/SKILL.md              # /advise command
-│   ├── retrospective/SKILL.md       # /retrospective command
+│   ├── retrospective/SKILL.md       # /learn command
 │   ├── documentation-patterns/SKILL.md  # How to write good skills
 │   └── validation-workflow/SKILL.md     # CI/CD setup
 ├── hooks/
@@ -26,7 +26,7 @@ skills-registry-commands/
 ### 1. Copy Plugin to Your Project
 
 ```bash
-cp -r plugins/tooling/skills-registry-commands your-project/plugins/tooling/
+cp -r plugins/tooling/mnemosyne your-project/plugins/tooling/
 ```
 
 ### 2. Install Hooks
@@ -34,10 +34,10 @@ cp -r plugins/tooling/skills-registry-commands your-project/plugins/tooling/
 ```bash
 mkdir -p your-project/.claude/hooks
 
-cp plugins/tooling/skills-registry-commands/hooks/retrospective-trigger.py \
+cp plugins/tooling/mnemosyne/hooks/retrospective-trigger.py \
    your-project/.claude/hooks/
 
-cp plugins/tooling/skills-registry-commands/hooks/settings.json.example \
+cp plugins/tooling/mnemosyne/hooks/settings.json.example \
    your-project/.claude/settings.json
 ```
 
@@ -46,7 +46,7 @@ cp plugins/tooling/skills-registry-commands/hooks/settings.json.example \
 ```bash
 mkdir -p your-project/scripts
 
-cp plugins/tooling/skills-registry-commands/scripts/*.py \
+cp plugins/tooling/mnemosyne/scripts/*.py \
    your-project/scripts/
 ```
 
@@ -65,7 +65,7 @@ Search skills registry for relevant experiments before starting work.
 4. Summarize: what worked, what failed, recommended parameters
 5. Always prioritize Failed Attempts - these prevent wasted effort
 
-### /retrospective
+### /learn
 
 Save learnings after a session (auto-creates PR).
 
@@ -96,7 +96,7 @@ mkdir -p plugins/{training,evaluation,optimization,debugging,architecture,toolin
 | Component | Purpose |
 |-----------|---------|
 | `/advise` | Search registry before starting work |
-| `/retrospective` | Capture learnings after sessions |
+| `/learn` | Capture learnings after sessions |
 | `documentation-patterns` | How to write discoverable skills |
 | `validation-workflow` | CI/CD for quality enforcement |
 | `retrospective-trigger.py` | Auto-prompt on session end |

--- a/plugins/tooling/mnemosyne/skills/documentation-patterns/SKILL.md
+++ b/plugins/tooling/mnemosyne/skills/documentation-patterns/SKILL.md
@@ -19,7 +19,7 @@ How to write skills that Claude can find and use effectively.
 
 ## When to Use
 
-- Creating a new skill after `/retrospective`
+- Creating a new skill after `/learn`
 - Improving an existing skill's discoverability
 - Writing trigger conditions for `/advise` matching
 - Documenting failed attempts (most valuable content)
@@ -185,7 +185,7 @@ skill_quality_indicators:
 
 From the Sionic AI blog:
 
-1. **Frictionless contribution**: `/retrospective` takes 30 seconds; Claude writes it
+1. **Frictionless contribution**: `/learn` takes 30 seconds; Claude writes it
 2. **Reward specificity**: Skills with precise descriptions get surfaced, reused, cited
 3. **Celebrate failures**: "I tried X and it broke because Y" is the most valuable content
 4. **Timing matters**: Capture knowledge while fresh (end-of-session, not two weeks later)

--- a/plugins/tooling/mnemosyne/skills/retrospective/SKILL.md
+++ b/plugins/tooling/mnemosyne/skills/retrospective/SKILL.md
@@ -4,7 +4,7 @@ description: Save session learnings as a new skill plugin. Use after experiments
 user-invocable: false
 ---
 
-# /retrospective
+# /learn
 
 Capture session learnings and create a new skill plugin with PR.
 
@@ -54,6 +54,6 @@ N/A — this skill describes a workflow pattern.
 
 ## References
 
-- See `commands/retrospective.md` for the full command implementation
+- See `commands/learn.md` for the full command implementation
 - See `validation-workflow` for CI validation details
 - See `documentation-patterns` for writing quality skills

--- a/skills/architecture-hierarchical-agent-command-creation.md
+++ b/skills/architecture-hierarchical-agent-command-creation.md
@@ -86,7 +86,7 @@ description: Brief description of what the command does
 
 6. **Implement auto-invocation of /advise** — Use the Skill tool:
    ```
-   Skill(skill: "skills-registry-commands:advise", args: "<task description>")
+   Skill(skill: "mnemosyne:advise", args: "<task description>")
    ```
 
 7. **Use Agent tool with model parameter** for spawning tiered sub-agents:
@@ -163,7 +163,7 @@ Key rules from `wave-based-bulk-issue-triage` skill:
 | Integration | Required? | How |
 |-------------|-----------|-----|
 | ProjectMnemosyne `/advise` | Yes (auto) | Skill tool invocation in Phase 1 |
-| ProjectMnemosyne `/retrospective` | No (suggest) | User decides in Phase 5 |
+| ProjectMnemosyne `/learn` | No (suggest) | User decides in Phase 5 |
 | AI Maestro | No (detect) | Check for `~/.aimaestro/` directory |
 | ProjectScylla T0-T6 | No (when relevant) | Only for agent evaluation tasks |
 

--- a/skills/claude-code-v21-adoption.md
+++ b/skills/claude-code-v21-adoption.md
@@ -196,7 +196,7 @@ Capture the workflow for future version upgrades.
 - [ ] Update templates with new fields
 - [ ] Document in CLAUDE.md
 - [ ] Create documentation skills for complex patterns
-- [ ] Run `/retrospective` after completion
+- [ ] Run `/learn` after completion
 
 ### PR Template
 

--- a/skills/claude-code-v21-adoption.notes.md
+++ b/skills/claude-code-v21-adoption.notes.md
@@ -34,7 +34,7 @@ Updated sub-skills:
 - ci-failure-workflow: analyze, fix
 - gh-pr-review-workflow: fix-feedback, get-comments, reply-comment
 - git-worktree-workflow: cleanup, create, switch, sync
-- skills-registry-commands: advise, documentation-patterns, retrospective, validation-workflow
+- mnemosyne: advise, documentation-patterns, retrospective, validation-workflow
 
 ### PR #71: Agent hooks + tool blocking
 **Branch**: `feature/agent-hooks`

--- a/skills/claude-config-branch-audit.md
+++ b/skills/claude-config-branch-audit.md
@@ -109,7 +109,7 @@ git commit -m "fix(claude): <summary of fixes>"
 ```json
 {
   "enabledPlugins": {
-    "skills-registry-commands@ProjectMnemosyne": true,
+    "mnemosyne@ProjectMnemosyne": true,
     "safety-net@cc-marketplace": true
   }
 }

--- a/skills/claude-plugin-format.notes.md
+++ b/skills/claude-plugin-format.notes.md
@@ -9,7 +9,7 @@
 ## Problem Discovery Timeline
 
 ### Issue 1: Skills not appearing
-User installed `skills-registry-commands` plugin but `/advise` and `/retrospective` didn't appear.
+User installed `mnemosyne` plugin but `/advise` and `/learn` didn't appear.
 
 **Investigation**:
 - Checked plugin structure
@@ -68,17 +68,17 @@ version: 1.0.0
 - `scripts/generate_marketplace.py` - output to `.claude-plugin/`
 - `scripts/validate_plugins.py` - removed non-standard required fields
 - `plugins/ci-cd/github-actions-mojo/.claude-plugin/plugin.json` - removed tags
-- `plugins/tooling/skills-registry-commands/.claude-plugin/plugin.json` - removed tags
+- `plugins/tooling/mnemosyne/.claude-plugin/plugin.json` - removed tags
 - `plugins/training/grpo-external-vllm/.claude-plugin/plugin.json` - removed tags
 - `plugins/training/spec-driven-experimentation/.claude-plugin/plugin.json` - removed tags
-- `plugins/tooling/skills-registry-commands/skills/advise/SKILL.md` - removed category, invokedBy
-- `plugins/tooling/skills-registry-commands/skills/retrospective/SKILL.md` - removed category, invokedBy
-- `plugins/tooling/skills-registry-commands/skills/documentation-patterns/SKILL.md` - removed category, source, date
-- `plugins/tooling/skills-registry-commands/skills/validation-workflow/SKILL.md` - removed category, source, date
+- `plugins/tooling/mnemosyne/skills/advise/SKILL.md` - removed category, invokedBy
+- `plugins/tooling/mnemosyne/skills/retrospective/SKILL.md` - removed category, invokedBy
+- `plugins/tooling/mnemosyne/skills/documentation-patterns/SKILL.md` - removed category, source, date
+- `plugins/tooling/mnemosyne/skills/validation-workflow/SKILL.md` - removed category, source, date
 
 ### Added
-- `plugins/tooling/skills-registry-commands/commands/advise.md` - slash command
-- `plugins/tooling/skills-registry-commands/commands/retrospective.md` - slash command
+- `plugins/tooling/mnemosyne/commands/advise.md` - slash command
+- `plugins/tooling/mnemosyne/commands/retrospective.md` - slash command
 
 ## Commits Created
 
@@ -103,7 +103,7 @@ After all fixes:
 - Plugin validation script passes: 4/4 plugins valid
 - Marketplace location correct: `.claude-plugin/marketplace.json`
 - No schema errors on installation
-- Commands appear as `/skills-registry-commands:advise` and `/skills-registry-commands:retrospective`
+- Commands appear as `/mnemosyne:advise` and `/mnemosyne:learn`
 
 ## Lessons for Future Plugins
 

--- a/skills/claude-plugin-marketplace.notes.md
+++ b/skills/claude-plugin-marketplace.notes.md
@@ -87,6 +87,6 @@ claude plugin marketplace list
 Key points from blog:
 
 - `/advise` command searches marketplace before work
-- `/retrospective` captures learnings and creates PR
+- `/learn` captures learnings and creates PR
 - Failed Attempts section is required in SKILL.md
 - Plugin structure: `.claude-plugin/plugin.json` + `skills/*/SKILL.md`

--- a/skills/comprehensive-pr-review-orchestration.notes.md
+++ b/skills/comprehensive-pr-review-orchestration.notes.md
@@ -285,7 +285,7 @@ Task tool with:
 
 ## Retrospective Skill Creation
 
-User requested: `/skills-registry-commands:retrospective`
+User requested: `/mnemosyne:learn`
 User specified: "make sure retrospective only goes to ProjectMnemosyne"
 
 **Skill Details**:

--- a/skills/consolidate-skills-directory.md
+++ b/skills/consolidate-skills-directory.md
@@ -19,7 +19,7 @@ Migrate from a dual `plugins/` + `skills/` structure to a single canonical `skil
 |------|---------|
 | Date | 2026-02-23 |
 | Objective | Consolidate 225 plugins/ + 88 legacy skills/ into a single skills/ directory |
-| Outcome | ✅ 310 skills in skills/, plugins/ contains only skills-registry-commands |
+| Outcome | ✅ 310 skills in skills/, plugins/ contains only mnemosyne |
 
 ## When to Use
 
@@ -65,7 +65,7 @@ for category in plugins/*/; do
   cat_name=$(basename "$category")
   for plugin in "$category"*/; do
     plugin_name=$(basename "$plugin")
-    [ "$cat_name/$plugin_name" = "tooling/skills-registry-commands" ] && continue
+    [ "$cat_name/$plugin_name" = "tooling/mnemosyne" ] && continue
     mkdir -p "skills/$cat_name"
     [ -d "skills/$cat_name/$plugin_name" ] && rm -rf "skills/$cat_name/$plugin_name"
     mv "$plugin" "skills/$cat_name/$plugin_name"
@@ -89,7 +89,7 @@ find skills -maxdepth 1 -mindepth 1 -type d | grep -v -E "^skills/(architecture|
 
 - `.github/workflows/validate-plugins.yml`: trigger on `skills/**` + `plugins/**`, pass both to script
 - `.github/workflows/update-marketplace.yml`: same
-- `plugins/tooling/skills-registry-commands/commands/retrospective.md`: generate into `skills/<category>/<name>/`
+- `plugins/tooling/mnemosyne/commands/retrospective.md`: generate into `skills/<category>/<name>/`
 - `CLAUDE.md`, `README.md`, `.claude/shared/plugin-standards.md`: update Required Structure section
 
 ### 6. Add YAML frontmatter to migrated legacy SKILL.md files
@@ -126,7 +126,7 @@ for plugin_json_path in skills_root.rglob('.claude-plugin/plugin.json'):
 # Final state after migration
 skills_count: 310
 skills_location: skills/<category>/<name>/
-exception: plugins/tooling/skills-registry-commands/  # stays in plugins/
+exception: plugins/tooling/mnemosyne/  # stays in plugins/
 
 # Validation command
 validate: python3 scripts/validate_plugins.py skills/ plugins/

--- a/skills/consolidate-skills-directory.notes.md
+++ b/skills/consolidate-skills-directory.notes.md
@@ -18,7 +18,7 @@ plugins/
 ├── evaluation/     (32 skills)
 ├── optimization/   (8 skills)
 ├── testing/        (37 skills)
-├── tooling/        (38 skills including skills-registry-commands)
+├── tooling/        (38 skills including mnemosyne)
 └── training/       (3 skills)
 
 skills/
@@ -71,4 +71,4 @@ These 10 skills (across 3 commits) were added directly to `plugins/` and needed 
 
 - 971 files changed in PR #183
 - 310 total skills, all passing validation
-- 309 sources in `./skills/`, 1 in `./plugins/` (skills-registry-commands)
+- 309 sources in `./skills/`, 1 in `./plugins/` (mnemosyne)

--- a/skills/dry-consolidation-workflow.md
+++ b/skills/dry-consolidation-workflow.md
@@ -46,7 +46,7 @@ Use this workflow when:
 
 ```bash
 # Use /advise to search team knowledge
-/skills-registry-commands:advise analyze codebase for duplicates DRY
+/mnemosyne:advise analyze codebase for duplicates DRY
 ```
 
 **What this does**:

--- a/skills/fix-resource-prompt-consistency.md
+++ b/skills/fix-resource-prompt-consistency.md
@@ -277,6 +277,6 @@ tests/unit/e2e/test_tier_manager.py::TestDiscoverSubtestsRootLevelMapping::test_
 
 ## Related Skills
 
-- `skills-registry-commands:advise` - Search for prior learnings before starting
+- `mnemosyne:advise` - Search for prior learnings before starting
 - Test-first development for configuration changes
 - Parallel agent usage for faster exploration

--- a/skills/fix-skill-validation-warnings.md
+++ b/skills/fix-skill-validation-warnings.md
@@ -216,5 +216,5 @@ python3 scripts/validate_plugins.py plugins/
 
 - PR #108: https://github.com/HomericIntelligence/ProjectMnemosyne/pull/108
 - CI validation script: `scripts/validate_plugins.py`
-- Related skill: `skills-registry-commands:validation-workflow`
-- Related skill: `skills-registry-commands:documentation-patterns`
+- Related skill: `mnemosyne:validation-workflow`
+- Related skill: `mnemosyne:documentation-patterns`

--- a/skills/fix-skill-validation-warnings.notes.md
+++ b/skills/fix-skill-validation-warnings.notes.md
@@ -108,7 +108,7 @@ if re.search(r'^## Failed Attempts.*?$', content, re.MULTILINE):
 
 ## Documentation Updates
 
-Also updated `/retrospective` skill documentation to:
+Also updated `/learn` skill documentation to:
 - Add explicit ✅ CORRECT and ❌ INCORRECT format examples for Failed Attempts
 - Clarify that pipe (`|`) characters are REQUIRED by CI
 - Show best practice: summary table + detailed subsections

--- a/skills/git-worktree-cleanup.notes.md
+++ b/skills/git-worktree-cleanup.notes.md
@@ -41,7 +41,7 @@ BLOCKED by Safety Net
 Reason: git worktree remove --force can delete uncommitted changes. Remove --force flag.
 ```
 
-The untracked files were `ProjectMnemosyne/` directories — transient clones from prior `/retrospective`
+The untracked files were `ProjectMnemosyne/` directories — transient clones from prior `/learn`
 operations. Not project files, but Safety Net couldn't know that.
 
 **Workaround for next time**: Use `rm -rf .worktrees/issue-NNNN/ProjectMnemosyne` first, then

--- a/skills/github-actions-pytest-pixi.notes.md
+++ b/skills/github-actions-pytest-pixi.notes.md
@@ -296,7 +296,7 @@ All unit tests passing before CI setup.
 ### Investigation
 ```bash
 # Search skills registry
-/skills-registry-commands:advise Make sure all tests are added to CI/CD correctly
+/mnemosyne:advise Make sure all tests are added to CI/CD correctly
 
 # Check existing config
 grep -r "pytest" pyproject.toml pixi.toml

--- a/skills/orphan-branch-recovery.notes.md
+++ b/skills/orphan-branch-recovery.notes.md
@@ -78,14 +78,14 @@ git push origin --delete skill/debugging/fixme-todo-cleanup-v2
 
 ## Root Cause
 
-Someone ran `/retrospective` from within ProjectOdyssey's working directory but pushed to ProjectMnemosyne-marketplace's remote. This created a branch with ProjectOdyssey's entire history instead of branching from ProjectMnemosyne-marketplace's main.
+Someone ran `/learn` from within ProjectOdyssey's working directory but pushed to ProjectMnemosyne-marketplace's remote. This created a branch with ProjectOdyssey's entire history instead of branching from ProjectMnemosyne-marketplace's main.
 
 ## Prevention
 
 1. Always verify you're in the correct repository before pushing
 2. Check `git remote -v` matches expected repository
 3. Use separate directories for different projects
-4. The `/retrospective` command now clones the target repo to a build directory to avoid this issue
+4. The `/learn` command now clones the target repo to a build directory to avoid this issue
 
 ## Key Commands Reference
 

--- a/skills/persist-automation-logs.md
+++ b/skills/persist-automation-logs.md
@@ -163,7 +163,7 @@ def _run_retrospective(self, session_id: str, worktree_path: Path, issue_number:
     try:
         result = run([
             "claude", "--resume", session_id,
-            "/skills-registry-commands:retrospective commit the results and create a PR",
+            "/mnemosyne:learn commit the results and create a PR",
             "--print", "--permission-mode", "dontAsk",
             "--allowedTools", "Read,Write,Edit,Glob,Grep,Bash",
         ], cwd=self.repo_root, timeout=600)

--- a/skills/plan-review-interview.md
+++ b/skills/plan-review-interview.md
@@ -156,4 +156,4 @@ sections:
 ## References
 
 - See `/advise` for searching existing knowledge
-- See `/retrospective` for capturing session learnings
+- See `/learn` for capturing session learnings

--- a/skills/publication-pipeline-enhancement.notes.md
+++ b/skills/publication-pipeline-enhancement.notes.md
@@ -281,7 +281,7 @@ statsmodels = ">=0.14"  # For OLS regression and model diagnostics
 User requested three prompts during session:
 1. Continuation prompts: "wp3", "lets cleanup", "continue working"
 2. Final analysis prompt request: "give me a prompt to do a final analysis in another agent"
-3. Skills registry: `/retrospective` command
+3. Skills registry: `/learn` command
 
 No negative feedback or correction requests throughout session.
 

--- a/skills/retrospective-hook-integration.md
+++ b/skills/retrospective-hook-integration.md
@@ -8,7 +8,7 @@ version: 1.0.0
 ---
 # Retrospective Hook Integration
 
-Setup SessionEnd hooks to automatically prompt for `/retrospective` when ending Claude Code sessions.
+Setup SessionEnd hooks to automatically prompt for `/learn` when ending Claude Code sessions.
 
 ## Overview
 
@@ -22,7 +22,7 @@ Setup SessionEnd hooks to automatically prompt for `/retrospective` when ending 
 ## When to Use
 
 - Integrating ProjectMnemosyne skills marketplace with another repository
-- Setting up `/advise` and `/retrospective` commands in a new project
+- Setting up `/advise` and `/learn` commands in a new project
 - Configuring automatic session-end knowledge capture prompts
 - Implementing worktree-based workflow to avoid conflicts with other Claude instances
 

--- a/skills/retrospective-hook-integration.notes.md
+++ b/skills/retrospective-hook-integration.notes.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Session focused on analyzing the Hugging Face blog post about Claude Code skills training and setting up `/advise` and `/retrospective` commands in ProjectOdyssey by integrating with the ProjectMnemosyne marketplace.
+Session focused on analyzing the Hugging Face blog post about Claude Code skills training and setting up `/advise` and `/learn` commands in ProjectOdyssey by integrating with the ProjectMnemosyne marketplace.
 
 ## Initial Discovery
 
@@ -18,7 +18,7 @@ Session focused on analyzing the Hugging Face blog post about Claude Code skills
    - Returns: what worked, what failed, recommended parameters
    - Triggered before starting new work
 
-2. **`/retrospective`**: Auto-save session learnings as a new skill
+2. **`/learn`**: Auto-save session learnings as a new skill
    - Analyzes entire conversation
    - Extracts successes, failures, parameters
    - Creates PR automatically
@@ -42,7 +42,7 @@ The "Failed Attempts" section is the most valuable - prevents repeated mistakes.
 ### 1. Explored ProjectMnemosyne Repository
 
 - Repository already had 5 skills (grpo-external-vllm, mojo-simd-errors, github-actions-mojo, layerwise-gradient-check, skill-marketplace-design)
-- `/advise` and `/retrospective` skills already implemented in `.claude/skills/`
+- `/advise` and `/learn` skills already implemented in `.claude/skills/`
 - CI/CD automation for marketplace.json generation
 - SessionEnd hook infrastructure already present
 
@@ -72,7 +72,7 @@ The "Failed Attempts" section is the most valuable - prevents repeated mistakes.
 ### User Question Clarifications
 
 1. **Repository existence**: Clarified repo was private at ~/ProjectMnemosyne-marketplace
-2. **Command naming**: Confirmed `/retrospective` (not `/introspective`)
+2. **Command naming**: Confirmed `/learn` (not `/introspective`)
 3. **Setup method**: Chose marketplace registration over copying skills
 4. **README enhancements**: Installation focus, no troubleshooting section
 

--- a/skills/retrospective-integration.md
+++ b/skills/retrospective-integration.md
@@ -13,7 +13,7 @@ user-invocable: false
 |-----------|-------|
 | **Date** | 2026-02-13 |
 | **Category** | Automation |
-| **Objective** | Integrate `/retrospective` skill into `implement_issues.py` to automatically capture learnings |
+| **Objective** | Integrate `/learn` skill into `implement_issues.py` to automatically capture learnings |
 | **Outcome** | ✅ Success - Full implementation with comprehensive test coverage |
 | **PR** | https://github.com/HomericIntelligence/ProjectScylla/pull/609 |
 
@@ -43,13 +43,13 @@ except (json.JSONDecodeError, AttributeError):
 
 ### 2. Resume Session to Run Retrospective with Proper Permissions
 
-**Critical**: When resuming a session to run `/retrospective`, you MUST provide tool permissions for git and gh commands:
+**Critical**: When resuming a session to run `/learn`, you MUST provide tool permissions for git and gh commands:
 
 ```python
 run([
     "claude",
     "--resume", session_id,
-    "/skills-registry-commands:retrospective commit the results and create a PR",
+    "/mnemosyne:learn commit the results and create a PR",
     "--print",
     "--tools", "Bash",
     "--allowedTools", "Bash(git:*)",
@@ -58,7 +58,7 @@ run([
 ```
 
 **Key Points**:
-- Use `/skills-registry-commands:retrospective` as the command (not `--message`)
+- Use `/mnemosyne:learn` as the command (not `--message`)
 - Add explicit instructions: "commit the results and create a PR"
 - `--print` mode for non-interactive execution
 - `--tools "Bash"` enables Bash tool
@@ -71,7 +71,7 @@ run([
 # ❌ Missing tool permissions
 run([
     "claude", "--resume", session_id, "--message",
-    "Use the /skills-registry-commands:retrospective skill..."
+    "Use the /mnemosyne:learn skill..."
 ], ...)
 ```
 

--- a/skills/skill-audit-and-merge.notes.md
+++ b/skills/skill-audit-and-merge.notes.md
@@ -56,7 +56,7 @@ Added tags to these plugin.json files:
 - claude-plugin-format: plugin, validation, schema, claude-code, format
 - claude-plugin-marketplace: marketplace, registry, plugin, claude-code, installation
 - verify-issue-before-work: github, issues, workflow, verification, duplicate-prevention
-- skills-registry-commands: skills, advise, retrospective, knowledge-capture, team-learning
+- mnemosyne: skills, advise, retrospective, knowledge-capture, team-learning
 - grpo-external-vllm: ml, training, llm, vllm, grpo, reinforcement-learning
 - spec-driven-experimentation: ml, training, methodology, experiments, ablation, hyperparameters
 

--- a/skills/spec-driven-experimentation.md
+++ b/skills/spec-driven-experimentation.md
@@ -99,7 +99,7 @@ experiments = [
 
 ### 4. Capture Results Back to Skills Registry
 
-After experiments, `/retrospective` saves findings with TECHSPEC reference:
+After experiments, `/learn` saves findings with TECHSPEC reference:
 
 ```markdown
 ## Results vs TECHSPEC Predictions

--- a/skills/tooling-plugin-marketplace-hourly-cron.md
+++ b/skills/tooling-plugin-marketplace-hourly-cron.md
@@ -45,10 +45,10 @@ tags:
 claude plugin marketplace update ProjectMnemosyne
 
 # 2. Update the installed plugin to pick up new versions
-claude plugin update skills-registry-commands@ProjectMnemosyne
+claude plugin update mnemosyne@ProjectMnemosyne
 
 # Install as hourly cron (runs at minute 0 of every hour):
-(crontab -l 2>/dev/null; echo "0 * * * * /home/<user>/.local/bin/claude plugin marketplace update ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1 && /home/<user>/.local/bin/claude plugin update skills-registry-commands@ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "0 * * * * /home/<user>/.local/bin/claude plugin marketplace update ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1 && /home/<user>/.local/bin/claude plugin update mnemosyne@ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1") | crontab -
 ```
 
 ### Detailed Steps
@@ -66,7 +66,7 @@ claude plugin update skills-registry-commands@ProjectMnemosyne
 5. **Install the cron job**:
    ```bash
    (crontab -l 2>/dev/null; echo "# Update ProjectMnemosyne plugin marketplace hourly
-   0 * * * * /home/<user>/.local/bin/claude plugin marketplace update ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1 && /home/<user>/.local/bin/claude plugin update skills-registry-commands@ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1") | crontab -
+   0 * * * * /home/<user>/.local/bin/claude plugin marketplace update ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1 && /home/<user>/.local/bin/claude plugin update mnemosyne@ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1") | crontab -
    ```
 
 6. **Verify installation**: `crontab -l`
@@ -104,12 +104,12 @@ claude plugin update skills-registry-commands@ProjectMnemosyne
 # Schedule: every hour at minute 0
 # Log file: /tmp/claude-plugin-update.log
 # Binary: absolute path to claude CLI
-0 * * * * /home/<user>/.local/bin/claude plugin marketplace update ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1 && /home/<user>/.local/bin/claude plugin update skills-registry-commands@ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1
+0 * * * * /home/<user>/.local/bin/claude plugin marketplace update ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1 && /home/<user>/.local/bin/claude plugin update mnemosyne@ProjectMnemosyne >> /tmp/claude-plugin-update.log 2>&1
 ```
 
 ### Adapting for Other Marketplaces
 
-Replace `ProjectMnemosyne` and `skills-registry-commands@ProjectMnemosyne` with your marketplace and plugin names:
+Replace `ProjectMnemosyne` and `mnemosyne@ProjectMnemosyne` with your marketplace and plugin names:
 
 ```bash
 # List your marketplaces

--- a/skills/tooling-pr-auto-merge-worktree-command-migration.md
+++ b/skills/tooling-pr-auto-merge-worktree-command-migration.md
@@ -109,8 +109,8 @@ success_rate: 100%
 ### Files Modified for Worktree Migration
 
 ```
-plugins/tooling/skills-registry-commands/commands/retrospective.md  # Primary: new worktree setup + cleanup
-plugins/tooling/skills-registry-commands/commands/advise.md          # Minor: remove "Never delete" note
+plugins/tooling/mnemosyne/commands/retrospective.md  # Primary: new worktree setup + cleanup
+plugins/tooling/mnemosyne/commands/advise.md          # Minor: remove "Never delete" note
 CLAUDE.md                                                            # Update workflow description
 ADVISE_RETROSPECTIVE_UPDATED.md                                      # Update workflow comparison
 ```

--- a/skills/tooling-skill-deduplication-semver-versioning.md
+++ b/skills/tooling-skill-deduplication-semver-versioning.md
@@ -25,7 +25,7 @@ tags: [deduplication, merge, semver, versioning, skills-registry, consolidation]
 - Multiple skills share a common prefix (e.g., `adr009-*`, `pr-review-*`, `mojo-test-*`)
 - `/advise` returns redundant or contradictory advice for the same topic
 - Need to identify duplicate clusters in a large skills registry (1000+ skills)
-- Updating `/retrospective` versioning rules to use semantic versioning
+- Updating `/learn` versioning rules to use semantic versioning
 
 ## Verified Workflow
 


### PR DESCRIPTION
## Summary

Updates 35 files across docs and skills to reference the renamed mnemosyne plugin:

- `skills-registry-commands` → `mnemosyne` (everywhere)
- `/skills-registry-commands:` → `/mnemosyne:` (command invocations)
- `/retrospective` → `/learn` (command references)
- `skills-registry-commands@ProjectMnemosyne` → `mnemosyne@ProjectMnemosyne`

Follows PR #1046 (plugin directory rename) and PR #1052 (command rename).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>