### PR TITLE
feat: amend arch-research-myrmidon-swarm-review skill (v1.1.0)

### DIFF
--- a/skills/arch-research-myrmidon-swarm-review.history
+++ b/skills/arch-research-myrmidon-swarm-review.history
@@ -1,0 +1,25 @@
+# arch-research-myrmidon-swarm-review — History
+
+## v1.1.0 (2026-04-14)
+
+**Changed by:** ArchIdeas session — adding 4 new architectural ideas to existing 31-idea corpus
+**Verification:** verified-local
+
+### What changed
+- Added Phase A: Research New Ideas workflow for ideas with no prior research docs
+- Added new "When to Use" trigger for new-idea research
+- Added 2 new Failed Attempts rows (N4-before-siblings; trust-author-complexity-claim)
+- Added New Idea Research Parameters section with 8 verified arXiv IDs and N1–N4 verdicts
+- Extended Verified On table with new-idea research row
+
+### Why
+The existing skill only covered reviewing an existing corpus (Phase 1–3). The ArchIdeas session needed to generate brand-new research docs for 4 previously-undocumented ideas (N1–N4) and include them in the paper alongside the existing 31 reviewed ideas. The same 5-role Myrmidon pattern applies, but the trigger condition and prior-art search terms are different.
+
+### Previous version (v1.0.0) snapshot
+Commit reference: initial v1.0.0 (2026-04-13). See `skills/arch-research-myrmidon-swarm-review.md` git history.
+
+---
+
+## v1.0.0 (2026-04-13)
+
+**Initial version.**

--- a/skills/arch-research-myrmidon-swarm-review.md
+++ b/skills/arch-research-myrmidon-swarm-review.md
@@ -2,11 +2,12 @@
 name: arch-research-myrmidon-swarm-review
 description: "Parallel AI architecture research review using Myrmidon Swarm pattern: 1 lead agent per idea + 5 parallel sub-agents (citation verifier, complexity auditor, literature gap finder, comparison validator, feasibility checker) + coordinator. Use when: (1) reviewing a corpus of 10+ research documents for correctness, (2) verifying citations, Big-O claims, and baseline comparisons at scale, (3) producing independent review documents that can be cross-checked."
 category: architecture
-date: 2026-04-13
-version: "1.0.0"
+date: 2026-04-14
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
 tags: []
+history: arch-research-myrmidon-swarm-review.history
 ---
 
 # Myrmidon Swarm: Parallel Architecture Research Review
@@ -27,6 +28,7 @@ tags: []
 - Cross-checking Big-O complexity tables and Nx improvement claims against canonical baseline specs
 - Finding missing literature that changes novelty classifications
 - Producing independent review documents for a research corpus
+- Generating research docs for new ideas that have no prior `research_*.md`/`summary_*.md` files, where each new idea needs full 5-role Myrmidon treatment alongside (or after) the existing corpus review
 
 ## Verified Workflow
 
@@ -71,6 +73,27 @@ Phase 3b: Coordinator → review_summary.md
 
 6. **Phase 3b coordinator** — One coordinator reads all 31 reviews + synthesis validation report. Produces: per-idea verdict table, aggregate stats, systemic error pattern analysis, revised priority ranking.
 
+### Phase A: Research New Ideas (when ideas have no prior docs)
+
+When adding N new ideas to an existing corpus that already has Phase 1–3 complete:
+
+1. **Read the existing `SHARED_PRELUDE.md`** verbatim — inject into every new-idea lead agent prompt. New ideas get the same canonical baseline specs.
+
+2. **Launch N new-idea lead agents in parallel** (one per idea). Each agent:
+   - Spawns 5 sub-agents in parallel (same roles: Citation Verifier, Complexity Auditor, Literature Gap Finder, Comparison Validator, Feasibility Checker)
+   - Produces `research_6_N_<slug>.md`, `summary_6_N_<slug>.md`, 5× `verification_6_N_<role>.md`, then `review_6_N_<slug>.md`
+   - Follows the same 8-section review template as Phase 2 lead agents
+
+3. **Critical prior art each new-idea agent MUST check** (inject these search terms explicitly):
+   - N1 (in-arch AR loop with stop-token break): RWKW inference loops, Medusa/EAGLE speculative decoding trained-in, PonderNet, ACT (Adaptive Computation Time)
+   - N2 (prefill/decode split): Splitwise (Patel 2023, arXiv:2311.18677), DistServe (Zhong 2024, arXiv:2401.09670), SARATHI-Serve chunked prefill (Agrawal 2023)
+   - N3 (block-diffusion AR decoder): BD3-LM (arXiv:2406.15253), MDLM (Sahoo 2024, arXiv:2406.07524), LLaDA (Nie 2025, arXiv:2502.09992), Fast-dLLM (arXiv:2505.05175)
+   - N4 (combined N1+N2+N3): cite all three base papers above; cross-synergy analysis required
+
+4. **arXiv IDs must be WebFetch-verified** before citation — same rule as Phase 1.
+
+5. **After Phase A completes**: new `research_6_N_*.md` files are equivalent to existing `research_1_*`–`research_5_*` files and can be included in the LaTeX paper on equal footing.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -79,6 +102,8 @@ Phase 3b: Coordinator → review_summary.md
 | Single-agent review | Tried reviewing multiple ideas sequentially | Context window exhaustion; cross-contamination between ideas | One lead agent per idea; no agent works on more than one idea |
 | Agent self-approval stall | 4 agents invoked `/hephaestus:advise` internally, presented a plan, and waited for approval | Agents stalled indefinitely waiting for human approval in background context | Detect stalled agents by checking for verification files without corresponding review files; unblock by sending explicit approval via SendMessage |
 | Trusting "68 GB KV at 32K" for A2 | SHARED_PRELUDE stated A2 (Qwen3-32B) KV cache = ~68 GB at 32K context | Wrong: used 64 Q-heads instead of 8 KV-heads in formula; ~8× overestimate. Correct: 64L × 2 × 8KV × 128hd × 32768tok × 2B = ~8.59 GB | Always verify KV cache formulas use KV head count not Q head count |
