### PR TITLE
feat: amend dns-resolution and compose-pipeline skills (v1.1.0)

### DIFF
--- a/skills/e2e-homeric-compose-cpp-pipeline.history
+++ b/skills/e2e-homeric-compose-cpp-pipeline.history
@@ -1,0 +1,25 @@
+# e2e-homeric-compose-cpp-pipeline — History
+
+## v1.1.0 (2026-03-30)
+
+**Changed by:** E2E pipeline iteration — DNS workaround, Promtail, GitHub push
+**Verification:** verified-local
+
+### What changed
+- Added Promtail container for log shipping (10th container)
+- Documented podman socket mount requirement for Promtail docker_sd_configs
+- Added start-stack.sh launcher pattern as recommended startup method
+- Added 2 new Failed Attempts (Promtail socket, compose-only DNS)
+- Updated topology from 9 to 10 containers
+
+### Why
+v1.0.0 described `podman compose up -d` as the startup method, but DNS failures
+meant services couldn't connect to NATS. The start-stack.sh launcher automates
+the IP discovery workaround. Also, Promtail needs the podman socket mounted to
+discover container logs via docker_sd_configs.
+
+---
+
+## v1.0.0 (2026-03-30)
+
+**Initial version.**

--- a/skills/e2e-homeric-compose-cpp-pipeline.md
+++ b/skills/e2e-homeric-compose-cpp-pipeline.md
@@ -3,7 +3,8 @@ name: e2e-homeric-compose-cpp-pipeline
 description: "Wire HomericIntelligence C++20 services into a podman compose E2E stack with NATS JetStream, Prometheus, Grafana. Use when: (1) setting up the full E2E pipeline, (2) adding new C++20 services to the compose stack, (3) debugging multi-container C++ service orchestration."
 category: architecture
 date: 2026-03-30
-version: "1.0.0"
+version: "1.1.0"
+history: e2e-homeric-compose-cpp-pipeline.history
 user-invocable: false
 verification: verified-local
 tags:
@@ -56,7 +57,7 @@ curl localhost:8085/health     # Hermes (Python)
 curl localhost:8222/healthz    # NATS
 ```
 
-### Service Topology (9 containers)
+### Service Topology (10 containers)
 
 ```
 NATS (nats:latest, :4222/:8222)
@@ -68,6 +69,7 @@ NATS (nats:latest, :4222/:8222)
 
 Prometheus (:19090) ← scrapes argus-exporter
 Loki (:13100) ← log aggregation
