### PR TITLE
chore(skill): amend e2e-compose-cpp-pipeline to v1.3.0

### DIFF
--- a/skills/e2e-homeric-compose-cpp-pipeline.history
+++ b/skills/e2e-homeric-compose-cpp-pipeline.history
@@ -1,5 +1,30 @@
 # e2e-homeric-compose-cpp-pipeline — History
 
+## v1.3.0 (2026-04-03)
+
+**Changed by:** Dual-runtime verification, distroless NATS fix, aardvark-dns workaround, Docker build fixes, argus-exporter migration
+**Verification:** verified-local
+
+### What changed
+- Changed NATS image from `nats:latest` (distroless) to `nats:alpine` for compose healthcheck compatibility
+- Added aardvark-dns stale state workaround for WSL2 rootless podman (kill PID before fresh start)
+- Added Docker build requirements: `make` package + `conan profile detect --force` in Dockerfiles
+- Migrated argus-exporter from removed ai-maestro (`MAESTRO_URL`/`:23000`) to `AGAMEMNON_URL`/`NESTOR_URL` with `/v1/agents`, `/v1/tasks`, `/v1/health` endpoints and `hi_*` metric prefix
+- Fixed port mapping mismatch: start-stack.sh mapped argus-exporter to `-p 19100:9100` instead of `-p 9100:9100`
+- Verified dual-runtime compatibility: both podman compose and docker compose pass all 7 E2E phases with same docker-compose.e2e.yml
+- Added 5 new Failed Attempts (nats:latest healthcheck, aardvark-dns stale state, Docker build without make, Docker build without profile, argus-exporter MAESTRO_URL)
+- Updated description to include docker compose as verified runtime
+- Added docker tag to metadata
+
+### Why
+Expanding the pipeline to support both podman and docker runtimes uncovered multiple issues:
+distroless nats:latest breaks shell healthchecks, WSL2 podman aardvark-dns accumulates stale
+DNS mappings across down/up cycles, Docker cached builds lack make and Conan default profiles,
+and argus-exporter still referenced the removed ai-maestro service. All resolved and verified
+across both runtimes.
+
+---
+
 ## v1.2.0 (2026-03-30)
 
 **Changed by:** PR review fixes — portability, security, consistency

--- a/skills/e2e-homeric-compose-cpp-pipeline.md
+++ b/skills/e2e-homeric-compose-cpp-pipeline.md
@@ -1,9 +1,9 @@
 ---
 name: e2e-homeric-compose-cpp-pipeline
-description: "Wire HomericIntelligence C++20 services into a podman compose E2E stack with NATS JetStream, Prometheus, Grafana. Use when: (1) setting up the full E2E pipeline, (2) adding new C++20 services to the compose stack, (3) debugging multi-container C++ service orchestration."
+description: "Wire HomericIntelligence C++20 services into a podman/docker compose E2E stack with NATS JetStream, Prometheus, Grafana. Use when: (1) setting up the full E2E pipeline, (2) adding new C++20 services to the compose stack, (3) debugging multi-container C++ service orchestration, (4) troubleshooting podman vs docker runtime differences."
 category: architecture
-date: 2026-03-30
-version: "1.2.0"
+date: 2026-04-03
+version: "1.3.0"
 history: e2e-homeric-compose-cpp-pipeline.history
 user-invocable: false
 verification: verified-local
@@ -11,11 +11,14 @@ tags:
   - e2e
   - compose
   - podman
+  - docker
   - cpp20
   - nats
   - prometheus
   - grafana
   - homeric-intelligence
+  - dual-runtime
+  - wsl2
 ---
 
 # HomericIntelligence E2E Compose Pipeline (C++20 + NATS)
@@ -24,9 +27,9 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-30 |
-| **Objective** | Wire all HomericIntelligence services into a single podman compose stack for E2E testing |
-| **Outcome** | 9-container stack running: NATS, Agamemnon (C++), Nestor (C++), Hermes (Python), hello-myrmidon (C++), Prometheus, Loki, Grafana, argus-exporter. 14/18 E2E checks passing. |
+| **Date** | 2026-04-03 |
+| **Objective** | Wire all HomericIntelligence services into a dual-runtime (podman + docker) compose E2E stack for testing |
+| **Outcome** | 10-container stack running on both podman compose and docker compose: NATS, Agamemnon (C++), Nestor (C++), Hermes (Python), hello-myrmidon (C++), Prometheus, Loki, Promtail, Grafana, argus-exporter. All 7 E2E phases passing on both runtimes. |
 | **Verification** | verified-local |
 
 ## When to Use
