### PR TITLE
feat: amend mojo-jit-crash-retry (v3.1.0) and batch-pr-ci-fix-workflow (v2.5.0)

### DIFF
--- a/skills/batch-pr-ci-fix-workflow.history
+++ b/skills/batch-pr-ci-fix-workflow.history
@@ -1,5 +1,36 @@
 # batch-pr-ci-fix-workflow — Version History
 
+## v2.5.0 (2026-04-12)
+
+**Changed by:** ProjectOdyssey 12-open-PR batch fix session
+**Verification:** verified-ci (9 PRs rebased, 2 closed as subsumed, all with auto-merge armed)
+
+### What changed
+
+- Added Phase 0.6: Detect Subsumed PRs Before Rebasing
+  - Pattern: `git log --oneline origin/main..origin/<branch>` empty → subsumed; confirm
+    with `git diff origin/<branch> origin/main` before closing
+  - From PRs #5224 and #5221: identical patch content on branch and main (different SHA)
+    due to rebase; both auto-closed when rebased to empty
+- Added Phase 0.7: Required Checks Failing Non-Deterministically on Every Main Run
+  - Evidence command: loop over 5 recent main runs, collect failed job names — different
+    sets each run = JIT flakiness
+  - Corrective action: RC/CA ADR + import audit; explicitly NOT retry logic
+  - Cross-reference to `mojo-jit-crash-retry` skill
+- Added 2 new Failed Attempts rows:
+  - Assuming PR has unique content without checking → run git log first
+  - Responding to required-check JIT flakiness with retry → RC/CA ADR instead
+
+### Why
+
+Session exposed two new patterns not covered in v2.4.0: subsumed PRs that auto-close on
+empty rebase, and systemic JIT flakiness on required checks that looks like a code blocker
+but is a pre-existing infrastructure issue requiring root-cause investigation.
+
+---
+
+# batch-pr-ci-fix-workflow — Version History
+
 ## v2.4.0 (2026-04-12)
 
 **Changed by:** ProjectHephaestus open-PR cleanup — PRs #268 (feat/automation-module rebase) and #269 (dependabot setup-pixi bump) via fix PR #270

--- a/skills/batch-pr-ci-fix-workflow.md
+++ b/skills/batch-pr-ci-fix-workflow.md
@@ -3,7 +3,7 @@ name: batch-pr-ci-fix-workflow
 description: "Use when: (1) multiple PRs have failing CI checks (formatting, pre-commit, broken links, broken JSON, mypy), (2) a common CI failure pattern affects many PRs and needs a root-cause fix before rebasing, (3) PRs need batch auto-merge after fixes, (4) JSON files are bulk-corrupted and must be repaired before merging, (5) identifying required vs non-required checks, (6) recovering auto-merge after force-push, (7) reconstructing a branch that conflicts with a src-layout migration, (8) pytest caplog test failures with LogRecord.message, (9) gcovr coverage reports 0% in CI, (10) ruff F841 unused variable not auto-fixable, (11) dependabot PR blocked by pre-existing main-branch workflow bug, (12) check-yaml fails on duplicate GHA job keys, (13) small-batch rebase-then-resolve in a worktree."
 category: ci-cd
 date: 2026-04-12
-version: "2.4.0"
+version: "2.5.0"
 user-invocable: false
 verification: verified-ci
 history: batch-pr-ci-fix-workflow.history
@@ -31,6 +31,8 @@ tags: []
 - **[NEW v2.0.0]** Auto-merge was cleared by a force-push and must be re-enabled
 - **[NEW v2.0.0]** A branch conflicts with a src-layout migration and standard rebase fails immediately
 - **[NEW v2.0.0]** Pre-existing failures look like blockers but are not required checks
+- **[NEW v2.5.0]** A PR branch's content may already be in main (subsumed by rebase) — detect before rebasing
+- **[NEW v2.5.0]** Required checks fail non-deterministically on every main run (JIT flakiness) blocking all PRs
 
 ## Verified Workflow
 
