### PR TITLE
feat: amend parallel-rebase-agent-worktree-isolation (v1.1.0)

### DIFF
--- a/skills/parallel-rebase-agent-worktree-isolation.history
+++ b/skills/parallel-rebase-agent-worktree-isolation.history
@@ -1,0 +1,32 @@
+# parallel-rebase-agent-worktree-isolation — History
+
+## v1.1.0 (2026-03-27)
+
+**Changed by:** Myrmidon swarm rebase of 13 PRs across 4 batched agents
+**Verification:** verified-ci
+
+### What changed
+- Added batch strategy: 3-4 PRs per agent instead of 1 per agent
+- Added Failed Attempt: plan mode inheritance blocks sub-agent execution
+- Added Failed Attempt: agents sharing main repo worktree get stuck on stale rebase state
+- Updated scale from 70 PRs to 13 PRs with 4 batched agents
+- Added `isolation: "worktree"` as the preferred Agent tool parameter
+- Added pre-rebase conflict check with `git merge-tree`
+
+### Why
+v1.0.0 used manual `git worktree add` inside agent prompts. The Agent tool now supports
+`isolation: "worktree"` which handles worktree creation/cleanup automatically. Also, batching
+3-4 PRs per agent (sequential within agent, parallel across agents) is more efficient than
+1 PR per agent because it reduces agent spawn overhead while still parallelizing across cores.
+
+Additionally, plan mode in the parent context is inherited by sub-agents spawned with the
+Agent tool, blocking them from executing any writes. Must exit plan mode before spawning.
+
+### Previous version (v1.0.0) snapshot
+[Preserved in git history]
+
+---
+
+## v1.0.0 (2026-03-15)
+
+**Initial version.**

--- a/skills/parallel-rebase-agent-worktree-isolation.md
+++ b/skills/parallel-rebase-agent-worktree-isolation.md
@@ -6,9 +6,10 @@ description: 'Run multiple rebase agents in parallel without working tree collis
   Net hooks block git branch -D or git reset --hard in shared working tree, (3) background
   agents need isolated git state to avoid checkout conflicts.'
 category: ci-cd
-date: 2026-03-15
-version: 1.0.0
+date: 2026-03-27
+version: "1.1.0"
 user-invocable: false
+history: parallel-rebase-agent-worktree-isolation.history
 ---
 ## Overview
 
@@ -17,15 +18,18 @@ user-invocable: false
 | **Problem** | Multiple background agents rebasing branches switch git checkout, colliding with each other and blocking the main conversation's commits |
 | **Root cause** | All agents share the same working tree; branch switches by one agent leave another in unexpected state mid-rebase |
 | **Fix** | Give each agent a dedicated `git worktree` so they operate on isolated directory copies |
-| **Scale** | Tested with 70 PRs rebased via 2 parallel agents + 1 main conversation agent |
+| **Scale** | Tested with 70 PRs (v1.0) and 13 PRs batched 3-4 per agent (v1.1) |
+| **History** | [changelog](./parallel-rebase-agent-worktree-isolation.history) |
 
 ## When to Use
 
 - Launching 2+ background agents to mass-rebase branches in parallel
 - Agents use `git switch`/`git checkout` and leave rebase-in-progress state behind
 - Safety Net blocks `git branch -D` or `git reset --hard` in the shared working tree
-- CI failures on all PRs require rebasing 50+ branches quickly
+- CI failures on all PRs require rebasing many branches quickly
 - Main conversation needs to commit while background agents are running
+- Using `Agent(isolation: "worktree")` for automatic worktree management
+- Batching 3-4 PRs per agent for efficiency (sequential within, parallel across)
 
 ## Verified Workflow
 
@@ -207,15 +211,49 @@ by_s={}
 | Use `git reset --hard origin/<branch>` to sync diverged local branch | Safety Net blocked the command | `reset --hard` is classified as destructive | Use `git pull --rebase origin/<branch>` instead |
 | Commit matrix.mojo fix while batch 1 agent was switching branches | Commit landed on `tmp-rebase-3956` instead of `fix-baseline-ci-errors` | Agent switched branches between our `git add` and `git commit` | When agents are actively switching branches in the same worktree, either wait for them to finish or do your work in a separate worktree |
 | Agent used prefix `tmp-r2-*` for temp branches, same as other agent | Two agents used same temp branch names | First agent created `tmp-r2-4096`, second agent tried to create same name | Include unique batch ID in temp branch prefix: `tmp-b1-<N>`, `tmp-b2-<N>` |
+| Spawned agents while parent was in plan mode | Agents completed analysis but couldn't execute any writes | Plan mode is INHERITED by sub-agents — they can only read files, not edit/commit/push | Always exit plan mode BEFORE spawning execution agents |
+| Agents sharing main repo worktree found stale rebase state | Agent B found Agent A's interrupted rebase on `5108-auto-impl` with conflict in `justfile` | Multiple agents checking out branches in the same `.git` directory leave stale `rebase-merge/` state | Use `Agent(isolation: "worktree")` — gives each agent its own git worktree automatically |
+| 1 PR per agent for 13 PRs | Spawned 13 individual agents | Excessive agent spawn overhead; 5-agent-per-wave limit means 3 waves minimum | Batch 3-4 PRs per agent (sequential within agent) — 4 agents handle 13 PRs in 1 wave |
 
 ## Results & Parameters
 
-### Session outcome
+### Session outcomes
 
+**v1.1 (2026-03-27):**
+- **13 PRs** rebased with 4 batched agents (3-4 PRs each)
+- **5 conflicts** resolved semantically (CI workflow, justfile, Dockerfile)
+- **Time**: ~7 minutes with 4 parallel agents
+- Used `Agent(isolation: "worktree")` for automatic worktree management
+
+**v1.0 (2026-03-15):**
 - **70 PRs** rebased from 125 commits behind → 0 behind main
 - **0 DIRTY** PRs (was 12+)
 - **All PRs** have auto-merge enabled
 - **Time**: ~45 minutes with 3 parallel agents
+
+### Pre-rebase conflict check
+
+```bash
+# Check all PRs for conflicts BEFORE spawning agents
+for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+  branch=$(gh pr view $pr --json headRefName --jq '.headRefName')
+  git fetch origin "$branch" 2>/dev/null
+  conflicts=$(git merge-tree --merge-base origin/main origin/main "origin/$branch" 2>&1 | grep -c "CONFLICT")
+  echo "PR#$pr: $conflicts conflicts"
+done
+```
+
+### Batching strategy
+
+```yaml
+# Optimal: 3-4 PRs per agent
+# Each agent processes PRs sequentially (checkout → rebase → push → next)
+# Agents run in parallel across different worktrees
+agents: 4
+prs_per_agent: 3-4
+total_prs: 13
+waves: 1  # All agents launch simultaneously
+```
 
 ### Temp branch naming convention
 


### PR DESCRIPTION
## Summary

Amends `parallel-rebase-agent-worktree-isolation` from v1.0.0 to v1.1.0.

## Key Findings

**What Worked**:
- Batching 3-4 PRs per agent: 13 PRs handled by 4 agents in ~7 min
- `Agent(isolation: "worktree")` automates worktree lifecycle
- Pre-rebase `git merge-tree` check identifies conflicts before spawning

**What Failed**:
- Plan mode inherits to sub-agents → they can't write/commit/push
- Agents sharing main repo worktree find stale rebase state from other agents
- 1 PR per agent is wasteful for clean rebases

## Verification Level

**verified-ci** — 13 PRs successfully rebased and CI triggered

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1060/1060)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>