@@ -35,14 +38,21 @@ tags:
 - Adding a new C++20 service to the compose stack
 - Debugging service-to-service communication in the HomericIntelligence mesh
 - Understanding the architecture: what connects to what, on which ports
+- Troubleshooting podman vs docker runtime differences
+- Fixing WSL2-specific DNS or container networking issues
 
 ## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# Start the stack (from Odysseus root)
+# WSL2 podman: kill stale aardvark-dns before fresh start
+kill $(cat /run/user/$(id -u)/containers/networks/aardvark-dns/aardvark.pid 2>/dev/null) 2>/dev/null || true
+
+# Start the stack — works with both runtimes (from Odysseus root)
 podman compose -f docker-compose.e2e.yml up -d --build
+# OR
+docker compose -f docker-compose.e2e.yml up -d --build
 
 # Run E2E test
 just e2e-test
@@ -60,12 +70,13 @@ curl localhost:8222/healthz    # NATS
 ### Service Topology (10 containers)
 
 ```
-NATS (nats:latest, :4222/:8222)
+NATS (nats:alpine, :4222/:8222)  ← NOT nats:latest (distroless, no shell)
   ├── Agamemnon (C++20, :8080) — REST API, NATS pub/sub
   ├── Nestor (C++20, :8081) — Research stats, NATS pub
   ├── Hermes (Python/FastAPI, :8085) — Webhook→NATS bridge
   ├── hello-myrmidon (C++20) — NATS pull consumer
-  └── argus-exporter (Python, :9100) — Scrapes all services → Prometheus
+  └── argus-exporter (Python, :9100) — Scrapes Agamemnon + Nestor → Prometheus
+          Uses AGAMEMNON_URL/NESTOR_URL (NOT MAESTRO_URL — ai-maestro removed per ADR-006)
 
 Prometheus (:19090) ← scrapes argus-exporter
 Loki (:13100) ← log aggregation
@@ -76,21 +87,30 @@ Grafana (:13001) ← dashboards from Prometheus + Loki
 ### Detailed Steps
 
 1. C++20 services use multi-stage Dockerfiles: `ubuntu:24.04` builder → slim runtime
-2. NATS uses official `nats:latest` image with `-js -m 8222` flags (JetStream + monitoring)
+2. NATS uses `nats:alpine` (NOT `nats:latest` which is distroless) with `-js -m 8222` flags (JetStream + monitoring)
 3. All services on `homeric-mesh` bridge network
 4. Symlinked submodules need absolute paths in compose build contexts
 5. argus-exporter needs a standalone Dockerfile (inline `dockerfile_inline` not supported by podman compose)
 6. Port remapping needed if host ports are already bound (observability → 19090, 13001, 13100, 19100)
+7. On WSL2 rootless podman: kill aardvark-dns PID before starting a fresh stack to avoid stale DNS mappings
+8. Docker builds require `make` in apt-get install (gtest CMake recipe uses Unix Makefiles) and `conan profile detect --force` before `conan install`
+9. argus-exporter uses `AGAMEMNON_URL`/`NESTOR_URL` with `/v1/agents`, `/v1/tasks`, `/v1/health` endpoints and `hi_*` metric prefix (ai-maestro removed per ADR-006)
+10. Both `podman compose` and `docker compose` work with the same `docker-compose.e2e.yml` — no compose-file changes needed between runtimes
 
 ### C++20 Dockerfile Pattern
 
 ```dockerfile
 FROM ubuntu:24.04 AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake ninja-build g++ git ca-certificates libssl-dev \
