### PR TITLE
learn(pixi-lock-rebase-regenerate): v1.3.0 — multi-commit rebase with migrated-code second commit

### DIFF
--- a/skills/pixi-lock-rebase-regenerate.history
+++ b/skills/pixi-lock-rebase-regenerate.history
@@ -1,5 +1,67 @@
 # pixi-lock-rebase-regenerate — History
 
+## v1.3.0 — 2026-04-21
+
+**Amendment**: Added multi-commit rebase pattern where the second commit patches code migrated to an external repo (hephaestus wrapper migration), requiring `git rebase --skip` for the empty resolved commit.
+
+**Changed by:** Session — Rebasing `5047-separate-dev-production-deps` branch (pixi.toml dev/prod split) onto main in ProjectOdyssey; PR #5266
+**Verification:** verified-local
+
+### What changed
+
+- Bumped version 1.2.0 → 1.3.0; updated date to 2026-04-21
+- Added new "When to Use" trigger: second commit in rebase chain patches code migrated to an external package
+- Added new `### Phase 3d: Multi-Commit Rebase Where Second Commit Is Superseded` subsection with step-by-step rebase flow, example commit messages, and detection signals
+- Added new Failed Attempts row: `git rebase --continue` after resolving empty commit (migrated-code scenario)
+- Added ProjectOdyssey PR #5266 entry to Verified On table
+
+### Why
+
+The v1.2.0 skill covered double-rebase pixi.lock conflicts (where the previous pixi.lock-fix commit itself conflicts). This session surfaced a distinct pattern: a branch with two commits where Commit B patches standalone scripts that main has since rewritten as thin wrapper stubs (delegating to an external package). Commit A applies cleanly; Commit B's changes are entirely superseded. After accepting `HEAD` for all conflicted files, the commit is empty — `--skip` is required, not `--continue`. This distinction (empty commit due to external migration vs. stale lock) was not captured before.
+
+### Previous version (v1.2.0) snapshot
+
+```
+---
+name: pixi-lock-rebase-regenerate
+description: "Correctly resolve pixi.lock staleness after git rebase or when main advances. Use when: (1) CI fails with 'lock-file not up-to-date with the workspace', (2) multiple PRs all fail identical CI jobs after a version bump on main, (3) git rebase causes pixi.lock conflicts, (4) Dependabot PRs fail CI fast (6-12 seconds) because Dependabot only bumps pyproject.toml not pixi.lock, (5) a second rebase of the same branch produces a pixi.lock commit conflict — skip the stale commit and re-run pixi install."
+category: ci-cd
+date: 2026-04-13
+version: "1.2.0"
+user-invocable: true
+verification: verified-ci
+history: pixi-lock-rebase-regenerate.history
+tags: [dependabot, pixi, rebase, pixi-lock, ci-cd]
+---
+```
+
+See git log for full v1.2.0 file content.
+
+---
+
+## v1.2.0 — 2026-04-13
+
+**Amendment**: Added Dependabot PR fast-failure pattern (6–12s CI duration = stale pixi.lock) and double-rebase pixi.lock commit conflict pattern (git rebase --skip the stale pixi.lock-fix commit).
+
+**Changed by:** Session — Fixing multiple Dependabot PRs failing CI in ProjectScylla; double-rebase pixi.lock skip pattern used on 2 PRs
+**Verification:** verified-ci
+
+### What changed
+
+- Bumped version 1.1.0 → 1.2.0; updated date to 2026-04-13
+- Added "When to Use" trigger: Dependabot PRs fail CI very fast (6–12 seconds)
+- Added "When to Use" trigger: double-rebase pixi.lock commit conflict requiring `--skip`
+- Added `### Phase 3b: Dependabot PR pixi.lock Fix` subsection
+- Added `### Phase 3c: Double-Rebase pixi.lock Commit Conflict` subsection
+- Added 2 new Failed Attempts rows (double-rebase `--continue` and Dependabot CI misdiagnosis)
+- Added ProjectScylla Dependabot entry to Verified On table
+
+### Why
+
+Dependabot PRs show a distinct fast-failure signature (6–12s) that is easy to misdiagnose as a test failure. Once identified, the fix is the same rebase + pixi install pattern, but must be run sequentially rather than in parallel. The double-rebase pattern (where a branch already has a pixi.lock-fix commit) also emerged — `--skip` is correct because the old regeneration commit is entirely superseded.
+
+---
+
 ## v1.1.0 (2026-03-30)
 
 **Changed by:** Session — Fixing stale pixi.lock CI failures across 5 feature branches in ProjectHephaestus (version bump 0.5.0 → 0.6.0 + resilience subpackage)

