### PR TITLE
feat: amend security-pep508-parser-replaces-regex skill (v2.0.0)

### DIFF
--- a/skills/security-pep508-parser-replaces-regex.history
+++ b/skills/security-pep508-parser-replaces-regex.history
@@ -1,0 +1,113 @@
+# security-pep508-parser-replaces-regex — History
+
+## v2.0.0 (2026-03-25)
+
+**Changed by:** PR #126 for issue #62 — regex tightening as interim fix
+**Verification:** verified-local
+
+### What changed
+- Updated Failed Attempts table to note that the regex-tightening approach was actually shipped as PR #126 (issue #62), not just "considered"
+- Added issue #62 and PR #126 to Overview table as the interim regex fix
+- Added Verified On entry for the regex-tightening session
+- Clarified that two PRs address the same underlying problem: #126 (regex tightening) and #69 (PEP 508 parser replacement)
+
+### Why
+Issue #62 was a refinement of issue #31, specifically targeting the regex problems (`\s` allowing newlines, `!` allowing shell history expansion). The regex was tightened using `re.fullmatch` with literal space and `!` removed. This is a valid interim hardening even though the PEP 508 parser approach (issue #31, PR #69) is the more complete solution.
+
+### Previous version (v1.0.0) snapshot
+---
+name: security-pep508-parser-replaces-regex
+description: "Replace custom regex validation of pip requirement strings with packaging.requirements.Requirement (PEP 508 parser). Use when: (1) validating pip/PyPI package names in install_package or similar functions, (2) custom regex allows unintended characters like whitespace or shell metacharacters in package names."
+category: architecture
+date: 2026-03-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - security
+  - input-validation
+  - pip
+  - packaging
+  - pep508
+---
+
+# Replace Regex Package Validation with PEP 508 Parser
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-25 |
+| **Objective** | Eliminate shell-metachar injection risk in `install_package()` by replacing a permissive custom regex with the canonical PEP 508 parser |
+| **Outcome** | Successful — all valid pip requirement syntax accepted, all dangerous inputs rejected |
+| **Verification** | verified-local |
+| **Issue** | HomericIntelligence/ProjectHephaestus#31 |
+| **PR** | HomericIntelligence/ProjectHephaestus#69 |
+
+## When to Use
+
+- A function validates pip/PyPI package names using a custom regex
+- The regex allows unintended characters (whitespace, `!`, `<`, `>`, `;`, `|`, `&`) in package names
+- You need to support the full PEP 508 requirement grammar (extras, version specifiers) without rolling your own parser
+- Security review flags a package name validation regex as overly permissive
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+from packaging.requirements import InvalidRequirement, Requirement
+
+def validate_requirement(package_name: str) -> None:
+    """Validate a single PEP 508 requirement string."""
+    if not package_name or not package_name.strip():
+        raise ValueError(f"Invalid package requirement: {package_name!r}")
+
+    try:
+        req = Requirement(package_name)
+    except InvalidRequirement as e:
+        raise ValueError(f"Invalid package requirement: {package_name!r}") from e
+
+    # Reject URL-based requirements for security
+    if req.url is not None:
+        raise ValueError(f"URL-based requirements are not supported: {package_name!r}")
+```
+
+### Detailed Steps
+
+1. **Add `packaging` as a dependency** in `pyproject.toml`
+2. **Replace the regex block** with `Requirement()` parse + URL check
+3. **Add empty/whitespace guard** before the parser call
+4. **Write parametrized tests** covering valid, invalid, and URL-based inputs
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Original regex | `r"^[A-Za-z0-9_\-\.\[\],>=<!\s]+$"` | Allowed whitespace, standalone `!`, `<`, `>` — more permissive than intended | Custom regex for complex grammars (PEP 508) is inherently incomplete; use the canonical parser |
+| Tightening the regex | Considered removing `\s` and `!` from the character class | Would still miss edge cases in PEP 508 (markers, extras with dots, etc.) | When a well-maintained parser exists for the grammar, always prefer it over regex |
+
+## Results & Parameters
+
+**Dependency**: `packaging>=21.0`
+
+**Key behaviors verified**:
+```
+"requests"                          → accepted (simple name)
+"pkg[extra1,extra2]"                → accepted (extras syntax)
+"pkg>=1.0,<2"                       → accepted (version specifiers)
+"pkg!=1.3"                          → accepted (exclusion specifier)
+"pkg1 pkg2"                         → rejected (whitespace/multi-package)
+"pkg; rm -rf /"                     → rejected (shell injection)
+"pkg && echo pwned"                 → rejected (shell metacharacters)
+"pkg @ https://evil.com/mal.tar.gz" → rejected (URL-based requirement)
+""                                  → rejected (empty string)
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #31 — install_package shell-metachar injection | 54 unit tests pass, ruff/mypy clean, helpers.py at 94.83% coverage |
+
+---