+    cmake ninja-build g++ git ca-certificates libssl-dev make python3-pip \
+    && pip3 install --break-system-packages conan \
     && rm -rf /var/lib/apt/lists/*
+# make is required — gtest's CMake recipe uses Unix Makefiles generator
+# conan profile detect is required in fresh containers (no default profile exists)
+RUN conan profile detect --force
 WORKDIR /src
-COPY CMakeLists.txt cmake/ include/ src/ test/ ./
+COPY CMakeLists.txt cmake/ include/ src/ test/ conanfile.py ./
+RUN conan install . --output-folder=build --build=missing
 RUN cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DProjectFoo_BUILD_TESTING=OFF \
     -DProjectFoo_ENABLE_CLANG_TIDY=OFF \
@@ -112,7 +132,8 @@ CMD ["ProjectFoo_server"]
 |---------|----------------|---------------|----------------|
 | Symlink build contexts | `context: ./infrastructure/ProjectHermes/` (symlink) | Podman compose can't follow symlinks for build contexts | Use absolute paths: `context: /home/user/ProjectHermes/` |
 | `dockerfile_inline` in compose | Inline Dockerfile for argus-exporter | Podman's external compose provider doesn't support `dockerfile_inline` | Create a standalone Dockerfile and reference via `dockerfile:` key |
-| CMD-SHELL healthcheck on NATS | `test: ["CMD-SHELL", "wget ..."]` | NATS official image is scratch — no shell, no wget, no curl | Remove healthchecks for scratch images; use simple `depends_on` |
+| CMD-SHELL healthcheck on NATS (v1.0) | `test: ["CMD-SHELL", "wget ..."]` on `nats:latest` | NATS official `nats:latest` is scratch — no shell, no wget, no curl | Remove healthchecks for scratch images; use simple `depends_on` |
+| nats:latest healthcheck (v1.3) | Used wget in CMD-SHELL healthcheck with `nats:latest` | `nats:latest` is distroless, no wget/shell available | Use `nats:alpine` for compose healthchecks — includes shell and wget |
 | `depends_on: condition: service_healthy` | Wait for healthy NATS before starting services | Combined with NATS healthcheck failure, blocks all dependent containers | Use simple `depends_on` (start-order only) for scratch images |
 | Same host ports as existing services | Ports 9090, 3100, 3001, 9100 | Zombie `rootlessport` processes from crashed containers hold ports | Remap to non-conflicting ports (19090, 13100, 13001, 19100) |
 | Python stubs for Agamemnon/Nestor | FastAPI Python services as temporary implementation | Violates architecture constraint: all services must be C++/Mojo | Implement in C++20 with cpp-httplib + nlohmann-json + nats.c |
@@ -123,11 +144,21 @@ CMD ["ProjectFoo_server"]
 | Mixed `docker compose` / `podman compose` | Some justfile recipes used `docker compose` | Inconsistent — podman is the standard per ADR-001 | Use `podman compose` everywhere, remove all `docker compose` references |
 | Hardcoded UID in podman socket path | `/run/user/1000/podman/podman.sock` | Breaks for non-1000 UIDs | Use `${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock` via `.env` variable |
 | Lambda `[&store]` capture in cpp-httplib | Reference to function parameter in route handler | cpp-httplib copies lambdas — reference dangles after `register_routes()` returns | Use `Store* sp = &store; [sp]` pointer capture pattern |
+| podman compose up after down (WSL2) | Ran `podman compose down && up` on WSL2 | aardvark-dns retained stale container-to-IP DNS records across runs | Kill aardvark-dns PID before fresh start: `kill $(cat /run/user/$(id -u)/containers/networks/aardvark-dns/aardvark.pid)` |
+| Docker build without make | Built C++ Dockerfile in Docker | gtest CMake recipe needs `make` (Unix Makefiles generator) | Add `make` to `apt-get install` in Dockerfiles |
+| Docker build without conan profile | Ran `conan install` in fresh Docker container | No Conan default profile exists in fresh containers | Run `conan profile detect --force` before `conan install` |
+| argus-exporter with MAESTRO_URL | Started exporter pointing to ai-maestro on port 23000 | ai-maestro removed per ADR-006 — service doesn't exist | Migrate to `AGAMEMNON_URL`/`NESTOR_URL` with `/v1/agents`, `/v1/tasks`, `/v1/health` and `hi_*` prefix |
+| Port mapping mismatch in start-stack.sh | start-stack.sh mapped argus-exporter to `-p 19100:9100` | Test script expected `:9100` matching compose file definition | Ensure start-stack.sh port mappings match compose file: `-p 9100:9100` |
 
 ## Results & Parameters
 
 ```yaml
-# E2E test results (28/28 passing)
+# E2E test results (28/28 passing, both runtimes)
+# Verified: podman compose AND docker compose pass all 7 E2E phases
+dual_runtime: true
+runtimes_verified:
+  - podman compose (rootless, WSL2)
+  - docker compose (Docker Desktop / Docker CE)
 passing:
   - All 4 service health checks (Agamemnon, Nestor, Hermes, NATS)
   - Webhook → Hermes → NATS accepted
@@ -139,6 +170,39 @@ passing:
   - NATS JetStream (3 connections, 480+ messages)
   - Grafana + Loki API responding
   - Chaos inject + list + remove (3 checks)
+
+# NATS image selection (v1.3.0)
+nats_image: "nats:alpine"  # NOT nats:latest (distroless, no shell/wget/curl)
+nats_healthcheck: |
+  # Works with nats:alpine (has shell + wget)
+  healthcheck:
+    test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+    interval: 5s
+    timeout: 3s
+    retries: 5
+
+# WSL2 podman aardvark-dns fix (v1.3.0)
+aardvark_dns_fix: |
+  # Kill stale aardvark-dns before starting a fresh stack on WSL2
+  # aardvark-dns accumulates stale container-to-IP mappings across down/up cycles
+  kill $(cat /run/user/$(id -u)/containers/networks/aardvark-dns/aardvark.pid 2>/dev/null) 2>/dev/null || true
+
+# Docker build requirements (v1.3.0)
+docker_build_prereqs: |
+  # In Dockerfile builder stage:
+  # 1. Install make (gtest CMake recipe uses Unix Makefiles generator)
+  RUN apt-get install -y make
+  # 2. Create Conan default profile (doesn't exist in fresh containers)
+  RUN conan profile detect --force
+  # 3. Then run conan install
+  RUN conan install . --output-folder=build --build=missing
+
+# argus-exporter migration (v1.3.0 — ai-maestro removed per ADR-006)
+argus_exporter: |
+  # OLD (broken): MAESTRO_URL=http://ai-maestro:23000, /api/agents
+  # NEW: AGAMEMNON_URL=http://agamemnon:8080, NESTOR_URL=http://nestor:8081
+  # Endpoints: /v1/agents, /v1/tasks, /v1/health
+  # Metric prefix: hi_* (e.g., hi_agamemnon_health, hi_nestor_health)
 
 # Portability pattern (v1.2.0)
 env_generation: |
@@ -174,3 +238,4 @@ hermes_build: ~15s (pip install)
 | Project | Context | Details |
 |---------|---------|---------|
 | Odysseus | Full E2E pipeline on feat/cpp-skeleton branch | 9-container stack with C++20 Agamemnon, Nestor, hello-myrmidon |
+| Odysseus | Dual-runtime E2E on fix/governance-compliance-files branch | 10-container stack passing all 7 phases on both podman compose and docker compose. WSL2 aardvark-dns workaround verified. |


### PR DESCRIPTION
## Summary

- Amends `e2e-homeric-compose-cpp-pipeline` skill from v1.2.0 to v1.3.0
- Archives v1.2.0 to history file with full changelog
- Adds 6 new learnings and 6 new failed attempts from dual-runtime E2E verification

## New Learnings

1. **nats:latest is distroless** -- use `nats:alpine` for compose healthchecks (has shell + wget)
2. **Podman aardvark-dns stale state on WSL2** -- kill PID before fresh stack start
3. **Docker builds need `make` + `conan profile detect --force`** -- gtest uses Unix Makefiles, fresh containers lack default Conan profile
4. **argus-exporter still targeted ai-maestro** -- migrated to AGAMEMNON_URL/NESTOR_URL with /v1/* endpoints
5. **Dual-runtime compatibility verified** -- podman compose and docker compose pass all 7 E2E phases with same compose file
6. **Port mapping mismatch bug** -- start-stack.sh used -p 19100:9100 instead of -p 9100:9100

## Test plan

- [ ] Skill frontmatter validates (version 1.3.0, date 2026-04-03)
- [ ] History file has v1.3.0 entry above v1.2.0
- [ ] All 6 new failed attempts present in Failed Attempts table
- [ ] NATS image references updated from nats:latest to nats:alpine
- [ ] Dockerfile pattern includes make + conan profile detect

🤖 Generated with [Claude Code](https://claude.com/claude-code)