### PR TITLE
feat(skills): amend architecture-crosshost-nats-compose-deployment to v1.1.0

### DIFF
--- a/skills/architecture-crosshost-nats-compose-deployment.history
+++ b/skills/architecture-crosshost-nats-compose-deployment.history
@@ -1,0 +1,24 @@
+# architecture-crosshost-nats-compose-deployment -- History
+
+## v1.1.0 (2026-04-06)
+
+**Changed by:** Full cross-host validation PASS — slirp4netns port remapping fix, Hermes PYTHONPATH fix
+**Verification:** verified-local
+
+### What changed
+- Bumped version to 1.1.0, updated date to 2026-04-06
+- Updated Overview Outcome to note full 6-phase cross-host validation PASS confirmed 2026-04-06
+- Added two new "When to Use" entries: rootlessport-absent NATS native binary scenario; Hermes `No module named 'hermes'` diagnosis
+- Added new "Native Binary Startup Pattern" subsection in Verified Workflow with complete startup sequence and NATS reconnection warning
+- Added three new Failed Attempts rows:
+  1. NATS via podman container with slirp4netns — rootlessport absent causes ephemeral port remapping
+  2. Hermes started without PYTHONPATH — `No module named 'hermes'`; fix: `PYTHONPATH=src pixi run ...`
+  3. No restart after NATS port change — Agamemnon/Hermes lose connection, do not auto-reconnect
+- Updated Verified On table: added 2026-04-06 entry with 6-check full validation result; added Date column
+- Added tags: native-binary, pythonpath
+
+### Why
+Cross-host validation 2026-04-06 uncovered three blockers not present in the initial 2026-04-03 session. (1) On a host where rootlessport is absent, podman's slirp4netns remaps NATS port 4222 to an ephemeral port (e.g. 14222), making `curl http://<worker-ip>:4222/varz` return "Connection refused" from external hosts even though the container appeared to start cleanly. Fix: run nats-server as a native binary. (2) Starting Hermes via `pixi run python -m uvicorn hermes.main:app` fails with `No module named 'hermes'` because the `src/` layout is not automatically added to PYTHONPATH. Fix: prefix with `PYTHONPATH=src`. (3) After switching NATS from container to native binary the running Agamemnon and Hermes processes do not reconnect — both must be restarted once NATS is stable on port 4222.
+
+### References
+- Odysseus cross-host E2E session 2026-04-06

--- a/skills/architecture-crosshost-nats-compose-deployment.md
+++ b/skills/architecture-crosshost-nats-compose-deployment.md
@@ -2,8 +2,8 @@
 name: architecture-crosshost-nats-compose-deployment
 description: "Deploy HomericIntelligence ecosystem across two Tailscale hosts using Docker Compose overlays and direct NATS connections. Use when: (1) splitting the E2E stack across multiple machines, (2) configuring NATS leafnode or direct connections over Tailscale, (3) debugging cross-host service communication, (4) setting up NATS-to-Loki log forwarding bridges."
 category: architecture
-date: 2026-04-03
-version: "1.0.0"
+date: 2026-04-06
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
 tags:
@@ -17,6 +17,8 @@ tags:
   - e2e
   - homeric-intelligence
   - loki
+  - native-binary
+  - pythonpath
 ---
 
 # Cross-Host NATS Compose Deployment
@@ -25,9 +27,9 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-03 |
+| **Date** | 2026-04-06 |
 | **Objective** | Deploy HomericIntelligence ecosystem across two Tailscale hosts for E2E agent evaluation |
-| **Outcome** | Two-host deployment with worker host running full compose stack and control host running native Nestor + odysseus-console. Direct NATS over Tailscale, no leaf node needed. |
+| **Outcome** | Two-host deployment with worker host running full compose stack and control host running native Nestor + odysseus-console. Direct NATS over Tailscale, no leaf node needed. Full 6-phase cross-host validation PASS confirmed 2026-04-06. |
 | **Verification** | verified-local |
 
 ## When to Use
@@ -37,6 +39,8 @@ tags:
 - Debugging cross-host service communication issues (DNS, ports, connectivity)
 - Setting up NATS-to-Loki log forwarding for distributed observability
 - Understanding when NATS leaf nodes add value vs. when direct connections suffice
+- Running NATS as a native binary when rootlessport is absent (slirp4netns port remapping issue)
+- Diagnosing `No module named 'hermes'` when starting Hermes with uvicorn
 
 ## Verified Workflow
 