--- a/skills/security-pep508-parser-replaces-regex.md
+++ b/skills/security-pep508-parser-replaces-regex.md
@@ -3,9 +3,10 @@ name: security-pep508-parser-replaces-regex
 description: "Replace custom regex validation of pip requirement strings with packaging.requirements.Requirement (PEP 508 parser). Use when: (1) validating pip/PyPI package names in install_package or similar functions, (2) custom regex allows unintended characters like whitespace or shell metacharacters in package names."
 category: architecture
 date: 2026-03-25
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
 verification: verified-local
+history: security-pep508-parser-replaces-regex.history
 tags:
   - security
   - input-validation
@@ -24,8 +25,11 @@ tags:
 | **Objective** | Eliminate shell-metachar injection risk in `install_package()` by replacing a permissive custom regex with the canonical PEP 508 parser |
 | **Outcome** | Successful — all valid pip requirement syntax accepted, all dangerous inputs rejected |
 | **Verification** | verified-local |
-| **Issue** | HomericIntelligence/ProjectHephaestus#31 |
-| **PR** | HomericIntelligence/ProjectHephaestus#69 |
+| **Issue (broad)** | HomericIntelligence/ProjectHephaestus#31 |
+| **Issue (regex-specific)** | HomericIntelligence/ProjectHephaestus#62 |
+| **PR (PEP 508 parser)** | HomericIntelligence/ProjectHephaestus#69 |
+| **PR (regex tightening)** | HomericIntelligence/ProjectHephaestus#126 |
+| **History** | [changelog](./security-pep508-parser-replaces-regex.history) |
 
 ## When to Use
 
@@ -33,10 +37,13 @@ tags:
 - The regex allows unintended characters (whitespace, `!`, `<`, `>`, `;`, `|`, `&`) in package names
 - You need to support the full PEP 508 requirement grammar (extras, version specifiers) without rolling your own parser
 - Security review flags a package name validation regex as overly permissive
+- As an interim fix: tighten the regex by replacing `\s` with literal space and removing `!`
 
 ## Verified Workflow
 
 ### Quick Reference
+
+**Preferred approach (PEP 508 parser):**
 
 ```python
 from packaging.requirements import InvalidRequirement, Requirement
@@ -54,6 +61,16 @@ def validate_requirement(package_name: str) -> None:
     # Reject URL-based requirements for security
     if req.url is not None:
         raise ValueError(f"URL-based requirements are not supported: {package_name!r}")
+```
+
+**Interim approach (tightened regex):**
+
+```python
+import re
+
+# Use re.fullmatch (not re.match) with literal space (not \s) and no !
+if not re.fullmatch(r"[A-Za-z0-9_\-.\[\],>=< ]+", package_name):
+    raise ValueError(f"Invalid package name: {package_name!r}")
 ```
 
 ### Detailed Steps