+Promtail ← scrapes container logs → ships to Loki
 Grafana (:13001) ← dashboards from Prometheus + Loki
 ```
 
@@ -114,6 +116,8 @@ CMD ["ProjectFoo_server"]
 | `depends_on: condition: service_healthy` | Wait for healthy NATS before starting services | Combined with NATS healthcheck failure, blocks all dependent containers | Use simple `depends_on` (start-order only) for scratch images |
 | Same host ports as existing services | Ports 9090, 3100, 3001, 9100 | Zombie `rootlessport` processes from crashed containers hold ports | Remap to non-conflicting ports (19090, 13100, 13001, 19100) |
 | Python stubs for Agamemnon/Nestor | FastAPI Python services as temporary implementation | Violates architecture constraint: all services must be C++/Mojo | Implement in C++20 with cpp-httplib + nlohmann-json + nats.c |
+| Promtail docker_sd without socket | Promtail config uses `docker_sd_configs` but no socket mounted | "Cannot connect to the Docker daemon at unix:///var/run/podman/podman.sock" | Mount podman socket: `- /run/user/1000/podman/podman.sock:/var/run/podman/podman.sock:ro` |
+| Using `podman compose up` alone | Expected DNS to work after compose up | Podman rootless DNS gateway mismatch — services can't resolve each other | Use `start-stack.sh` launcher: compose up → discover IPs → restart services with direct IPs |
 
 ## Results & Parameters
 

--- a/skills/podman-rootless-dns-container-resolution.history
+++ b/skills/podman-rootless-dns-container-resolution.history
@@ -1,0 +1,29 @@
+# podman-rootless-dns-container-resolution — History
+
+## v1.1.0 (2026-03-30)
+
+**Changed by:** E2E pipeline DNS debugging — start-stack.sh workaround script
+**Verification:** verified-local
+
+### What changed
+- Added start-stack.sh launcher script pattern as the recommended workaround
+- Documented root cause: aardvark-dns gateway IP (10.89.2.1) mismatches container resolv.conf (10.89.0.1) across compose recreate cycles
+- Added `network_mode` DNS aliases finding: explicit aliases don't help
+- Added `dns_enabled: true` driver option finding: doesn't fix the issue
+- Added Promtail socket mount pattern for log shipping
+- New failed attempt: patching /etc/resolv.conf inside running container (glibc caches NXDOMAIN)
+
+### Why
+The v1.0.0 approach of manually restarting containers with direct IPs worked but was tedious.
+The start-stack.sh script automates the entire process: compose up → discover IPs → restart
+NATS-dependent services with direct IPs. Also discovered that the root cause is aardvark-dns
+binding to a different subnet than the containers' gateway.
+
+### Previous version (v1.0.0) snapshot
+(See skills/podman-rootless-dns-container-resolution.md at commit containing v1.0.0)
+
+---
+
+## v1.0.0 (2026-03-30)
+
+**Initial version.**

--- a/skills/podman-rootless-dns-container-resolution.md
+++ b/skills/podman-rootless-dns-container-resolution.md
@@ -3,9 +3,10 @@ name: podman-rootless-dns-container-resolution
 description: "Fix podman rootless DNS resolution failures between containers in compose networks. Use when: (1) containers cannot resolve each other by service name, (2) NATS/HTTP connections fail with 'Temporary failure in name resolution', (3) aardvark-dns is running but resolution still fails."
 category: debugging
 date: 2026-03-30
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: podman-rootless-dns-container-resolution.history
 tags:
   - podman
   - rootless
@@ -23,7 +24,8 @@ tags:
 |-------|-------|
 | **Date** | 2026-03-30 |
 | **Objective** | Fix container-to-container DNS resolution in podman rootless compose networks |
-| **Outcome** | Workaround found — use container IPs directly via NATS_URL env var override |
+| **Outcome** | Automated workaround via start-stack.sh launcher script |
+| **History** | [changelog](./podman-rootless-dns-container-resolution.history) |
 | **Verification** | verified-local |
 
 ## When to Use
@@ -59,22 +61,55 @@ podman run -d --name <container> --network <network> \
   -e "NATS_URL=nats://${NATS_IP}:4222" <image>
 ```
 
+### Automated Launcher Script (Recommended)
+
+Create a `start-stack.sh` that automates the workaround:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+get_ip() {
+  podman inspect "$1" 2>/dev/null | python3 -c "
+import sys,json; d=json.load(sys.stdin)
+nets=d[0]['NetworkSettings']['Networks']
+print(list(nets.values())[0]['IPAddress'])"
+}
+
+# Step 1: Start everything via compose
+podman compose -f docker-compose.e2e.yml up -d
+sleep 10
+
+# Step 2: Discover IPs (stable — containers are running)
+NATS_IP=$(get_ip odysseus-nats-1)
+
+# Step 3: Restart NATS-dependent services with direct IPs
+podman run -d --replace --name odysseus-agamemnon-1 \
+  --network odysseus_homeric-mesh \
+  -p 8080:8080 -e "NATS_URL=nats://${NATS_IP}:4222" \
+  odysseus-agamemnon:latest
+# ... repeat for hermes, myrmidon, exporter
+```
+
 ### Detailed Steps
 
 1. Check if `aardvark-dns` is running: `ps aux | grep aardvark`
 2. Check network has DNS: `podman network inspect <net> | grep dns_enabled`
-3. Check container `/etc/resolv.conf` points to `10.89.0.1` (podman DNS)
-4. If resolution still fails, get target container IP: `podman inspect <target> | jq '.[0].NetworkSettings.Networks'`
-5. Restart failing containers with `NATS_URL=nats://<IP>:4222` (or equivalent env var)
-6. For production: file podman bug report; for E2E testing: IP workaround is acceptable
+3. Check aardvark-dns config: `cat /run/user/1000/containers/networks/aardvark-dns/<network>` — first line is DNS IP
+4. Check container `/etc/resolv.conf` — if nameserver doesn't match aardvark-dns IP, that's the bug
+5. Use the launcher script (above) or manually restart with direct IPs
+6. Use `--replace` flag on `podman run` to avoid "name already in use" errors
 
 ### Root Cause Analysis
 