--- a/skills/pixi-lock-rebase-regenerate.md
+++ b/skills/pixi-lock-rebase-regenerate.md
@@ -1,11 +1,11 @@
 ---
 name: pixi-lock-rebase-regenerate
-description: "Correctly resolve pixi.lock staleness after git rebase or when main advances. Use when: (1) CI fails with 'lock-file not up-to-date with the workspace', (2) multiple PRs all fail identical CI jobs after a version bump on main, (3) git rebase causes pixi.lock conflicts, (4) Dependabot PRs fail CI fast (6-12 seconds) because Dependabot only bumps pyproject.toml not pixi.lock, (5) a second rebase of the same branch produces a pixi.lock commit conflict — skip the stale commit and re-run pixi install."
+description: "Correctly resolve pixi.lock staleness after git rebase or when main advances. Use when: (1) CI fails with 'lock-file not up-to-date with the workspace', (2) multiple PRs all fail identical CI jobs after a version bump on main, (3) git rebase causes pixi.lock conflicts, (4) Dependabot PRs fail CI fast (6-12 seconds) because Dependabot only bumps pyproject.toml not pixi.lock, (5) a second rebase of the same branch produces a pixi.lock commit conflict — skip the stale commit and re-run pixi install, (6) a second commit in the rebase chain patches code that was migrated to an external package — accept HEAD's version and use git rebase --skip."
 category: ci-cd
-date: 2026-04-13
-version: "1.2.0"
+date: 2026-04-21
+version: "1.3.0"
 user-invocable: true
-verification: verified-ci
+verification: verified-local
 history: pixi-lock-rebase-regenerate.history
 tags: [dependabot, pixi, rebase, pixi-lock, ci-cd]
 ---
@@ -15,10 +15,10 @@ tags: [dependabot, pixi, rebase, pixi-lock, ci-cd]
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-03-30 |
+| **Date** | 2026-04-21 |
 | **Objective** | Correctly resolve `pixi.lock` staleness after `git rebase` or main-branch advancement without producing an invalid lock file |
 | **Outcome** | Eliminates `lock-file not up-to-date` CI failures; multi-branch parallel fix completes 5 PRs in ~1 minute |
-| **Verification** | verified-local |
+| **Verification** | verified-local (v1.3.0) |
 | **History** | [changelog](./pixi-lock-rebase-regenerate.history) |
 
 ## When to Use
@@ -30,6 +30,7 @@ tags: [dependabot, pixi, rebase, pixi-lock, ci-cd]
 - All test matrix jobs pass but infrastructure jobs (lock-check, pre-commit, dep-scan) uniformly fail
 - **Dependabot PRs fail CI very fast (6–12 seconds)**: Dependabot bumps `pyproject.toml` version bounds but does NOT regenerate `pixi.lock`. CI runs `pixi install --locked` which rejects the stale lock immediately — hence the fast failure. Fix is the same: rebase + `pixi install` + commit pixi.lock.
 - A branch that previously had a pixi.lock-fix commit is rebased a second time and the old pixi.lock commit conflicts with the freshly-rebased state. Resolution: `git rebase --skip` the conflicting commit, then re-run `pixi install` fresh.
+- **Second commit in the rebase chain patches code migrated to an external package**: A branch has Commit A (structural change, e.g., pixi.toml restructure) and Commit B (follow-on fix to local scripts that have since been rewritten as thin wrapper stubs delegating to an external package). Commit A applies cleanly; Commit B conflicts because the functions it patches no longer exist. Accept `HEAD`'s version of all conflicted files and use `git rebase --skip` (not `--continue`) to drop the now-empty commit.
 
 **Do NOT use `--ours` or `--theirs`** to resolve a `pixi.lock` conflict — either side will be stale
 relative to the rebased branch's actual `pixi.toml`.
@@ -216,6 +217,56 @@ git push --force-with-lease origin <branch>
 regenerate pixi.lock. After the new rebase, the lock needs to be regenerated fresh anyway —
 the old regeneration commit is entirely superseded. Skipping it is semantically correct.
 
