### PR TITLE
feat: amend batch-low-difficulty-issue-impl skill (v1.4.0)

### DIFF
--- a/skills/batch-low-difficulty-issue-impl.history
+++ b/skills/batch-low-difficulty-issue-impl.history
@@ -1,5 +1,42 @@
 # History: batch-low-difficulty-issue-impl
 
+## v1.4.0 (2026-04-23)
+
+**Changed by:** HomericIntelligence/AchaeanFleet 235-issue myrmidon swarm session (91 PRs merged, 202 issues closed, 24+ waves)
+**Verification:** verified-ci
+
+### What changed
+- Added AchaeanFleet 235-issue session summary row (largest session to date: 91 PRs, 202 issues, 24+ waves)
+- Added Phase 0: fix-test-failures branch pattern for pre-existing CI failures blocking swarm
+- Renamed LOW→EASY tier to match AchaeanFleet naming convention; added MEDIUM/HARD signals section
+- Added EASY queue exhaustion pattern (~76% of infra-only repo issues)
+- Extended Phase 3 with ci.yml conflict avoidance: batch ALL ci.yml issues into ONE agent per wave; use Sonnet
+- Extended Phase 6 worktree-safe grep to also exclude `.issue_implementer` directory
+- Added Phase 7: Wave Ground-Truth Reconciliation
+- Added Quick Reference subsection with wave sizing, model routing, and escape hatch reminders
+- Added 4 new Failed Attempts entries:
+  - Docker inline comment inside multi-line RUN block causes parse error
+  - Two agents dispatched to same ci.yml file in same wave → guaranteed merge conflict
+  - Trivy action SHA pinning with unverified/fabricated SHAs
+  - pixi.lock not committed after pixi.toml change
+- Added AchaeanFleet 235-issue session statistics table
+- Added Deferred MEDIUM/HARD Categories table (infra-repo pattern)
+- Added Haiku Prompt Template section (validated at scale in AchaeanFleet)
+- Added AchaeanFleet to Verified On table
+- Updated description to reference 200+ issue scale and Docker/ci.yml learnings
+
+### Why
+AchaeanFleet session (235 issues, 24+ waves, 91 PRs merged) revealed several new failure patterns and operational patterns not documented in prior sessions:
+1. Docker inline RUN comment parse error: `curl \ # comment` causes "unknown instruction" — move comment before RUN block
+2. ci.yml conflict: two agents touching same file in same wave always conflict — batch into one Sonnet agent
+3. Trivy SHA fabrication: agents generate plausible non-existent SHAs — verify before accepting
+4. pixi.lock staleness: any pixi.toml change requires `pixi install` + commit of both files
+5. EASY queue exhaustion at ~76%: remaining 24% are all MEDIUM/HARD (evaluate/investigate/arm64/Phase 6)
+6. fix-test-failures branch pattern: accumulate pre-existing CI fixes on one branch before swarm proceeds
+7. Haiku prompt requirements validated at scale: must include exact branch name as `git checkout -B` imperative + STOP escape hatches
+
+---
+
 ## v1.3.0 (2026-04-23)
 
 **Changed by:** HomericIntelligence/Odysseus 35-issue triage session (19 resolved: 17 PRs + 2 ALREADY-DONE closures)

--- a/skills/batch-low-difficulty-issue-impl.md
+++ b/skills/batch-low-difficulty-issue-impl.md
@@ -1,13 +1,14 @@
 ---
 name: batch-low-difficulty-issue-impl
-description: 'Classify, deduplicate, and batch-implement 15-30 low-difficulty GitHub
-  issues (doc edits, text fixes, trivial cleanup) in a single session. Use when: (1)
-  a large backlog of open issues needs triage, (2) many issues are pure doc/text changes,
-  (3) duplicate issues need closing before implementation. Includes worktree-safe grep
-  pattern for ALREADY-DONE verification and correct pre-filter order.'
+description: 'Classify, deduplicate, and batch-implement GitHub issues in a large swarm
+  session (24+ waves, 200+ issues). Use when: (1) a large backlog of open issues needs
+  triage, (2) many issues are pure doc/text or infra-only changes, (3) duplicate issues
+  need closing before implementation. Includes worktree-safe grep pattern for ALREADY-DONE
+  verification, correct pre-filter order, ci.yml conflict avoidance, EASY queue exhaustion
+  detection, and Docker inline comment parse error pattern.'
 category: tooling
 date: 2026-04-23