@@ -113,6 +115,55 @@ treat it as advisory-only. Never spend time fixing advisory failures when requir
 
 **When in doubt**: Enable auto-merge and let GitHub report whether it can proceed. If auto-merge
 reports "Waiting for required checks", those are the blocking ones.
+
+### Phase 0.6: [NEW v2.5.0] Detect Subsumed PRs Before Rebasing
+
+A PR branch may be fully or partially subsumed by main after a rebase-heavy history. Rebasing
+an empty branch closes the PR automatically — detect this before touching anything.
+
+```bash
+# Check unique commits on each PR branch not yet in main
+git fetch origin
+git log --oneline origin/main..origin/<branch>
+# Empty → all commits already in main; PR can be closed
+
+# Confirm content-level identity (same patch, different SHA after rebase)
+git diff origin/<branch> origin/main -- <key-file>
+# Empty diff → subsumed; close the PR with a comment explaining why
+```
+
+**Pattern from ProjectOdyssey 2026-04-12**: PRs #5224 and #5221 had 3 commits each that
+matched main 1:1 (identical patch content, rebased SHA). Both PRs were auto-closed when
+rebased to empty. The remaining unique content (`.devcontainer/`, `.editorconfig`) was still
+present, confirming the check is necessary — don't assume subsumption, verify with `git diff`.
+
+### Phase 0.7: [NEW v2.5.0] Required Checks Failing Non-Deterministically on Every Main Run
+
+When a required check fails on every consecutive `main` run but with **different job sets**
+each time, this is systemic JIT flakiness — not a code regression. The correct action is
+**RC/CA investigation**, not adding retry logic.
+
+```bash
+# Confirm non-deterministic pattern across multiple main runs
+for run in $(gh run list --branch main --workflow "Comprehensive Tests" \
+  --limit 5 --json databaseId --jq '.[].databaseId'); do
+  echo "=== run $run ==="; gh run view $run --json jobs \
+    --jq '.jobs[] | select(.conclusion=="failure") | .name'
+done
+# Different failed jobs each run → non-deterministic JIT crash
+```
+
+**Corrective action**: Write an RC/CA ADR (see `docs/adr/template.md`) and open a GitHub
+issue with the evidence table. Then audit import styles in the failing test groups:
+
+```bash
+# Find package-level imports in required-check test files (the crash trigger)
+grep -rn "^from shared\.core import\|^from shared import" \
+  tests/shared/core/test_dtype* tests/shared/integration/ --include="*.mojo"
+```
+
+**DO NOT** increase `TEST_WITH_RETRY_MAX` or add retry logic. See `mojo-jit-crash-retry`
+skill for the canonical corrective action workflow.
 
 ### Phase 1: Fix Root Cause on Main First (When a Common Pattern Exists)
 
@@ -591,6 +642,8 @@ gh pr list --state open
 | Hand-merging `pixi.lock` during rebase | Tried to manually resolve lockfile conflict markers | Lockfile format is too intricate — produces invalid lock that fails `pixi.lock` pre-commit check | `git checkout --theirs pixi.lock && pixi install` to regenerate atomically |
 | Worktree `git rebase` from default detached HEAD | `git worktree add` left a detached HEAD; rebase ran, but couldn't push without a branch ref | Worktrees default to detached HEAD for the target commit | Immediately `git checkout -b <branch> --track origin/<branch>` inside the worktree before rebasing |
 | Running `pre-commit` only on main before rebasing a PR | Assumed main-branch green meant branch would be green post-rebase | Branch's own copy of `test.yml` still contained the duplicate-key bug even though main was fixed | Re-run `pre-commit run --all-files` inside the rebased worktree and fix any branch-local regressions |
