### PR TITLE
feat: amend corpus-surgical-correction-batch skill (v1.1.0)

### DIFF
--- a/skills/corpus-surgical-correction-batch.history
+++ b/skills/corpus-surgical-correction-batch.history
@@ -1,13 +1,32 @@
+# corpus-surgical-correction-batch — History
+
+## v1.1.0 (2026-04-14)
+
+**Changed by:** ArchIdeas session — post-correction narrative removal pass on LaTeX paper
+**Verification:** verified-local
+
+### What changed
+- Added Optional Phase: Post-Correction Narrative Removal workflow
+- Added new "When to Use" trigger for narrative-removal use case
+- Added 4 new Failed Attempts rows (regex orphan fragments, table column drift, broken `\href` mid-sentence, single-regex phrasing miss)
+- Added "Post-Correction Narrative Removal Notes" section with actual parameters from the 3,320-line paper run
+- Extended Verified On table
+
+### Why
+The existing skill covered correction application (adding `[corrected: ...]` markers) but not the downstream cleanup where those markers and the surrounding error-narrative text need to be permanently removed before publishing. This is a distinct phase with its own failure modes, particularly around LaTeX syntax breakage from mid-sentence regex removal.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
 ---
 name: corpus-surgical-correction-batch
-description: "Surgical batch correction of a large research document corpus (50+ files) after a review pass. Use when: (1) a review process has identified specific errors across many documents that share a common root cause, (2) you need corrections to be traceable (auditable inline markers), (3) stripping correction-narrative text from a document corpus after corrections have been accepted and made permanent, (4) you want to preserve all surrounding text and structure, (5) corrections span multiple independent document groups that can be parallelized."
+description: "Surgical batch correction of a large research document corpus (50+ files) after a review pass. Use when: (1) a review process has identified specific errors across many documents that share a common root cause, (2) you need corrections to be traceable (auditable inline markers), (3) you want to preserve all surrounding text and structure, (4) corrections span multiple independent document groups that can be parallelized."
 category: architecture
-date: 2026-04-14
-version: "1.1.0"
+date: 2026-04-13
+version: "1.0.0"
 user-invocable: false
 verification: verified-local
-history: corpus-surgical-correction-batch.history
-tags: [latex, narrative-removal, corpus-edit]
+tags: []
 ---
 
 # Corpus Surgical Correction: Batch Parallel Pattern
@@ -20,7 +39,6 @@ tags: [latex, narrative-removal, corpus-edit]
 | **Objective** | Apply corrections identified by a review pass to 62 research/summary documents and 4 synthesis documents — without rewriting sections or losing provenance |
 | **Outcome** | All 66 files corrected across 8 parallel batches; every change marked with `[corrected: ...]` inline notes |
 | **Verification** | verified-local |
-| **History** | [changelog](./corpus-surgical-correction-batch.history) |
 
 ## When to Use
 
@@ -29,7 +47,6 @@ tags: [latex, narrative-removal, corpus-edit]
 - You need corrections to be auditable (reviewable by humans without re-reading the full doc)
 - Document groups are independent and can be processed in parallel
 - You want to preserve original structure, prior art classifications, and verdict text
-- Stripping correction-narrative text (e.g., `[corrected: ...]` markers, 'Threats to Validity' sections, 'not X as stated' inline fragments, `.bak` references) from a corpus AFTER corrections have been permanently accepted — the narrative is a legacy artifact, not a live threat
 
 ## Verified Workflow
 
@@ -81,58 +98,6 @@ tags: [latex, narrative-removal, corpus-edit]
 
 6. **Verify completion**: After all batches complete, spot-check 2–3 corrections per batch by reading the affected file sections.
 
