### PR TITLE
feat: amend ci-cd-cross-repo-skill-maintenance (v1.1.0) + add tooling-python-codebase-symbol-rename

### DIFF
--- a/skills/ci-cd-cross-repo-skill-maintenance.history
+++ b/skills/ci-cd-cross-repo-skill-maintenance.history
@@ -1,12 +1,42 @@
+# ci-cd-cross-repo-skill-maintenance — History
+
+## v1.1.0 (2026-03-28)
+
+**Changed by:** Session context (myrmidon-swarm skill fix — make /learn mandatory;
+ProjectScylla retrospective→learn rename; HomericIntelligence/ProjectHephaestus#205)
+**Verification:** verified-precommit (PR created; CI pending)
+
+### What changed
+
+- Added new "Verified On" entry for ProjectHephaestus#205 (myrmidon-swarm skill fix)
+- Added Failed Attempts row documenting sub-agent workflow that completed code changes
+  but did not finish the git workflow (no commit, no push, no PR)
+- Added new trigger condition in When to Use: fixing incorrect auto-invoke directives
+  in a skill definition
+- Added new Key Patterns row: git operations must be done in main context after sub-agent
+
+### Why
+
+The myrmidon-swarm skill in ProjectHephaestus had three bugs:
+1. Phase 5 said "Suggest running /hephaestus:learn" — should be mandatory auto-invoke
+2. Integrations section said "Do not auto-invoke — let the user decide" — wrong
+3. Final Summary template referenced `/retrospective` (old, deleted command) instead of `/hephaestus:learn`
+
+The fix required editing `$HOME/.agent-brain/ProjectHephaestus/skills/myrmidon-swarm/SKILL.md`
+directly and creating a PR. The sub-agent approach was attempted but the agent returned without
+completing git operations — main context had to handle commit/push/PR.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
 ---
 name: ci-cd-cross-repo-skill-maintenance
-description: "Fix conflicting rename/refactor PRs and coordinate skill definition updates across repositories. Use when: (1) a rename PR shows CONFLICTING status after main advances, (2) a skill definition in repo A needs updating because of changes in repo B, (3) batch-resolving homogeneous conflicts in a refactor PR, (4) fixing incorrect auto-invoke directives in a skill definition."
+description: "Fix conflicting rename/refactor PRs and coordinate skill definition updates across repositories. Use when: (1) a rename PR shows CONFLICTING status after main advances, (2) a skill definition in repo A needs updating because of changes in repo B, (3) batch-resolving homogeneous conflicts in a refactor PR."
 category: ci-cd
-date: 2026-03-28
-version: "1.1.0"
+date: 2026-03-26
+version: "1.0.0"
 user-invocable: false
 verification: verified-local
-history: ci-cd-cross-repo-skill-maintenance.history
 tags:
   - cross-repo
   - skill-maintenance
@@ -21,11 +51,10 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-28 |
-| **Objective** | Fix conflicting rename PRs, coordinate skill definition updates, and fix incorrect skill behavior directives across repositories |
-| **Outcome** | Multiple PRs across ProjectMnemosyne and ProjectHephaestus successfully merged |
+| **Date** | 2026-03-26 |
+| **Objective** | Fix a conflicting rename PR in ProjectMnemosyne and coordinate a skill definition update in ProjectHephaestus |
+| **Outcome** | PR #1061 rebased and MERGEABLE, skill definition PR #203 created in ProjectHephaestus |
 | **Verification** | verified-local |
-| **History** | [changelog](./ci-cd-cross-repo-skill-maintenance.history) |
 
 ## When to Use
 
@@ -33,8 +62,6 @@ tags:
 - All conflicts follow the same pattern (e.g., both sides changed the same text references being renamed)
 - A skill definition in one repo (e.g., ProjectHephaestus) needs a coordinated update because of changes in another repo (e.g., ProjectMnemosyne)
 - You need to validate a plugin repository after resolving conflicts to ensure no structural corruption
-- A skill definition has incorrect auto-invoke directives (e.g., says "suggest" instead of "auto-invoke", references a deleted command)
-- Fixing stale command references in skill files (e.g., `/retrospective` → `/hephaestus:learn`)
 
 ## Verified Workflow
 
@@ -57,19 +84,6 @@ python3 scripts/validate_plugins.py
 # 4. Push and verify merge state
 git push --force-with-lease
 gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus'
-
-# 5. Fix skill definition in second repo — always do git ops in main context
-HEPHAESTUS_DIR="$HOME/.agent-brain/ProjectHephaestus"
-git -C "$HEPHAESTUS_DIR" fetch origin
-git -C "$HEPHAESTUS_DIR" checkout -b fix-skill origin/main
-# ... edit SKILL.md ...
-git -C "$HEPHAESTUS_DIR" add <files>
-git -C "$HEPHAESTUS_DIR" commit -m "fix(skills): <description>"
-git -C "$HEPHAESTUS_DIR" push -u origin fix-skill
-gh pr create --repo HomericIntelligence/ProjectHephaestus ...
-PR_NUMBER=$(gh pr list --repo HomericIntelligence/ProjectHephaestus \
-  --head fix-skill --json number --jq '.[0].number')
-gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectHephaestus
 ```
 
 ### Detailed Steps
@@ -77,7 +91,6 @@ gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectHepha
 **Phase 1: Fix the conflicting rename PR**
 
 1. Fetch latest main and check out the PR branch:
-
    ```bash
    git fetch origin
    git checkout <branch>
@@ -87,7 +100,6 @@ gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectHepha
 2. When rebase stops at a conflict, check if all conflicts follow the same pattern. For a rename PR, conflicts are almost always the same: both sides changed the text being renamed.
 
 3. Batch-resolve with `--theirs` (the PR's version is the rename target):
-
    ```bash
    # List conflicting files
    git diff --name-only --diff-filter=U
@@ -102,14 +114,12 @@ gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectHepha
 4. Repeat for each rebase step if multiple commits conflict. The pattern is the same each time.
 
 5. Validate and push:
-
    ```bash
    python3 scripts/validate_plugins.py  # e.g., 1059/1059 valid
    git push --force-with-lease
    ```
 
 6. Verify PR is now MERGEABLE:
-
    ```bash
    gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus'
    # Expected: MERGEABLE
@@ -118,34 +128,22 @@ gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectHepha
 **Phase 2: Coordinate the skill definition update in the second repo**
 
 1. Clone or update the skill-definition repo (e.g., ProjectHephaestus):
-
    ```bash
-   # Prefer the shared clone at $HOME/.agent-brain if already present
-   HEPHAESTUS_DIR="$HOME/.agent-brain/ProjectHephaestus"
-   git -C "$HEPHAESTUS_DIR" fetch origin
-   git -C "$HEPHAESTUS_DIR" checkout main
-   git -C "$HEPHAESTUS_DIR" pull --ff-only origin main
-   git -C "$HEPHAESTUS_DIR" checkout -b fix-skill-definition origin/main
+   gh repo clone HomericIntelligence/ProjectHephaestus /tmp/ProjectHephaestus
+   cd /tmp/ProjectHephaestus
+   git checkout -b update-skill-definition origin/main
    ```
 
 2. Edit the skill definition to reflect the new behavior, naming, or execution model.
 
-3. **CRITICAL**: Do git operations (add/commit/push/PR) in the main context, not inside a
-   sub-agent. Sub-agents that edit files may return without completing the git workflow
-   (see Failed Attempts).
-
-4. Commit, push, and create a PR linking to the original rename PR:
-
+3. Commit, push, and create a PR linking to the original rename PR:
    ```bash
-   git -C "$HEPHAESTUS_DIR" add <files>
-   git -C "$HEPHAESTUS_DIR" commit -m "fix(skills): update <skill> definition for <change>"
-   git -C "$HEPHAESTUS_DIR" push -u origin fix-skill-definition
-   gh pr create --repo HomericIntelligence/ProjectHephaestus \
-     --title "Fix <skill> definition" \
+   git add <files>
+   git commit -m "feat(skills): update <skill> definition for <change>"
+   git push -u origin update-skill-definition
+   gh pr create --title "Update <skill> definition" \
      --body "Coordinates with HomericIntelligence/ProjectMnemosyne#<number>"
-   PR_NUMBER=$(gh pr list --repo HomericIntelligence/ProjectHephaestus \
-     --head fix-skill-definition --json number --jq '.[0].number')
-   gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectHephaestus
+   gh pr merge --auto --rebase
    ```
 
 **Phase 3: Verify both PRs**
@@ -168,8 +166,7 @@ Is the PR a rename/refactor where the intent is to change text references?
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| N/A (Phase 1) | Direct approach worked first try | N/A | Batch `--theirs` was correct because all 8 conflicts followed the identical rename pattern |
-| Sub-agent for skill definition fix | Delegated the myrmidon-swarm SKILL.md edits to a sub-agent | Agent made all file edits correctly but returned to main context without running git add/commit/push/PR | Sub-agents may not complete git workflows — always run git operations in main context after the agent returns |
+| N/A | Direct approach worked first try | N/A | Batch `--theirs` was correct because all 8 conflicts followed the identical rename pattern |
 
 ## Results & Parameters
 
@@ -198,25 +195,19 @@ secondary_pr:
   number: 203
   change: "Add Execution Model section to /learn skill definition"
 
-myrmidon_fix_pr:
-  repo: ProjectHephaestus
-  number: 205
-  change: "Fix myrmidon-swarm skill: make /learn auto-invoke mandatory, fix stale /retrospective reference"
-
 dependency: none  # PRs are independently mergeable
-coordination: "Secondary PRs reference primary for context"
+coordination: "Secondary PR references primary for context"
 ```
 
 ### Key Patterns
 
 | Pattern | Description |
 |---------|-------------|
-| Homogeneous conflicts | All conflicts in a rename PR tend to be the same pattern — safe to batch-resolve |
-| `--theirs` for renames | The PR branch has the correct renamed text; main has the old text — always take theirs |
+| Homogeneous conflicts | All conflicts in a rename PR tend to be the same pattern -- safe to batch-resolve |
+| `--theirs` for renames | The PR branch has the correct renamed text; main has the old text -- always take theirs |
 | Validate after resolve | Always run the repo's validation script before pushing (e.g., `validate_plugins.py`) |
-| Independent PRs | Cross-repo updates should not block each other — file them as separate PRs |
+| Independent PRs | Cross-repo updates should not block each other -- file them as separate PRs |
 | Link PRs for context | Reference the related PR in the body so reviewers understand the coordination |
-| Git ops in main context | Sub-agents may not complete git workflows — always run add/commit/push/PR in main context |
 
 ## Verified On
 
@@ -224,11 +215,16 @@ coordination: "Secondary PRs reference primary for context"
 |---------|---------|---------|
 | ProjectMnemosyne | PR #1061, rename retrospective to learn (8 conflicts resolved) | 2026-03-26 session |
 | ProjectHephaestus | PR #203, add Execution Model section to /learn skill | 2026-03-26 session |
-| ProjectHephaestus | PR #205, fix myrmidon-swarm skill auto-invoke directives | 2026-03-28 session |
 
 ## References
 
 - [tooling-plugin-command-codebase-rename](tooling-plugin-command-codebase-rename.md) - The rename operation itself (41-file content changes)
-- [tooling-python-codebase-symbol-rename](tooling-python-codebase-symbol-rename.md) - Renaming Python symbols across a Python codebase
 - [mass-pr-rebase-conflict-resolution](mass-pr-rebase-conflict-resolution.md) - Batch-rebasing many PRs with diverse conflicts
 - [pixi-lock-rebase-regenerate](pixi-lock-rebase-regenerate.md) - Related: lock file regeneration after rebase
+```
+
+---
+
+## v1.0.0 (2026-03-26)
+
+**Initial version.**

--- a/skills/tooling-python-codebase-symbol-rename.md
+++ b/skills/tooling-python-codebase-symbol-rename.md
@@ -1,0 +1,222 @@
+---
+name: tooling-python-codebase-symbol-rename
+description: "Rename Python symbols (functions, classes, constants, CLI flags, enum variants, filenames) across an entire Python codebase. Use when: (1) renaming a concept across src/, tests/, and scripts/ Python files, (2) renaming a CLI flag with dashes to match a new convention, (3) renaming enum variants to match a renamed operation phase."
+category: tooling
+date: 2026-03-28
+version: "1.0.0"
+user-invocable: false
+verification: verified-precommit
+tags:
+  - rename
+  - python
+  - refactor
+  - symbol-rename
+  - file-rename
+  - enum
+  - cli
+---
+
+# Python Codebase Symbol Rename
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-28 |
+| **Objective** | Rename `retrospective` concept to `learn` across ProjectScylla's Python automation pipeline |
+| **Outcome** | All Python symbols renamed, files renamed with `git mv`, PR HomericIntelligence/ProjectScylla#1734 created |
+| **Verification** | verified-precommit (pre-commit hooks pass; CI pending at time of capture) |
+
+> **Note:** This skill covers renaming Python-level symbols. For renaming plugin directories,
+> slash commands, and markdown-based skill references, see
+> [tooling-plugin-command-codebase-rename](tooling-plugin-command-codebase-rename.md).
+
+## When to Use
+
+- Renaming a concept across multiple Python files in `src/`, `tests/`, `scripts/`
+- Renaming function names (e.g., `run_retrospective()` → `run_learn()`)
+- Renaming constants (e.g., `RETROSPECTIVE_TIMEOUT` → `LEARN_TIMEOUT`)
+- Renaming enum variants (e.g., `ImplementationPhase.RETROSPECTIVE` → `LEARN`)
+- Renaming CLI flags (e.g., `--no-retrospective` → `--no-learn`)
+- Renaming module files (e.g., `retrospective.py` → `learn.py`) while preserving git history
+- Distinguishing "symbol renames" (change code) from "prose renames" (leave natural language as-is)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Discover all affected files
+grep -rn "<old_name>" src/ tests/ scripts/ --include="*.py" -l
+
+# 2. File renames — use git mv to preserve history
+git mv src/pkg/automation/old_name.py src/pkg/automation/new_name.py
+git mv tests/unit/automation/test_old_name.py tests/unit/automation/test_new_name.py
+
+# 3. Symbol renames in each file — use replace_all: true in Edit tool
+#    (or sed -i for each pattern if working in bash)
+for f in src/ tests/ scripts/; do
+  sed -i 's/old_symbol_name/new_symbol_name/g' $(grep -rl "old_symbol_name" $f --include="*.py")
+done
+
+# 4. Verify only prose remains (natural language comments are OK to leave)
+grep -rn "old_name" src/ tests/ scripts/ --include="*.py"
+# Expected: only comments/docstrings with natural language ("run a retrospective")
+
+# 5. Stage and commit
+git add src/ tests/ scripts/
+git status  # Confirm renames show as R  old.py -> new.py
+git commit -m "refactor: rename <old> to <new> across Python codebase"
+git push -u origin <branch>
+gh pr create --repo <org>/<repo> ...
+```
+
+### Detailed Steps
+
+**Phase 1: Discover all affected files**
+
+1. Find all Python files containing the old name (symbols only — check both snake_case and
+   UPPER_CASE and kebab-case for CLI flags):
+
+   ```bash
+   grep -rn "retrospective\|RETROSPECTIVE" src/ tests/ scripts/ --include="*.py" -l
+   ```
+
+2. Review each hit to distinguish:
+   - **Symbol references** (function calls, class names, constants, enum variants, imports,
+     CLI flags, log file names) → MUST rename
+   - **Prose comments/docstrings** ("run a retrospective", "the retrospective phase") → OK to leave
+
+**Phase 2: Rename files with `git mv`**
+
+Use `git mv` for file renames — git detects rename by content similarity (~50% threshold),
+so the rename appears in `git log --follow` and `git diff` as `R  old.py -> new.py`:
+
+```bash
+git mv src/pkg/automation/retrospective.py src/pkg/automation/learn.py
+git mv tests/unit/automation/test_retrospective.py tests/unit/automation/test_learn.py
+```
+
+After `git mv`, the old filename is staged for deletion and the new filename is staged as
+added. No separate `git add` or `git rm` needed for the renamed files.
+
+**Phase 3: Edit file contents**
+
+For each renamed file and any file that imports/references the old symbols, use `replace_all: true`
+on each distinct symbol pattern. Process symbols from most-specific to least-specific to avoid
+partial replacements:
+
+| Order | Pattern | Example |
+|-------|---------|---------|
+| 1 | Private helper function | `_run_retrospective` → `_run_learn` |
+| 2 | Private check function | `_retrospective_needs_rerun` → `_learn_needs_rerun` |
+| 3 | Public function | `run_retrospective` → `run_learn` |
+| 4 | Public check function | `retrospective_needs_rerun` → `learn_needs_rerun` |
+| 5 | Enum variant | `ImplementationPhase.RETROSPECTIVE` → `ImplementationPhase.LEARN` |
+| 6 | Enum definition | `.RETROSPECTIVE` → `.LEARN` |
+| 7 | Boolean flag field | `enable_retrospective` → `enable_learn` |
+| 8 | CLI flag (dashes) | `--no-retrospective` → `--no-learn` |
+| 9 | Log filename pattern | `retrospective-{n}.log` → `learn-{n}.log` |
+| 10 | Import name | `from .retrospective import` → `from .learn import` |
+| 11 | Module constant | `RETROSPECTIVE_TIMEOUT` → `LEARN_TIMEOUT` |
+
+**Phase 4: Verify only prose remains**
+
+```bash
+grep -rn "retrospective" src/ tests/ scripts/ --include="*.py"
+```
+
+Every remaining hit should be a natural-language comment or docstring, e.g.:
+
+```python
+# This runs a retrospective to capture session learnings  ← OK to leave
+"""Run a retrospective on the session."""                  ← OK to leave
+```
+
+If any symbol references remain, fix them before proceeding.
+
+**Phase 5: Stage, commit, and push**
+
+```bash
+# Stage all changed files (git mv files are already staged)
+git add src/ tests/ scripts/
+
+# Verify staging looks correct
+git status
+# Should show: R  src/pkg/automation/retrospective.py -> src/pkg/automation/learn.py
+# Should show: M  src/pkg/other_file.py (for files with content edits only)
+
+# Commit
+git commit -m "refactor: rename retrospective to learn across Python codebase
+
+- Renamed retrospective.py → learn.py and test_retrospective.py → test_learn.py
+- Renamed all public/private functions, constants, enum variants, CLI flags
+- Prose comments left unchanged (natural language)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+git push -u origin <branch>
+gh pr create --repo <org>/<repo> --title "refactor: rename retrospective to learn" ...
+```
+
+### Important: Do git operations in main context
+
+If a sub-agent makes the file edits, it may return to the main context without completing
+git operations. Always run `git add`, `git commit`, `git push`, and `gh pr create` in the
+main context after any sub-agent returns.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Sub-agent with worktree isolation | Delegated all code changes + git workflow to a sub-agent | Agent made all file edits correctly but returned without committing, pushing, or creating a PR | Sub-agents may not complete git workflows — run add/commit/push/PR in main context after agent returns |
+| Renaming all occurrences of "retrospective" | Tried replacing every occurrence including prose | Over-replaced prose comments/docstrings ("run a retrospective") | Only rename symbol references, not natural language prose |
+
+## Results & Parameters
+
+### Rename Scope (ProjectScylla)
+
+```yaml
+files_renamed:
+  - src/scylla/automation/retrospective.py → learn.py
+  - tests/unit/automation/test_retrospective.py → test_learn.py
+
+symbols_renamed:
+  functions:
+    - run_retrospective() → run_learn()
+    - retrospective_needs_rerun() → learn_needs_rerun()
+    - _run_retrospective() → _run_learn()
+    - _retrospective_needs_rerun() → _learn_needs_rerun()
+  enums:
+    - ImplementationPhase.RETROSPECTIVE → LEARN
+    - ReviewPhase.RETROSPECTIVE → LEARN
+  fields:
+    - enable_retrospective → enable_learn
+  cli_flags:
+    - --no-retrospective → --no-learn
+  constants:
+    - RETROSPECTIVE_TIMEOUT → LEARN_TIMEOUT
+  log_patterns:
+    - retrospective-{n}.log → learn-{n}.log
+
+prose_left_unchanged: true  # natural language comments
+```
+
+### Symbol Categories Reference
+
+| Category | Python Pattern | Rename Strategy |
+|----------|---------------|----------------|
+| Public function | `def run_retrospective(` | Rename definition + all call sites |
+| Private function | `def _run_retrospective(` | Rename definition + all call sites |
+| Enum variant | `RETROSPECTIVE = auto()` | Rename definition + all references |
+| Class field | `enable_retrospective: bool` | Rename definition + all attribute accesses |
+| CLI flag | `add_argument("--no-retrospective")` | Rename the string + dest parameter |
+| Module constant | `RETROSPECTIVE_TIMEOUT = 300` | Rename definition + all references |
+| Log filename | `f"retrospective-{n}.log"` | Rename the string template |
+| Import | `from .retrospective import` | Rename after file rename |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | PR #1734, rename retrospective → learn in Python automation pipeline | 2026-03-28 session |


### PR DESCRIPTION
## Summary

Amends `ci-cd-cross-repo-skill-maintenance` from v1.0.0 to v1.1.0 and adds a new skill
`tooling-python-codebase-symbol-rename`.

- **ci-cd-cross-repo-skill-maintenance v1.1.0**: Adds sub-agent git-workflow limitation
  finding, new trigger condition for fixing skill auto-invoke directives, and Verified On
  entry for ProjectHephaestus#205 (myrmidon-swarm skill fix)
- **tooling-python-codebase-symbol-rename (new)**: Documents the complete workflow for
  renaming Python symbols across a codebase — functions, enums, constants, CLI flags, and
  file renames using `git mv`

## Verification Level

**verified-precommit** — pre-commit hooks pass; CI validation pending

## Key Findings

**What Worked**:
- `git mv` for file renames preserves git history and auto-stages the rename
- `replace_all: true` on Edit tool handles each symbol category cleanly
- Prose comments/docstrings ("run a retrospective") should be left as-is — only symbol names need renaming
- Process symbol patterns from most-specific to least-specific (private helpers first, then public, then constants)

**What Failed**:
- Sub-agent with isolation made all code edits correctly but returned to main context without running `git add/commit/push/PR` → git operations must always be done in main context after sub-agent returns

## Test Plan

- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify both skills appear in marketplace
- [ ] Test skill discovery with keywords: `python rename symbol`, `retrospective learn`, `git mv`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>