### PR TITLE
feat(skills): amend e2e-crosshost-doctor-prerequisite-checker to v1.3.0

### DIFF
--- a/skills/e2e-crosshost-doctor-prerequisite-checker.history
+++ b/skills/e2e-crosshost-doctor-prerequisite-checker.history
@@ -1,5 +1,24 @@
 # e2e-crosshost-doctor-prerequisite-checker -- History
 
+## v1.3.0 (2026-04-06)
+
+**Changed by:** firewalld blocking Tailscale service ports — cross-host port diagnosis and worker provisioning fix
+**Verification:** verified-local (epimetheus 2026-04-06 — firewall fix unblocked all 6 cross-host test phases)
+
+### What changed
+- Added two new "When to Use" triggers: diagnosing cross-host port blocks despite Tailscale connectivity working; setting up new worker host in HomericIntelligence Tailscale mesh
+- Added Detailed Step 10: firewalld / Tailscale zone check with doctor.sh integration snippet, `--install` auto-fix, worker provisioning checklist (`firewall-cmd --permanent --zone=trusted --add-interface=tailscale0`), and diagnostic guidance ("No route to host" vs. connection timeout)
+- Renumbered old step 10 (Summary) to step 11
+- Added new Failed Attempts entry: "Misdiagnosed as Tailscale ACL" — documenting the "No route to host" ICMP reject signal, the false Tailscale ACL hypothesis, and the firewalld root cause on epimetheus
+- Added new "Verified On" entry for epimetheus worker (2026-04-06)
+- Added tags: firewalld, firewall, worker-provisioning
+
+### Why
+After fixing Tailscale connectivity and SSH access to the epimetheus worker, all service port connections (`curl http://<worker-ip>:4222/varz`, ports 8080, 8085, 3001, 9090, 9100) returned "No route to host". Initial diagnosis pointed at Tailscale ACL policy, but Tailscale's default ACL is "allow all". The ICMP reject (not a silent timeout) indicated the worker's kernel firewall was the culprit. `firewalld` (active on Debian 11+) had `tailscale0` in the `public` zone, which blocks most inbound ports. Adding `tailscale0` to the `trusted` zone immediately unblocked all 6 cross-host E2E test phases. Key insight: "No route to host" = ICMP reject = local firewall; connection timeout = silent drop = Tailscale ACL or routing. The doctor script does not currently surface this check — adding it prevents future engineers from spending time on the Tailscale admin console when the answer is on the worker host.
+
+### References
+- Validated on epimetheus (Debian 11, firewalld active), 2026-04-06
+
 ## v1.2.0 (2026-04-04)
 
 **Changed by:** Source-built podman socket fix -- systemd unit file detection and install

--- a/skills/e2e-crosshost-doctor-prerequisite-checker.md
+++ b/skills/e2e-crosshost-doctor-prerequisite-checker.md
@@ -2,8 +2,8 @@
 name: e2e-crosshost-doctor-prerequisite-checker
 description: "Build a `just doctor` prerequisite checker for the HomericIntelligence cross-host E2E pipeline. Use when: (1) creating or extending the doctor diagnostic tool, (2) adding new check categories or dependency verifications, (3) debugging missing prerequisites on worker/control hosts, (4) implementing auto-install modes for CI or fresh host setup."
 category: tooling
-date: 2026-04-04
-version: "1.2.0"
+date: 2026-04-06
+version: "1.3.0"
 user-invocable: false
 verification: verified-local
 tags:
@@ -25,6 +25,9 @@ tags:
   - source-build
   - unit-files
   - service-in-template
+  - firewalld
+  - firewall
+  - worker-provisioning
 ---
 
 # E2E Cross-Host Doctor Prerequisite Checker
@@ -33,7 +36,7 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-04 |
+| **Date** | 2026-04-06 |
 | **Objective** | Create a `just doctor` prerequisite checker/installer for the HomericIntelligence cross-host E2E evaluation pipeline, organized by component categories from docs/architecture.md |
 | **Outcome** | ~530-line bash script (`e2e/doctor.sh`) with 7 check categories, role filtering (`--role worker|control`), auto-install mode (`--install`), and post-deployment service health verification (`--check-services`). All 3 role modes verified on control host. |
 | **Verification** | verified-local |
@@ -48,6 +51,8 @@ tags:
 - Verifying cross-host service health after deployment (`--check-services`)
 - Diagnosing `systemctl --user` failures over SSH (missing `$DBUS_SESSION_BUS_ADDRESS` / `$XDG_RUNTIME_DIR`)
 - Diagnosing podman socket enable failures when podman was installed from source and `systemctl --user` reports "Unit podman.socket could not be found"
+- Diagnosing why cross-host service ports are blocked despite Tailscale connectivity working (SSH works but `curl` to service ports returns "No route to host")
+- Setting up a new worker host that participates in the HomericIntelligence Tailscale mesh for cross-host E2E validation
 
 ## Verified Workflow
 
