### PR TITLE
feat: add research-corpus-inline-derivation-standard skill

### DIFF
--- a/skills/research-corpus-inline-derivation-standard.md
+++ b/skills/research-corpus-inline-derivation-standard.md
@@ -1,0 +1,132 @@
+---
+name: research-corpus-inline-derivation-standard
+description: "Standard for tagging analytically-derived numeric claims in research corpus documents. Use when: (1) writing or reviewing research docs with numeric claims not backed by a paper, (2) auditing derivation tags for completeness, (3) deciding how to format a first-principles calculation in a table cell or prose."
+category: documentation
+date: 2026-04-17
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [research, corpus, derivation, citation, inline, numeric, documentation, annotation]
+---
+
+# Research Corpus Inline Derivation Standard
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-17 |
+| **Objective** | Define the required format for tagging analytically-derived numeric claims in AI architecture research corpus documents |
+| **Outcome** | Standard established during 39-file corpus audit; user explicitly rejected bare labels and confirmed inline computation format |
+| **Verification** | verified-local |
+
+## When to Use
+
+- Writing a numeric value (memory size, TPOT, bandwidth, parameter count) that comes from a formula, not a cited paper
+- Reviewing existing research docs for derivation tag completeness
+- Adding a Notes cell to a comparison table where the value is analytically computed
+- Any time you would write `[derived from first principles]` — instead, show the computation
+
+## Verified Workflow
+
+### Quick Reference
+
+```
+# Correct format — show the full computation inline:
+~5 MB [derived: 512 tokens × 5120 dims × 2 bytes (BF16) = 5,242,880 bytes ≈ 5 MB]
+
+# Wrong format — bare label gives no verifiable information:
+~5 MB [derived from first principles — no direct experimental citation]
+
+# Multi-step derivation — chain the arithmetic:
+~4.10 GB [derived: W_out = V × d × 2 bytes = 250,112 × 8,192 × 2 = 4,097,835,008 bytes ≈ 4.10 GB;
+           LM head fraction = 4.10/145.1 ≈ 2.83% of total model weights]
+```
+
+### Detailed Steps
+
+1. **Identify the claim type.** Is the number from a paper (→ use `[Author et al., Year] — p.N, §X.Y`)? Or is it analytically derived from known constants (→ use the inline derivation format)?
+
+2. **Write the formula with variable substitution.** Always replace variable names with actual values so the reader can verify without looking up definitions:
+   - Bad: `n_layers × 2 × n_heads × head_dim × seq_len × bytes`
+   - Good: `64 layers × 2 × 8 KV heads × 128 dims × 32,768 tokens × 2 bytes (BF16)`
+
+3. **Show the intermediate and final result.** Use `=` to chain steps:
+   ```
+   64 × 2 × 8 × 128 × 32768 × 2 = 8,589,934,592 bytes ≈ 8.0 GB
+   ```
+
+4. **Add a one-sentence note** (optional) when the formula measures something non-obvious:
+   ```
+   [derived: 64×2×8×128×32768×2 = 8.59 GB; KV cache at 32K context for A2 (32B dense, BF16)]
+   ```
+
+5. **For multi-step derivations**, chain them with a semicolon:
+   ```
+   [derived: weight_BW = 32B params × 2 bytes = 64 GB;
+             KV_BW = 68.7 GB (at 262K ctx);
+             TPOT improvement = (64+68.7)/(64+17.2) = 132.7/81.2 ≈ 1.63×;
+             note: INT4 compresses KV by 4×, weight BW unchanged]
+   ```
+
+6. **Placement.** In table cells, put the derivation inline after the value. In prose, put it immediately after the value in brackets. Never defer it to a footnote or endnote — the goal is on-the-spot verifiability.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Bare `[derived from first principles]` tag | Added the tag to numeric claims with no further detail | User explicitly rejected: "bare tags are useless to a reader — they signal 'trust me' without showing the work" | Always show the actual computation; the tag alone carries zero information |
+| `[derived from first principles — no direct experimental citation]` | Extended label explaining why there's no citation | Still no verifiable arithmetic; just a longer "trust me" | The explanation of why there's no citation is irrelevant — what matters is showing the derivation |
+| Deferring arithmetic to a notes.md file | Wrote `[derived — see notes.md §3.2]` | Reader must switch files to verify; breaks the audit flow | Inline derivations must be self-contained; the reader should never have to leave the file |
+| Using variable names without substitution | Wrote `n_layers × n_heads × head_dim × seq × bytes` | Reader can't verify without looking up each variable | Substitute actual values in the formula so the arithmetic is checkable on the spot |
+
+## Results & Parameters
+
+### Canonical format
+
+```
+# Single-step derivation:
+<value> [derived: <formula with values substituted> = <result>]
+
+# Single-step with explanatory note:
+<value> [derived: <formula> = <result>; <1-sentence note on what it measures>]
+
+# Multi-step derivation:
+<value> [derived: <step 1 formula> = <step 1 result>;
+                  <step 2 formula using step 1 result> = <step 2 result>;
+                  <optional note>]
+```
+
+### Real examples from the ArchIdeas corpus
+
+```
+# KV cache size:
+~8.0 GB [derived: 64 layers × 2 × 8 KV heads × 128 dims × 32,768 tokens × 2 bytes (BF16) = 8,589,934,592 bytes ≈ 8.0 GB]
+
+# TPOT improvement:
+~1.63× [derived: weight_BW = 32B × 2 = 64 GB; KV_BW_before = 68.7 GB (262K ctx, BF16); KV_BW_after = 17.2 GB (INT4, 4× compression); TPOT = (64+68.7)/(64+17.2) = 132.7/81.2 ≈ 1.63×]
+
+# Memory per token:
+~5 MB [derived: 512 tokens × 5,120 dims × 2 bytes (BF16) = 5,242,880 bytes ≈ 5 MB; activation memory per forward pass at seq_len=512]
+
+# LM head fraction:
+~2.83% [derived: W_out = 250,112 vocab × 8,192 dims × 2 bytes = 4,097,835,008 bytes ≈ 4.10 GB; fraction = 4.10/145.1 ≈ 2.83% of total model weights]
+```
+
+### When to cite a paper instead
+
+Use `[Author et al., Year] — p.N, §X.Y` when:
+- The value comes from a measurement in an experiment (throughput, accuracy, latency)
+- The value is a design choice from a specific model architecture (e.g., n_heads=8 from Qwen3-32B spec)
+- The formula itself is from a paper (e.g., the KIVI quantization error bound formula)
+
+Use `[derived: ...]` when:
+- The value follows mechanically from known constants (dimensions, bytes per dtype, sequence length)
+- The value is a ratio or improvement computed from two other values
+- The arithmetic is straightforward enough that a reader can verify it in under 30 seconds
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ArchIdeas corpus | 39-file audit, Phase C + D | Apr 2026 — user rejected bare tags mid-session, standard applied to multiple files during the audit |