+| Assuming a PR has unique content without checking | Rebased 9 PRs; 2 turned out fully subsumed by main — content already merged with different SHAs | Wasted setup time creating worktrees for empty rebases | Run `git log --oneline origin/main..origin/<branch>` first; if empty or diff is empty, close the PR with explanation |
+| Responding to required-check JIT flakiness with retry | When `Core Types & Fuzz` and `Integration Tests` failed on every main run, proposed increasing `TEST_WITH_RETRY_MAX` from 1 to 2 | Retry hides failures, prevents upstream bug filing, and will recur after Mojo upgrade — same pattern that led to removing ADR-014 | Write an RC/CA ADR and do the import audit instead; see `mojo-jit-crash-retry` skill Phase 0 |
 
 ## Results & Parameters
 
@@ -689,3 +742,4 @@ fn __hash__[H: Hasher](self, mut hasher: H):
 | ProjectTelemachy | PR #64 ruff F401/F841 in test_executor.py, 2026-03-31 | v2.2.0 additions |
 | ProjectKeystone | PR #146 std::atomic POSIX ADL collision, 2026-03-31 | see cpp-atomic-posix-socket-adl-collision skill |
 | ProjectHephaestus | PR #269 dependabot setup-pixi bump unblocked via main-branch `check-yaml` fix (#270); PR #268 6-file rebase in worktree with pixi.lock regeneration, 2026-04-12 | v2.3.0 additions |