@@ -147,7 +152,44 @@ just doctor --role worker --install
    ```
    Verify success with `systemctl --user is-active podman.socket` and check the socket file exists at `/run/user/$(id -u)/podman/podman.sock`. Fix: PR Odysseus#86, issue #85.
 
-10. **Summary**: Print pass/fail/warn counts. If any failures and `--install` was not used, print a hint to run `just doctor --install`.
+10. **Firewalld / Tailscale zone check** (for new worker hosts): On hosts using firewalld (default on Debian 11+ and many systemd distros), the `tailscale0` interface is not automatically placed in the `trusted` zone. This causes all non-SSH service ports to return "No route to host" (ICMP reject) even though Tailscale connectivity itself is working. Add a check that probes whether `tailscale0` is in the trusted zone (or equivalent iptables ACCEPT rule exists) and warn loudly if not:
+    ```bash
+    # Check if firewalld is active and tailscale0 is in trusted zone
+    if systemctl is-active --quiet firewalld 2>/dev/null; then
+        if firewall-cmd --get-active-zones 2>/dev/null | grep -A1 "trusted" | grep -q "tailscale0"; then
+            check_pass "firewalld: tailscale0 in trusted zone"
+        else
+            check_fail "firewalld: tailscale0 NOT in trusted zone (cross-host service ports will be blocked)"
+            if [[ "$INSTALL" == "true" ]]; then
+                sudo firewall-cmd --permanent --zone=trusted --add-interface=tailscale0
+                sudo firewall-cmd --reload
+                check_pass "firewalld: tailscale0 added to trusted zone (reload applied)"
+            else
+                echo "  Fix: sudo firewall-cmd --permanent --zone=trusted --add-interface=tailscale0 && sudo firewall-cmd --reload"
+            fi
+        fi
+    fi
+    ```
+    With `--install`, auto-apply the fix. Key diagnostic: "No route to host" (ICMP reject = firewall block) vs. connection timeout (silent drop = Tailscale ACL block). If `ping <worker-ip>` succeeds but `nc -zv <worker-ip> 4222` returns "No route to host", the worker's firewall is the culprit — not Tailscale ACL. See Failed Attempts for full diagnosis.
+
+    **Worker provisioning checklist addition** — run these on every new worker host before E2E validation:
+    ```bash
+    # On new worker host: add tailscale0 to firewalld trusted zone
+    # (firewalld is default on Debian 11+ and many systemd distros)
+    sudo firewall-cmd --permanent --zone=trusted --add-interface=tailscale0
+    sudo firewall-cmd --reload
+
+    # Verify zone assignment
+    firewall-cmd --get-active-zones
+    # Should show: tailscale0 in trusted zone
+
+    # Verify from control host (should be "Connection refused", not "No route to host")
+    nc -zv <worker-ip> 4222
+    # "Connection refused" = firewall open, NATS not running yet (correct)
+    # "No route to host"   = firewall still blocking (fix not applied)
+    ```
+
+11. **Summary**: Print pass/fail/warn counts. If any failures and `--install` was not used, print a hint to run `just doctor --install`.
 
 ### File Layout
 
@@ -179,6 +221,7 @@ justfile                 # Integration: doctor *ARGS: bash e2e/doctor.sh {{ ARGS
 | Reusing common.sh directly | Tried `source e2e/lib/common.sh` for color and output helpers | common.sh defines functions for E2E test phases (PHASE_START, PHASE_END) that conflict with the doctor's simpler pass/fail/skip model | Define doctor-specific helpers (check_pass, check_fail, check_warn, check_skip) that match common.sh's color palette but have different semantics |
 | Podman socket enable over SSH (silent failure) | `just doctor --role worker --install` ran `systemctl --user enable --now podman.socket` in the install path (`e2e/doctor.sh:233`), with stderr redirected to `/dev/null` | SSH sessions lack `$DBUS_SESSION_BUS_ADDRESS` and `$XDG_RUNTIME_DIR` env vars. Without these, `systemctl --user` cannot connect to the user's D-Bus session bus. The error was silently swallowed by `2>/dev/null`, and the fallback `check_warn` message told the user to run the same failing command manually. Confirmed with `loginctl show-user $USER --property=Linger` showing `Linger=no`. | (1) Always export `XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"` and `DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=${XDG_RUNTIME_DIR}/bus}"` before calling `systemctl --user`. (2) Setting env vars alone is NOT sufficient if the systemd user instance is not running at all (SSH without linger). Must detect this case and print actionable diagnostics: suggest `sudo loginctl enable-linger $USER`, then reconnect, or run from a desktop session. (3) Never swallow `systemctl --user` errors with `2>/dev/null` -- capture and surface them. Fix: PR Odysseus#82, issue #81. |
 | `systemctl --user` when unit files missing (source-built podman) | After PR #82 fixed env vars and linger, `systemctl --user enable --now podman.socket` still failed with "Unit podman.socket could not be found" on a host with podman 5.8.1 built from source to `~/.local/bin/podman` | Podman installed from source does not automatically install systemd user unit files. The `podman.socket` and `podman.service` units were absent from `~/.config/systemd/user/` and all systemd search paths. PR #82's env var fix was necessary but not sufficient — once the D-Bus session was reachable, the unit itself was simply missing. The error message "Unit podman.socket could not be found" is the key diagnostic signal. Source trees (e.g. `~/.local/src/podman-5.8.1/contrib/systemd/user/`) contain `podman.socket` and `podman.service.in` (a template requiring `@@PODMAN@@` substitution with the actual binary path). | Before calling `systemctl --user enable`, probe with `systemctl --user cat podman.socket`. If it fails, search `~/.local/src/podman-*/contrib/systemd/user/` and `/usr/local/src/podman-*/contrib/systemd/user/` for the unit templates. Copy `podman.socket` directly; process `podman.service.in` through `sed "s|@@PODMAN@@|$(command -v podman)|g"` to produce `podman.service`. Install both to `~/.config/systemd/user/`, run `systemctl --user daemon-reload`, then proceed with `enable --now`. Fix: PR Odysseus#86, issue #85. |
+| Misdiagnosed as Tailscale ACL | `curl http://<worker-ip>:4222/varz` from the control host returned "No route to host" and only port 22 (SSH) was reachable. Initial assumption: Tailscale ACL policy was blocking specific ports. Checked Tailscale admin console — default ACL was "allow all". Attempted to add explicit ACL rules for ports 4222, 8080, 8085, 3001, 9090, 9100 — no effect. | Tailscale's default ACL is "allow all" between devices on the same tailnet. A "No route to host" response is an ICMP reject from the kernel firewall (`firewalld`/`iptables`/`nftables`), not a Tailscale drop. If it were a Tailscale ACL block, the connection would timeout silently (no ICMP reject). The worker host (epimetheus, Debian 11+) had `firewalld` active with `tailscale0` in the `public` zone (default), which blocks inbound connections to most ports. Only SSH (port 22) was permitted through the public zone's default rules. Key diagnostic: `ping <worker-ip>` succeeds (Tailscale up) + `nc -zv <worker-ip> 4222` returns "No route to host" (ICMP reject = firewall block). If Tailscale ACL were blocking, `nc` would hang silently. | (1) Distinguish "No route to host" (ICMP reject = local firewall) from connection timeout (silent drop = network/ACL/Tailscale policy). (2) Tailscale default ACL is "allow all" — do not blame Tailscale ACL without first verifying the worker's kernel firewall. (3) Fix: `sudo firewall-cmd --permanent --zone=trusted --add-interface=tailscale0 && sudo firewall-cmd --reload` on the worker host. After this fix, all 6 cross-host E2E test phases unblocked on epimetheus (2026-04-06). (4) Add this as a `just doctor` check: warn if `tailscale0` is not in the firewalld `trusted` zone. |
 
 ## Results & Parameters
 