+### Phase 3d: Multi-Commit Rebase Where Second Commit Is Superseded
+
+When a branch has two commits — a structural change (Commit A) followed by a follow-on fix (Commit B)
+to local scripts that have since been migrated to an external package as thin wrapper stubs:
+
+```
+Commit A: chore(deps): separate dev from production dependencies in pixi.toml
+Commit B: fix(deps): fix pixi.lock and version-drift checkers for dev/prod split
+```
+
+Between branch creation and rebase, `main` rewrote the scripts Commit B patches (e.g.,
+`scripts/check_dep_sync.py`, `scripts/check_precommit_versions.py`) as one-line wrappers:
+
+```python
+# New form on main — the functions Commit B patched no longer exist
+from hephaestus.config.dep_sync import *  # noqa: F401,F403
+```
+
+**Rebase flow:**
+
+```bash
+git fetch origin
+git rebase origin/main
+# Commit A applies cleanly → git rebase --continue automatically or manually
+
+# Commit B conflicts — the files it patches are now thin wrappers on main
+# Accept main's version of ALL conflicted files:
+git checkout HEAD -- scripts/check_dep_sync.py scripts/check_precommit_versions.py
+git checkout HEAD -- pixi.lock   # if pixi.lock is also conflicted
+
+# The commit is now empty — skip it entirely:
+git rebase --skip       # NOT --continue (which would create an empty commit)
+
+# After rebase completes: re-run pixi install for any new environments from Commit A
+pixi install
+git add pixi.lock
+git commit -m "fix(deps): regenerate pixi.lock after rebase on main"
+git push --force-with-lease origin <branch>
+gh pr merge <pr-number> --auto --rebase
+```
+
+**Key distinction**: Use `--skip` (not `--continue`) when ALL conflicts in a commit are resolved
+by accepting `HEAD`'s version — the commit becomes empty and must be dropped to avoid polluting
+history with a no-op commit.
+
+**Signal that this pattern applies:**
+- Commit B patches functions or logic that simply does not exist in the current files on main
+- After `git checkout HEAD -- <files>`, running `git diff --cached` shows zero staged changes
+- The commit message of Commit B references "fixing" or "patching" scripts that main now delegates to an external package
+
 ### Phase 4: Verify
 
 ```bash
@@ -236,6 +287,7 @@ done
 | Parallel pixi install for Dependabot PRs | Ran pixi install across multiple worktrees simultaneously | Shared lock file state caused conflicts during resolution | Run Dependabot pixi.lock fixes sequentially per PR, not in parallel |
 | `git rebase --continue` on double-rebase pixi.lock conflict | Tried to resolve conflict and continue | The prior pixi.lock-fix commit is entirely stale; continuing produces a broken lock | Use `git rebase --skip` to discard the stale commit, then `pixi install` fresh |
 | Assumed Dependabot CI failure was a test failure | 6-12s CI duration seemed too fast; investigated test logs | Pre-flight `pixi install --locked` rejection happens before tests run | Fast CI failure (< 30s) on Dependabot PRs = stale pixi.lock, not a code issue |
+| `git rebase --continue` after resolving empty commit (migrated-code scenario) | After accepting `HEAD` for all conflicted files in Commit B, tried `git rebase --continue` | Creates an empty commit that pollutes history with a no-op; also may trigger pre-commit failure on zero-change commit | When all conflicts are resolved by accepting `HEAD`'s version entirely — the commit adds nothing — use `git rebase --skip` to drop it |
 
 ## Results & Parameters
 
@@ -280,3 +332,4 @@ gh pr view <pr-number> --json autoMergeRequest  # verify: should NOT be null
 | ProjectScylla | Multiple PRs on 2026-02-22 with pixi.lock conflicts and CI failures | v1.0.0 |
 | ProjectHephaestus | 5 PRs failed after version bump 0.5.0 to 0.6.0 + resilience subpackage; all fixed via parallel worktrees, 2026-03-30 | v1.1.0 |
 | ProjectScylla | Multiple Dependabot PRs failing CI in 6-12s; fixed sequentially via worktrees; double-rebase pixi.lock skip pattern used on 2 PRs, 2026-04-13 | v1.2.0 |
+| ProjectOdyssey | Rebased `5047-separate-dev-production-deps` branch onto main after PR #5241 closed without merging; Commit B (script fixes) conflicted because scripts were rewritten as hephaestus wrapper stubs; accepted HEAD for all conflicted files, used `git rebase --skip` to drop empty commit, re-ran `pixi install` for new environments; PR #5266, 2026-04-21 | v1.3.0 |


### PR DESCRIPTION
## Summary

- Bumps `pixi-lock-rebase-regenerate` from v1.2.0 to v1.3.0
- Adds Phase 3d workflow: multi-commit rebase where Commit B patches scripts that main has since rewritten as thin wrapper stubs (hephaestus migration)
- Key insight: after accepting `HEAD` for all conflicted files the commit is empty — `git rebase --skip` is required (not `--continue`)
- Adds new Failed Attempts row documenting the `--continue` mistake in this scenario
- Updates Verified On table with ProjectOdyssey PR #5266 (2026-04-21)
- Also adds missing v1.2.0 history entry to `.history` file (was absent — only v1.1.0 was recorded)

## Test plan

- [x] `python3 scripts/validate_plugins.py` — 961/961 valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)