### PR TITLE
feat: amend academic-paper-myrmidon-swarm-review skill (v1.1.0)

### DIFF
--- a/skills/academic-paper-myrmidon-swarm-review.history
+++ b/skills/academic-paper-myrmidon-swarm-review.history
@@ -1,0 +1,49 @@
+# academic-paper-myrmidon-swarm-review — History
+
+## v1.1.0 (2026-04-13)
+
+**Changed by:** TurboQuant (Idea 5.1) per-idea Myrmidon swarm review session
+**Verification:** verified-local
+
+### What changed
+- Extended description and "When to Use" to cover AI architecture research docs (not just LaTeX papers)
+- Added 2 new Failed Attempts: "Trust 32K ctx label" and "Use attention-kernel speedup as TPOT speedup"
+- Added "Architecture Research Doc Review — 5-Agent Pattern" to Results & Parameters
+- Added canonical architecture parameter reference (head_dim corrections, correct context lengths)
+- Added second "Verified On" row for TurboQuant review
+- Added history frontmatter field
+- Updated date 2026-04-08 → 2026-04-13
+- Bumped version 1.0.0 → 1.1.0
+
+### Why
+The v1.0.0 skill was scoped to LaTeX papers only. The TurboQuant review session demonstrated
+the same role-stratified parallel swarm pattern applies to AI architecture research docs with
+5 specialist domains: citation verifier, complexity auditor, literature gap finder, comparison
+validator, feasibility checker. The 5-agent structure and wave pattern are identical; only the
+specialist domains differ. Consolidating into one skill prevents redundant skill creation for
+each research corpus review.
+
+The two new Failed Attempts capture errors that will recur in future KV-related idea reviews
+(5.2, 5.5, 5.6, etc.) and must be documented here for future /advise lookups.
+
+### Previous version (v1.0.0) snapshot — key differences
+
+v1.0.0 described only LaTeX paper reviews with 5 agents:
+- Opus professor: statistical methodology
+- Sonnet expert A: data accuracy
+- Sonnet expert B: writing/framing
+- Haiku student A: lines 1-N/2
+- Haiku student B: lines N/2+1-N
+
+v1.1.0 adds the arch research doc review pattern with 5 different specialists:
+- Sonnet A: citation verifier
+- Sonnet B: complexity auditor
+- Sonnet C: literature gap finder
+- Sonnet D: comparison validator
+- Sonnet E: feasibility checker
+
+---
+
+## v1.0.0 (2026-04-08)
+
+**Initial version.**

--- a/skills/academic-paper-myrmidon-swarm-review.md
+++ b/skills/academic-paper-myrmidon-swarm-review.md
@@ -1,12 +1,13 @@
 ---
 name: academic-paper-myrmidon-swarm-review
-description: "Parallel myrmidon swarm review of academic papers using role-stratified agents (Opus=professor, Sonnet=expert, Haiku=student) for comprehensive, simultaneous coverage. Use when: (1) reviewing a large academic paper with statistical methodology, (2) need thorough parallel coverage faster than sequential review, (3) paper has figures generated from Vega-Lite specs that require caption verification."
+description: "Parallel myrmidon swarm review of academic papers and AI architecture research docs using role-stratified agents for comprehensive, simultaneous coverage. Use when: (1) reviewing a large academic paper with statistical methodology or Vega-Lite figures, (2) reviewing an AI architecture research doc for citation accuracy / complexity / literature gaps / comparison validity / feasibility, (3) need thorough parallel coverage faster than sequential review."
 category: documentation
-date: 2026-04-08
-version: "1.0.0"
+date: 2026-04-13
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
-tags: [academic, paper-review, myrmidon, swarm, latex, statistics, vega-lite]
+history: academic-paper-myrmidon-swarm-review.history
+tags: [academic, paper-review, myrmidon, swarm, latex, statistics, vega-lite, architecture-research, kv-cache, quantization-review]
 ---
 
 # Academic Paper Myrmidon Swarm Review