-version: 1.3.0
+version: 1.4.0
 user-invocable: false
 verification: verified-ci
 history: batch-low-difficulty-issue-impl.history
@@ -24,6 +25,12 @@ history: batch-low-difficulty-issue-impl.history
 | **Verification** | verified-ci |
 | **History** | [changelog](./batch-low-difficulty-issue-impl.history) |
 
+### Session (2026-04-23) — AchaeanFleet 235-Issue Myrmidon Swarm (Waves 1-24+)
+
+| Date | Objective | Outcome |
+|------|-----------|---------|
+| 2026-04-23 | Implement 235 open HomericIntelligence/AchaeanFleet issues (infra-only Docker/Nomad repo) using 24+ waves of ≤5 Haiku agents each | 202 issues closed, 91 PRs merged (verified-ci), 33 remaining (all MEDIUM/HARD). EASY queue exhausted at ~76% of total. |
+
 ### Session (2026-04-23) — HomericIntelligence/Odysseus 35-Issue Triage
 
 | Date | Objective | Outcome |
@@ -39,12 +46,36 @@ history: batch-low-difficulty-issue-impl.history
 ## When to Use
 
 - (1) Repository has 30+ open issues without PRs and a sprint/cleanup session is planned
-- (2) A significant fraction of issues are doc-only changes (README updates, comment fixes, docstring additions)
+- (2) A significant fraction of issues are doc-only changes (README updates, comment fixes, docstring additions) or infra-only changes (Dockerfile edits, CI/CD yaml)
 - (3) You suspect duplicate issues exist that should be closed before work begins
 - (4) Issues span many different files with minimal cross-file dependencies
 - (5) CI pre-commit hooks are stable (no known broken hooks)
+- (6) Pre-existing CI failures are blocking merges — create a `fix-test-failures` fix branch first
 
 ## Verified Workflow
+
+### Phase 0: Pre-existing CI Failures — fix-test-failures Branch
+
+If CI is already broken on main before the swarm starts, swarm PRs will auto-close but
+never merge. Create a dedicated fix branch first and accumulate all CI fixes there:
+
+```bash
+git checkout -b fix-test-failures origin/main
+# Fix each CI failure (inline comment, lock file sync, SHA pinning, etc.)
+git push -u origin fix-test-failures
+gh pr create --title "fix(ci): repair pre-existing CI failures blocking swarm" --body "..."
+# Accumulate fixes here until CI is green, then merge before final swarm waves
+```
+
+**Items that accumulate in fix-test-failures branches (AchaeanFleet pattern):**
+- Docker inline comment parse errors (see Failed Attempts)
+- pixi.lock staleness
+- hadolint `DL3006` suppressions
+- Bare `${WORKSPACE_ROOT}` variable references
+- Unpinned FROM digests
+- Nomad vault-policy.hcl guard conditions
+- npm CVE suppressions
+- Trivy action SHA corrections
 
 ### Phase 1: Classify Issues (30-60 min)
 
@@ -64,17 +95,25 @@ gh issue list --state open --limit 30 --skip 0 --json number,title,labels
 |------|----------|--------|
 | DUPLICATE | Same change as another open issue | `gh issue close N --comment "Duplicate of #M"` |
 | ALREADY-DONE | Change already in codebase | Grep (with worktree exclusion) to verify, then close with comment |
