### PR TITLE
feat: add worktree-cleanup-user-constraints and cross-repo-python-utility-port skills

### DIFF
--- a/skills/cross-repo-python-utility-port.md
+++ b/skills/cross-repo-python-utility-port.md
@@ -1,0 +1,235 @@
+---
+name: cross-repo-python-utility-port
+description: "Use when porting a Python utility (class, module, tests) from one repo to another
+  that already has a related implementation. Covers: (1) diff analysis between source and
+  destination implementations, (2) identifying which features to cherry-pick vs skip, (3)
+  merging test suites without duplication, (4) finding and fixing bugs exposed during porting,
+  (5) creating a re-export shim in the source repo and filing a cleanup issue."
+category: tooling
+date: 2026-04-12
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [porting, cross-repo, python, circuit-breaker, re-export, test-merge, shim]
+---
+
+# Cross-Repo Python Utility Port
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-12 |
+| **Objective** | Port `CircuitBreaker` from an orphaned Scylla worktree to ProjectHephaestus, which already had its own implementation |
+| **Outcome** | `success_threshold` feature added to Hephaestus; 10 new tests merged; bug found and fixed during porting; re-export shim issue filed in Scylla |
+| **Verification** | verified-local — 29/29 tests passing; PR pushed; CI pending |
+
+## When to Use
+
+- A file found in a worktree (orphaned, abandoned, or uncommitted) implements something similar to what exists in a shared utilities repo
+- Two repos have diverged implementations of the same pattern (circuit breaker, retry, rate limiter)
+- The destination repo already has the utility but is missing features the source has
+- The source file is to be replaced with a re-export shim pointing to the destination
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Read both implementations side by side
+Read <source_file>
+Read <destination_file>
+
+# 2. Diff feature sets
+# Source has: X, Y, Z
+# Destination has: X, W, V
+# → Port: Y, Z (missing from destination); skip repo-specific things
+
+# 3. Create branch in destination repo
+cd ~/DestinationRepo
+git checkout -b port-<feature-name>
+
+# 4. Edit destination implementation + tests
+# 5. Run tests
+pixi run python -m pytest tests/unit/<module>/ -v --no-cov
+
+# 6. Commit, push, file cleanup issue in source repo
+gh issue create --repo <source-repo> --title "cleanup: replace <file> with re-export from <dest>"
+```
+
+### Phase 1 — Side-by-Side Feature Analysis
+
+Read both files completely. Build a feature matrix:
+
+| Feature | Source | Destination | Action |
+|---------|--------|-------------|--------|
+| Core state machine | ✓ | ✓ | Skip (exists) |
+| `success_threshold` | ✓ | ✗ | **Port** |
+| `half_open_max_calls` | ✗ | ✓ | Skip (dest is better) |
+| Global registry | ✗ | ✓ | Skip |
+| `CircuitBreakerOpenError.time_until_recovery` | ✗ | ✓ | Skip |
+| Logging | ✗ | ✓ | Skip |
+
+**Rule**: Port features the source has that the destination lacks. Never downgrade the destination to match a weaker source.
+
+Also check the test files — source tests often cover edge cases that destination tests miss.
+
+### Phase 2 — Implement in Destination
+
+Add parameters as backward-compatible additions (new params with defaults matching old behavior):
+
+```python
+def __init__(
+    self,
+    name: str,
+    failure_threshold: int = 5,
+    recovery_timeout: float = 60.0,
+    half_open_max_calls: int = 1,
+    success_threshold: int = 1,   # NEW — default 1 = old behavior
+) -> None:
+```
+
+Track new state in `__init__`:
+```python
+self._half_open_successes = 0
+```
+
+In `_record_success`: count toward threshold before closing:
+```python
+if self._state == CircuitBreakerState.HALF_OPEN:
+    self._half_open_successes += 1
+    if self._half_open_successes < self.success_threshold:
+        self._half_open_calls = 0   # reset probe counter so next probe gets through
+        return
+```
+
+Clear the new counter in every state-reset path (`_effective_state` transition, `reset()`, `_record_failure` in HALF_OPEN).
+
+### Phase 3 — Merge Test Suites
+
+Don't duplicate tests that already exist in the destination. Add only:
+- Tests for the new feature (`success_threshold`)
+- Time-mocking tests if destination is missing them (more deterministic than `time.sleep`)
+- Parametrized threshold configs (good for regression coverage)
+
+```python
+# Add to existing test file — do not create a parallel file
+class TestCircuitBreakerSuccessThreshold:
+    def test_success_threshold_two_requires_two_successes(self) -> None: ...
+
+class TestCircuitBreakerTimeMocking:
+    @patch("dest.module.circuit_breaker.time.monotonic")
+    def test_open_to_half_open_exactly_at_timeout(self, mock_monotonic): ...
+
+@pytest.mark.parametrize(...)
+def test_parametrized_thresholds_full_cycle(...): ...
+```
+
+### Phase 4 — Run Tests and Fix Bugs
+
+```bash
+pixi run python -m pytest tests/unit/<module>/test_circuit_breaker.py -v --no-cov
+```
+
+**Watch for bugs exposed by new tests** — porting often reveals gaps in the original logic.
+
+In this session: `success_threshold=2` with `half_open_max_calls=1` failed because after the first successful probe, the call counter was exhausted so the second probe was rejected. Fix: reset `_half_open_calls = 0` between probes while success count hasn't reached threshold yet.
+
+### Phase 5 — Commit and Push
+
+```bash
+cd ~/DestinationRepo
+git add <impl-file> <test-file>
+# Allow pre-commit to reformat, re-stage if needed
+git commit -m "feat(<module>): add <feature> to <Class> for configurable <behavior>
+
+Ports <feature> from <SourceRepo>. <Description of what changed and why>.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push -u origin <branch>
+```
+
+### Phase 6 — File Cleanup Issue in Source Repo
+
+The source file should become a re-export shim (same pattern as other backward-compat shims):
+
+```python
+"""<Module> — re-exports from <dest-package>.<module>."""
+from dest_package.module import (
+    MainClass,
+    ErrorClass,
+    StateEnum,
+    factory_func,
+    reset_func,
+)
+__all__ = ["MainClass", "ErrorClass", "StateEnum", "factory_func", "reset_func"]
+```
+
+File the issue in the source repo:
+
+```bash
+gh issue create \
+  --repo <source-org>/<source-repo> \
+  --title "cleanup: replace <path> with re-export from <dest-package>" \
+  --body "## Objective
+...
+## Dependencies
+- <dest-repo> branch <name> must merge first (provides the new feature)
+..."
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Port the entire source implementation over destination | Replace destination `circuit_breaker.py` wholesale | Destination had more features (`time_until_recovery`, registry, logging, `half_open_max_calls`) | Never replace destination with source — do a feature diff first; only port what's missing |
+| `success_threshold=2` test with `half_open_max_calls=1` | First success probe left `_half_open_calls` exhausted, blocking second probe | `CircuitBreakerOpenError` raised on second call instead of passing through | When `success_threshold > 1`, reset `_half_open_calls = 0` after each non-final success so subsequent probes can pass |
+| Run tests with coverage | `pixi run python -m pytest ... -v` (no `--no-cov`) | Coverage measured whole project → 3.88% (far below 80% floor) → exit 1 | Use `--no-cov` for targeted test runs; full coverage run only at CI step |
+| Commit without allowing pre-commit to run | First commit attempt failed with `ruff-format-python` hook | Ruff reformatted the test file | Re-stage the reformatted file and re-commit; this is a normal 2-commit pattern |
+
+## Results & Parameters
+
+### Feature diff template
+
+```markdown
+| Feature | Source | Dest | Action |
+|---------|--------|------|--------|
+| success_threshold | ✓ | ✗ | Port |
+| half_open_max_calls | ✗ | ✓ | Skip |
+| Global registry | ✗ | ✓ | Skip |
+| Logging | ✗ | ✓ | Skip |
+```
+
+### The `success_threshold` fix (critical pattern)
+
+When `success_threshold > 1`, `_record_success` must reset the call counter between probes or the circuit self-blocks:
+
+```python
+if self._half_open_successes < self.success_threshold:
+    self._half_open_calls = 0   # ← this line is the fix
+    return
+```
+
+Without it: `half_open_max_calls=1`, probe 1 succeeds (counter=1), counter exhausted → probe 2 raises `CircuitBreakerOpenError` before reaching `_record_success`.
+
+### Re-export shim pattern
+
+```python
+"""<description> — re-exports from <package>.<module>."""
+from package.module import ClassA, ClassB, EnumC, func_d, func_e
+
+__all__ = ["ClassA", "ClassB", "EnumC", "func_d", "func_e"]
+```
+
+### Test count reference (this session)
+
+| Before port | After port | New tests |
+|-------------|------------|-----------|
+| 19 tests | 29 tests | +10 (4 success_threshold, 2 time-mock, 4 parametrized) |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | `CircuitBreaker.success_threshold` ported from Scylla orphaned worktree | Branch `port-circuit-breaker-success-threshold`; 29/29 local; CI pending |
+| ProjectScylla | Cleanup issue filed | HomericIntelligence/ProjectScylla#1805 |