@@ -15,17 +16,27 @@ tags: [academic, paper-review, myrmidon, swarm, latex, statistics, vega-lite]
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-08 |
-| **Objective** | Comprehensive parallel academic paper review using role-stratified myrmidon swarm agents across statistical methodology, data accuracy, writing quality, and figure/caption verification |
-| **Outcome** | Operational — caught 4 CRITICAL figure/caption mismatches, 8 missing statistical citations, effect size framing issues, and N-level labeling errors across a 2,180-line paper. Paper compiled cleanly post-fix. PR HomericIntelligence/ProjectScylla#1758 created. |
-| **Verification** | verified-local (paper compiled cleanly; CI pending) |
+| **Date** | 2026-04-13 |
+| **Objective** | Comprehensive parallel review of academic papers OR AI architecture research docs using role-stratified swarm agents. For LaTeX papers: statistical methodology, data accuracy, writing quality, figure/caption verification. For arch research docs: citation verification, complexity audit, literature gap finding, comparison validation, feasibility checking. |
+| **Outcome** | Operational — LaTeX paper: caught 4 CRITICAL figure/caption mismatches, 8 missing citations (ProjectScylla#1758). Arch research doc (TurboQuant 5.1): caught context length mislabel (68.7 GB labeled "32K"), head_dim error, TPOT overstatement, 3 missing literature citations. |
+| **Verification** | verified-local |
+| **History** | [changelog](./academic-paper-myrmidon-swarm-review.history) |
 
 ## When to Use
 
+**For LaTeX academic papers:**
 - Reviewing a large academic paper (>1,000 lines of LaTeX) presenting experimental results
 - Paper has figures generated from Vega-Lite `.vl.json` specs requiring caption verification
-- Need parallel coverage across statistical methodology, data accuracy, and writing quality simultaneously
 - Paper uses non-parametric statistics (Kruskal-Wallis, Mann-Whitney U, Cliff's delta, Krippendorff's alpha)
+
+**For AI architecture research docs:**
+- Reviewing a `research_*.md` or `summary_*.md` doc for numerical correctness (KV cache sizes, TPOT estimates, complexity claims)
+- Verifying citations (arXiv IDs, author names, venue, summary faithfulness) against known literature
+- Finding literature gaps (papers that should be cited but aren't)
+- Validating comparison Nx claims against canonical architecture parameters
+
+**Both:**
+- Need parallel coverage across multiple specialist domains simultaneously
 - Want to catch issues faster than sequential single-agent review
 
 ## Verified Workflow
@@ -88,6 +99,8 @@ pixi run --environment docs bash build.sh
 | Use system LaTeX | `pdflatex build.sh` or `latexmk` | No system LaTeX installed in the environment | Use `pixi install --environment docs` then `pixi run --environment docs bash build.sh` |
 | Sequential single-agent review | One Sonnet agent reading 2,180 lines end-to-end | Slow and likely to miss cross-domain issues (statistical + framing + data accuracy simultaneously) | Parallel role-stratified swarm is faster and catches more cross-domain issues |
 | Accept BCa bootstrap at n=9 | Reported BCa bootstrap confidence intervals for binary pass-rate data with n=9 per cell | BCa bootstrap is unreliable at very small sample sizes for binary data | Prefer Clopper-Pearson exact intervals for binary data at n<=15; report BCa as secondary |
+| Trust "32K ctx" label in arch research docs | Accepted KV cache figures labeled "32K ctx" without re-deriving from the formula | The 68.7 GB figure (A2 KV cache) was labeled "32K ctx" but computed with 262,144 tokens; the label was wrong | Always re-derive KV cache from scratch: `num_layers × 2 × n_KV_heads × head_dim × seq_len × 2`; check that the result matches the seq_len in the label |
+| Use attention-kernel speedup as TPOT speedup | Cited FlashInfer "4× speedup for 4-bit KV" as evidence of "4× TPOT improvement" | Attention kernel speedup is for the KV-attention portion only; TPOT also includes weight loading (unchanged); for a 32B model at 262K context, realistic TPOT gain is ~1.6×, not 4× | Compute realistic TPOT: `(weight_BW + KV_BW) / (weight_BW + KV_BW/4)` — weight_BW dominates at shorter contexts |
 
 ## Results & Parameters
 
@@ -165,8 +178,35 @@ for path in sorted(glob.glob("docs/arxiv/haiku/figures/*.vl.json")):
 EOF
 ```
 
+### Architecture Research Doc Review — 5-Agent Pattern
+
+When reviewing an individual `research_*.md` + `summary_*.md` doc from the ArchIdeas corpus:
+
+```
+5 Sonnet specialists in parallel (Wave 1), all read research_*.md and summary_*.md:
+  A — Citation Verifier:    arXiv IDs, author names, venue, summary faithfulness, fabrications
+  B — Complexity Auditor:   Re-derive KV/FLOPs formulas; check context length labels; dequant overhead
+  C — Literature Gap Finder: Missing papers, underweighted methods, key missing citations
+  D — Comparison Validator: Nx claims, layer fractions, TPOT derivation (include weight bandwidth!)
+  E — Feasibility Checker:  Scope discipline, STE soundness, training stability risks, implementation effort
+
+Each writes to: verification_{id}_{domain}.md
+
+Wave 2 — Lead reviewer synthesizes into: review_{id}_{name}.md
+  8 sections: Citation Verification / Missing Literature / Big-O Verification /
+               Nx Comparison / Feasibility / Quality Analysis / Novelty / Final Verdict
+```
+
+**Scope constraint discipline check**: For idea 5.1 (KV-cache-only quantization), each sub-agent must verify the analysis never bleeds into weight quantization territory. Each idea may have a scope constraint note in SHARED_PRELUDE.md.
+
+**Canonical architecture parameters to use** (may differ from SHARED_PRELUDE.md v1):
+- A1 GatedAttn head_dim = 256 (NOT 128); 24Q/4KV (full-attn layers)
+- A2: 8 KV heads, head_dim=128, all 64 layers; context=262,144 (not 32,768)
+- B: 2 KV heads × head_dim=256 (product=512; same footprint as 4×128)
+
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectScylla | docs/arxiv/haiku/paper.tex — 2,180-line ablation study, 1,080 runs, 7 tiers, Claude Haiku 4.5 | PR HomericIntelligence/ProjectScylla#1758 |
+| ArchIdeas research | review of idea 5.1 TurboQuant (KV cache QAT) — 5 Sonnet specialists + synthesis | Apr 2026 — found context mislabel, head_dim error, TPOT overstatement, 3 missing papers |


### PR DESCRIPTION
## Summary

Amends `academic-paper-myrmidon-swarm-review` from v1.0.0 to v1.1.0.

- Extends skill from LaTeX paper reviews only to also cover AI architecture research docs
- Documents the 5-specialist swarm pattern validated during TurboQuant (idea 5.1) review

## Verification Level

**verified-local** — 5-agent swarm (citation verifier, complexity auditor, literature gap finder, comparison validator, feasibility checker) successfully reviewed TurboQuant research doc, producing 5 verification files and a final review

## Key Findings

**What Worked**:
- Role-stratified 5-agent swarm with non-overlapping output files catches cross-domain issues (citation errors, numerical bugs, literature gaps, TPOT overstatements, feasibility gaps) faster than sequential review
- Scope discipline checking (KV-only constraint) is best handled by the feasibility agent separately from the complexity auditor
- Pre-reading SHARED_PRELUDE.md and an existing review (review_1_1_*.md) before spawning agents ensures consistent review format

**What Failed**:
- Trust context length labels in research docs → re-derive KV cache arithmetic from scratch
- Cite attention-kernel speedup (4×) as total TPOT speedup → always compute (weight_BW + KV_BW_before) / (weight_BW + KV_BW_after)

## Test Plan

- [x] `python3 scripts/validate_plugins.py` passes (942/942 valid)
- [ ] Verify skill discoverable with keywords: "architecture research", "kv cache", "quantization review"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>