+| ProjectOdyssey | 12 open PRs: 9 rebased + auto-merge armed, 2 subsumed PRs closed (#5224, #5221), 1 compile fix (#5238 raises propagation), 1 pixi dep-sync fix (#5241 feature.dev scanning), 2026-04-12 | v2.5.0 additions |

--- a/skills/mojo-jit-crash-retry.history
+++ b/skills/mojo-jit-crash-retry.history
@@ -1,5 +1,36 @@
 # mojo-jit-crash-retry Skill History
 
+## v3.1.0 (2026-04-12)
+
+**Changed by:** ProjectOdyssey 12-open-PR batch fix session
+**Verification:** verified-precommit
+
+### What changed
+
+- Added new top-level section: "When Required Checks Are Blocked by JIT Flakiness"
+  - 4-step workflow: confirm pre-existing on main → identify affected test files →
+    audit import styles → write RC/CA ADR
+  - Explicit guidance: do NOT increase TEST_WITH_RETRY_MAX; do NOT add retry logic
+  - RC/CA ADR content guidance cross-referencing docs/adr/template.md and ADR-014
+- Added new trigger to description: "(8) required CI checks are blocked by JIT
+  flakiness and PRs cannot auto-merge"
+- Added new Failed Attempts row: "Re-add retry when required checks block PRs" →
+  lesson: retry is always the wrong answer; do the import audit instead
+- Added `required-checks` tag
+
+### Why
+
+Session showed that when `Core Types & Fuzz` and `Integration Tests` failed on every
+consecutive main run (non-deterministic, different job sets each run), the initial plan
+proposed increasing TEST_WITH_RETRY_MAX. User corrected: "I want retry removed, not
+re-added." This is exactly the scenario the v3.0.0 → v3.1.0 amendment now documents
+explicitly, so future agents have a concrete decision rule rather than rediscovering
+that retry is the wrong answer.
+
+---
+
+# mojo-jit-crash-retry Skill History
+
 ---
 
 ## v3.0.0 — 2026-04-10 (MAJOR: retry workaround removed, root-cause investigation required)

--- a/skills/mojo-jit-crash-retry.md
+++ b/skills/mojo-jit-crash-retry.md
@@ -1,11 +1,12 @@
 ---
 name: mojo-jit-crash-retry
-description: "Use when: (1) CI produces 'execution crashed' (libKGENCompilerRTShared.so) before any test output, (2) multiple unrelated test files crash in the same CI run on unchanged code, (3) a Mojo test file crashes deterministically at the Nth sequential call to a complex function, (4) removing retry workarounds from CI test runners to expose root causes, (5) a Copyable struct with UnsafePointer fields and no explicit __copyinit__ is stored in List, (6) tests crash non-deterministically and the code changes don't touch those test files at all, (7) creating minimal crash reproducers to file upstream issues against modular/modular"
+description: "Use when: (1) CI produces 'execution crashed' (libKGENCompilerRTShared.so) before any test output, (2) multiple unrelated test files crash in the same CI run on unchanged code, (3) a Mojo test file crashes deterministically at the Nth sequential call to a complex function, (4) removing retry workarounds from CI test runners to expose root causes, (5) a Copyable struct with UnsafePointer fields and no explicit __copyinit__ is stored in List, (6) tests crash non-deterministically and the code changes don't touch those test files at all, (7) creating minimal crash reproducers to file upstream issues against modular/modular, (8) required CI checks are blocked by JIT flakiness and PRs cannot auto-merge"
 category: debugging
-date: 2026-04-10
-version: "3.0.0"
+date: 2026-04-12
+version: "3.1.0"
 user-invocable: false
 verification: verified-precommit
+history: mojo-jit-crash-retry.history
 tags:
   - mojo
   - jit
@@ -14,6 +15,7 @@ tags:
   - ci
   - libKGENCompilerRTShared
   - upstream
+  - required-checks
 ---
 # Mojo JIT Crash Diagnosis and Upstream Reporting
 
@@ -37,6 +39,80 @@ tags:
 - **Creating minimal standalone reproducers** to isolate a crash category for upstream filing
 - **A `Copyable` struct with `UnsafePointer` fields and no explicit `__copyinit__` is stored in `List`** — synthesized shallow copy + reallocation = double-free
 - **Tests crash non-deterministically and the code changes don't touch those test files at all** — suspect double-free, broken lock, or bitcast UAF before assuming JIT flakiness
+
+## When Required Checks Are Blocked by JIT Flakiness
+
+> **[NEW v3.1.0]** The correct response to required CI checks failing non-deterministically
+> on every main run is **RC/CA investigation and an import audit — NOT adding retry logic.**
+
+If `Core Types & Fuzz`, `Integration Tests`, or any other required check fails
+non-deterministically across multiple consecutive `main` runs on different commits, the
+corrective action workflow is:
+
+### Step 0: Confirm It Is Pre-existing on Main (Not PR-Specific)
+
+```bash
+# Compare multiple recent main runs
+gh run list --branch main --workflow "Comprehensive Tests" --limit 5 \
+  --json databaseId,conclusion,headSha --jq '.[]'
+
+# For each run, check which jobs failed
+gh run view <run-id> --json jobs \
+  --jq '.jobs[] | select(.conclusion=="failure") | .name'
+```
+
+If different jobs fail on different runs → non-deterministic → JIT crash, not code bug.
+If the same PR-unrelated docs PR (#5219 type) fails the same jobs → confirmed pre-existing.
+
+### Step 1: Identify the Affected Test Files
+
+```bash
+# Find which test files are in the failing required-check groups
+grep -A20 '"Core Types & Fuzz"\|"Integration Tests"' \
+  .github/workflows/comprehensive-tests.yml | grep "path:\|pattern:"
+```
+
+### Step 2: Audit Import Styles in Those Files
+
+```bash
+# Find package-level imports (the crash trigger)
+grep -rn "^from shared\.core import\|^from shared import" \
+  tests/shared/core/test_dtype* tests/shared/integration/ --include="*.mojo"
+```
+
+Convert any `from shared.core import X, Y` → targeted submodule imports per
+`docs/dev/mojo-jit-crash-workaround.md`. This reduces JIT compilation footprint by ~95%
+per file and lowers crash probability without hiding failures via retry.
+
+### Step 3: Write the RC/CA ADR
+
+Write a root-cause / corrective-action ADR (`docs/adr/ADR-NNN-...md`) documenting:
+
+- **Evidence table**: which runs failed, which jobs, non-deterministic pattern
+- **Root cause**: JIT compilation volume overflow in `libKGENCompilerRTShared.so`
+- **Corrective actions** (ordered by impact, not ease):
+  1. `[HIGH]` Import audit on affected test groups (see Step 2)
+  2. `[MEDIUM]` File/update upstream issue against modular/modular with crash repro
+  3. `[LOW]` Temporarily move affected checks from required to advisory IF crash rate
+     does not improve after actions 1+2 (document the decision explicitly)
+- **What NOT to do**: Do not increase `TEST_WITH_RETRY_MAX`; do not add retry logic.
+  Retry hides failures and prevents meaningful upstream bug reports.
+
+See `docs/adr/template.md` for the ADR format. Follow ADR-014 style (which documents
+the retry approach — now marked SUPERSEDED — as a reference for what not to repeat).
+
+### Step 4: PR the Import Fixes, Not a Retry Wrapper
+
+```bash
+git checkout -b fix/audit-required-check-imports
+# Edit test files to use targeted imports
+git commit -m "fix(tests): convert package-level imports in required-check groups
+
+Addresses non-deterministic JIT crash in Core Types & Fuzz and Integration Tests.
+See docs/adr/ADR-015-flaky-required-checks-jit-crash.md"
+gh pr create --title "fix(tests): audit imports in required-check test groups" \
+  --body "Closes #<issue>"
+```
 
 ## CRITICAL: Execution Crashes ARE Real Bugs — Investigate First
 
@@ -458,6 +534,7 @@ pattern for hook exceptions. Never use `--no-verify`.
 | Edit CLAUDE.md without Read | Tried to Edit before reading | Tool rejected: "File has not been read yet" | Always Read before Edit |
 | **Assume crash = JIT flake** | Closed/retried without investigating root cause | 16 test files crashing had 3 concrete source-code bugs: double-free, broken lock, bitcast UAF | **Check for double-free, broken locks, and bitcast UAF first before concluding JIT instability** |
 | **Add retry logic to CI** | Implemented `scripts/test-with-retry.sh` (88 lines) with `MAX_RETRIES=1` on `execution crashed` | Retry scripts hide real failures: a crash that is retried away cannot be filed upstream, prevents root cause investigation, masks reproducibility | **Delete retry scripts; use direct `pixi run mojo --Werror`; create minimal reproducers and file upstream** |
+| **Re-add retry when required checks block PRs** | When required checks (`Core Types & Fuzz`, `Integration Tests`) fail non-deterministically on every main run, temptation is to increase `TEST_WITH_RETRY_MAX` from 1 to 2 to absorb double-crash scenarios | Retry absorbs symptoms, not the cause; same crash will recur post-Mojo-upgrade; upstream can't reproduce the issue; RC/CA ADR cannot be written for a masked failure | **Do the import audit (targeted submodule imports) and write the RC/CA ADR instead. Retry is always the wrong answer.** |
 
 ## Results & Parameters
 


### PR DESCRIPTION
## Summary

Amends two skills based on learnings from a 12-open-PR batch fix session in ProjectOdyssey.

- `mojo-jit-crash-retry` v3.0.0 → **v3.1.0**
- `batch-pr-ci-fix-workflow` v2.4.0 → **v2.5.0**

## Key Findings

**What Worked**:
- `git log --oneline origin/main..origin/<branch>` is the fast subsumed-PR check — if
  empty, confirm with `git diff` then close the PR with an explanation
- Loop over 5 recent main runs collecting failed jobs: different failure sets each run =
  JIT flakiness = RC/CA ADR + import audit, not retry

**What Failed** (documented as Failed Attempts):
- Assuming PR branches have unique content without checking → 2 of 12 PRs were
  subsumed (identical patch, different SHA after rebase), auto-closed on empty rebase
- Proposing to increase `TEST_WITH_RETRY_MAX` when required checks failed
  non-deterministically → user correction: "I want retry removed, not re-added"

## Verification Level

**verified-precommit** — `validate_plugins.py` passes for both skills. CI pending.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skills appear in marketplace
- [ ] Test skill discovery with keywords: `subsumed`, `jit`, `required-checks`, `rc-ca`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>