-| LOW | Single-file doc/text/comment edit, no logic | Implement in batch |
-| MEDIUM | Test additions, audits, single-module refactor | Skip this phase |
-| HIGH | New features, backward passes, complex bugs | Skip this phase |
+| EASY | Single-file doc/text/comment/infra edit, no logic | Implement in batch with Haiku agents |
+| MEDIUM | Test additions, audits, single-module refactor, design decisions | Defer |
+| HARD | New features, multi-repo coordination, multi-phase rollout | Defer |
 
-**Pre-filter order matters**: Close DUPLICATEs and ALREADY-DONEs first to keep the final LOW count accurate. Run a verify-before-fix pass as a distinct phase — not as part of Haiku classification — before launching fix agents.
+**Pre-filter order matters**: Close DUPLICATEs and ALREADY-DONEs first to keep the final EASY count accurate. Run a verify-before-fix pass as a distinct phase — not as part of Haiku classification — before launching fix agents.
 
-**LOW difficulty signals**:
-- Title starts with "Update", "Fix typo", "Add note", "Document", "Remove stale"
+**EASY difficulty signals**:
+- Title starts with "Update", "Fix typo", "Add note", "Document", "Remove stale", "Pin", "Suppress"
 - Issue body says "change X to Y" or "add one line to docstring"
-- Affects only `.md`, `README.md`, or docstring lines (not function logic)
+- Affects only `.md`, `README.md`, docstring lines, or single Dockerfile/yaml stanza (not function logic)
 - Expected diff: < 20 lines
+- No design decision required
+
+**MEDIUM/HARD signals (defer these)**:
+- Title contains "evaluate", "investigate", "arm64", "Phase 6", cross-repo references
+- Issue body requires a design decision or multi-phase rollout
+- Requires coordination with another repository
+
+**EASY queue exhaustion**: For infra-only repos (~235 issues), expect EASY queue to exhaust at ~76% of total issues. Remaining 24% are MEDIUM/HARD. Recognizable when: remaining issues all contain "evaluate", "investigate", "arm64", "Phase 6", or cross-repo references.
 
 ### Phase 2: Close Duplicates First
 
@@ -91,7 +130,7 @@ gh issue close 3256 --comment "Duplicate of #3273 (both add __hash__ tests)"
 **Duplicate detection pattern**: Look for pairs of issues with nearly identical titles.
 Group by target file — issues touching the same file with similar descriptions are usually duplicates.
 
-### Phase 3: Group by Target File
+### Phase 3: Group by Target File (Critical for ci.yml)
 
 **CRITICAL — Branch base check before dispatching agents:**
 
@@ -108,14 +147,16 @@ git checkout -B <issue-number>-<slug> origin/main  # Explicit base, not inherite
 
 This prevents "This branch can't be rebased" errors caused by unrelated commits from the L0's current branch silently appearing in agent branches.
 
-Before branching, group LOW issues by which file they edit. Issues sharing a file
+Before branching, group EASY issues by which file they edit. Issues sharing a file
 **must go in the same PR** (to avoid merge conflicts):
 
 ```
 PR 1: agents/hierarchy.md → closes #3321, #3322
 PR 2: CLAUDE.md           → closes #3325, #3326, #3367, #3216
-PR 3: extensor.mojo       → closes #3290 first, then #3192 in separate PR
+PR 3: .github/workflows/ci.yml → closes #all-ci-issues-in-this-wave
 ```
+
+**CRITICAL — ci.yml conflict avoidance**: Multiple issues often touch `.github/workflows/ci.yml` per wave. Batch ALL ci.yml-touching issues into ONE agent per wave. Never dispatch two agents with the same target file in the same wave — guaranteed merge conflict. Use Sonnet (not Haiku) for ci.yml batches due to multi-issue interdependencies.
 
 Issues touching different files can be implemented in parallel.
 