@@ -82,30 +99,41 @@ def validate_requirement(package_name: str) -> None:
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Original regex | `r"^[A-Za-z0-9_\-\.\[\],>=<!\s]+$"` | Allowed whitespace, standalone `!`, `<`, `>` — more permissive than intended | Custom regex for complex grammars (PEP 508) is inherently incomplete; use the canonical parser |
-| Tightening the regex | Considered removing `\s` and `!` from the character class | Would still miss edge cases in PEP 508 (markers, extras with dots, etc.) | When a well-maintained parser exists for the grammar, always prefer it over regex |
+| Original regex | `r"^[A-Za-z0-9_\-\.\[\],>=<!\s]+$"` with `re.match` | Allowed newlines (via `\s`), `!` (shell history expansion), and other unintended whitespace | Custom regex for complex grammars (PEP 508) is inherently incomplete; use the canonical parser |
+| Tightened regex (PR #126) | `re.fullmatch(r"[A-Za-z0-9_\-.\[\],>=< ]+", ...)` — removed `\s` and `!`, used `fullmatch` | Blocks newlines/tabs/`!` but still can't handle full PEP 508 grammar (markers, extras with dots, etc.) | Useful as interim hardening but not a complete solution; a proper parser is still needed |
 
 ## Results & Parameters
 
 **Dependency**: `packaging>=21.0` (available since Python packaging ecosystem standardization)
 
-**Key behaviors verified**:
+**Key behaviors verified (PEP 508 parser approach)**:
 ```
-"requests"                          → accepted (simple name)
-"pkg[extra1,extra2]"                → accepted (extras syntax)
-"pkg>=1.0,<2"                       → accepted (version specifiers)
-"pkg!=1.3"                          → accepted (exclusion specifier)
-"pkg1 pkg2"                         → rejected (whitespace/multi-package)
-"pkg; rm -rf /"                     → rejected (shell injection)
-"pkg && echo pwned"                 → rejected (shell metacharacters)
-"pkg @ https://evil.com/mal.tar.gz" → rejected (URL-based requirement)
-""                                  → rejected (empty string)
+"requests"                          -> accepted (simple name)
+"pkg[extra1,extra2]"                -> accepted (extras syntax)
+"pkg>=1.0,<2"                       -> accepted (version specifiers)
+"pkg!=1.3"                          -> accepted (exclusion specifier)
+"pkg1 pkg2"                         -> rejected (whitespace/multi-package)
+"pkg; rm -rf /"                     -> rejected (shell injection)
+"pkg && echo pwned"                 -> rejected (shell metacharacters)
+"pkg @ https://evil.com/mal.tar.gz" -> rejected (URL-based requirement)
+""                                  -> rejected (empty string)
 ```
 
-**Error message pattern**: `ValueError: Invalid package requirement: <name!r>` (or `URL-based requirements are not supported` for URL inputs)
+**Key behaviors verified (tightened regex approach, PR #126)**:
+```
+"some-package"                      -> accepted (simple name)
+"torch>=2.0,<3"                     -> accepted (version constraints)
+"pkg[extra]"                        -> accepted (extras)
+"pkg\nmalicious"                    -> rejected (newline blocked)
+"pkg!exploit"                       -> rejected (! blocked)
+"pkg\texploit"                      -> rejected (tab blocked)
+```
+
+**Error message pattern**: `ValueError: Invalid package name: <name!r>` (regex) or `ValueError: Invalid package requirement: <name!r>` (PEP 508)
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | Issue #31 — install_package shell-metachar injection | 54 unit tests pass, ruff/mypy clean, helpers.py at 94.83% coverage |
+| ProjectHephaestus | Issue #31 — PEP 508 parser replacement | 54 unit tests pass, ruff/mypy clean, helpers.py at 94.83% coverage |
+| ProjectHephaestus | Issue #62 — regex tightening (interim fix) | 41 unit tests pass, `re.fullmatch` with literal space, `!` removed |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.0.0 to v2.0.0.

Documents the regex-tightening approach (PR #126, issue #62) as an interim fix alongside the PEP 508 parser replacement (PR #69, issue #31).

- Added issue #62 and PR #126 references for the interim regex fix
- Updated Failed Attempts to note regex tightening was actually shipped
- Added tightened regex quick reference and verified behaviors

## Verification Level

**verified-local**

Tests pass locally in ProjectHephaestus (41 unit tests for regex tightening, 54 for PEP 508 parser). CI validation pending.

## Key Findings

**What Worked**:
- `re.fullmatch` with literal space (not `\s`) and `!` removed blocks newlines, tabs, and shell history expansion
- PEP 508 parser remains the preferred long-term approach

**What Failed**:
- Original regex with `\s` and `!` was overly permissive -> tightened as interim fix

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1056/1056 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>