### PR TITLE
feat: amend desplit skill (v2.0.0), add hyphenated-dir-rename skill

### DIFF
--- a/skills/mojo-hyphenated-dir-rename-for-imports.md
+++ b/skills/mojo-hyphenated-dir-rename-for-imports.md
@@ -1,0 +1,126 @@
+---
+name: mojo-hyphenated-dir-rename-for-imports
+description: 'Rename hyphenated directories to underscores so Mojo can import from
+  them. Use when: (1) Mojo import fails from a hyphenated directory, (2) test files
+  cannot import from examples/ with hyphens, (3) renaming directories with many
+  cross-codebase references.'
+category: tooling
+date: 2026-03-27
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - mojo
+  - imports
+  - directory-rename
+  - hyphenated
+  - examples
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-27 |
+| **Objective** | Rename hyphenated example directories to underscores so Mojo can import from them |
+| **Outcome** | 9 directories renamed, 50+ files updated, all CI passes. Filed upstream: modular/modular#6275 |
+| **Verification** | verified-ci (PR #5130 merged, Comprehensive Tests pass) |
+
+## When to Use
+
+- Mojo cannot import from a directory with hyphens (e.g., `from examples.resnet18-cifar10.model import ...`)
+- Integration tests fail with "cannot dynamically import with hyphens"
+- Renaming directories that are referenced in many places (CI, docs, scripts, source code)
+- Python mypy also struggles with hyphenated directory names (related: `mypy-hyphenated-dir-per-file` skill)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Rename directories
+git mv examples/old-name examples/old_name
+
+# 2. Fix symlinks (targets are now wrong)
+rm examples/renamed_dir/symlink.py
+ln -s ../new_target_dir/symlink.py examples/renamed_dir/symlink.py
+
+# 3. Delete broken symlinks
+find examples/ -type l ! -exec test -e {} \; -print -delete
+
+# 4. Find ALL remaining references (CRITICAL — there are always more than you think)
+grep -rn 'old-name' --include='*.mojo' --include='*.py' --include='*.md' \
+  --include='*.yml' --include='*.yaml' --include='*.toml' --include='*.ini' \
+  --include='*.sh' --include='*.ipynb' . | grep -v '.git/'
+
+# 5. Update references (use Edit with replace_all per file)
+# 6. Run pre-commit: just pre-commit-all
+# 7. Push to CI for validation
+```
+
+### Detailed Steps
+
+1. **File upstream issue first** — the import limitation is a Mojo compiler bug: `gh issue create --repo modular/modular --title "Mojo cannot import from directories containing hyphens"`
+
+2. **Rename with `git mv`** — preserves git history tracking
+
+3. **Fix symlinks** — `git mv` renames the symlink file but NOT the target path inside it. Must delete and recreate with updated targets.
+
+4. **Distinguish context-sensitive renames**:
+   - `alexnet-cifar10` → `alexnet_cifar10` (ALWAYS rename — unique to examples/)
+   - `getting-started` → `getting_started` (ONLY when `examples/getting-started`, NOT `docs/getting-started/`)
+   - `mojo-patterns` → `mojo_patterns` (ONLY when `examples/mojo-patterns`, NOT `docs/core/mojo-patterns.md`)
+
+5. **Use sub-agents for bulk updates** — 50+ files is too many for one context. Split into "inside examples/" and "outside examples/" agents.
+
+6. **Verify with grep** — after all edits, confirm zero remaining hyphenated references in example directory context
+
+7. **Run pre-commit** — `nbstripout` hook may modify notebooks (expected, run twice)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Blind replace_all for `getting-started` | Would have changed `docs/getting-started/` references too | `docs/getting-started/` is a separate documentation directory NOT being renamed | Always check if a hyphenated name appears in multiple contexts before global replace |
+| Running full test suite locally after rename | `just test-mojo` to validate | Crashes the machine | Push to CI for full validation, use `just test-group` for targeted checks |
+
+## Results & Parameters
+
+### Scale
+
+```yaml
+directories_renamed: 9
+files_with_references_updated: 50+
+symlinks_fixed: 2  # googlenet, mobilenet download scripts
+broken_symlinks_deleted: 1  # densenet121_cifar10
+upstream_issue: modular/modular#6275
+```
+
+### Directories Renamed
+
+```text
+examples/alexnet-cifar10     → examples/alexnet_cifar10
+examples/custom-layers       → examples/custom_layers
+examples/getting-started     → examples/getting_started
+examples/googlenet-cifar10   → examples/googlenet_cifar10
+examples/lenet-emnist        → examples/lenet_emnist
+examples/mobilenetv1-cifar10 → examples/mobilenetv1_cifar10
+examples/mojo-patterns       → examples/mojo_patterns
+examples/resnet18-cifar10    → examples/resnet18_cifar10
+examples/vgg16-cifar10       → examples/vgg16_cifar10
+```
+
+### NOT Renamed (Important!)
+
+```text
+docs/getting-started/           — mkdocs documentation dir, NOT an examples dir
+docs/core/mojo-patterns.md      — standard markdown filename
+docs/advanced/custom-layers.md  — standard markdown filename
+skill/tool names with hyphens   — unrelated to directory imports
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectOdyssey | PR #5130, CI pass, modular/modular#6275 filed | Renamed 9 dirs, updated 50+ files |

--- a/skills/testing-desplit-adr009-merge-workflow.history
+++ b/skills/testing-desplit-adr009-merge-workflow.history
@@ -1,0 +1,55 @@
+# testing-desplit-adr009-merge-workflow — History
+
+## v2.0.0 (2026-03-27)
+
+**Changed by:** PR #5130 — fixing CI failures from the de-split merge
+**Verification:** verified-ci
+
+### What changed
+- Added critical Failed Attempt: merge script `<top-level>` dedup bug drops struct definitions
+- Added critical Failed Attempt: unclosed docstring from merge script
+- Added critical Failed Attempt: stale `_part` imports in `run_all_tests.mojo`
+- Added critical Failed Attempt: `DEFAULT_SEED` comptime constant dropped by same bug
+- Updated Verified Workflow with post-merge audit steps
+- Updated Results with list of files damaged by dedup bug
+- Updated verification from `verified-local` to `verified-ci`
+- Noted merge script was deleted (served its purpose, had ruff violations)
+
+### Why
+v1.0.0 documented the merge workflow but missed a critical bug in the merge script:
+`_deduplicate_functions()` assigned ALL struct/alias/var definitions the name `"<top-level>"`,
+causing only the first struct per file to survive deduplication. This silently dropped 4 struct
+definitions across 3 files, causing CI compile failures. Additionally, `run_all_tests.mojo`
+still imported from `_partN` module names, and `test_tensor_fuzz.mojo` lost its `DEFAULT_SEED`
+constant. The merge script also had ruff lint/format violations that failed CI.
+
+### Previous version (v1.0.0) snapshot
+
+```yaml
+---
+name: testing-desplit-adr009-merge-workflow
+description: 'Reverse ADR-009 test file splitting by merging _partN.mojo files back
+  into single test files. Use when: (1) ADR-009 workaround is no longer needed, (2)
+  test file bloat from splitting needs cleanup, (3) merging split Mojo test files
+  with deduplication.'
+category: testing
+date: 2026-03-25
+version: 1.0.0
+user-invocable: false
+verification: verified-local
+tags:
+  - adr-009
+  - test-splitting
+  - merge
+  - mojo
+  - refactor
+  - myrmidon-swarm
+---
+[Full v1.0.0 content preserved in git history at commit that created this file]
+```
+
+---
+
+## v1.0.0 (2026-03-25)
+
+**Initial version.**

--- a/skills/testing-desplit-adr009-merge-workflow.md
+++ b/skills/testing-desplit-adr009-merge-workflow.md
@@ -3,12 +3,13 @@ name: testing-desplit-adr009-merge-workflow
 description: 'Reverse ADR-009 test file splitting by merging _partN.mojo files back
   into single test files. Use when: (1) ADR-009 workaround is no longer needed, (2)
   test file bloat from splitting needs cleanup, (3) merging split Mojo test files
-  with deduplication.'
+  with deduplication. CRITICAL: merge script has a dedup bug that drops struct definitions.'
 category: testing
-date: 2026-03-25
-version: 1.0.0
+date: 2026-03-27
+version: "2.0.0"
 user-invocable: false
-verification: verified-local
+verification: verified-ci
+history: testing-desplit-adr009-merge-workflow.history
 tags:
   - adr-009
   - test-splitting
@@ -16,16 +17,18 @@ tags:
   - mojo
   - refactor
   - myrmidon-swarm
+  - dedup-bug
 ---
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-25 |
+| **Date** | 2026-03-27 |
 | **Objective** | Reverse ADR-009 test file splitting — merge 391 `_partN.mojo` files back into 132 unified test files |
-| **Outcome** | All 132 groups merged, all tests pass locally, net -20,170 lines, -259 files. PR #5122. |
-| **Verification** | verified-local (full `just test-mojo` passes, CI pending) |
+| **Outcome** | All 132 groups merged. Merge script had a critical dedup bug dropping struct definitions — 4 structs lost across 3 files, plus stale imports and missing constants. All fixed in PR #5130. |
+| **Verification** | verified-ci (Comprehensive Tests pass, PR merged to main) |
+| **History** | [changelog](./testing-desplit-adr009-merge-workflow.history) |
 
 ## When to Use
 
@@ -33,74 +36,74 @@ tags:
 - Test file bloat from `_partN.mojo` splitting needs cleanup
 - Merging any set of Mojo test files that were mechanically split
 - Automated merge of test files with shared imports and independent test functions
+- **Post-merge audit**: checking for dropped struct definitions, stale imports, missing constants
 
 ## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# Dry-run to see what would be merged
-python3 scripts/merge_split_tests.py --dry-run
+# After merge, ALWAYS audit for dropped structs (the merge script has a dedup bug)
+# 1. Find files with undefined struct references
+for f in $(find tests/ -name "*.mojo"); do
+  grep -oP '(?<=var \w+ = )[A-Z]\w+(?=\()' "$f" 2>/dev/null | sort -u | while read s; do
+    if ! grep -q "^struct $s" "$f" 2>/dev/null; then
+      echo "MISSING: $f uses $s but doesn't define it"
+    fi
+  done
+done
 
-# Merge a single directory
-python3 scripts/merge_split_tests.py --directory tests/shared/core/
+# 2. Check for stale _part imports
+grep -rn "from.*_part[0-9]" tests/ --include="*.mojo"
 
-# Merge everything
-python3 scripts/merge_split_tests.py
+# 3. Check for missing comptime constants
+# Compare original part files against merged files for comptime definitions
 
-# Delete the old part files after verifying
-find tests/ -name "test_*_part*.mojo" -exec git rm {} +
-
-# Update CI workflow
-# (manual — replace _part* patterns with single filenames)
-
-# Verify
-just build && just test-mojo
+# 4. Delete the merge script after verification (it has ruff violations)
+git rm scripts/merge_split_tests.py
 ```
 
 ### Detailed Steps
 
-1. **Build the merge script** (`scripts/merge_split_tests.py`):
-   - Discovers all `test_*_partN.mojo` files recursively
-   - Groups by base name (strips `_partN` suffix)
-   - Parses each file: imports, test functions, helper functions, main()
-   - Deduplicates imports (union across all parts)
-   - Concatenates test functions in part order
-   - Creates unified `fn main()` calling all test functions
-   - Handles dual-version cases (base file + parts both exist)
+1. **Run the merge script** (same as v1.0.0)
 
-2. **Run with `--dry-run` first** to verify grouping and counts
+2. **CRITICAL: Post-merge audit** (NEW in v2.0.0):
 
-3. **Run the actual merge** — creates merged files, does NOT delete originals
+   The merge script (`scripts/merge_split_tests.py`) has a **dedup bug on line 234**: ALL struct/alias/var definitions get assigned the generic name `"<top-level>"`. The `_deduplicate_functions()` function then keeps only the FIRST one, silently dropping all subsequent structs.
 
-4. **Fix merge script edge cases** — the script may strip helper function signatures.
-   Check for "failed to parse" errors:
+   **Audit checklist:**
+
+   - [ ] Check every merged file that had 2+ struct definitions in any single part file
+   - [ ] Verify all `comptime` constants were preserved
+   - [ ] Verify `run_all_tests.mojo` and similar runner files have updated import paths
+   - [ ] Verify docstrings don't reference `_part` filenames
+   - [ ] Fix unclosed docstrings (merge script can mangle multi-line docstrings)
+
+3. **Restore dropped code from git history:**
+
    ```bash
-   just test-mojo 2>&1 | grep "failed to parse"
+   # Get the struct definition from the original part file
+   git show <merge-commit>^:tests/path/to/test_foo_part1.mojo | grep -A 30 "struct MissingStruct"
    ```
-   For each, compare against `git show main:<original_part_file>` and restore
-   missing function signatures/bodies.
 
-5. **Delete part files**: `find tests/ -name "test_*_part*.mojo" -exec git rm {} +`
+4. **Delete the merge script** — it served its purpose and has ruff lint/format violations that will fail CI.
 
-6. **Update CI workflow** (`.github/workflows/comprehensive-tests.yml`):
-   - Replace `test_foo_part*.mojo` with `test_foo.mojo`
-   - Replace explicit part lists with single filenames
-   - Remove ADR-009 comments
-   - Fix wildcard patterns that matched `_part*` but not the merged file
+5. **Update CI workflow and run pre-commit**
 
-7. **Fix test coverage hooks**: Update badge and validate coverage
-
-8. **Run full test suite**: `just build && just test-mojo`
+6. **Verify in CI** (not just locally — local test suite can crash the machine)
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Merge script v1: strip all non-test functions | Stripped helper function signatures and bodies along with run_all_tests/main | Helper functions (create_basic_block, concatenate_depthwise, struct definitions) look syntactically similar to boilerplate | Parse helper functions as content to preserve, not boilerplate to strip |
-| Spawning 5 parallel Haiku agents for directory merges | Planned as Wave 2 of Myrmidon swarm | Script runs in seconds — faster to run directly than spawn agents | Use agents for design/analysis, not for running scripts that already exist |
-| CI pattern `test_initializers_*.mojo` after merge | Wildcard matched old `_part*.mojo` files AND `_validation.mojo` | Changing to `test_initializers.mojo` lost coverage of `test_initializers_validation.mojo` | Use `test_initializers*.mojo` (no underscore before wildcard) to match both |
-| Running `--dry-run` expecting no side effects | Dry-run wrote to dual-version base files (modified them in-place) | Script's dual-version handling modified base files even in dry-run mode | True dry-run needs to skip file writes entirely, not just skip creating new files |
+| Merge script v1: strip all non-test functions | Stripped helper function signatures and bodies | Helper functions look syntactically similar to boilerplate | Parse helper functions as content to preserve |
+| Spawning 5 parallel Haiku agents for directory merges | Planned as Wave 2 of Myrmidon swarm | Script runs in seconds — faster to run directly | Use agents for design/analysis, not for running scripts |
+| CI pattern `test_initializers_*.mojo` | Wildcard matched old `_part*.mojo` AND `_validation.mojo` | Lost coverage of `test_initializers_validation.mojo` | Use `test_initializers*.mojo` (no underscore before wildcard) |
+| Running `--dry-run` expecting no side effects | Dry-run wrote to dual-version base files in-place | Script's dual-version handling modified base files | True dry-run needs to skip ALL file writes |
+| **Trusting merge script dedup for structs** | Script used `"<top-level>"` name for ALL struct/alias/var definitions | Only the FIRST struct survives — all subsequent dropped silently | **CRITICAL**: Extract ACTUAL names for struct definitions, never use a generic placeholder |
+| **Trusting merged files compile** | Assumed merge preserved all code blocks | Also dropped `comptime DEFAULT_SEED` and left unclosed docstrings | Always compile-check merged files, don't just count test functions |
+| **Trusting import paths auto-update** | `run_all_tests.mojo` still imported from `_part1` module names | Merge script only updates merged files, not files that import from them | Search entire codebase for `_part` imports after any file merge |
+| **Running full test suite locally** | `just test-mojo` to validate | Crashes the machine due to resource constraints | Use `just test-group` for targeted checks, push to CI for full validation |
 
 ## Results & Parameters
 
@@ -110,46 +113,33 @@ just build && just test-mojo
 split_files_merged: 391
 groups_created: 132
 directories_affected: 22
-dual_version_cases: 11  # base file + parts both existed
-missing_part1_anomalies: 2  # test_unsigned, test_tensor_factories
 test_functions_preserved: 2872
 net_files_reduced: 259
 net_lines_reduced: 20170
 ```
 
-### Merge Script Location
+### Files Damaged by Dedup Bug (4 structs across 3 files)
 
 ```text
-scripts/merge_split_tests.py (614 lines)
-
-Usage:
-  python3 scripts/merge_split_tests.py                          # All directories
-  python3 scripts/merge_split_tests.py --directory tests/shared/core/  # One directory
-  python3 scripts/merge_split_tests.py --dry-run                # Preview only
+tests/shared/data/transforms/test_pipeline.mojo     — missing StubPipeline (7 references)
+tests/shared/core/test_composed_op.mojo              — missing ScaleAdd (10+ references)
+tests/shared/core/test_elementwise_dispatch.mojo     — missing IncrementOp + AverageOp
 ```
 
-### Files That Needed Manual Fixes After Merge
+### Additional Merge Script Casualties
 
 ```text
-tests/models/test_googlenet_e2e.mojo      — concatenate_depthwise + GoogLeNetSmall struct
-tests/models/test_googlenet_layers.mojo   — concatenate_depthwise body
-tests/models/test_lenet5_e2e.mojo         — LeNet5.update_parameters method
-tests/models/test_resnet18_layers.mojo    — create_basic_block signature
-tests/training/test_training_infrastructure.mojo — mock_compute_loss signature
+tests/shared/fuzz/test_tensor_fuzz.mojo              — missing comptime DEFAULT_SEED: Int = 42
+tests/shared/core/test_elementwise_dispatch.mojo     — unclosed module docstring
+tests/shared/data/run_all_tests.mojo                 — stale _part1/_part2 import paths
 ```
 
-All had the same bug: helper function closing `) raises -> AnyTensor:` stripped.
+### Merge Script Status
 
-### CI Workflow Changes
-
-```text
-7 pattern fields updated in comprehensive-tests.yml
-3 ADR-009 comments removed
-Key fix: test_initializers_*.mojo → test_initializers*.mojo (keep wildcard for _validation)
-```
+Deleted after merge — served its one-time purpose and had ruff violations (F841 unused variables, formatting issues) that failed CI.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | PR #5122, full test suite pass | [notes.md](./testing-desplit-adr009-merge-workflow.notes.md) |
+| ProjectOdyssey | PR #5130, CI Comprehensive Tests pass | [notes.md](./testing-desplit-adr009-merge-workflow.notes.md) |


### PR DESCRIPTION
## Summary

Amends `testing-desplit-adr009-merge-workflow` from v1.0.0 to v2.0.0.
Creates new `mojo-hyphenated-dir-rename-for-imports` skill.

Documents critical findings from PR HomericIntelligence/ProjectOdyssey#5130.

## Verification Level

**verified-ci** — PR #5130 merged to main with Comprehensive Tests passing.

## Key Findings

**What Worked**:
- Post-merge audit with grep for undefined struct references caught all 4 dropped structs
- Sub-agents with worktree isolation for parallel rebase of 7 conflicting PRs
- Filing upstream issue (modular/modular#6275) before implementing workaround

**What Failed**:
- Merge script dedup silently dropped struct definitions
- Trusting merged file compilation without auditing definitions
- Running full test suite locally (crashes machine)

## Test Plan

- [x] Validate with python3 scripts/validate_plugins.py (1059/1059 valid)
- [ ] Verify skills appear in marketplace

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>