@@ -165,11 +206,12 @@ gh pr merge --auto --rebase
 For issues claiming a change is needed, grep first — and always exclude worktrees:
 
 ```bash
-# CORRECT: exclude worktrees and git internals
+# CORRECT: exclude worktrees, issue_implementer, claude, and git internals
 grep -rn "pattern" /path/to/repo/ \
   --include="*.py" --include="*.toml" --include="*.yml" \
   --exclude-dir=".git" \
   --exclude-dir=".worktrees" \
+  --exclude-dir=".issue_implementer" \
   --exclude-dir=".claude"
 
 # WRONG: plain grep picks up stale worktree content — gives false "still present" signals
@@ -180,9 +222,39 @@ Stale worktrees contain old branch state from prior work. If you grep without ex
 - An issue that claims "remove stale `--cov` flag" may appear as still present because the flag exists in a worktree from a prior branch — but is already gone from main.
 - A dependency pin done via direct curl (not in a config file) may not appear in `pixi.toml` but the worktree shows an old pinned version string.
 
+**ALREADY-DONE detection rate**: ~12% of issues in a large backlog are already implemented. Detect with grep before dispatching. Most common: CI checks already added by earlier waves, Dockerfile pins already applied.
+
 ```bash
 # If no matches in main tree → change already done → close with verification comment
 gh issue close NNNN --comment "Verified: already resolved. [pattern] not found in main tree. Closing."
