### PR TITLE
feat: amend test-implementation-gap-analysis skill (v1.1.0)

### DIFF
--- a/skills/test-implementation-gap-analysis.history
+++ b/skills/test-implementation-gap-analysis.history
@@ -1,11 +1,12 @@
+## v1.0.0 — 2026-03-19
+
+```markdown
 ---
 name: test-implementation-gap-analysis
-description: "Test-Implementation Gap Analysis — detects gaps between test expectations and implementation, including PR commit message/diff mismatches where a route or feature is described but never added to the relevant source file"
+description: "Test-Implementation Gap Analysis"
 category: testing
-date: 2026-04-24
-version: "1.1.0"
-verification: verified-ci
-history: test-implementation-gap-analysis.history
+date: 2026-03-19
+version: "1.0.0"
 user-invocable: false
 ---
 # Test-Implementation Gap Analysis
@@ -28,9 +29,6 @@ Use this skill when:
 - Auditing epic/milestone implementation completeness
 - Pytest collection warnings appear for production classes
 - Python version compatibility issues in tests
-- A rebased PR's tests fail with 404/ImportError but the error implies the feature was never implemented (not a conflict issue)
-- `git show HEAD --stat` doesn't include the file where the feature should live (routes, handlers, etc.)
-- Commit message uses language like "add X endpoint" or "implement Y" but the diff only shows tests
 
 ## Verified Workflow
 
@@ -119,31 +117,7 @@ timeout_error.stdout = b"partial"
 timeout_error.stderr = b""
 ```
 
-### Step 8: Detecting PR Description/Diff Mismatch
-
-When a rebased PR's tests fail with 404 or ImportError on a feature the commit message claims was added, verify the diff actually includes the right files before debugging conflict resolution:
-
-```bash
-# See the actual files changed in the commit
-git show HEAD --stat
-```
-
-Compare the output against what the commit message claims was done. If a claimed feature has a test but no implementation file in the stat output, the implementation was never committed.
-
-**Fix pattern:**
-1. Run `git show HEAD --stat` to see the actual changed files
-2. Compare against what the commit message claims was done
-3. For any claimed feature with a test but no implementation: add the missing implementation
-4. In this case: add the route to the relevant server/router file, import the needed symbols, commit the fix on the branch
-
-**Specific example (ProjectHermes, 2026-04-24):**
-- PR 120: "feat: promote event constants to public API and add GET /events endpoint"
-- `git show HEAD --stat` showed: `scripts/register-webhooks.sh`, `src/hermes/publisher.py`, `src/hermes/registrar.py`, `tests/test_events_endpoint.py`
-- Missing: `src/hermes/server.py` — the route was never added
-- Fix: Added `@app.get("/events")` route to `server.py`, imported `AGENT_EVENTS, TASK_EVENTS` from `publisher`
-- Result: All 160 tests passed after the route was added
-
-### Step 9: Verify All Tests Pass
+### Step 8: Verify All Tests Pass
 
 ```bash
 pixi run pytest tests/ --tb=short
@@ -155,8 +129,6 @@ pixi run pytest tests/ --tb=short
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | N/A | Direct approach worked | N/A | Solution was straightforward |
-| Assuming test failure = conflict resolution error | Looked at merge conflicts and rebase output when test returned 404 | The 404 was because the route was never implemented — git show HEAD showed server.py wasn't in the changed files | Always run `git show HEAD --stat` to verify the actual diff matches the commit message claims before debugging conflict resolution |
-
 ## Results & Parameters
 
 ### Files Modified
@@ -193,3 +165,4 @@ pixi run pytest tests/ --tb=short
 - `pytest-production-class-conflicts` - Deep dive on Test* naming
 - `python-version-compatibility` - Handling API changes across versions
 - `stub-to-implementation` - Completing stub implementations
+```


### PR DESCRIPTION
## Summary

- Bumps `test-implementation-gap-analysis` from v1.0.0 to v1.1.0
- Adds new pattern: **PR commit message / diff mismatch** — when a commit claims to add a route/feature but the implementation file was never touched
- Archives v1.0.0 snapshot in `test-implementation-gap-analysis.history`
- Sets verification to `verified-ci` (160 tests passed after the fix in the live session)

## New Pattern Added

**Scenario**: PR 120 in ProjectHermes claimed "add GET /events endpoint". Tests for the endpoint existed in the diff. Running the tests returned 404. Root cause: `server.py` was never in the changed files — `git show HEAD --stat` revealed the gap immediately.

**Detection trigger added to "When to Use"**:
- A rebased PR's tests fail with 404/ImportError implying a feature was never implemented
- `git show HEAD --stat` excludes the file where the feature should live
- Commit message says "add X endpoint" but the diff only shows tests

**New workflow step**: Step 8 — "Detecting PR Description/Diff Mismatch"

**New failed attempt row**: Assuming 404 = conflict resolution error (was actually a missing implementation)

## Verification

`verified-ci` — missing route pattern caught in a live ProjectHermes session; all 160 tests passed after adding the `@app.get("/events")` route to `server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)