-The failure occurs when:
-- Multiple containers start simultaneously via `podman compose up -d`
-- Some containers attempt DNS resolution before `aardvark-dns` has fully registered all container names
-- The DNS resolution failure is cached by glibc, and even after `aardvark-dns` has the record, the container's resolver returns stale NXDOMAIN
-- Restarting the container (not just the process) clears the DNS cache
+The failure occurs because:
+- `aardvark-dns` binds to a gateway IP on a specific bridge subnet (e.g., `10.89.2.1`)
+- After `podman compose down` + `up` cycles, the network gets recreated on a different subnet
+- Container `/etc/resolv.conf` gets `nameserver 10.89.0.1` (from the new bridge gateway)
+- But aardvark-dns is still listening on `10.89.2.1` (from a previous incarnation)
+- The mismatch means DNS queries go to a non-existent resolver
+- Additionally, glibc caches NXDOMAIN responses — even patching `/etc/resolv.conf` inside a running container doesn't help (the cache persists)
+- Only destroying and recreating the container clears the glibc DNS cache
 
 ## Failed Attempts
 
@@ -85,6 +120,9 @@ The failure occurs when:
 | `healthcheck: test: ["CMD-SHELL", "wget ..."]` | Wget-based health check | NATS image has no wget, no curl, no shell | NATS official image is a minimal scratch image |
 | `healthcheck: test: ["CMD", "nats-server", "--help"]` | Use existing binary for health | `nats-server --help` returns exit code 1 (not 0) when server is already running | Even binary-based checks can have unexpected exit codes |
 | Removing all healthchecks | Simple `depends_on` without conditions | Services start but DNS still fails on first boot — race condition | Ordering alone doesn't solve DNS registration race |
+| Patching `/etc/resolv.conf` live | `podman exec <c> sh -c "echo nameserver 10.89.2.1 > /etc/resolv.conf"` | glibc caches NXDOMAIN — even with correct resolv.conf, cached failures persist | Must destroy+recreate container to clear glibc DNS cache |
+| `dns_enabled: true` in network config | Added `driver_opts: dns_enabled: "true"` to compose network | DNS was already enabled; this option is the default and has no effect | The issue is gateway mismatch, not DNS being disabled |
+| Explicit network aliases | Added `aliases: [nats]` under each service's network config | Aliases registered correctly in aardvark-dns config file but containers still can't resolve | Aliases don't help when the resolver IP itself is wrong |
 
 ## Results & Parameters
 
@@ -98,7 +136,8 @@ network_driver: bridge
 rootless: true
 
 # Working configuration
-workaround: direct_container_ip
+workaround: start-stack.sh launcher script (compose up → discover IPs → restart with direct IPs)
+workaround_alt: direct_container_ip via manual podman run --replace
 nats_image: nats:latest  # scratch image, no shell
 affected_images:
   - python:3.12-slim (Hermes, argus-exporter)


### PR DESCRIPTION
## Summary

Amends 2 existing skills from v1.0.0 to v1.1.0 with learnings from continued E2E debugging.

### podman-rootless-dns-container-resolution (v1.1.0)
- Added `start-stack.sh` launcher script as recommended automated workaround
- Documented true root cause: aardvark-dns gateway IP mismatches container resolv.conf across compose recreate cycles
- 3 new Failed Attempts: resolv.conf patching (glibc caches NXDOMAIN), dns_enabled option (no effect), network aliases (don't help)

### e2e-homeric-compose-cpp-pipeline (v1.1.0)
- Added Promtail as 10th container for log shipping to Loki
- Documented podman socket mount requirement for docker_sd_configs
- 2 new Failed Attempts: Promtail without socket, compose-only startup

## Verification Level

**verified-local** — both workarounds tested on 10-container podman compose stack, 17/18 E2E checks passing.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (990/990)
- [ ] Verify skills appear in marketplace
- [ ] Test skill discovery with keywords: podman, dns, promtail

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>