--- a/skills/worktree-cleanup-user-constraints.md
+++ b/skills/worktree-cleanup-user-constraints.md
@@ -1,0 +1,243 @@
+---
+name: worktree-cleanup-user-constraints
+description: "Use when cleaning up worktrees under user-specified constraints: (1) no branch
+  deletion allowed, (2) all destructive ops must go into a reviewable script, (3) uncommitted
+  work in merged-branch worktrees must be analyzed and committed if useful. Covers classification
+  of dirty worktrees (artifact noise vs real work), generating a section-annotated cleanup script,
+  and handling files left orphaned in merged-branch working trees."
+category: tooling
+date: 2026-04-12
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [worktree, cleanup, script, branches, artifacts, safety, merged-branch, circuit-breaker]
+---
+
+# Worktree Cleanup Under User Constraints
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-12 |
+| **Objective** | Remove 36 stale worktrees from ProjectScylla while preserving all branches and not executing any destructive ops directly |
+| **Outcome** | Produced a reviewable 7-section shell script; identified real uncommitted work (circuit breaker) in a merged-branch worktree; classified 6 dirty worktrees |
+| **Verification** | verified-local — script produced and validated; not yet executed by user |
+| **Scale** | 36 worktrees → target: 1 (main only) |
+
+## When to Use
+
+- User says "no branch deletion" before or during a cleanup session
+- User says "give me a script to review first" — do NOT run destructive ops directly
+- Worktrees from merged branches have uncommitted files that might be real work
+- 20+ worktrees need cleanup and some have dirty working trees
+- Agent-generated worktrees (`.claude/worktrees/agent-*`) accumulated from parallel runs
+
+**Red flags that trigger this pattern:**
+- `git worktree list | wc -l` > 15
+- `git branch -v | grep '\[gone\]' | wc -l` > 10
+- Any worktree with `dirty > 10` files (could be artifacts or could be real work)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Classify every dirty worktree
+for wt in <dirty-worktrees>; do
+  echo "=== $wt ===" && git -C "$wt" status --short
+done
+
+# 2. For each non-artifact file: check if on main
+git -C "$wt" diff HEAD -- "$f" | head -20
+git show main:"$f" 2>&1 | head -3        # path as-is
+git show main:"src/$f" 2>&1 | head -3    # src-layout alternate
+
+# 3. For merged branches: check cherry
+git cherry origin/main <branch> | grep "^+" | wc -l   # 0 = superseded
+
+# 4. Generate script, hand to user — do not execute
+# 5. User runs: bash -x /tmp/cleanup.sh 2>&1 | tee /tmp/cleanup.log
+```
+
+### Phase 0 — Read-Only Inventory
+
+Run before touching anything:
+
+```bash
+git fetch --prune origin
+
+git worktree list --porcelain | awk '/^worktree /{print $2}' | tail -n +2 | while read wt; do
+  br=$(git -C "$wt" branch --show-current 2>/dev/null || echo "(detached)")
+  ahead=$(git rev-list --count origin/main.."$br" 2>/dev/null || echo "?")
+  dirty=$(git -C "$wt" status --short 2>/dev/null | wc -l)
+  echo "$wt | branch=$br | ahead=$ahead | dirty=$dirty"
+done | tee /tmp/wt-inventory.txt
+```
+
+### Phase 1 — Classify Dirty Worktrees
+
+**Artifact patterns (always discard, never commit):**
+
+```
+__pycache__/  *.pyc  *.pyo  build/  dist/  *.egg-info/
+.claude-prompt-*.md  ProjectMnemosyne/  .issue_implementer
+.pytest_cache/  .mypy_cache/  .ruff_cache/  .coverage.*  htmlcov/
+```
+
+**Potentially real (inspect with diff):**
+
+```
+src/  scripts/  tests/  docs/  .claude/ (excl. prompt files)
+config/  schemas/  pyproject.toml  pixi.toml  CHANGELOG.md  justfile
+```
+
+**Per-file decision logic:**
+
+```bash
+# Is the change in the working tree already reflected on main?
+git -C "$wt" diff HEAD -- "$f" | head -20       # vs branch tip
+git -C "$wt" diff origin/main -- "$f" | head -20 # vs main
+
+# For src-layout repos: check both paths
+git show main:"$f" 2>&1 | head -3
+git show main:"src/$f" 2>&1 | head -3
+```
+
+Decision rules:
+- Working tree reverts branch edits back to main content → noise
+- File exists on main at either path → check if content differs meaningfully
+- File NOT on main at any path → **potentially real, commit it**
+- File on merged branch (`git cherry` returns 0) → work is superseded → artifact
+
+### Phase 2 — Handle Merged-Branch Worktrees
+
+When a branch's PR is MERGED but the worktree has uncommitted files:
+
+```bash
+# Verify merged
+gh pr list --head <branch> --state all --json state | grep MERGED
+
+# Check which untracked files are NOT on main at any path
+for f in <untracked-files>; do
+  on_main=$(git show main:"$f" 2>&1; git show main:"src/$f" 2>&1)
+  echo "$on_main" | grep -q "fatal" && echo "NOT ON MAIN: $f" || echo "on main: $f"
+done
+```
+
+Files NOT on main in a merged-branch worktree = **orphaned work** that was never committed before the PR closed. Note them for the user — they cannot be committed to the merged branch (dead branch); user needs a new branch/issue.
+
+### Phase 3 — Generate the Reviewable Script
+
+Structure of `/tmp/<repo>-worktree-cleanup.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Review every section before running.
+# Rules: no branch deletion; salvage useful uncommitted work; no push.
+set -euo pipefail
+cd /path/to/repo
+
+# SECTION 1: PRE-FLIGHT (read-only audit)
+echo "Worktree count: $(git worktree list | wc -l)"
+echo "Branch count: $(git branch | wc -l)"
+
+# SECTION 2: COMMIT useful uncommitted work
+# One subshell block per worktree with real edits:
+# ( cd .claude/worktrees/agent-XXXX
+#   git add path/to/real_file.py   # NEVER -A
+#   git commit -m "type(scope): salvage uncommitted work on <branch>"
+# )
+# NOTE on merged branches: list orphaned files the user must copy manually
+
+# SECTION 3: TWO-PASS ARTIFACT CLEAN (artifact-only worktrees)
+for wt in <artifact-only-worktrees>; do
+  git -C "$wt" checkout -- .    # Pass 1: restore tracked files
+  git -C "$wt" clean -fd --quiet  # Pass 2: remove untracked
+done
+
+# SECTION 4: REMOVE stray agent files (prevents --force)
+while IFS= read -r wt; do
+  [ "$wt" = "$REPO" ] && continue
+  rm -f  "$wt"/.claude-prompt-*.md 2>/dev/null || true
+  rm -rf "$wt/ProjectMnemosyne"    2>/dev/null || true
+  rm -f  "$wt/.issue_implementer"  2>/dev/null || true
+done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+
+# SECTION 5: REMOVE worktrees (explicit list, no wildcards, no --force)
+WORKTREES=( ".claude/worktrees/agent-XXXX" ... )
+for wt in "${WORKTREES[@]}"; do
+  git worktree remove "$wt"   # fails loud on unexpected dirt
+done
+
+# SECTION 6: PRUNE (does NOT delete branches)
+git worktree prune
+git remote prune origin
+
+# SECTION 7: VERIFY
+git worktree list          # expect 1 line
+git branch | wc -l         # expect same as pre-flight
+git status --short
+```
+
+**Key script properties:**
+- `set -euo pipefail` — stops on any unexpected failure
+- Explicit worktree list (auditable, not `for wt in .claude/worktrees/*`)
+- `git add <specific-files>` — never `git add -A`
+- Zero `git branch -d/-D` or `gh api DELETE`
+- No `--force` on `git worktree remove`
+- Interactive confirmation before cleaning merged-branch worktrees with orphaned files
+
+### Phase 4 — Hand Off to User
+
+```bash
+bash -n /tmp/<repo>-worktree-cleanup.sh && echo "Syntax OK"
+# Then report to user:
+# 1. Inventory summary (dirty counts, classification)
+# 2. List of commits Section 2 will make (branch + files + message)
+# 3. List of orphaned files in merged branches (user must copy manually)
+# 4. Script path + invocation command
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assume large dirty count = artifacts | 187 files dirty → assumed `__pycache__` noise | Agent-a117bab3 had 32 real modified Python files (real uncommitted work) on a merged branch | Always inspect `git status --short` output per-file; never assume based on count alone |
+| Present branch deletion list to user | Plan Phase 5 proposed deletions for user to approve | User explicitly rejected — branches must never be deleted | No branch deletion at all, even with user confirmation; branches are permanent |
+| Execute destructive ops via tool calls | Initial plan executed `git worktree remove` directly | User rejected — wants a script to review first | All destructive ops go into a script file; only read-only analysis runs directly |
+| Assume all dirty files in merged-branch worktree are noise | issue-1529 (PR MERGED): treated 188 dirty files as abandoned | Two files (`circuit_breaker.py`, `test_circuit_breaker.py`) were genuinely new work not on main | Check every potentially-real file vs main even on merged branches |
+| Trust `[gone]` status as sole triage signal | Tried to use `ahead=0` + `[gone]` to classify all worktrees | Doesn't reveal uncommitted working-tree changes; must still inspect `git status` | `[gone]` = branch tracking gone, NOT = working tree clean; always check dirty count |
+| `git worktree remove --force` | Planned to use `--force` for stubborn cases | Safety Net blocks `--force` | Clean stray files individually first, then `git worktree remove` without `--force` |
+
+## Results & Parameters
+
+### Artifact classification regex (Python)
+
+```python
+ARTIFACT_PATTERNS = {
+    "__pycache__", ".pyc", ".pyo", "build/", "dist/", ".egg-info/",
+    ".claude-prompt-", "ProjectMnemosyne", ".issue_implementer",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache", ".coverage.", "htmlcov/",
+}
+
+def is_artifact(path: str) -> bool:
+    return any(p in path for p in ARTIFACT_PATTERNS)
+```
+
+### Scale reference
+
+| Worktrees | Dirty | Approach | Script size |
+|-----------|-------|----------|-------------|
+| 36 | 6 dirty | Sequential script | 7 sections, ~120 lines |
+| 20-35 | Mixed | Same pattern | Adjust WORKTREES array |
+
+### Real work found in merged-branch worktrees (this session)
+
+- `issue-1529` (PR #1760 MERGED): `src/scylla/automation/circuit_breaker.py` + `tests/unit/automation/test_circuit_breaker.py` — both NOT on main, subsequently ported to ProjectHephaestus
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectScylla | 36 worktrees, 6 dirty, 26 `[gone]` branches | Script at `/tmp/scylla-worktree-cleanup.sh`; execution pending |


### PR DESCRIPTION
## Summary

Two new skills from a ProjectScylla worktree cleanup + circuit breaker port session.

- **worktree-cleanup-user-constraints**: Worktree cleanup when user prohibits branch deletion and requires a reviewable script
- **cross-repo-python-utility-port**: Porting a Python utility between repos that both have related implementations

## Verification Level

**verified-local** — workflows executed this session; Hephaestus CI pending

## Key Findings

**worktree-cleanup-user-constraints**:
- Never assume large dirty count = artifacts (187-file worktree had 32 real modified Python files)
- Files in merged-branch worktrees can be genuinely new work not on main — check per-file
- `[gone]` status ≠ working tree clean; always check dirty count separately
- Script: explicit worktree list, zero branch deletion, `set -euo pipefail`

**cross-repo-python-utility-port**:
- Feature diff first: only port what destination lacks, never downgrade destination
- `success_threshold > 1` + `half_open_max_calls=1` bug: reset `_half_open_calls=0` between non-final successes
- Use `--no-cov` for targeted runs to avoid whole-project coverage floor failures
- Pre-commit ruff reformat = normal 2-commit pattern

## Test Plan

- [x] `python3 scripts/validate_plugins.py` — 942/942 valid
- [ ] Skills appear in marketplace after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>