+| N4 before N1/N2/N3 | Tried to research the combined idea before the three component ideas had research docs | N4 requires cross-references to N1, N2, N3 prior art and Big-O analysis; without them the N4 agent fabricates component details | Always research component ideas N1, N2, N3 fully before launching N4 agent |
+| Trusting author complexity claims for new ideas | Accepted "O(n) per token" claim from a new idea's mechanism description without re-deriving | Author was counting attention heads as O(1); when DeltaNet state per head is O(d²), full per-token cost is O(d²) not O(n·d) | Complexity Auditor sub-agent must re-derive every Big-O for new ideas, same as for existing corpus |
 
 ## Results & Parameters
 
@@ -111,8 +136,33 @@ After reviews complete, launch parallel surgical correction agents (one per grou
 - Adds `[corrected: ...]` inline notes so changes are traceable
 - Never touches review_*.md or verification_*.md (read-only ground truth)
 
+### New Idea Research — Verified arXiv IDs (2026-04-14)
+
+These IDs were WebFetch-verified during the N1–N4 research pass:
+
+| Idea | Key paper | arXiv ID | Verified |
+|------|-----------|----------|---------|
+| N1 (AR loop + stop token) | PonderNet | arXiv:2107.05407 | YES |
+| N1 | EAGLE speculative decoding | arXiv:2401.15077 | YES |
+| N2 (prefill/decode split) | Splitwise | arXiv:2311.18677 | YES |
+| N2 | DistServe | arXiv:2401.09670 | YES |
+| N3 (block diffusion AR) | BD3-LM | arXiv:2406.15253 | YES |
+| N3 | MDLM | arXiv:2406.07524 | YES |
+| N3 | LLaDA | arXiv:2502.09992 | YES |
+| N3 | Fast-dLLM | arXiv:2505.05175 | YES |
+
+### N1–N4 Final Verdicts
+
+| Idea | Verdict | Rationale |
+|------|---------|-----------|
+| N1 (In-arch AR loop + stop token) | INVESTIGATE | Novel framing; prior art (PonderNet, Medusa) covers components but not the specific trained-in stop-token-as-architecture-gate |
+| N2 (Prefill/decode split) | PURSUE | Splitwise and DistServe validate the operational benefit; architectural-level split (vs. system-level) is the novel angle |
+| N3 (Block-diffusion AR decoder) | INVESTIGATE | BD3-LM and LLaDA are close prior art; the AR-across-blocks + diffusion-within-block combination at architecture level has novelty |
+| N4 (Combined N1+N2+N3) | INVESTIGATE | Synergy benefit is plausible but compounding complexity; depends on N2 and N3 independently proving out first |
+
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ArchIdeas | 31 AI architecture ideas (sections 1–5 plus 4.7) | Qwen3.5-27B Hybrid, Qwen3-32B Dense, Qwen3.5-397B-A17B MoE baselines |
+| ArchIdeas | 4 new ideas (N1–N4) added to existing 31-idea corpus | research_6_1 through research_6_4 produced by parallel Myrmidon swarms; all 4 included in final LaTeX paper |


### PR DESCRIPTION
## Summary

- Adds **Phase A: Research New Ideas** workflow for ideas that have no prior `research_*.md`/`summary_*.md` files, enabling full 5-role Myrmidon treatment for brand-new ideas alongside an existing reviewed corpus
- Documents the N1–N4 pattern with per-topic prior-art search terms (PonderNet/EAGLE for N1, Splitwise/DistServe for N2, BD3-LM/LLaDA for N3, cross-synergy for N4)
- Adds 8 WebFetch-verified arXiv IDs, 2 new Failed Attempts rows, and N1–N4 final verdicts table
- Creates `arch-research-myrmidon-swarm-review.history` with v1.0.0 → v1.1.0 changelog

## Test plan

- [x] `python3 scripts/validate_plugins.py` passes (947/947 valid)
- [x] Frontmatter updated: `version: "1.1.0"`, `date: 2026-04-14`, `history:` field added
- [x] All 6 content sections amended per spec
- [x] History file created with correct v1.1.0 and v1.0.0 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)