+```
+
+### Phase 7: Wave Ground-Truth Reconciliation
+
+After each wave completes, always run:
+```bash
+gh pr list --author "@me" --state all --limit 50
+```
+
+Never trust agent-reported PR numbers — agents report stale in-flight views. This is the only reliable source of truth for wave reconciliation.
+
+### Quick Reference
+
+```bash
+# Wave sizing: ≤5 agents/wave optimal for infra repos
+# Model routing:
+#   Haiku: single-file mechanical EASY issues
+#   Sonnet: batched ci.yml issues, multi-file or multi-issue PRs
+
+# Exact branch name imperative in every agent prompt:
+# "Run: git checkout -B <N>-auto-impl origin/main"
+
+# STOP escape hatches in every agent prompt:
+# "If the issue is already implemented, STOP and report ALREADY-DONE"
+# "If the spec is unclear, STOP and report BLOCKED"
+
+# After each wave:
+gh pr list --author "@me" --state all --limit 50
 ```
 
 ## Failed Attempts
@@ -193,15 +265,35 @@ gh issue close NNNN --comment "Verified: already resolved. [pattern] not found i
 | Sub-agents completing full git workflow (2026-03-06) | Asked sub-agents to create branches, commit, push, and create PRs | Agents completed the file edits but did not execute the git commands (output descriptions instead) | Sub-agents reliably edit files but frequently skip the git+PR workflow. Always execute git operations in the main agent after sub-agents return. (Note: NOT observed in 2026-04-12 session with worktree isolation — all 12 agents completed full git workflow.) |
 | Reading files after `git checkout -b` from stash | Assumed `git checkout stash -- file` would have the correct content immediately | The `git checkout stash` command works correctly but the branch check showed "branch already exists" because a previous stash attempt created it | Check for existing branches with `git branch --list` before creating; use `git checkout existing-branch` if it exists. |
 | Running `pixi run pre-commit run <specific-file>` | Tried to run hooks on only the changed file | Hook IDs don't match file paths — the command fails with "No hook with id path/to/file" | Always run `pixi run pre-commit run --all-files`, never by file path. |
-| Grepping for ALREADY-DONE without worktree exclusion (2026-04-12) | Plain `grep -rn pattern /repo/` to detect whether issue content still exists | Worktrees contain stale branch state — gave false "still present" for #1655 (nats-server) and #1671 (--cov refs) | Always pass `--exclude-dir=.worktrees --exclude-dir=.claude --exclude-dir=.git` when grepping for ALREADY-DONE verification |
+| Grepping for ALREADY-DONE without worktree exclusion (2026-04-12) | Plain `grep -rn pattern /repo/` to detect whether issue content still exists | Worktrees contain stale branch state — gave false "still present" for #1655 (nats-server) and #1671 (--cov refs) | Always pass `--exclude-dir=.worktrees --exclude-dir=.issue_implementer --exclude-dir=.claude --exclude-dir=.git` when grepping for ALREADY-DONE verification |
 | Running verify-before-fix as part of Haiku classification (2026-04-12) | Expected Haiku to catch all ALREADY-DONE issues during the classification pass | Haiku missed 2 ALREADY-DONE issues (4.7% miss rate) where implementation was in a different location than the issue title implied | Always run verify-before-fix as a distinct separate phase after Haiku classification, not as part of it |
 | Haiku agents with `isolation: "worktree"` dispatched while L0 was on a non-main branch (`15-exporter-port-9101`) | Agents created worktrees and checked out branches, which inherited the L0's current branch as base | Worktrees start from the current HEAD of the base repo — not from `origin/main` — so each branch silently included 4-5 unrelated commits. GitHub refused rebase merge: "This branch can't be rebased." | Always verify L0 is on `main` before dispatching worktree agents, OR explicitly include `git fetch origin && git checkout -B <branch> origin/main` as step 1 in every agent prompt instead of relying on worktree inheritance |
 | PR number collision from parallel agents (2026-04-23) | Two parallel agents working in HomericIntelligence/Odysseus simultaneously both reported "PR #120" in their output | Agents report their own in-flight view of PR numbers, which can be stale when two agents race to create PRs in the same repo; both PRs existed but with different numbers | Always run `gh pr list --author "@me" --state all` after each wave to get ground-truth PR numbers — never trust agent-reported PR numbers |
 | Worktree creation failure on symlink-heavy repo (2026-04-23) | Agent for issue #58 failed during worktree creation with "Updating files: X%" timeout error | HomericIntelligence/Odysseus has 12 submodule symlinks; worktree checkout can time out on repos with many symlinks when many files must be resolved | Fallback: `git checkout -b <branch> origin/main` in main worktree directly, push the branch, then `git checkout <original-branch>` to return afterward |
 | Agent branch naming drift (2026-04-23) | Agent for issue #18 used branch `18-fix-runbook` instead of the specified `18-auto-impl` convention | Haiku agents sometimes derive branch names from the issue title rather than following the `<N>-auto-impl` convention when the convention is only mentioned as a note rather than an explicit command | Explicitly spell out the exact branch name in every agent prompt as an imperative: "Run: git checkout -b 18-auto-impl origin/main" — never rely on the agent interpreting a naming convention |
 | Two agents merging into same PR branch (2026-04-23) | Agents for #50 and #53 (both in Wave A1 parallel) both committed to branch `50-auto-impl` | Parallel worktree agents targeting similar branch names in the same repo; the worktrees may have been assigned the same directory, causing both agents to commit to the same branch | Use distinct, non-overlapping branch names per agent; verify each agent's branch with `gh pr list` after the wave; both issues still closed correctly but PR was messy |
+| Docker inline comment inside multi-line RUN block (AchaeanFleet 2026-04-23) | Wrote `RUN curl \ # download step` or `wget \ # comment` inside a `RUN` backslash-continuation block | Docker parser interprets the comment text as a new instruction; emits "unknown instruction: wget" or "unknown instruction: comment" parse error | Move comments BEFORE the RUN block entirely: `# download step\nRUN curl \` — never put comments inside multi-line RUN backslash blocks |
+| Two agents dispatched to the same ci.yml file in the same wave (AchaeanFleet 2026-04-23) | Multiple issues touched `.github/workflows/ci.yml`; separate Haiku agents dispatched per issue | Guaranteed merge conflict — both agents produce PRs touching ci.yml in overlapping locations; only one can merge automatically | Batch ALL ci.yml issues within a wave into ONE agent. Use Sonnet for this agent due to multi-issue interdependencies |
+| Trivy action SHA pinning with unverified SHAs (AchaeanFleet 2026-04-23) | Agents generated plausible-looking SHAs for `aquasecurity/trivy-action` version pins | Some agent-generated SHAs were non-existent (fabricated). CI failed on `uses: aquasecurity/trivy-action@<bad-sha>` | Always verify pinned SHAs exist on GitHub before accepting. Correct SHA for aquasecurity/trivy-action v0.35.0: `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` |
+| pixi.lock not committed after pixi.toml change (AchaeanFleet 2026-04-23) | Agent updated `pixi.toml` (added/changed dependency) without also committing updated `pixi.lock` | CI fails with "lock-file not up-to-date with workspace" — pixi enforces lock-file consistency in CI | After any `pixi.toml` change, run `pixi install` to regenerate `pixi.lock`, then commit both files together |
 
 ## Results & Parameters
