### PR TITLE
feat: amend docker-mojo-uid-mismatch-crash-fix skill (v1.0.0 → v1.1.0)

### DIFF
--- a/skills/docker-mojo-uid-mismatch-crash-fix.history
+++ b/skills/docker-mojo-uid-mismatch-crash-fix.history
@@ -1,0 +1,65 @@
+# docker-mojo-uid-mismatch-crash-fix — History
+
+## v1.1.0 (2026-04-14)
+
+**Changed by:** Session context — PR #5252 CI investigation, container UID cache key fix
+**Verification:** verified-precommit (PR #5252 open, CI not yet confirmed passing)
+
+### What changed
+
+- Added CI cache key UID isolation as Fix 4 (include runner UID in image cache key so
+  UID-1000 and UID-1001 builds are cached separately)
+- Added justfile HOME-fixup fragment as Fix 5 (runtime fallback for any `podman compose exec`
+  invocation in the justfile)
+- Added new Failed Attempts row: GitHub Actions env var vs step output evaluation timing
+- Extended "When to Use" with two new trigger conditions
+- Added GitHub Actions step output pattern to Results & Parameters
+- Updated verification to verified-precommit (was verified-local)
+
+### Why
+
+v1.0.0 fixed the crash for a known-UID build but did not address the upstream scenario where
+the CI image cache is keyed only by Dockerfile+pixi content hash. If a prior CI run cached
+the image at UID-1000 and the current run executes at UID-1001, the *cached* image is reused
+with the wrong UID baked in. Fix 4 adds the runner UID to the cache key so this can't happen.
+Fix 5 adds belt-and-suspenders HOME-fixup in the justfile for any exec path that bypasses the
+entrypoint.
+
+Also documents the GitHub Actions `${{ env.VAR }}` vs `${{ steps.id.outputs.name }}` timing
+difference — use step outputs to be safe when the value is set in the same action's earlier step.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: docker-mojo-uid-mismatch-crash-fix
+description: "Fix deterministic Mojo runtime crash (exit 134) when container image UID
+  differs from host runner UID. Use when: (1) mojo run crashes before executing any
+  user code with 'filesystem error: status: Permission denied [/home/.../.modular]',
+  (2) CI passes locally (UID 1000) but fails in CI runner (UID 1001+), (3) crash is
+  100% reproducible — not a flaky JIT issue."
+category: ci-cd
+date: 2026-04-11
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - docker
+  - mojo
+  - uid
+  - permissions
+  - container
+  - crash
+  - modular
+---
+
+# Docker Mojo UID Mismatch Crash Fix
+
+[... full v1.0.0 content as committed to main branch ...]
+```
+
+---
+
+## v1.0.0 (2026-04-11)
+
+**Initial version.**

--- a/skills/docker-mojo-uid-mismatch-crash-fix.md
+++ b/skills/docker-mojo-uid-mismatch-crash-fix.md
@@ -4,12 +4,15 @@ description: "Fix deterministic Mojo runtime crash (exit 134) when container ima
   differs from host runner UID. Use when: (1) mojo run crashes before executing any
   user code with 'filesystem error: status: Permission denied [/home/.../.modular]',
   (2) CI passes locally (UID 1000) but fails in CI runner (UID 1001+), (3) crash is
-  100% reproducible — not a flaky JIT issue."
+  100% reproducible — not a flaky JIT issue, (4) cached CI image was built at a
+  different UID than the current runner's uid, (5) execution crashed with
+  __fortify_fail_abort in libKGENCompilerRTShared.so before any test output."
 category: ci-cd
-date: 2026-04-11
-version: "1.0.0"
+date: 2026-04-14
+version: "1.1.0"
 user-invocable: false
-verification: verified-local
+verification: verified-precommit
+history: docker-mojo-uid-mismatch-crash-fix.history
 tags:
   - docker
   - mojo
@@ -18,6 +21,8 @@ tags:
   - container
   - crash
   - modular
+  - cache-key
+  - github-actions
 ---
 
 # Docker Mojo UID Mismatch Crash Fix
@@ -26,34 +31,37 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-11 |
+| **Date** | 2026-04-14 |
 | **Objective** | Fix deterministic CI failures where `mojo run` crashes before executing any user code |
-| **Outcome** | Successful — crash reproduced and fixed locally; CI PR #5217 filed with auto-merge |
-| **Verification** | verified-local (crash reproduced and fixed locally; CI validation pending) |
-| **Root Cause** | `libAsyncRTMojoBindings.so` calls throwing `std::filesystem::status("$HOME/.modular")` at startup. When container UID ≠ home dir owner UID, `filesystem_error: Permission denied` propagates to `std::terminate` → `abort()` |
+| **Outcome** | Successful — crash reproduced and fixed; CI cache key fix added to prevent recurrence |
+| **Verification** | verified-precommit (PR #5252 open, CI validation pending) |
+| **Root Cause** | `libAsyncRTMojoBindings.so` calls `std::filesystem::status("$HOME/.modular")` at startup. When container UID ≠ home dir owner UID, `filesystem_error: Permission denied` propagates to `std::terminate` → `abort()`. Also triggered when CI image cache is keyed without runner UID, causing a UID-1000 cached image to run as UID-1001. |
 | **Exit Code** | 134 (SIGABRT) |
+| **History** | [changelog](./docker-mojo-uid-mismatch-crash-fix.history) |
 
 ## When to Use
 
 - `mojo run` or `mojo test` crashes with exit code 134 before printing any user output
 - Error message contains: `terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'`
 - Error message contains: `filesystem error: status: Permission denied [/home/dev/.modular]`
+- Stack trace shows `libKGENCompilerRTShared.so+0x6d4ab` / `+0x6a686` / `+0x6e157` + `libc.so.6+0x45330` (`__fortify_fail_abort`)
 - CI fails deterministically but local tests pass (local UID 1000 matches image build UID)
 - Image was built with `useradd -m` on Ubuntu (creates home dir with mode 750 by default)
 - Container is run with a different UID than the one used during `docker build`
+- CI image cache key does not include runner UID — a prior run cached at UID-1000, current run uses UID-1001
 
 ## Verified Workflow
+
+> **Note:** Fixes 1-3 are verified-local (PR #5217). Fixes 4-5 are verified-precommit only (PR #5252, CI pending). Treat Fixes 4-5 as proposed until CI confirms.
 
 ### Quick Reference
 
 ```bash
 # Fix 1: Dockerfile — make home dir traversable by other UIDs
-# After useradd, add:
 RUN chmod 755 /home/${USER_NAME}
 
 # Fix 2: Dockerfile — remove overly restrictive pixi permissions
-# REMOVE this line:
-# RUN chmod -R 700 $PIXI_HOME $PIXI_CACHE_DIR
+# REMOVE: RUN chmod -R 700 $PIXI_HOME $PIXI_CACHE_DIR
 
 # Fix 3: entrypoint.sh — pre-create .modular or redirect HOME
 if [ ! -d "${HOME}/.modular" ]; then
@@ -63,6 +71,19 @@ if [ ! -d "${HOME}/.modular" ]; then
         export PIXI_HOME="${HOME}/.pixi"
     }
 fi
+
+# Fix 4: GitHub Actions cache key — include runner UID
+- name: Get runner UID
+  id: uid
+  run: echo "user_id=$(id -u)" >> "$GITHUB_OUTPUT"
+- uses: actions/cache@v4
+  with:
+    key: container-image-uid${{ steps.uid.outputs.user_id }}-${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+
+# Fix 5: justfile HOME-fixup for podman compose exec
+HOME_FIXUP := "if [ ! -w \"$$HOME\" ]; then export HOME=\"/tmp/mojo-home-$$(id -u)\"; mkdir -p \"$$HOME/.modular\" \"$$HOME/.pixi\"; fi;"
+_run CMD:
+    podman compose exec -T myservice bash -c "{{ HOME_FIXUP }} {{ CMD }}"
 ```
 
 ### Detailed Steps
@@ -125,7 +146,40 @@ fi
    exec "$@"
    ```
 
-6. **Rebuild and verify**:
+6. **Apply Fix 4 — CI image cache key includes runner UID** — prevents stale UID-1000 image
+   being reused on a UID-1001 runner:
+
+   ```yaml
+   # In GitHub Actions workflow or composite action:
+   - name: Get runner UID
+     id: uid
+     run: echo "user_id=$(id -u)" >> "$GITHUB_OUTPUT"
+
+   - name: Cache container image
+     uses: actions/cache@v4
+     with:
+       path: /tmp/container-image.tar
+       # Include UID in key so UID-1000 and UID-1001 images are cached separately
+       key: container-image-uid${{ steps.uid.outputs.user_id }}-${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+   ```
+
+   **Important**: Use `${{ steps.uid.outputs.user_id }}` (step output), NOT `${{ env.USER_ID }}`.
+   Environment variables set in an earlier step of the same action may not be evaluated correctly
+   depending on runner version. Step outputs are always safe.
+
+7. **Apply Fix 5 — justfile HOME-fixup for every `podman compose exec`** — belt-and-suspenders
+   for any execution path that bypasses the entrypoint:
+
+   ```makefile
+   # In justfile, define a HOME fixup fragment
+   HOME_FIXUP := "if [ ! -w \"$$HOME\" ]; then export HOME=\"/tmp/mojo-home-$$(id -u)\"; mkdir -p \"$$HOME/.modular\" \"$$HOME/.pixi\"; fi;"
+
+   # Prepend to every podman compose exec invocation:
+   _run CMD:
+       podman compose exec -T myservice bash -c "{{ HOME_FIXUP }} {{ CMD }}"
+   ```
+
+8. **Rebuild and verify**:
 
    ```bash
    podman compose build --no-cache
@@ -142,6 +196,8 @@ fi
 | Assumed JIT flakiness | Classified crash as non-deterministic `__fortify_fail_abort` JIT issue | Crash was 100% deterministic at UID mismatch; warm-cache local tests at UID 1000 always passed, masking the real bug | Never close a crash as "unfixable JIT flakiness" without first reproducing at the exact CI UID |
 | Local parallel test run | Ran 10 parallel `mojo test` locally without replicating CI UID | Local UID = 1000 matched image owner, so home dir was accessible and all tests passed | Always replicate the exact runtime UID of the CI runner when diagnosing "CI-only" crashes |
 | Setting `MODULAR_HOME` env var | Tried redirecting via `MODULAR_HOME=/tmp/.modular` | `libAsyncRTMojoBindings.so` reads `$HOME/.modular` directly via `std::filesystem::status`; env var redirect does not affect this call | The crash happens in native C++ before any Mojo env var handling; must fix permissions or pre-create the directory |
+| Cache key without UID | CI image cache key used only `hashFiles(Dockerfile, pixi.toml, pixi.lock)` | A prior CI run at UID-1000 cached the image; current run at UID-1001 reused the stale image with wrong home dir owner | Include `$(id -u)` in the cache key so UID-1000 and UID-1001 images are always cached separately |
+| `${{ env.VAR }}` for UID in cache key | Tried setting UID via `${{ env.USER_ID }}` in the same composite action | `${{ env.VAR }}` may not be evaluated when the env var is set in an earlier step of the same action (runner version dependent) | Use `${{ steps.<id>.outputs.<name> }}` for values computed in earlier steps — step outputs are always safe |
 
 ## Results & Parameters
 
@@ -154,6 +210,15 @@ Aborted (core dumped)
 ```
 
 Exit code: **134** (SIGABRT from `std::terminate` → `abort()`)
+
+Stack trace identifiers (Mojo 0.26.x):
+
+```text
+libKGENCompilerRTShared.so+0x6d4ab
+libKGENCompilerRTShared.so+0x6a686
+libKGENCompilerRTShared.so+0x6e157
+libc.so.6+0x45330  (= __fortify_fail_abort)
+```
 
 ### Root Cause Chain
 
@@ -180,6 +245,22 @@ RUN groupadd -g ${GROUP_ID} ${USER_NAME} && \
 ENV PIXI_HOME=/home/${USER_NAME}/.pixi
 ENV PIXI_CACHE_DIR=/home/${USER_NAME}/.cache/rattler
 # Do NOT: RUN chmod -R 700 $PIXI_HOME $PIXI_CACHE_DIR
+```
+
+### GitHub Actions Cache Key Template
+
+```yaml
+- name: Get runner UID
+  id: uid
+  run: echo "user_id=$(id -u)" >> "$GITHUB_OUTPUT"
+
+- name: Cache container image
+  uses: actions/cache@v4
+  with:
+    path: /tmp/container-image.tar
+    key: container-image-uid${{ steps.uid.outputs.user_id }}-${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+    restore-keys: |
+      container-image-uid${{ steps.uid.outputs.user_id }}-
 ```
 
 ### Upstream Bug
@@ -215,3 +296,4 @@ podman compose exec -T myservice bash -c "id && mojo run -e 'print(42)'"
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectOdyssey | CI deterministic crash reproduced and fixed locally, PR #5217 | UID 1001 CI runner vs UID 1000 image owner; `docker-compose.yml` with `USER_ID` ARG |
+| ProjectOdyssey | CI cache key UID isolation added, PR #5252 | `setup-container/action.yml` amended to include `uid` step output in cache key; justfile `_run` recipe amended with HOME_FIXUP |


### PR DESCRIPTION
## Summary

Amends existing skill `docker-mojo-uid-mismatch-crash-fix` from v1.0.0 to v1.1.0.

Documents two new fixes learned from ProjectOdyssey PR #5252 for the container UID
mismatch root cause:

- **Fix 4**: Include runner UID in CI image cache key (`container-image-uid{UID}-{hash}`)
  so UID-1000 and UID-1001 images are always cached separately, preventing a stale
  UID-1000 image from being reused on a UID-1001 runner
- **Fix 5**: `HOME_FIXUP` justfile variable prepended to every `podman compose exec`
  invocation as belt-and-suspenders runtime fallback when entrypoint is bypassed

Also documents: `${{ steps.<id>.outputs.<name> }}` (step outputs) is always safe for
values computed in earlier steps; `${{ env.VAR }}` may not evaluate correctly depending
on runner version.

## Verification Level

**verified-precommit** — PR #5252 is open in CI, not yet confirmed passing.
Fixes 1-3 from v1.0.0 are verified-local (PR #5217).

## Key Findings

**What Worked**:
- UID-scoped cache key prevents cache reuse across different runner UIDs
- Step outputs (`${{ steps.id.outputs.name }}`) reliably forward computed values across steps

**What Failed**:
- Cache key without UID → stale UID-1000 image reused on UID-1001 runner
- `${{ env.VAR }}` for UID in cache key → may not evaluate in same-action earlier step

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (948/948 pass)
- [ ] Verify skill appears in marketplace
- [ ] CI confirms fixes in PR #5252

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>