### PR TITLE
feat: amend mojo-closures-capturing-numerical-forward-trait skill (v2.0.0)

### DIFF
--- a/skills/mojo-closures-capturing-numerical-forward-trait.history
+++ b/skills/mojo-closures-capturing-numerical-forward-trait.history
@@ -1,16 +1,40 @@
+# mojo-closures-capturing-numerical-forward-trait — History
+
+## v2.0.0 (2026-04-09)
+
+**Changed by:** ProjectOdyssey PR #5209 — fix-all-ci-root-causes branch
+**Verification:** verified-local (CI pending)
+
+### What changed
+
+- Added NumericalBackward trait for two-function pattern (check_gradient takes both forward and backward)
+- Added no-capture struct pattern (zero-field structs for pure ops like relu/sigmoid)
+- Added unified {read} removal rule (struct methods must not use it)
+- Added bulk migration guidance (35 files, parallel sub-agents)
+- Added struct naming convention (_DescriptiveName[Fwd|Bwd])
+- Bumped verification: pattern scaled to 100+ closure pairs, not just 4
+
+### Why
+
+v1.0.0 only covered the forward-only case (compute_numerical_gradient). The session revealed
+that check_gradient() takes BOTH forward AND backward closures, requiring NumericalBackward
+trait in addition to NumericalForward. Additionally, v1.0.0 only covered capture closures;
+this version adds the no-capture (zero-field) case and struct method rules.
+
+### Previous version (v1.0.0) snapshot
+
 ---
 name: mojo-closures-capturing-numerical-forward-trait
-description: "Workaround for Mojo 0.26.3: capturing closures cannot be passed to def(T) raises -> T parameters. Use when: (1) a nested def captures outer variables and must be passed to a higher-order function, (2) compiler gives 'capturing nested functions must be declared unified' or 'cannot pass unified closure to escaping parameter', (3) higher-order function takes BOTH forward AND backward function arguments (e.g., check_gradient(fwd, bwd, ...)), (4) need to migrate a large codebase (10+ files) of capturing closures in parallel."
+description: "Workaround for Mojo 0.26.3: capturing closures cannot be passed to def(T) raises -> T parameters. Use when: (1) a nested def captures outer variables and must be passed to a higher-order function, (2) compiler gives 'capturing nested functions must be declared unified' or 'cannot pass unified closure to escaping parameter'."
 category: debugging
 date: 2026-04-09
-version: "2.0.0"
-history: mojo-closures-capturing-numerical-forward-trait.history
+version: "1.0.0"
 user-invocable: false
 verification: verified-local
 tags: []
 ---
 
-# Mojo 0.26.3: Capturing Closures → NumericalForward / NumericalBackward Trait Pattern
+# Mojo 0.26.3: Capturing Closures → NumericalForward Trait Pattern
 
 ## Overview
 
@@ -18,7 +42,7 @@ tags: []
 |-------|-------|
 | **Date** | 2026-04-09 |
 | **Objective** | Pass capturing closures (that close over runtime variables) to higher-order functions in Mojo 0.26.3 |
-| **Outcome** | Successful — struct + trait pattern compiles with zero `--Werror` errors. Applied to ~35 test files in ProjectOdyssey PR #5209 |
+| **Outcome** | Successful — struct + trait pattern compiles with zero `--Werror` errors |
 | **Verification** | verified-local — CI pending |
 
 ## When to Use
@@ -27,12 +51,10 @@ tags: []
 - Compiler error: `capturing nested functions must be declared 'unified'`
 - Compiler error after adding `unified {read}`: `cannot pass non-escaping closure to escaping parameter`
 - You need a higher-order function that works with both capturing and non-capturing forwards
-- Higher-order function takes BOTH forward AND backward function arguments (e.g., `check_gradient(fwd, bwd, ...)`)
-- Need to migrate a large codebase (10+ files) of capturing closures in parallel
 
 ## Verified Workflow
 
-### Quick Reference — Forward (Single-Function) Pattern
+### Quick Reference
 
 ```mojo
 # 1. Define trait in your module
@@ -55,58 +77,18 @@ var fwd = MyForward(captured_value)
 var grad = compute_gradient(fwd, input)
 ```
 