@@ -294,3 +337,4 @@ All 22 checks passed.
 | Odysseus | feat/crosshost-e2e-pipeline branch | Ran `just doctor`, `just doctor --role worker`, `just doctor --role control` on control host. All 3 modes passed. |
 | Odysseus | main branch, PR #82 (issue #81) | Fixed `just doctor --role worker --install` failing to enable podman socket over SSH due to missing `$DBUS_SESSION_BUS_ADDRESS` and `$XDG_RUNTIME_DIR`. Verified locally on worker host via SSH. |
 | Odysseus | main branch, PR #86 (issue #85) | Fixed `just doctor --role worker --install` failing to enable podman socket when podman 5.8.1 was built from source (`~/.local/bin/podman`) and systemd unit files were not installed. Implemented unit file detection and install from source tree `contrib/systemd/user/`. Verified: `systemctl --user is-active podman.socket` → `active`, socket at `/run/user/1000/podman/podman.sock`. |
+| Odysseus (epimetheus worker) | main branch, 2026-04-06 | Diagnosed and fixed firewalld blocking all cross-host service ports on epimetheus despite Tailscale connectivity being up. Running `sudo firewall-cmd --permanent --zone=trusted --add-interface=tailscale0 && sudo firewall-cmd --reload` unblocked all 6 cross-host E2E test phases. Confirmed: `nc -zv <worker-ip> 4222` changed from "No route to host" to "Connection refused" (NATS not yet running, firewall open). |


### PR DESCRIPTION
## Summary

- Adds firewalld/Tailscale zone blocking as a documented failure mode: `tailscale0` not in `trusted` zone causes "No route to host" on all service ports even when SSH works
- Adds new `doctor.sh` check recommendation to warn when `tailscale0` is not in the firewalld trusted zone, with `--install` auto-fix
- Adds worker provisioning checklist with `firewall-cmd --permanent --zone=trusted --add-interface=tailscale0` steps and diagnostic guide (ICMP reject vs. silent timeout to distinguish firewall from Tailscale ACL)
- Bumps version 1.2.0 → 1.3.0, appends v1.3.0 entry to `.history` file

## Test plan

- [x] `python3 scripts/validate_plugins.py` — Valid: 955/955, no errors
- [x] Verified on epimetheus 2026-04-06: firewall fix unblocked all 6 cross-host E2E test phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)