+
+### Session Statistics (2026-04-23) — AchaeanFleet 235-Issue Swarm
+
+| Metric | Value |
+|--------|-------|
+| Starting open issues | 235 |
+| Ending open issues | 33 |
+| Issues closed/implemented | 202 |
+| PRs merged (verified-ci) | 91 |
+| PRs still pending CI | 7 |
+| Waves | 24+ |
+| Wave size | ≤5 agents |
+| ALREADY-DONE rate | ~12% (25+ of 235) |
+| EASY queue exhaustion | ~76% of total (180 of 235) |
+| Remaining issues | 33 — all MEDIUM/HARD |
+| Total wall-clock time | Multi-day session |
 
 ### Session Statistics (2026-03-06) — ProjectOdyssey
 
@@ -230,6 +322,18 @@ gh issue close NNNN --comment "Verified: already resolved. [pattern] not found i
 
 **Note on `isolation="worktree"` reliability**: In this session on ProjectScylla (Python/pixi repo), `Task(isolation="worktree")` worked correctly — agents created branches and PRs in isolated worktrees without polluting the main worktree. The failure mode documented in the 2026-03-06 session (agents editing main worktree) did NOT occur. Hypothesis: the failure may be environment-specific. Always verify that each PR was created from the correct branch, not from main.
 
+### Deferred MEDIUM/HARD Categories (AchaeanFleet Infra-Repo Pattern)
+
+These categories consistently remain after EASY queue exhausts in infra-only repos:
+
+| Category | Signal | Why MEDIUM/HARD |
+|----------|--------|-----------------|
+| Artifact pipeline refactor | "push-to-registry", "reuse build-vessels output" | Multi-step architecture change |
+| Multi-arch support | "arm64", "QEMU", "multi-arch matrix" | CI matrix expansion + QEMU setup |
+| New test functions | "dagger testVesselTools()", "add test for X" | Requires understanding tool API |
+| Compose overlay design | "depends_on", "service ordering" | Cross-service dependency design |
+| Nomad TLS/cert distribution | "Phase 6", "cert rotation" | Multi-phase future work |
+
 ### Branch Naming Convention
 
 ```
@@ -250,11 +354,11 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 ### Issue Classification Heuristics
 
 ```
-LOW if ALL of:
-  - Title has: "Update", "Document", "Fix typo", "Remove stale", "Add note"
+EASY if ALL of:
+  - Title has: "Update", "Document", "Fix typo", "Remove stale", "Add note", "Pin", "Suppress"
   - Body has: single file target
   - Expected diff: < 20 lines
-  - No logic/behavior change (only text/comments/docs)
+  - No logic/behavior change (only text/comments/docs/infra stanza)
 
 DUPLICATE if:
   - Same target file as another open issue
@@ -264,6 +368,31 @@ DUPLICATE if:
 ALREADY-DONE if:
   - Issue says "remove X" → grep for X → not found
   - Issue says "add Y to Z" → grep for Y in Z → already present
