### PR TITLE
feat: add 5 skills from E2E C++20 pipeline implementation

### DIFF
--- a/skills/cpp-httplib-lambda-capture-ub.md
+++ b/skills/cpp-httplib-lambda-capture-ub.md
@@ -1,0 +1,95 @@
+---
+name: cpp-httplib-lambda-capture-ub
+description: "Fix dangling reference UB in cpp-httplib route handler lambdas. Use when: (1) registering cpp-httplib routes that capture shared state by reference, (2) debugging crashes in HTTP handlers after register_routes() returns, (3) reviewing cpp-httplib lambda captures."
+category: debugging
+date: 2026-03-30
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - cpp-httplib
+  - lambda
+  - undefined-behavior
+  - dangling-reference
+  - cpp20
+---
+
+# cpp-httplib Lambda Capture Dangling Reference UB
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-30 |
+| **Objective** | Fix undefined behavior in cpp-httplib route handlers that capture shared state |
+| **Outcome** | Successful — root cause identified and fixed across 20+ route handlers |
+| **Verification** | verified-local |
+
+## When to Use
+
+- Registering cpp-httplib route handlers via a `register_routes(server, store, nats)` helper function
+- Route handlers that capture shared state (Store, NatsClient, etc.)
+- Debugging HTTP handlers that work in simple tests but crash/corrupt under load
+- Code review of any cpp-httplib route registration
+
+## Verified Workflow
+
+### Quick Reference
+
+```cpp
+// WRONG — dangling reference after register_routes() returns:
+void register_routes(httplib::Server& server, Store& store) {
+  server.Get("/v1/agents", [&store](auto& req, auto& res) {
+    // store reference dangles if register_routes stack frame is gone
+    // cpp-httplib copies the lambda by value into internal storage
+  });
+}
+
+// CORRECT — capture pointer by value:
+void register_routes(httplib::Server& server, Store& store) {
+  Store* sp = &store;  // pointer lives in lambda's capture, not stack
+  server.Get("/v1/agents", [sp](auto& req, auto& res) {
+    // sp is a copy of the pointer — safe after register_routes returns
+    res.set_content(sp->list_agents().dump(), "application/json");
+  });
+}
+```
+
+### Detailed Steps
+
+1. In `register_routes()`, extract raw pointers from references at the top:
+   ```cpp
+   Store* sp = &store;
+   NatsClient* np = &nats;
+   ```
+2. Capture `sp` and `np` by value in all lambdas: `[sp, np](...)`
+3. Never capture `&store` or `&nats` — they're function parameters on the stack
+4. This is safe because Store and NatsClient outlive the server (created in main())
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `[&store]` capture | Reference capture of function parameter | cpp-httplib stores handlers in `std::function` by value — the lambda outlives the `register_routes` stack frame, leaving a dangling reference | cpp-httplib copies lambdas into internal handler storage; any by-ref capture of a local/parameter is UB |
+| `[&]` default capture | Capture everything by reference | Same problem — all references dangle after function returns | Never use `[&]` in cpp-httplib route handlers |
+
+## Results & Parameters
+
+```cpp
+// Pattern used across all 20+ route handlers in ProjectAgamemnon:
+void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
+  Store* sp = &store;
+  NatsClient* np = &nats;
+
+  server.Get("/v1/health", [](auto&, auto& res) { /* no captures needed */ });
+  server.Get("/v1/agents", [sp](auto&, auto& res) { /* uses sp-> */ });
+  server.Post("/v1/agents", [sp, np](auto& req, auto& res) { /* uses both */ });
+  // ... all handlers follow same pattern
+}
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectAgamemnon | E2E pipeline implementation | 20+ route handlers fixed from [&store] to [sp] capture pattern |

--- a/skills/e2e-homeric-compose-cpp-pipeline.md
+++ b/skills/e2e-homeric-compose-cpp-pipeline.md
@@ -1,0 +1,153 @@
+---
+name: e2e-homeric-compose-cpp-pipeline
+description: "Wire HomericIntelligence C++20 services into a podman compose E2E stack with NATS JetStream, Prometheus, Grafana. Use when: (1) setting up the full E2E pipeline, (2) adding new C++20 services to the compose stack, (3) debugging multi-container C++ service orchestration."
+category: architecture
+date: 2026-03-30
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - e2e
+  - compose
+  - podman
+  - cpp20
+  - nats
+  - prometheus
+  - grafana
+  - homeric-intelligence
+---
+
+# HomericIntelligence E2E Compose Pipeline (C++20 + NATS)
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-30 |
+| **Objective** | Wire all HomericIntelligence services into a single podman compose stack for E2E testing |
+| **Outcome** | 9-container stack running: NATS, Agamemnon (C++), Nestor (C++), Hermes (Python), hello-myrmidon (C++), Prometheus, Loki, Grafana, argus-exporter. 14/18 E2E checks passing. |
+| **Verification** | verified-local |
+
+## When to Use
+
+- Setting up the HomericIntelligence E2E pipeline from scratch
+- Adding a new C++20 service to the compose stack
+- Debugging service-to-service communication in the HomericIntelligence mesh
+- Understanding the architecture: what connects to what, on which ports
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Start the stack (from Odysseus root)
+podman compose -f docker-compose.e2e.yml up -d --build
+
+# Run E2E test
+just e2e-test
+
+# Tear down
+just e2e-down
+
+# Check service health
+curl localhost:8080/v1/health  # Agamemnon (C++)
+curl localhost:8081/v1/health  # Nestor (C++)
+curl localhost:8085/health     # Hermes (Python)
+curl localhost:8222/healthz    # NATS
+```
+
+### Service Topology (9 containers)
+
+```
+NATS (nats:latest, :4222/:8222)
+  ├── Agamemnon (C++20, :8080) — REST API, NATS pub/sub
+  ├── Nestor (C++20, :8081) — Research stats, NATS pub
+  ├── Hermes (Python/FastAPI, :8085) — Webhook→NATS bridge
+  ├── hello-myrmidon (C++20) — NATS pull consumer
+  └── argus-exporter (Python, :9100) — Scrapes all services → Prometheus
+
+Prometheus (:19090) ← scrapes argus-exporter
+Loki (:13100) ← log aggregation
+Grafana (:13001) ← dashboards from Prometheus + Loki
+```
+
+### Detailed Steps
+
+1. C++20 services use multi-stage Dockerfiles: `ubuntu:24.04` builder → slim runtime
+2. NATS uses official `nats:latest` image with `-js -m 8222` flags (JetStream + monitoring)
+3. All services on `homeric-mesh` bridge network
+4. Symlinked submodules need absolute paths in compose build contexts
+5. argus-exporter needs a standalone Dockerfile (inline `dockerfile_inline` not supported by podman compose)
+6. Port remapping needed if host ports are already bound (observability → 19090, 13001, 13100, 19100)
+
+### C++20 Dockerfile Pattern
+
+```dockerfile
+FROM ubuntu:24.04 AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake ninja-build g++ git ca-certificates libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY CMakeLists.txt cmake/ include/ src/ test/ ./
+RUN cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+    -DProjectFoo_BUILD_TESTING=OFF \
+    -DProjectFoo_ENABLE_CLANG_TIDY=OFF \
+    -DProjectFoo_ENABLE_CPPCHECK=OFF \
+    && cmake --build build --target ProjectFoo_server
+
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl3 wget && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/build/ProjectFoo_server /usr/local/bin/
+EXPOSE 8080
+ENV NATS_URL=nats://localhost:4222
+CMD ["ProjectFoo_server"]
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Symlink build contexts | `context: ./infrastructure/ProjectHermes/` (symlink) | Podman compose can't follow symlinks for build contexts | Use absolute paths: `context: /home/user/ProjectHermes/` |
+| `dockerfile_inline` in compose | Inline Dockerfile for argus-exporter | Podman's external compose provider doesn't support `dockerfile_inline` | Create a standalone Dockerfile and reference via `dockerfile:` key |
+| CMD-SHELL healthcheck on NATS | `test: ["CMD-SHELL", "wget ..."]` | NATS official image is scratch — no shell, no wget, no curl | Remove healthchecks for scratch images; use simple `depends_on` |
+| `depends_on: condition: service_healthy` | Wait for healthy NATS before starting services | Combined with NATS healthcheck failure, blocks all dependent containers | Use simple `depends_on` (start-order only) for scratch images |
+| Same host ports as existing services | Ports 9090, 3100, 3001, 9100 | Zombie `rootlessport` processes from crashed containers hold ports | Remap to non-conflicting ports (19090, 13100, 13001, 19100) |
+| Python stubs for Agamemnon/Nestor | FastAPI Python services as temporary implementation | Violates architecture constraint: all services must be C++/Mojo | Implement in C++20 with cpp-httplib + nlohmann-json + nats.c |
+
+## Results & Parameters
+
+```yaml
+# E2E test results (14/18 passing)
+passing:
+  - Agamemnon health check
+  - Nestor health check
+  - Hermes health check (nats_connected=true)
+  - NATS health check
+  - Webhook → Hermes → NATS accepted
+  - Agent CRUD (create, start, list, verify online)
+  - Team create
+  - Task create + NATS dispatch
+  - hi_agents_total metric present
+  - hi_tasks_total metric present
+  - NATS 3 connections, 39+ messages
+  - Grafana running with dashboards
+
+failing:
+  - Myrmidon task completion (NATS subject mismatch)
+  - hi_agamemnon_health metric (exporter path mismatch)
+  - hi_nestor_health metric (exporter path mismatch)
+  - Hermes /subjects tracking (API difference)
+
+# Container build times
+agamemnon_build: ~90s (94 cmake targets)
+nestor_build: ~70s (48 cmake targets)
+myrmidon_build: ~60s (89 cmake targets)
+hermes_build: ~15s (pip install)
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Odysseus | Full E2E pipeline on feat/cpp-skeleton branch | 9-container stack with C++20 Agamemnon, Nestor, hello-myrmidon |

