### PR TITLE
feat: amend research-corpus-audit-parallel-agent-pattern skill (v1.4.0)

### DIFF
--- a/skills/research-corpus-audit-parallel-agent-pattern.history
+++ b/skills/research-corpus-audit-parallel-agent-pattern.history
@@ -1,5 +1,36 @@
 # research-corpus-audit-parallel-agent-pattern — History
 
+## v1.4.0 (2026-04-18)
+
+**Changed by:** ArchIdeas corpus final remediation pass (39-file strict quality audit, 4 remaining issues fixed)
+**Verification:** verified-local
+
+### What changed
+- Added 3 new Failed Attempts: 5.9/5.10 treated as standard-template docs, bibliography entries without paper-internal locators, impl_spec numeric drift from source doc
+- Added Schema Variants declaration pattern to Results & Parameters (SHARED_PRELUDE.md template when corpus has multiple templates)
+- Added 4-fix remediation order (numeric corrections → table row insertions → schema declarations → bibliography PDF fetches)
+- Added TTFT ≈ ref row template for KV-cache-only quantization files
+- Added Verified On row for 4-fix final remediation pass (Apr 2026)
+- Bumped version 1.3.0 → 1.4.0
+
+### Why
+The final audit pass surfaced three new failure patterns not previously documented: (1) 5.9/5.10
+were treated as standard-template docs despite using the thematic template — pre-flight must now
+explicitly list which 7 files use thematic template; (2) numbered bibliography format `[N]: Author...
+arXiv:XXXX` requires per-entry `§X.Y` or `Table N` locators (not just in-text prose citations) for
+D2 to pass; (3) impl_spec range claims (0.74–0.79×) can drift from source point estimates (0.68×)
+when the source formula is not cross-checked. The 4-fix remediation order prevents wasted time on
+slow PDF fetches before fixing fast numeric corrections.
+
+### Previous version (v1.3.0) snapshot
+
+The v1.3.0 skill content is preserved in git history at the commit prior to the v1.4.0 amendment.
+Key additions in v1.3.0 were: Remediation Workflow section, wave-based parallel fix agent rules,
+terminology drift fix pattern (S-03), structural section addition placement rules (D5), and 4 new
+Failed Attempts covering background agent failure modes and overlapping file sets.
+
+---
+
 ## v1.3.0 (2026-04-17)
 
 **Changed by:** ArchIdeas corpus remediation session (post-audit wave-based parallel fix agents)

--- a/skills/research-corpus-audit-parallel-agent-pattern.md
+++ b/skills/research-corpus-audit-parallel-agent-pattern.md
@@ -2,8 +2,8 @@
 name: research-corpus-audit-parallel-agent-pattern
 description: "Strict 10-dimension quality audit of AI architecture research corpora using parallel agent delegation. Use when: (1) auditing a large set of research/summary docs for structural compliance, (2) enforcing citation standards and TPOT framing conventions across a corpus, (3) grading research output with file:line evidence, (4) reviewing individual idea research docs for KV cache / quantization numerical correctness."
 category: architecture
-date: 2026-04-17
-version: "1.3.0"
+date: 2026-04-18
+version: "1.4.0"
 user-invocable: false
 verification: verified-local
 history: research-corpus-audit-parallel-agent-pattern.history
@@ -130,6 +130,9 @@ When an executive summary value conflicts with a detailed body derivation, the b
 | Background agents for S-04 derivation tag addition (large batch) | Launched two `run_in_background: true` agents to add inline derivation tags across 29 files | Both failed with "API Error: Unable to connect to API (ConnectionRefused)" after ~2M tokens / 77 tool uses — background agents have higher failure rate on long-running tasks | Prefer foreground agents with clear scopes; split large batches into smaller foreground agents; avoid background agents for tasks that run >50 tool calls |
 | Broadcasting wrong tag standard to background agents | Launched background agents with `[derived from first principles]` bare tag instruction; user corrected the standard mid-session to require inline arithmetic | Could not propagate correction to in-flight background agents; correction only reached agents not yet started | Finalize all standards and formats before launching agents. If user corrects a standard mid-session, abort/ignore in-flight agents and re-launch with correct instructions |
 | Parallel fix agents on overlapping file sets | Dispatched two remediation agents whose file lists were not explicitly partitioned | Both agents edited some of the same files; merge produced conflicts | Always partition the file list explicitly between parallel agents — never rely on agents to "avoid" the same file organically |
+| Treating 5.9/5.10 as standard-template docs | Audited research_5_9 and research_5_10 with standard-template expectations (numbered sections 1–8) | They use the thematic template (like Group 6); structural checks D1/D3/D4/D7 failed spuriously | Pre-flight must identify which docs are thematic-template; 7 files total use thematic template (Group 6 + 5.9/5.10). Declare schema variants in SHARED_PRELUDE.md |
+| Bibliography entries without paper-internal locators | Group 5 and Group 6 files used numbered bibliography format `[N]: Author... arXiv:XXXX` with no `§X.Y` or `Table N` locators | D2 citation audit requires locators at the bibliography entry level, not just in-text prose | When a file uses numbered bibliography format, locators must be added to each entry — fetch arXiv abstract page and add the most relevant section/table locator |
+| impl_spec numeric drift from source doc | `implementation_spec_phase1.md` claimed k̄_l=7 TPOT as `0.74–0.79×`; source doc `research_1_3.md` derives `0.68×` via `(k̄_l/11) × 0.88 + 0.12` | Range claims (0.74–0.79×) were not cross-checked against the exact formula in the source research doc | Always cross-check spec numeric claims against source research docs using the exact formula — range claims are especially prone to drifting from point estimates |
 
 ## Results & Parameters
 
