### PR TITLE
feat: add docker-buildx-multiarch-local-image skill

### DIFF
--- a/skills/docker-buildx-multiarch-local-image.md
+++ b/skills/docker-buildx-multiarch-local-image.md
@@ -1,0 +1,146 @@
+---
+name: docker-buildx-multiarch-local-image
+description: "Use when: (1) a multi-arch Docker buildx job fails with 'pull access denied' for a locally-built base image, (2) chaining two buildx multi-arch builds where the second depends on the first's image, (3) using docker-container buildx driver and needing to pass a base image to a downstream build."
+category: ci-cd
+date: 2026-04-23
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags: [docker, buildx, multi-arch, oci, local-image, base-image, github-actions, ci]
+---
+
+# Docker Buildx Multi-Arch Local Image Chaining
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-23 |
+| **Objective** | Chain two multi-arch buildx builds without a registry when the second depends on the first |
+| **Outcome** | OCI tarball export + build-contexts reference pattern resolves pull access denied; CI passed |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- A GitHub Actions CI job builds a base image with buildx, then builds a vessel/child image that uses it
+- The vessel build fails with `pull access denied for <base-image>` or `not found`
+- You are using the default `docker-container` buildx driver (which does NOT share the Docker daemon image store)
+- You cannot or do not want to push the base image to a registry just to use it in the same CI job
+
+## Verified Workflow
+
+### Quick Reference
+
+```yaml
+# Step 1: Build base image and export as OCI tarball
+- name: Build base image
+  uses: docker/build-push-action@v6
+  with:
+    file: bases/Dockerfile.minimal
+    platforms: linux/amd64,linux/arm64
+    outputs: type=oci,dest=/tmp/base-minimal.tar
+    tags: achaean-base-minimal:latest
+
+# Step 2: Build vessel using build-contexts to reference the OCI tarball
+- name: Build vessel image
+  uses: docker/build-push-action@v6
+  with:
+    file: vessels/goose/Dockerfile
+    platforms: linux/amd64,linux/arm64
+    build-contexts: achaean-base-minimal:latest=oci-layout:///tmp/base-minimal.tar
+    build-args: BASE_IMAGE=achaean-base-minimal:latest
+    push: true
+    tags: ghcr.io/org/achaean-goose:latest
+```
+
+### Detailed Steps
+
+1. **Diagnose**: Confirm you are using the docker-container buildx driver:
+   ```yaml
+   - uses: docker/setup-buildx-action@v3
+     # No 'driver: docker' → defaults to docker-container driver
+   ```
+
+2. **Export base image as OCI tarball** instead of loading into daemon:
+   ```yaml
+   outputs: type=oci,dest=/tmp/base-<name>.tar
+   ```
+   The `docker` output type (`outputs: type=docker`) does not work with multi-arch builds.
+   Use `type=oci` for multi-arch OCI archives.
+
+3. **Reference the OCI tarball in the downstream build** using `build-contexts`:
+   ```yaml
+   build-contexts: <image-name>=oci-layout:///tmp/<tarball>.tar
+   ```
+   The image name in `build-contexts` must exactly match the `FROM` line in the Dockerfile
+   (or the `BASE_IMAGE` build-arg value).
+
+4. **Verify the vessel Dockerfile uses the build-arg**:
+   ```dockerfile
+   ARG BASE_IMAGE=achaean-base-minimal:latest
+   FROM ${BASE_IMAGE}
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Build base with `outputs: type=docker,dest=/tmp/base.tar` then load | Used docker output type thinking it would work like OCI | `type=docker` does not support multi-platform builds — build fails with "multiple platforms not supported" | Use `type=oci` for multi-arch OCI archives; `type=docker` is single-platform only |
+| Build base with `load: true`, reference by image name in vessel | Used `load: true` to push into daemon, then let vessel FROM pull from daemon | `docker-container` driver builds in an isolated container that does NOT share the host Docker daemon image store; vessel build cannot resolve the image | Either switch to `driver: docker` (loses multi-arch) or export via OCI tarball |
+| Switch buildx driver to `driver: docker` | Set `driver: docker` in setup-buildx-action | Works for single-arch, but `driver: docker` does NOT support multi-platform builds — `--platform linux/amd64,linux/arm64` fails | Only use `driver: docker` when multi-arch is not needed; for multi-arch you must use the tarball pattern |
+| Push base to registry, reference by registry URL | Built and pushed base to GHCR, then referenced in vessel FROM | Adds registry round-trip latency and requires push permissions for intermediate images; overly complex | OCI tarball via `/tmp` is simpler and faster for same-job chaining |
+
+## Results & Parameters
+
+### Driver Comparison
+
+| Driver | Multi-Arch | Shares Daemon Store | Best For |
+|--------|-----------|---------------------|----------|
+| `docker-container` (default) | Yes | No | Multi-arch builds, caching, push to registry |
+| `docker` | No | Yes | Single-arch builds, load into local daemon |
+
+### OCI Tarball Pattern Template
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+        # Default docker-container driver
+
+      - name: Build base image (OCI tarball)
+        uses: docker/build-push-action@v6
+        with:
+          file: bases/Dockerfile.node
+          platforms: linux/amd64,linux/arm64
+          outputs: type=oci,dest=/tmp/base-node.tar
+          tags: achaean-base-node:latest
+
+      - name: Build vessel image
+        uses: docker/build-push-action@v6
+        with:
+          file: vessels/claude/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-contexts: achaean-base-node:latest=oci-layout:///tmp/base-node.tar
+          build-args: BASE_IMAGE=achaean-base-node:latest
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/achaean-claude:latest
+```
+
+### Key Notes
+
+- `oci-layout://` prefix is required in `build-contexts` value
+- The path after `oci-layout://` must be an absolute path (use `/tmp/` not `./tmp/`)
+- The image name key in `build-contexts` must exactly match what the Dockerfile's `FROM` resolves to
+- This works without any registry — base image stays local to the runner
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| AchaeanFleet | CI repair — goose multi-arch vessel build failing with pull access denied | 2026-04-23; OCI tarball pattern resolved the issue, CI passed |


### PR DESCRIPTION
## Summary

New skill documenting OCI tarball chaining for multi-arch buildx builds without a registry.

- `docker-container` buildx driver (default) does NOT share the host Docker daemon image store
- Downstream builds fail with "pull access denied" when referencing a locally-built base image
- Fix: export base as `type=oci` tarball, reference via `build-contexts: image=oci-layout:///tmp/file.tar`

## Verification Level

**verified-ci** — AchaeanFleet goose vessel multi-arch build resolved after implementing OCI tarball pattern.

## Key Findings

**What Worked**:
- `outputs: type=oci,dest=/tmp/base.tar` for base image export
- `build-contexts: name=oci-layout:///tmp/base.tar` for downstream vessel build

**What Failed**:
- `type=docker` output: doesn't support multi-arch
- `load: true`: image stays in isolated buildx container, not accessible to next build step
- Switching to `driver: docker`: loses multi-arch capability

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: buildx, multi-arch, OCI, local image, pull access denied

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>