-### Backward (Two-Function) Pattern
-
-When the higher-order function takes BOTH forward AND backward closures (e.g., `check_gradient(fwd, bwd, ...)`):
-
-```mojo
-# Backward trait — note different signature: (grad_out, x) not just (x)
-trait NumericalBackward(Copyable, Movable):
-    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor: ...
-
-@fieldwise_init
-struct _MyLayerBwd(NumericalBackward):
-    var weights: AnyTensor
-    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return my_layer_backward(grad_out, x, self.weights)
-
-# Both forward and backward passed to check_gradient:
-check_gradient(_MyLayerFwd(weights), _MyLayerBwd(weights), input, grad_output)
-```
-
-### Additional Rules
-
-- **No-capture structs**: If the closure uses no outer variables (e.g., pure activation functions like relu, sigmoid), create a zero-field struct — `@fieldwise_init` still works and generates an empty `__init__`:
-
-  ```mojo
-  @fieldwise_init
-  struct _ReluFwd(NumericalForward):
-      def __call__(self, x: AnyTensor) raises -> AnyTensor:
-          return relu(x)
-  ```
-
-  Instantiated as `_ReluFwd()` with no arguments.
-
-- **Remove `unified {read}` from struct methods**: `unified {read}` only applies to NESTED `def` closures, not struct instance methods. Change `def __call__(self, ...) raises unified {read} -> AnyTensor:` to `def __call__(self, ...) raises -> AnyTensor:`.
-
-- **Struct naming convention**: Use `_DescriptiveName[Fwd|Bwd]` with underscore prefix (private). Place structs at MODULE level (outside any function), not inside test functions.
-
-- **Reuse structs across test functions**: If the same op is tested in multiple test functions (e.g., relu appears in 3 tests), define ONE shared struct at module level — don't create duplicates per function.
-
 ### Detailed Steps
 
 1. Define a trait with `__call__` that matches the closure signature. Inherit `Copyable, Movable`
    so the struct can be stored/moved.
 2. For each capturing closure, create a `@fieldwise_init` struct with fields for each captured
-   variable. For non-capturing closures, create a zero-field struct.
+   variable.
 3. Implement `__call__` on the struct, reading from `self.fieldname` instead of the captured
-   variable. Do NOT add `unified {read}` to struct methods.
+   variable.
 4. Add a parametric overload `[F: TraitName]` to every higher-order function that previously
    took `def(T) raises -> T`.
 5. At each call site, instantiate the struct with the captured values and pass it as a value
    argument.
-6. For two-function patterns (e.g., `check_gradient`), define BOTH `NumericalForward` and
-   `NumericalBackward` traits and create struct pairs.
 
 **Note**: The existing `def(T) raises -> T` overload can coexist for non-capturing closures
 (which remain escaping and can still be passed directly).
@@ -120,11 +102,10 @@ check_gradient(_MyLayerFwd(weights), _MyLayerBwd(weights), input, grad_output)
 | Compile-time param | `compute_gradient[forward](x)` | "cannot use a dynamic value in a parameter list" — closures that capture runtime vars are not compile-time values | Compile-time params only work for module-scope non-capturing functions |
 | `AnyType` param | `def f[T: AnyType](fn: T, x: AnyTensor)` | Closures don't conform to `AnyType` or user-defined traits directly | Must use struct wrapper; closures are not first-class trait implementors |
 | Module-scope function | Extract closure to top-level `def` | Cannot capture runtime values at module scope | Only works if the function needs no captured context |
-| `unified {read}` on struct methods | Applied `unified {read}` to `def __call__(self, ...) raises unified {read} -> AnyTensor:` on struct methods | "unified effect is only applicable on nested functions" compile error | `unified` only applies to NESTED def functions, never struct methods |
 
 ## Results & Parameters
 
-**Forward struct template** (copy-paste):
+**Struct template** (copy-paste):
 
 ```mojo
 @fieldwise_init
@@ -136,30 +117,11 @@ struct _MyLayerForward(NumericalForward):
         return my_layer_op(x, self.field1, field2=self.field2)
 ```
 
-**Backward struct template** (copy-paste):
-
-```mojo
-@fieldwise_init
-struct _MyLayerBackward(NumericalBackward):
-    var weights: AnyTensor
-    var bias: AnyTensor
-
-    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return my_layer_backward(grad_out, x, self.weights, self.bias)
-```
-
-**Forward trait definition** (copy-paste, place near top of module):
+**Trait definition** (copy-paste, place near top of module):
 
 ```mojo
 trait NumericalForward(Copyable, Movable):
     def __call__(self, x: AnyTensor) raises -> AnyTensor: ...
-```
-
-**Backward trait definition** (copy-paste, place near top of module):
-
-```mojo
-trait NumericalBackward(Copyable, Movable):
-    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor: ...
 ```
 
 **Parametric overload** (copy-paste):
@@ -199,4 +161,3 @@ var grad = compute_numerical_gradient(fwd, input, epsilon)
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | Mojo 0.26.3 migration, branch fix-ci-root-causes | 4 closures in layer_testers.mojo replaced with structs; package compiles --Werror clean |
-| ProjectOdyssey | PR #5209 — 35 test files, ~100+ closure pairs migrated (Groups A-D: activations, losses, conv, normalization, reduction, matrix, gradient checking/validation tests) | Parallel sub-agents handled groups concurrently |


### PR DESCRIPTION
Amends v1.0.0 -> v2.0.0 with NumericalBackward trait pattern and bulk migration guidance.

Applied in ProjectOdyssey PR #5209 to 35 test files (~100+ closure pairs).

Key additions:
- NumericalBackward trait for two-function gradient check (check_gradient takes both fwd+bwd)
- Zero-field struct pattern for pure ops (relu, sigmoid, etc.)
- Rule: unified {read} must NOT appear on struct methods
- Struct naming/reuse conventions for large-scale migration
- Parallel sub-agent approach for migrating many files concurrently

Verification: verified-local (CI pending on PR #5209)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>