@@ -176,6 +179,50 @@ D10 Spec: A=all 4 cross-checks pass, C=3/4, F=any fabricated number
 
 Structural cap: D3=F OR D10=F → overall capped at C
 ```
+
+### Schema Variant Declaration Pattern (for SHARED_PRELUDE.md)
+
+When a corpus contains documents that follow different templates, declare the schema variants
+explicitly in SHARED_PRELUDE.md so auditors know which structural checks apply to which files:
+
+```markdown
+## Schema Variants
+
+This corpus uses two document templates:
+
+**Standard template** (Groups 1–5, excluding 5.9/5.10):
+- Numbered sections 1-8 under Executive Summary
+
+**Thematic template** (Group 6 + research_5_9, research_5_10 — 7 files total):
+- Unnumbered sections + per-baseline ## Benefits vs Baseline X sections
+
+Audit dimensions D1/D3/D4/D7 apply only to standard-template docs.
+Thematic-template docs verified against their own structural checklist.
+```
+
+### 4-Fix Remediation Order (for post-audit fix sessions)
+
+When a final audit finds a small set of remaining issues (4–10 fixes), apply in this order
+to minimize time and avoid blocking dependencies:
+
+1. **Single-line numeric corrections** (fastest, no dependencies) — Fix immediately in main context
+2. **Table row insertions** (fast, targeted) — Fix in main context
+3. **Schema/documentation declarations** (e.g., SHARED_PRELUDE.md Schema Variants) — Fix in main context
+4. **Bibliography PDF fetches** (~76+ papers) — Dispatch 4 parallel worktree agents last (one per file, never overlap file sets)
+
+Rationale: Steps 1–3 are fast (seconds each) and unblocking. Step 4 (arXiv abstract fetches) is
+the slowest and should always be parallelized and deferred until after fast fixes are confirmed.
+
+### TTFT Row Template for KV-Cache-Only Quantization
+
+For ideas where quantization applies only to KV cache (not weights), TTFT is always `≈ ref`
+because prefill is compute-bound and KV quantization only affects decode-time KV reads:
+
+```
+| TTFT (8K prompt) | ref | ≈ ref | ≈ ref | Prefill is compute-bound at 8K; KV quantization affects decode-time KV reads only, not prefill FLOPs; attention-kernel dequant overhead <2% (§4.2) |
+```
+
+This row is baseline-independent — use `≈ ref` for all baselines (A1/A2/B/C) for these ideas.
 
 ### Structural Deficit Remediation Pattern
 
@@ -255,3 +302,4 @@ When reviewing a research doc about KV cache quantization (ideas referencing KIV
 | ArchIdeas idea 5.1 (TurboQuant) | Per-idea review with 5-agent swarm | Apr 2026 — found context length mislabel (68.7 GB at 262K labeled "32K"), A1 head_dim error, TPOT overstatement |
 | ArchIdeas corpus (post Phase C/D) | 39 ideas, 4-baseline grading | Apr 2026 — D1=F (7 Phase A thematic docs missing all 4 baseline sections), D4=F (94/156 TTFT, 125/156 TPOT), D5=F (research_6_4 no TPOT rows), D7=F (10/39 have strict Accuracy header), D3/D6/D8/D9/D10=A; overall grade D; synthesis artifacts excellent, per-file structural compliance poor |
 | ArchIdeas corpus remediation (post-audit) | Wave-based parallel fix agents across 39-file corpus | Apr 2026 — two-pass remediation: Pass 1 fixed arithmetic/framing (Critical + Major); Pass 2 fixed terminology drift (S-03) and section additions (D5); background agents failed at ~2M tokens; foreground agents succeeded; all fixes confirmed, no remaining bare tags |
+| ArchIdeas corpus | 4-fix final remediation pass | Apr 2026 — impl_spec numeric corrected (0.68× per research_1_3 formula); 4 TTFT rows added to research_5_1; 77 bibliography locators added across 4 files via arXiv fetch; SHARED_PRELUDE.md Schema Variants section added for 5.9/5.10 thematic-template declaration; all fixes verified via grep |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.3.0 to v1.4.0.

Documents final remediation pass learnings from a 39-file ArchIdeas corpus strict quality audit — 4 remaining issues found and fixed.

- Three new Failed Attempts entries covering thematic-template misidentification, bibliography locator gaps, and impl_spec numeric drift
- Schema Variants declaration pattern for SHARED_PRELUDE.md (multi-template corpora)
- 4-fix remediation order to prioritize fast fixes before slow PDF fetches
- TTFT `≈ ref` row template for KV-cache-only quantization ideas

## Verification Level

**verified-local**

All fixes were applied and confirmed via grep in the ArchIdeas corpus session. CI validation pending.

## Key Findings

**What Worked**:
- Fetching arXiv abstract pages to add per-entry `§X.Y` / `Table N` locators to numbered bibliography entries
- Cross-checking impl_spec range claims against the exact source formula in research docs
- Declaring schema variants in SHARED_PRELUDE.md to scope structural audit dimensions

**What Failed**:
- Treating research_5_9 / research_5_10 as standard-template docs → spurious D1/D3/D4/D7 failures (they use thematic template like Group 6)
- Bibliography entries in numbered `[N]: Author... arXiv:XXXX` format without `§X.Y` locators → D2 failures despite in-text prose citations
- impl_spec range claims (0.74–0.79×) not cross-checked against source point estimate (0.68×) → numeric drift

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — 952/952 valid
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: corpus, audit, bibliography, schema-variants, thematic-template

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>