--- a/skills/natsc-fetchcontent-cpp20-integration.md
+++ b/skills/natsc-fetchcontent-cpp20-integration.md
@@ -1,0 +1,146 @@
+---
+name: natsc-fetchcontent-cpp20-integration
+description: "Integrate nats.c v3.9.1 into C++20 projects via CMake FetchContent. Use when: (1) adding NATS JetStream pub/sub to a C++20 service, (2) creating JetStream streams/consumers from C++, (3) debugging nats.c API signature mismatches in C++."
+category: tooling
+date: 2026-03-30
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - nats
+  - cmake
+  - fetchcontent
+  - cpp20
+  - jetstream
+---
+
+# nats.c FetchContent C++20 Integration
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-30 |
+| **Objective** | Add NATS JetStream support to C++20 services (ProjectAgamemnon, ProjectNestor, hello-myrmidon) via nats.c |
+| **Outcome** | Successful — all 3 binaries compile and link with nats.c v3.9.1, JetStream streams created, pub/sub working |
+| **Verification** | verified-local |
+
+## When to Use
+
+- Adding NATS JetStream messaging to any C++20 project in the HomericIntelligence ecosystem
+- Creating JetStream streams and durable pull consumers from C++
+- Publishing JSON events to NATS subjects from a cpp-httplib REST server
+- Debugging nats.c API compilation errors in C++20 code
+
+## Verified Workflow
+
+### Quick Reference
+
+```cmake
+# In CMakeLists.txt — add BEFORE your executable target
+FetchContent_Declare(
+  nats_c
+  GIT_REPOSITORY https://github.com/nats-io/nats.c.git
+  GIT_TAG v3.9.1
+  GIT_SHALLOW TRUE
+)
+set(NATS_BUILD_STREAMING OFF CACHE BOOL "" FORCE)
+set(NATS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTING_SAVED "${BUILD_TESTING}")
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(nats_c)
+set(BUILD_TESTING "${BUILD_TESTING_SAVED}" CACHE BOOL "" FORCE)
+
+# Link to your target
+target_link_libraries(my_server PRIVATE nats_static)
+```
+
+```cpp
+// Include — NOT <nats/nats.h>, just:
+#include "nats.h"
+```
+
+### Detailed Steps
+
+1. Add FetchContent block to CMakeLists.txt (see Quick Reference)
+2. Use `nats_static` target (static link avoids runtime dep)
+3. Disable streaming/examples/testing to speed up build
+4. Save and restore BUILD_TESTING to avoid breaking your own tests
+5. Include `"nats.h"` (not `<nats/nats.h>`) — the target sets include dirs automatically
+6. Requires `libssl-dev` at build time (nats.c uses OpenSSL for TLS)
+
+### JetStream Stream Creation (C++)
+
+```cpp
+jsCtx* js = nullptr;
+natsConnection_JetStream(&js, conn, nullptr);
+
+jsStreamConfig cfg;
+jsStreamConfig_Init(&cfg);
+cfg.Name = "homeric-myrmidon";
+const char* subjects[] = {"hi.myrmidon.>"};
+cfg.Subjects = subjects;
+cfg.SubjectsLen = 1;
+
+jsStreamInfo* si = nullptr;
+jsErrCode jerr = static_cast<jsErrCode>(0);  // CRITICAL: C enum needs cast in C++
+natsStatus s = js_AddStream(&si, js, &cfg, nullptr, &jerr);
+// Ignore "already exists" errors — idempotent
+if (s == NATS_OK && si) jsStreamInfo_Destroy(si);
+```
+
+### JetStream Publish (C++)
+
+```cpp
+jsPubAck* pa = nullptr;
+jsErrCode jerr = static_cast<jsErrCode>(0);
+natsStatus s = js_Publish(&pa, js, subject.c_str(),
+                          payload.c_str(), payload.size(),
+                          nullptr, &jerr);
+if (s == NATS_OK && pa) jsPubAck_Destroy(pa);
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `#include <nats/nats.h>` | Standard angle-bracket include | nats.c installs headers flat, not in nats/ subdirectory | Use `#include "nats.h"` — the CMake target sets include dirs |
+| `js_AddStream(&si, js, &cfg, nullptr, nullptr)` | Passing nullptr for jsErrCode | v3.9.1 requires `jsErrCode*` parameter, nullptr causes segfault in some builds | Always pass `&jerr` with `jsErrCode jerr = static_cast<jsErrCode>(0)` |
+| `jsErrCode jerr = 0` | Direct int initialization | `jsErrCode` is a C enum — C++ doesn't allow implicit int→enum conversion | Use `static_cast<jsErrCode>(0)` in C++20 |
+| nats.c v3.12.0 | Tried latest version | v3.12.0 not found on GitHub (latest tag is v3.9.1) | Pin to `v3.9.1` which is the actual latest release |
+| `NATS_BUILD_STREAMING ON` | Default streaming support | Adds unnecessary STAN dependency, increases build time | Set `NATS_BUILD_STREAMING OFF` — JetStream is built-in, STAN is separate |
+
+## Results & Parameters
+
+```yaml
+# Verified configuration
+nats_c_version: v3.9.1
+cmake_target: nats_static
+build_time: ~60s (89 C objects)
+binary_size_overhead: ~500KB (static link)
+requires: libssl-dev (build), libssl3 (runtime)
+openssl_version_tested: 3.0.13
+
+# JetStream streams created successfully:
+streams:
+  - name: homeric-agents
+    subjects: ["hi.agents.>"]
+  - name: homeric-tasks
+    subjects: ["hi.tasks.>"]
+  - name: homeric-myrmidon
+    subjects: ["hi.myrmidon.>"]
+  - name: homeric-research
+    subjects: ["hi.research.>"]
+  - name: homeric-pipeline
+    subjects: ["hi.pipeline.>"]
+  - name: homeric-logs
+    subjects: ["hi.logs.>"]
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectAgamemnon | E2E pipeline implementation | C++20 REST server with 20+ routes + NATS event publishing |
+| ProjectNestor | E2E pipeline implementation | C++20 research stats server with NATS research event publishing |
+| hello-myrmidon | E2E pipeline implementation | Standalone C++20 NATS pull consumer worker |

--- a/skills/podman-rootless-dns-container-resolution.md
+++ b/skills/podman-rootless-dns-container-resolution.md
@@ -1,0 +1,116 @@
+---
+name: podman-rootless-dns-container-resolution
+description: "Fix podman rootless DNS resolution failures between containers in compose networks. Use when: (1) containers cannot resolve each other by service name, (2) NATS/HTTP connections fail with 'Temporary failure in name resolution', (3) aardvark-dns is running but resolution still fails."
+category: debugging
+date: 2026-03-30
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - podman
+  - rootless
+  - dns
+  - aardvark-dns
+  - compose
+  - networking
+---
+
+# Podman Rootless DNS Container Name Resolution Failure
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-30 |
+| **Objective** | Fix container-to-container DNS resolution in podman rootless compose networks |
+| **Outcome** | Workaround found — use container IPs directly via NATS_URL env var override |
+| **Verification** | verified-local |
+
+## When to Use
+
+- `podman compose up` starts services but they can't connect to each other by name
+- Container logs show: `socket.gaierror: [Errno -3] Temporary failure in name resolution`
+- `aardvark-dns` process is running, network has `dns_enabled: true`, but resolution still fails
+- NATS clients (nats.c or nats-py) fail to connect when using `nats://nats:4222`
+- Python containers (python:3.12-slim) are most affected; C++ containers may also fail
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Diagnosis: verify DNS is running but not resolving
+podman exec <container> python3 -c "import socket; socket.gethostbyname('nats')"
+# → socket.gaierror: [Errno -3] Temporary failure in name resolution
+
+# Verify network connectivity works by IP
+NATS_IP=$(podman inspect odysseus-nats-1 | python3 -c "
+import sys,json; d=json.load(sys.stdin)
+nets=d[0]['NetworkSettings']['Networks']
+print(list(nets.values())[0]['IPAddress'])")
+
+podman exec <container> python3 -c "
+import socket; s=socket.socket(); s.connect(('${NATS_IP}', 4222)); print('OK')"
+# → OK (connectivity works, only DNS is broken)
+
+# Workaround: restart containers with direct IPs
+podman rm -f <container>
+podman run -d --name <container> --network <network> \
+  -e "NATS_URL=nats://${NATS_IP}:4222" <image>
+```
+
+### Detailed Steps
+
+1. Check if `aardvark-dns` is running: `ps aux | grep aardvark`
+2. Check network has DNS: `podman network inspect <net> | grep dns_enabled`
+3. Check container `/etc/resolv.conf` points to `10.89.0.1` (podman DNS)
+4. If resolution still fails, get target container IP: `podman inspect <target> | jq '.[0].NetworkSettings.Networks'`
+5. Restart failing containers with `NATS_URL=nats://<IP>:4222` (or equivalent env var)
+6. For production: file podman bug report; for E2E testing: IP workaround is acceptable
+
+### Root Cause Analysis
+
+The failure occurs when:
+- Multiple containers start simultaneously via `podman compose up -d`
+- Some containers attempt DNS resolution before `aardvark-dns` has fully registered all container names
+- The DNS resolution failure is cached by glibc, and even after `aardvark-dns` has the record, the container's resolver returns stale NXDOMAIN
+- Restarting the container (not just the process) clears the DNS cache
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `depends_on: condition: service_healthy` | Wait for NATS healthy before starting dependent containers | NATS scratch image has no shell — `CMD-SHELL` healthchecks fail. Also, even with delay, DNS can still fail. | Healthcheck-based ordering doesn't fix DNS race |
+| `healthcheck: test: ["CMD-SHELL", "true"]` | Trivial healthcheck that always passes | NATS image has no `/bin/sh` at all — scratch/distroless image | Cannot use CMD-SHELL with scratch images |
+| `healthcheck: test: ["CMD-SHELL", "wget ..."]` | Wget-based health check | NATS image has no wget, no curl, no shell | NATS official image is a minimal scratch image |
+| `healthcheck: test: ["CMD", "nats-server", "--help"]` | Use existing binary for health | `nats-server --help` returns exit code 1 (not 0) when server is already running | Even binary-based checks can have unexpected exit codes |
+| Removing all healthchecks | Simple `depends_on` without conditions | Services start but DNS still fails on first boot — race condition | Ordering alone doesn't solve DNS registration race |
+
+## Results & Parameters
+
+```yaml
+# Environment where this was observed
+podman_version: 4.9.3
+os: Ubuntu 24.04 (WSL2)
+kernel: 6.6.87.2-microsoft-standard-WSL2
+dns_server: aardvark-dns
+network_driver: bridge
+rootless: true
+
+# Working configuration
+workaround: direct_container_ip
+nats_image: nats:latest  # scratch image, no shell
+affected_images:
+  - python:3.12-slim (Hermes, argus-exporter)
+  - custom C++20 ubuntu:24.04 (Agamemnon, Nestor, hello-myrmidon)
+
+# Ports that can become zombies after compose down
+zombie_port_issue: true
+fix: pkill -f rootlessport  # or remap to non-conflicting ports
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Odysseus | E2E pipeline with 9 containers | NATS, Agamemnon, Nestor, Hermes, Myrmidon all affected by DNS race |

--- a/skills/podman-scratch-image-healthcheck-workaround.md
+++ b/skills/podman-scratch-image-healthcheck-workaround.md
@@ -1,0 +1,117 @@
+---
+name: podman-scratch-image-healthcheck-workaround
+description: "Work around healthcheck failures for scratch/distroless container images in podman compose. Use when: (1) NATS or other scratch images fail CMD-SHELL healthchecks, (2) depends_on service_healthy blocks container startup, (3) minimal images have no shell or utilities."
+category: debugging
+date: 2026-03-30
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - podman
+  - healthcheck
+  - scratch
+  - distroless
+  - nats
+  - compose
+---
+
+# Podman Scratch Image Healthcheck Workaround
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-03-30 |
+| **Objective** | Fix compose startup blocked by healthcheck failures on scratch/distroless images |
+| **Outcome** | Successful — remove healthchecks for scratch images, use simple depends_on |
+| **Verification** | verified-local |
+
+## When to Use
+
+- `podman compose up` hangs because a dependency's healthcheck keeps failing
+- Container logs show: `exec: "sh": executable file not found` or `exec: "wget": executable file not found`
+- The failing container is a minimal/scratch/distroless image (NATS, etcd, CoreDNS, etc.)
+- Services that `depends_on: condition: service_healthy` never start
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# WRONG — fails for scratch images:
+services:
+  nats:
+    image: nats:latest
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8222/healthz"]
+  app:
+    depends_on:
+      nats:
+        condition: service_healthy  # blocks forever
+
+# CORRECT — simple ordering for scratch images:
+services:
+  nats:
+    image: nats:latest
+    # No healthcheck — scratch image has no shell/tools
+  app:
+    depends_on:
+      - nats  # start-order only, no health condition
+```
+
+### Detailed Steps
+
+1. Identify if the image is scratch/distroless: `podman exec <container> sh -c "true"` → `executable file not found`
+2. Remove the `healthcheck:` block entirely from that service
+3. Change all `depends_on: condition: service_healthy` to simple `depends_on: - name`
+4. Add retry logic in the dependent service (connection retry loop) instead of relying on compose health
+
+### What scratch images lack
+
+| Tool | Available? | Used by |
+|------|-----------|---------|
+| `/bin/sh` | No | CMD-SHELL healthchecks |
+| `wget` | No | HTTP healthchecks |
+| `curl` | No | HTTP healthchecks |
+| `true` | No | Trivial healthchecks |
+| `which` | No | Tool detection |
+| The service binary | Yes | Only thing present |
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| `CMD-SHELL "wget ..."` | Shell-based HTTP healthcheck | No shell in scratch image | Scratch = no shell at all |
+| `CMD-SHELL "true"` | Simplest possible shell command | Still requires a shell to interpret "true" | Even `true` needs `/bin/sh` |
+| `CMD ["nats-server", "--help"]` | Use existing binary as health proxy | `nats-server --help` exits with code 1 (not 0) when already running | Binary help commands often return non-zero |
+| `CMD-SHELL "nats-server --help > /dev/null 2>&1"` | Redirect stderr/stdout | No shell to do the redirection | Same shell issue |
+
+## Results & Parameters
+
+```yaml
+# Known scratch/distroless images affected:
+scratch_images:
+  - nats:latest (NATS server)
+  - nats:2.10 (NATS server)
+  - gcr.io/distroless/* (Google distroless)
+  - cgr.dev/chainguard/* (Chainguard images)
+
+# Workaround pattern for compose:
+pattern: |
+  Remove healthcheck from scratch image service.
+  Use simple depends_on (start-order only).
+  Add connection retry loop in dependent services.
+
+# Example retry in C++ (nats.c):
+cpp_retry: |
+  for (int i = 0; i < 30 && !connected; ++i) {
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    s = natsConnection_ConnectTo(&conn, url.c_str());
+  }
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Odysseus | E2E compose with NATS | nats:latest scratch image caused compose deadlock |


### PR DESCRIPTION
## Summary

5 new skills documenting learnings from building the HomericIntelligence E2E pipeline with C++20 services, nats.c JetStream, and podman compose.

1. **natsc-fetchcontent-cpp20-integration** — CMake FetchContent patterns for nats.c v3.9.1, jsErrCode cast requirement, API signature differences
2. **cpp-httplib-lambda-capture-ub** — Dangling reference UB in route handler lambdas (capture pointer by value, not reference)
3. **podman-rootless-dns-container-resolution** — DNS race condition in podman rootless compose networks, direct IP workaround
4. **podman-scratch-image-healthcheck-workaround** — Scratch images have no shell, CMD-SHELL healthchecks always fail
5. **e2e-homeric-compose-cpp-pipeline** — Full 9-container compose stack architecture, C++ Dockerfile patterns, port remapping

## Verification Level

**verified-local** — All patterns tested on a 9-container podman compose stack (NATS, Agamemnon C++, Nestor C++, Hermes Python, hello-myrmidon C++, Prometheus, Loki, Grafana, argus-exporter). 14/18 E2E checks passing.

## Key Findings

**What Worked**:
- nats.c v3.9.1 via FetchContent with `nats_static` target
- cpp-httplib + nlohmann-json + nats.c stack for C++20 REST+messaging services
- Multi-stage Dockerfiles (ubuntu:24.04 builder → slim runtime)
- Direct container IP as NATS_URL workaround for DNS failures

**What Failed**:
- `#include <nats/nats.h>` → use `"nats.h"` instead
- `jsErrCode jerr = 0` in C++ → needs `static_cast<jsErrCode>(0)`
- CMD-SHELL healthchecks on NATS scratch image → remove healthchecks entirely
- Podman rootless DNS → unreliable between containers on first boot

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (990/990 valid)
- [ ] Verify skills appear in marketplace
- [ ] Test skill discovery with keywords: nats, podman, healthcheck, cpp-httplib

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>