+
+MEDIUM/HARD if:
+  - Requires design decision or "evaluate"/"investigate" verb
+  - Cross-repo coordination required
+  - "arm64", "Phase 6", multi-phase rollout
+```
+
+### Haiku Prompt Template (validated at scale)
+
+```
+You are implementing GitHub issue #<N> in repo <REPO>.
+
+Issue: <title>
+Body: <body>
+
+Steps:
+1. Run: git checkout -B <N>-auto-impl origin/main
+2. [implementation steps specific to issue]
+3. Run pre-commit and fix any failures
+4. Commit with message: "type(scope): description\n\nCloses #<N>\n\nCo-Authored-By: Claude <noreply@anthropic.com>"
+5. Push and create PR with `gh pr create --title "..." --body "Closes #<N>"`
+6. Run: gh pr merge <PR_NUMBER> --auto --rebase
+
+STOP and report ALREADY-DONE if the change described in the issue is already present in the codebase.
+STOP and report BLOCKED if the spec is unclear or requires a design decision.
 ```
 
 ## Verified On
@@ -273,3 +402,4 @@ ALREADY-DONE if:
 | ProjectOdyssey | 165-issue backlog cleanup, March 2026 | [notes.md](../references/notes.md) |
 | ProjectScylla | 64-issue myrmidon swarm pass, 4 waves, 12 PRs (2026-04-12) | 11/12 PRs merged CI-green; worktree isolation worked correctly; verify-before-fix caught 3 ALREADY-DONE issues |
 | HomericIntelligence/Odysseus | 35-issue triage, 19 resolved (17 PRs + 2 ALREADY-DONE), meta-repo with 12 submodule symlinks (2026-04-23) | 0 git-op failures; worktree creation timeout on symlink-heavy repo (fallback to main worktree); parallel agents reported colliding PR numbers; Haiku branch naming drift to title-slug form |
+| HomericIntelligence/AchaeanFleet | 235-issue myrmidon swarm, 24+ waves, 91 PRs merged verified-ci (2026-04-23) | 202/235 issues closed; EASY queue exhausted at 76%; Docker inline comment parse error; ci.yml conflict avoidance; trivy SHA pinning; pixi.lock sync |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.3.0 to v1.4.0 with verified-ci learnings from the AchaeanFleet 235-issue myrmidon swarm session (largest session documented to date: 91 PRs merged, 202 issues closed, 24+ waves).

- Docker inline RUN comment parse error: `curl \ # comment` causes Docker parse failure — move comment before the RUN block
- ci.yml conflict avoidance: batch ALL ci.yml-touching issues into ONE Sonnet agent per wave — two agents on same file always conflict
- fix-test-failures branch pattern: accumulate pre-existing CI fixes on dedicated branch before swarm can merge
- EASY queue exhaustion at ~76% in infra-only repos; remaining 24% are all MEDIUM/HARD
- Trivy action SHA pinning: agents fabricate plausible non-existent SHAs — always verify on GitHub
- pixi.lock sync: commit both pixi.toml and pixi.lock together after any dependency change
- ALREADY-DONE rate ~12%; grep must exclude `.issue_implementer` in addition to `.worktrees`/`.claude`/`.git`
- Haiku prompt requirements validated at scale: exact `git checkout -B` imperative + STOP escape hatches mandatory

## Verification Level

**verified-ci** — 91 PRs merged to main branch on HomericIntelligence/AchaeanFleet with CI passing.

## Key Findings

**What Worked**:
- Wave size ≤5 agents optimal for infra repos (larger waves increase shared-file collision risk)
- Model routing: Haiku for single-file EASY, Sonnet for batched ci.yml with multiple interdependencies
- fix-test-failures branch as staging area for pre-existing CI failures before swarm proceeds
- Phase 7 wave reconciliation via `gh pr list --author "@me" --state all` as ground truth

**What Failed**:
- Docker inline comments in RUN blocks → "unknown instruction" parse error — move before RUN block
- Two agents per wave on ci.yml → guaranteed merge conflict — batch into one agent
- Agent-generated Trivy SHAs → non-existent SHAs in CI — verify all SHAs on GitHub
- pixi.toml change without pixi.lock update → CI lock-file staleness failure

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — passed
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: myrmidon, swarm, batch, issue, haiku, wave, ci.yml, docker, trivy

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>