@@ -58,6 +62,31 @@ WORKER_HOST_IP=100.92.173.32 just crosshost-test $WORKER_HOST_IP
 # Control host — start event viewer
 just odysseus-console nats://100.92.173.32:4222
 ```
+
+### Native Binary Startup Pattern (when rootlessport absent)
+
+When `rootlessport` is not available on the worker host, podman's slirp4netns network stack remaps container ports to ephemeral ports invisible to external hosts. In this case, run all services as native binaries:
+
+```bash
+# Worker host: start all services as native binaries (when rootlessport absent)
+
+# NATS — must use native binary when rootlessport missing
+~/.local/bin/nats-server -js -p 4222 -m 8222 > /tmp/nats-crosshost.log &
+sleep 2 && curl http://localhost:4222/varz | python3 -c "import sys,json; d=json.load(sys.stdin); print('NATS OK:', d['server_id'][:12])"
+
+# Agamemnon
+NATS_URL=nats://localhost:4222 ./control/ProjectAgamemnon/build/debug/ProjectAgamemnon_server > /tmp/agamemnon-crosshost.log &
+
+# Hermes — PYTHONPATH=src required
+cd infrastructure/ProjectHermes
+PYTHONPATH=src pixi run python -m uvicorn hermes.main:app --host 0.0.0.0 --port 8085 > /tmp/hermes-crosshost.log &
+cd -
+
+# hello-myrmidon Python worker
+python3 provisioning/Myrmidons/hello-world/main.py > /tmp/myrmidon-crosshost.log &
+```
+
+**Important:** If NATS port changes mid-session (e.g., switching from container to native binary), restart both Agamemnon and Hermes — they do not automatically reconnect to the new NATS address.
 
 ### Deployment Topology
 
@@ -192,6 +221,9 @@ The Myrmidons submodule was pinned to an old commit still targeting `ai-maestro`
 | Direct leaf.conf to port 4222 | Connected leaf node to NATS client port | Leaf nodes require dedicated leafnode listener port (7422) | Always use the leafnode-specific port (7422), not the client port (4222) |
 | Submodule scripts as-is | Tried to use provisioning/Myrmidons scripts | Submodule pinned to old commit with `aim_*` functions targeting ai-maestro | Verify submodule pins match standalone checkouts after migrations |
 | Keystone as transport daemon | Planned to use Keystone to bridge BlazingMQ to NATS | Keystone is a C++ library with MessageBus abstraction, not a deployable service. No BlazingMQ binary exists. | Components connect to NATS directly; Keystone transport abstraction is aspirational |
+| NATS via podman container with slirp4netns | `podman run -d --network=host` for NATS | slirp4netns (rootless network stack when rootlessport absent) remaps port 4222 to an ephemeral port (e.g., 14222) invisible to external clients; cross-host `curl http://<worker-ip>:4222/varz` gets "Connection refused" | Start NATS as a native binary (`~/.local/bin/nats-server -js -p 4222 -m 8222`) when rootlessport is absent |
+| Hermes started without PYTHONPATH | `pixi run python -m uvicorn hermes.main:app` | `src/` directory is not on PYTHONPATH by default; fails with `No module named 'hermes'` | Always prefix with `PYTHONPATH=src`: `PYTHONPATH=src pixi run python -m uvicorn hermes.main:app --host 0.0.0.0 --port 8085` |
+| No restart after NATS port change | Left Agamemnon and Hermes running when switching NATS from container to native binary | Running processes lose their NATS connection and do not automatically reconnect to the new address | Restart both services after NATS is stable on the correct port |
 
 ## Results & Parameters
 
@@ -245,6 +277,7 @@ env_vars:
 
 ## Verified On
 
-| Project | Context | Details |
-|---------|---------|---------|
-| Odysseus | Cross-host E2E deployment | 2-host topology: worker (epimetheus) + control host over Tailscale mesh |
+| Project | Date | Details |
+|---------|------|---------|
+| Odysseus | 2026-04-03 | Cross-host E2E deployment — 2-host topology: worker (epimetheus) + control host over Tailscale mesh |
+| Odysseus | 2026-04-06 | Full cross-host validation PASS after firewalld fix; all 6 checks: NATS reachable, Agamemnon health, Hermes webhook, task lifecycle, observability metrics |


### PR DESCRIPTION
## Summary

- Bumps `architecture-crosshost-nats-compose-deployment` from v1.0.0 to v1.1.0
- Adds full 6-phase cross-host validation PASS results (2026-04-06)
- Documents slirp4netns port-remapping failure and native `nats-server` binary fix
- Documents Hermes `No module named 'hermes'` failure and `PYTHONPATH=src` fix
- Documents NATS reconnection disruption and restart requirement after port change
- Creates new history file with structured v1.1.0 changelog entry

## Test plan

- [x] `python3 scripts/validate_plugins.py` — 955/955 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)