### PR DESCRIPTION
## Summary

New skill documenting the required inline derivation format for analytically-derived numeric claims in AI architecture research corpus documents.

- Every numeric claim derived from first principles must show its full formula with values substituted and the computed result
- Bare `[derived from first principles]` tags are explicitly rejected — they carry no verifiable information
- Multi-step derivations chain arithmetic steps with semicolons inside the bracket

## Verification Level

**verified-local**

Standard confirmed by user mid-session during a 39-file ArchIdeas corpus audit. Applied to multiple files during the session.

## Key Findings

**What Worked**:
- Inline format: `~5 MB [derived: 512 tokens × 5120 dims × 2 bytes (BF16) = 5,242,880 bytes ≈ 5 MB]`
- Substituting actual values (not variable names) allows on-the-spot verification without context switching
- Chaining multi-step derivations with semicolons keeps complex computations readable

**What Failed**:
- `[derived from first principles]` bare tag → user explicitly rejected: "signals 'trust me' without showing the work"
- `[derived from first principles — no direct experimental citation]` → still no arithmetic, just a longer label
- Deferring to a notes file (`see notes.md §3.2`) → forces reader to switch files, breaks audit flow
- Using variable names without substitution → not checkable without looking up definitions

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — 950/950 valid
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: research, derivation, inline, corpus, annotation, numeric

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>