### PR TITLE
feat: amend wave-based-bulk-issue-triage skill (v1.1.0)

### DIFF
--- a/skills/wave-based-bulk-issue-triage.history
+++ b/skills/wave-based-bulk-issue-triage.history
@@ -1,0 +1,47 @@
+# History: wave-based-bulk-issue-triage
+
+## v1.1.0 — 2026-04-06
+
+**Amendment**: Add myrmidon swarm pattern for bulk `gh issue create` operations.
+
+### Changes from v1.0.0
+- Bumped version to 1.1.0, updated date to 2026-04-06
+- Added `verification: verified-local` to frontmatter (was missing)
+- Added `history` frontmatter field pointing to this file
+- Extended description to cover bulk gh issue create via myrmidon swarm
+- **When to Use**: Added item 5 — filing 10+ GitHub issues from an audit or walkthrough report
+- **Results**: New section "Myrmidon Swarm Pattern for Bulk Issue Filing" covering:
+  - Plain Agent calls (not Task isolation:worktree) for pure gh issue create
+  - Haiku model tier for fully-specified commands requiring no design decisions
+  - Wave limit: ≤5 agents per wave to prevent API rate limiting
+  - No worktrees needed when no repository files are modified
+  - Body-file pattern for issue bodies containing single quotes or apostrophes
+  - Verified: 11 issues in ~30s (HomericIntelligence/Odysseus #99-#109)
+- **Failed Attempts**: Added body quoting gotcha — single-quoted strings break on embedded apostrophes; use `--body-file` instead
+- **Verified On**: Added HomericIntelligence/Odysseus entry
+
+### Verification
+- verified-local: 11 issues filed on HomericIntelligence/Odysseus (#99-109) on 2026-04-06
+
+---
+
+## v1.0.0 — 2026-02-22 (snapshot)
+
+**Original skill** — Wave-based bulk issue triage using `Task(isolation="worktree")`.
+
+### Summary
+- Verified on ProjectScylla: 8 PRs created (Wave 6+7), 23 new tests, ~2 min per wave
+- Pattern: Group issues by complexity → Wave A (simple) then Wave B (test additions)
+- Key innovation: `Task(isolation="worktree")` — zero manual worktree management
+- Issues resolved: #920, #930, #959, #985, #986, #987, #898, #1042
+- PRs created: #1051–#1059
+
+### Frontmatter at v1.0.0
+```yaml
+name: wave-based-bulk-issue-triage
+description: "Fix 5+ independent GitHub issues in parallel waves using Task isolation:worktree. No manual worktree setup — Claude Code auto-manages isolation."
+category: architecture
+date: 2026-02-22
+version: 1.0.0
+user-invocable: false
+```

--- a/skills/wave-based-bulk-issue-triage.md
+++ b/skills/wave-based-bulk-issue-triage.md
@@ -1,11 +1,14 @@
 ---
 name: wave-based-bulk-issue-triage
 description: "Fix 5+ independent GitHub issues in parallel waves using Task isolation:worktree.\
-  \ No manual worktree setup \u2014 Claude Code auto-manages isolation."
+  \ No manual worktree setup \u2014 Claude Code auto-manages isolation. Also covers\
+  \ bulk gh issue create via myrmidon swarm (plain Agent calls, no worktrees needed)."
 category: architecture
-date: 2026-02-22
-version: 1.0.0
+date: 2026-04-06
+version: 1.1.0
 user-invocable: false
+verification: verified-local
+history: wave-based-bulk-issue-triage.history
 ---
 # Skill: Wave-Based Bulk Issue Triage
 
@@ -24,6 +27,7 @@ Use this skill when:
 2. **Issues fall into categories** — e.g., simple doc/config fixes vs. test additions
 3. **Issues modify different files** — no shared file conflicts
 4. **Want maximum parallelism** with minimal orchestration overhead
+5. **Filing 10+ GitHub issues from an audit or walkthrough report** — use myrmidon swarm (plain Agent calls, no worktrees needed)
 
 **Don't use when:**
 - Issues depend on each other (use sequential PRs)
@@ -143,8 +147,57 @@ You are fixing GitHub issue #NNN in the ProjectScylla repository.
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| N/A | Direct approach worked | N/A | Solution was straightforward |
+| N/A | Direct approach worked for code-fix waves | N/A | Solution was straightforward |
+| Body quoting (2026-04-06) | Single-quoted `--body '...'` strings with apostrophes/single quotes embedded | Shell interprets `'` inside `'...'` as end of string, breaking the command | Use `--body-file /tmp/issue-body.md` for any body containing single quotes or apostrophes |
 ## Results & Parameters
+
+### Myrmidon Swarm Pattern for Bulk Issue Filing (2026-04-06)
+
+When filing 10+ `gh issue create` calls (e.g., from a walkthrough or audit report), use the **myrmidon swarm** (plain Agent calls) instead of `Task(isolation="worktree")`. No file modifications means no worktrees needed.
+
+**Pattern:**
+
+```
+Wave 1 (≤5 Haiku agents in parallel):
+  Agent 1: gh issue create --repo ORG/REPO --title "..." --label "..." --body-file /tmp/issue-1.md
+  Agent 2: gh issue create --repo ORG/REPO --title "..." --label "..." --body-file /tmp/issue-2.md
+  ...
+
+Wave 2 (≤5 Haiku agents):
+  ...
+
+Wave 3 (remainder):
+  ...
+```
+
+**Rules:**
+1. Each agent gets exactly one `gh issue create` command
+2. Multi-line or apostrophe-containing bodies: write to a temp file first, then pass `--body-file /tmp/issue-N.md`
+3. Labels: pass multiple `--label` flags (one per label), **not** comma-separated in a single flag
+4. Wave limit: **≤5 agents per wave** to prevent GitHub API rate limiting
+5. Model tier: **Haiku** — fully-specified `gh issue create` calls require no design decisions
+6. No worktrees needed since no repository files are modified
+
+**Verified performance:** 11 issues filed in ~30 seconds total (3 waves: 5+5+1 agents) on HomericIntelligence/Odysseus (issues #99–109, 2026-04-06).
+
+#### Body-File Pattern for Complex Issue Bodies
+
+```bash
+# In each agent's prompt:
+cat > /tmp/issue-body.md << 'EOF'
+## Summary
+...content with 'single quotes' and apostrophes freely...
+
+## Steps to Reproduce
+...
+EOF
+gh issue create \
+  --repo ORG/REPO \
+  --title "Issue title" \
+  --label "bug" \
+  --label "priority:high" \
+  --body-file /tmp/issue-body.md
+```
 
 ### Session Results (2026-02-22)
 
@@ -194,3 +247,4 @@ Add a comment in the plan when excluding:
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectScylla | Wave 6+7, PRs #1051-#1059 | [notes.md](references/notes.md) |
+| HomericIntelligence/Odysseus | Bulk issue filing, issues #99-#109 (2026-04-06) | 11 issues, 3 waves (5+5+1 Haiku agents), ~30s total |


### PR DESCRIPTION
## Summary

Amends wave-based-bulk-issue-triage from v1.0.0 to v1.1.0 with validated myrmidon swarm pattern for bulk `gh issue create` operations.

## Key Additions

- Haiku Agent calls (not Task isolation:worktree) for pure gh issue create — no files modified = no worktrees needed
- <=5 agents per wave; 11 issues filed in ~30 seconds total (3 waves)
- Body quoting gotcha documented: use --body-file for bodies containing single quotes

## Verification Level
**verified-local** -- 11 issues filed on HomericIntelligence/Odysseus (#99-109) on 2026-04-06.

## Test Plan
- [x] Validate with `python3 scripts/validate_plugins.py`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>