-### Optional Phase: Post-Correction Narrative Removal
-
-Use this phase when correction markers and error-narrative text has been permanently accepted and should be stripped from the final output (e.g., before publishing a paper or freezing a corpus).
-
-#### Quick Reference
-
-```python
-import re, pathlib
-
-# Pass 1: Remove [corrected: ...] markers (possibly multiline)
-corrected_marker_re = re.compile(r'\[corrected[^\]]*\]', re.IGNORECASE | re.DOTALL)
-
-# Pass 2: Remove inline error-reference fragments
-inline_fragments = [
-    r'\(not ~?\d+\s*GB as stated[^)]*\)',
-    r'\(prior prelude[^)]*\)',
-    r'as stated in the prior prelude[^.]*\.',
-    r'The prelude erroneously[^.]*\.',
-    r'\(erroneously[^)]*\)',
-]
-
-# Pass 3: Remove whole sections/paragraphs
-section_patterns = [
-    r'\\section\{Threats to Validity\}.*?(?=\\section|\Z)',
-    r'\\subsection\{Known Prelude Errors\}.*?(?=\\subsection|\\section|\Z)',
-]
-```
-
-#### Detailed Steps
-
-1. **Classify narrative text** before writing any regex:
-   - Inline markers: `[corrected: ...]`, `(not X as stated)`, `(prior prelude had X)`
-   - Section-level narrative: `\section{Threats to Validity}`, `\subsection{Known Prelude Errors}`
-   - Reference fragments: `.bak` file paths, "six factual errors" counts
-
-2. **Apply passes sequentially** — broadest (section removal) last:
-   a. Pass 1: Remove inline `[corrected: ...]` markers with DOTALL regex (they can span lines)
-   b. Pass 2: Remove specific inline fragment patterns (each pattern must be verified to be unique enough not to match live content)
-   c. Pass 3: Remove whole section blocks (regex must anchor to the next `\section` or end-of-file)
-
-3. **After each pass, rebuild LaTeX** (`pdflatex + bibtex + pdflatex×2`) and inspect the log:
-   - `grep "^!" paper.log` → must be 0 errors
-   - `grep "Undefined control sequence" paper.log` — regex may have left orphan LaTeX fragments (e.g., `\5`, `\59`) from mid-sentence removal
-
-4. **Diagnose orphan fragments** by grepping the `.tex` for the literal text around the error line number:
-   - Common cause: regex deleted text that was *inside* an `\href{}{}` argument, leaving a syntactically broken sequence
-   - Fix: rewrite the surrounding sentence completely rather than just removing the fragment
-
-5. **Diagnose table column count drift**: if narrative was in a `tabular` cell and was removed entirely, the table may now have fewer cells than its column spec. Fix by rewriting the full table row.
-
-6. **Verify clean**: `grep -rn "\[corrected" .` and `grep -rn "Threats to Validity" .` → both return empty after all passes complete.
-
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -142,10 +107,6 @@ section_patterns = [
 | Rewriting whole sections | Replaced entire paragraphs to fix one number | Lost surrounding context and nuance; introduced new errors | Surgical edits only: change the minimum needed, preserve everything else |
 | Mixing research and synthesis doc corrections | One agent correcting both research docs and synthesis docs | Agent tried to apply research-file corrections to synthesis docs and vice versa; file naming conventions differ | Dedicated separate agent for synthesis docs; they have different structure and different error sets |
 | Agent correcting review files | Agent "fixed" errors it found in review_*.md | Destroyed the audit trail (review files are ground truth) | Explicitly state in every prompt which files are read-only |
-| Single regex pass for all inline fragments | One big alternation `(pattern_A\|pattern_B\|...)` applied once | Different phrasing of the same error narrative required different patterns; a single pass missed variants that used different sentence structure | Run separate targeted passes per phrasing variant; verify with `grep` after each pass |
-| Removing mid-sentence fragment without checking context | Stripped `(not ~68 GB as stated)` from inside a sentence | Left orphan `\5` (LaTeX undefined control sequence) because the fragment was mid-sentence inside an `\href{}` arg | After each regex removal, rebuild LaTeX immediately and inspect log before proceeding |
-| Regex removal inside tabular cell | Removed entire cell content that contained correction narrative | Left row with fewer cells than column spec; caused "Missing \item" or tabular alignment error | After removing content from table cells, count columns against the `{ll...}` spec and add empty cells if needed |
-| Grepping for exact phrase | Used `grep "not ~68 GB as stated"` to verify removal | Phrase had slight variants in different sections (e.g., "not 68 GB" vs "not ~68 GB") | Always use flexible patterns with `grep -E` and check the count drops to 0 for all variants |
 
 ## Results & Parameters
 
@@ -185,21 +146,15 @@ Per review_[id].md:
 | Idea-specific arithmetic errors | 8/62 | Targeted |
 | Synthesis doc corrections | 4/4 synthesis | 1 dedicated batch |
 
-### Post-Correction Narrative Removal Notes (2026-04-14)
-
-Applied to: `/home/mvillmow/Random/ArchIdeas/research/report/paper.tex` (3,320 lines, 102 pages)
-
-Passes required: 3 (inline markers → inline fragments → section block)
-LaTeX rebuilds required: 3 (one after each pass, plus 1 extra to fix orphan `\5` sequence)
-Final state: 0 errors, 0 unresolved references, 102 pages
-
-Patterns that required special care:
-- `[corrected: ...]` markers: used `re.DOTALL` because some spanned 3+ lines
-- `\section{Threats to Validity}` block: must use `re.DOTALL` + lookahead for next `\section`
-- Inline `\href` argument removal: verify the enclosing sentence remains syntactically valid after removal
-
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ArchIdeas | 31 AI architecture ideas post-review correction | 62 research/summary docs + 4 synthesis docs; 8 parallel correction batches |
+```
+
+---
+
+## v1.0.0 (2026-04-13)
+
+**Initial version.**


### PR DESCRIPTION
## Summary

Amends `corpus-surgical-correction-batch` from v1.0.0 to v1.1.0. Adds a post-correction narrative-removal phase: the cleanup that happens AFTER corrections are permanently accepted, when the `[corrected: ...]` markers and surrounding error narrative need to be stripped without breaking surrounding markdown/LaTeX syntax.

## Verification Level

**verified-local** — applied to a 3,320-line LaTeX paper; 3 passes, 3 LaTeX rebuilds, final: 0 errors, 102 pages.

## Key Findings

**What Worked**:
- Multi-pass regex with `re.DOTALL` for multiline `[corrected: ...]` markers
- LaTeX rebuild + log inspection after each pass
- Rewriting full sentences (not fragments) when a regex removal lands mid-\href arg

**What Failed**:
- Single-regex pass for all phrasing variants → missed variants
- Mid-sentence fragment removal → orphan \5 LaTeX sequence
- Cell-content removal inside tabular → column count drift
- Grep-for-exact-phrase verification → missed near-variants

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (passed 947/947)
- [ ] Verify skill appears in marketplace at v1.1.0
- [ ] History file preserves v1.0.0 snapshot

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>