### PR TITLE
feat: amend pre-commit-hook-configuration skill (v2.1.0)

### DIFF
--- a/skills/pre-commit-hook-configuration.history
+++ b/skills/pre-commit-hook-configuration.history
@@ -1,0 +1,55 @@
+# pre-commit-hook-configuration — History
+
+## v2.1.0 (2026-04-24)
+
+**Changed by:** Myrmidons shellcheck-warnings session — pre-commit hook REPO_ROOT resolution in test repos (2026-04-24)
+**Verification:** verified-ci (332 unit tests pass, CI green)
+
+### What changed
+- Bumped version 2.0.0 → 2.1.0; updated date to 2026-04-24; updated verification from unverified to verified-ci
+- Added 3 new "When to Use" conditions: REPO_ROOT resolves to .git/ in test repos; just finds Justfile in parent dir; SKIP_TESTS guard needed for bats tests
+- Added `### Step 7: Fix REPO_ROOT Resolution in Hooks Installed in Test Repos` with:
+  - Root cause explanation (SCRIPT_DIR/../ resolves to .git/ when hook is in .git/hooks/)
+  - `REPO_ROOT_HOOK` pattern using `git rev-parse --show-toplevel`
+  - Test-suite step guard with `[[ -f "${REPO_ROOT_HOOK}/Justfile" ]]`
+  - `SKIP_TESTS=1` pattern for bats tests
+  - `|| true` fix for short-circuit conditionals under `set -euo pipefail`
+  - Diagnosis checklist
+- Added 4 new Failed Attempts rows:
+  - Using `${REPO_ROOT}` for find paths when hook is in .git/hooks/
+  - Removed `$# -eq 0` guard from wrong function (report_unmanaged vs get_unmanaged_names)
+  - `just test` without Justfile guard finds parent repo's Justfile
+  - `[[ -n "$n" ]] && printf` without `|| true` aborts under set -e
+- Added `REPO_ROOT_HOOK Pattern for Hooks Installed in .git/hooks/` to Results & Parameters
+- Updated Quick Reference table to include REPO_ROOT/just/SKIP_TESTS fixes
+- Added Verified On table with Myrmidons entry
+- Added `history` frontmatter field referencing this history file
+- Added tags and updated verification
+
+### Why
+Myrmidons shellcheck-warnings session (2026-04-24) involved fixing pre-commit hooks that were
+tested with bats. The hook was installed as `.git/hooks/pre-commit` in temporary test repos,
+causing `REPO_ROOT` to resolve to `.git/` instead of the repo root. Three specific fix patterns
+emerged:
+1. `REPO_ROOT_HOOK` via `git rev-parse --show-toplevel` — immune to install location
+2. Justfile guard — prevents `just` from finding Justfile in parent directories
+3. `SKIP_TESTS=1` — lets bats tests invoke the hook without triggering the test suite
+
+### Previous version (v2.0.0) snapshot
+
+<details>
+<summary>v2.0.0 frontmatter</summary>
+
+```yaml
+name: pre-commit-hook-configuration
+description: "Use when: ... (6) writing pytest tests to verify pre-commit hook YAML configuration"
+category: ci-cd
+date: 2026-03-29
+version: 2.0.0
+user-invocable: false
+verification: unverified
+tags: []
+```
+
+Key state at v2.0.0: Consolidated from 7 source skills. No REPO_ROOT resolution pattern. No bats test isolation patterns. Verification was unverified.
+</details>

--- a/skills/pre-commit-hook-configuration.md
+++ b/skills/pre-commit-hook-configuration.md
@@ -1,12 +1,13 @@
 ---
 name: pre-commit-hook-configuration
-description: "Use when: (1) ruff or other linter hooks run on hardcoded directories instead of staged files, (2) aligning pre-commit hook versions with pixi-resolved tool versions, (3) updating hook versions with autoupdate, (4) adding a language: pygrep regex hook to catch forbidden patterns, (5) evaluating whether a hook should use pass_filenames: true or false, (6) writing pytest tests to verify pre-commit hook YAML configuration"
+description: "Use when: (1) ruff or other linter hooks run on hardcoded directories instead of staged files, (2) aligning pre-commit hook versions with pixi-resolved tool versions, (3) updating hook versions with autoupdate, (4) adding a language: pygrep regex hook to catch forbidden patterns, (5) evaluating whether a hook should use pass_filenames: true or false, (6) writing pytest tests to verify pre-commit hook YAML configuration, (7) pre-commit hook uses SCRIPT_DIR/../ to find REPO_ROOT but is installed as .git/hooks/pre-commit in a test repo — resolves to .git/ not repo root, (8) SKIP_TESTS env var needed to prevent test-suite step from running in temporary test repos, (9) just command finds Justfile in a parent directory instead of the test repo"
 category: ci-cd
-date: 2026-03-29
-version: 2.0.0
+date: 2026-04-24
+version: 2.1.0
 user-invocable: false
-verification: unverified
-tags: []
+verification: verified-ci
+tags: [pre-commit, hooks, bats, shell-testing, repo-root, test-isolation]
+history: pre-commit-hook-configuration.history
 ---
 
 ## Overview
@@ -14,9 +15,10 @@ tags: []
 | Field | Value |
 |-------|-------|
 | Date | 2026-03-29 |
-| Objective | Consolidated pre-commit hook configuration patterns: pass_filenames, version alignment, pygrep hooks, maintenance, and config testing |
-| Outcome | Merged from 7 source skills |
-| Verification | unverified |
+| Objective | Consolidated pre-commit hook configuration patterns: pass_filenames, version alignment, pygrep hooks, maintenance, config testing, and REPO_ROOT resolution in test repos |
+| Outcome | v2.1.0: Added REPO_ROOT resolution fix for hooks installed in .git/hooks/ of test repos; all 332 unit tests pass, CI green |
+| Verification | verified-ci |
+| History | [changelog](./pre-commit-hook-configuration.history) |
 
 ## When to Use
 
@@ -31,6 +33,9 @@ tags: []
 - Updating pre-commit hook versions to latest releases
 - Writing pytest tests to verify hook YAML config (skip lists, `files:` patterns, flag presence)
 - A security scanner hook (bandit, semgrep) has a `--skip` list that should be intentional and documented
+- Pre-commit hook uses `SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"` and `REPO_ROOT="${SCRIPT_DIR}/.."` — but when the hook is installed as `.git/hooks/pre-commit` in a test repo, `SCRIPT_DIR` resolves to `.git/hooks/` and `REPO_ROOT` resolves to `.git/` (not the repo root)
+- bats test suite step inside the hook finds `Justfile` in a parent directory instead of the test repo — hook runs unrelated test suites from parent directories
+- `SKIP_TESTS=1` env var pattern needed to allow bats tests to invoke the hook without triggering the test-suite step inside the hook
 
 ## Verified Workflow
 
@@ -44,6 +49,9 @@ tags: []
 | Add zero-dep regex guardrail | Add `language: pygrep` hook stanza |
 | Hook with `pass_filenames: false` needs rationale | Read script, add inline comment if global scan is intentional |
 | Verify hook config without running pre-commit | Parse YAML with `yaml.safe_load()` in pytest |
+| Hook REPO_ROOT resolves to .git/ in test repos | Use `git rev-parse --show-toplevel` to find repo root; use dedicated variable `REPO_ROOT_HOOK` |
+| `just` finds Justfile in parent dir during hook test | Guard with `command -v just && [[ -f "${REPO_ROOT_HOOK}/Justfile" ]]` |
+| bats tests trigger hook's test-suite step | Set `SKIP_TESTS=1` in bats test before invoking hook |
 
 ### Step 1: Fix pass_filenames for Ruff (and Other Linters)
 
@@ -315,6 +323,71 @@ def test_pattern_excludes_non_targets(bandit_hook, path):
     assert not re.search(pattern, path)
 ```
 
+### Step 7: Fix REPO_ROOT Resolution in Hooks Installed in Test Repos
+
+**Root cause**: When a hook is installed as `.git/hooks/pre-commit` in a temporary test repo,
+`SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"` resolves to `.git/hooks/`, so
+`REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"` resolves to `.git/` — not the repo root.
+
+All working-tree paths derived from `REPO_ROOT` (find, validate, agents directory) will silently
+operate on `.git/` contents instead of the actual source tree.
+
+**Fix pattern**:
+
+```bash
+# At the top of the hook, after SCRIPT_DIR is set:
+# Use git rev-parse to find the actual working-tree root — immune to install location
+REPO_ROOT_HOOK="$(git rev-parse --show-toplevel 2>/dev/null || echo "${REPO_ROOT}")"
+
+# Use REPO_ROOT_HOOK for ALL working-tree path references:
+find "${REPO_ROOT_HOOK}/agents" -name "*.yaml" ...
+"${REPO_ROOT_HOOK}/scripts/check-dangerous-flags.sh"
+```
+
+**Test-suite step guard** — prevents `just` from finding a Justfile in a parent directory when the hook runs in a temporary test repo:
+
+```bash
+# BEFORE fix — just finds Justfile in parent directory:
+if command -v just &>/dev/null; then
+  just test
+fi
+
+# AFTER fix — guards that Justfile is in the hook's own repo:
+if command -v just &>/dev/null && [[ -f "${REPO_ROOT_HOOK}/Justfile" ]]; then
+  just --justfile "${REPO_ROOT_HOOK}/Justfile" test
+fi
+```
+
+**SKIP_TESTS guard** — allows bats tests to invoke the hook without triggering the test-suite step:
+
+```bash
+# In hook:
+if [[ "${SKIP_TESTS:-0}" != "1" ]] && command -v just &>/dev/null && [[ -f "${REPO_ROOT_HOOK}/Justfile" ]]; then
+  just --justfile "${REPO_ROOT_HOOK}/Justfile" test
+fi
+
+# In bats test:
+SKIP_TESTS=1 run .git/hooks/pre-commit
+```
+
+**`|| true` in conditional pipelines**:
+
+```bash
+# BROKEN under set -euo pipefail — false condition aborts the script:
+[[ -n "$n" ]] && printf '%s\n' "$n"
+
+# FIXED:
+[[ -n "$n" ]] && printf '%s\n' "$n" || true
+```
+
+The `|| true` prevents the shell from aborting when the `&&` condition is false. Required in any
+`set -euo pipefail` hook that uses short-circuit conditionals.
+
+**Diagnosis**:
+- bats test fails with "No such file or directory" on agents/fleet paths → likely `REPO_ROOT` pointing to `.git/`
+- `just` finds unrelated Justfile from parent directory → add `[[ -f "${REPO_ROOT_HOOK}/Justfile" ]]` guard
+- Hook works on real commits but fails in bats tests → `SKIP_TESTS=1` pattern needed
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -332,6 +405,10 @@ def test_pattern_excludes_non_targets(bandit_hook, path):
 | `pygrep` commented-out print as negative case | Added `# print("NOTE: ...")` to NEGATIVE_CASES | `pygrep` matches raw line — `# print(...)` still contains `print.*NOTE` | Move commented-out prints to POSITIVE_CASES; pygrep does not understand comments |
 | Using `\|` alternation in pygrep entry | Wrote `print.*NOTE\|print.*TODO\|print.*FIXME` (grep syntax) | pygrep uses Python `re` syntax; `\|` is a literal pipe | Use `(NOTE|TODO|FIXME)` group syntax |
 | Treating all CI failures as PR-related | Initially considered fixing flaky test failures | Failures were `mojo: error: execution crashed` — pre-existing infra issue | Check `main` branch CI history to distinguish pre-existing flaky failures from PR regressions |
+| Using `${REPO_ROOT}` for find/validate paths in hook installed in .git/hooks/ | Used `find "${REPO_ROOT}/agents" -name "*.yaml"` in hook where `REPO_ROOT="${SCRIPT_DIR}/.."` | When hook is `.git/hooks/pre-commit`, `SCRIPT_DIR` is `.git/hooks/` so `REPO_ROOT` is `.git/` — find operates on `.git/agents/` which doesn't exist | Use `REPO_ROOT_HOOK="$(git rev-parse --show-toplevel 2>/dev/null || echo "${REPO_ROOT}")"` and replace all working-tree paths with `${REPO_ROOT_HOOK}` |
+| Removed `[[ $# -eq 0 ]] && return 0` guard from `report_unmanaged()` | Cleaned up what appeared to be a redundant guard in `report_unmanaged()` | Broke bats test 299 — the guard is needed in `report_unmanaged()` specifically (different from `get_unmanaged_names()` where the check was correctly replaced with array-length check) | Only remove the `$# -eq 0` guard from `get_unmanaged_names()`; keep it in `report_unmanaged()` |
+| `just test` inside hook without Justfile guard | Hook ran `if command -v just; then just test; fi` | When hook runs in a temporary test repo (bats test), `just` searches upward and finds the real repo's Justfile, running the full test suite inside the temp repo context | Add `[[ -f "${REPO_ROOT_HOOK}/Justfile" ]]` guard before calling `just`; also set `SKIP_TESTS=1` in bats tests that invoke the hook |
+| `[[ -n "$n" ]] && printf '%s\n' "$n"` without `|| true` | Short-circuit conditional in hook body under `set -euo pipefail` | When the `&&` condition is false (empty `$n`), bash treats the command as having failed (exit 1), which triggers `set -e` to abort the script | Add `|| true`: `[[ -n "$n" ]] && printf '%s\n' "$n" || true` |
 
 ## Results & Parameters
 
@@ -388,6 +465,33 @@ TestBanditFilesPattern      (12 tests) — 8 match + 4 exclude, parametrized
 TestBanditNosecRationale    (4 tests)  — urlopen/extractall exist, safe usage verified
 ```
 
+### REPO_ROOT_HOOK Pattern for Hooks Installed in .git/hooks/
+
+```bash
+# In the hook file (.git/hooks/pre-commit or scripts/pre-commit.sh):
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"  # May be .git/ when installed as .git/hooks/pre-commit
+
+# Use git rev-parse to find actual repo root regardless of install location:
+REPO_ROOT_HOOK="$(git rev-parse --show-toplevel 2>/dev/null || echo "${REPO_ROOT}")"
+
+# All working-tree references use REPO_ROOT_HOOK:
+find "${REPO_ROOT_HOOK}/agents" -name "*.yaml" -not -path "*/.git/*" | ...
+"${REPO_ROOT_HOOK}/scripts/check-dangerous-flags.sh"
+
+# Test-suite guard (prevents just from running in temp repos):
+if [[ "${SKIP_TESTS:-0}" != "1" ]] && command -v just &>/dev/null && [[ -f "${REPO_ROOT_HOOK}/Justfile" ]]; then
+  just --justfile "${REPO_ROOT_HOOK}/Justfile" test
+fi
+```
+
+```bash
+# In bats tests that invoke the hook:
+SKIP_TESTS=1 run "${REPO_ROOT}/.git/hooks/pre-commit"
+assert_success
+```
+
 ### Verification Commands
 
 ```bash
@@ -401,3 +505,9 @@ pixi run pre-commit run <hook-id> --all-files
 gh run list --branch main --limit 10
 gh run view <run-id> --log-failed
 ```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| Myrmidons | shellcheck-warnings swarm; 332 unit tests pass, CI green; REPO_ROOT_HOOK pattern, SKIP_TESTS guard, Justfile guard, || true fix (2026-04-24) | verified-ci |


### PR DESCRIPTION
## Summary

Amends `pre-commit-hook-configuration` from v2.0.0 to v2.1.0 based on the Myrmidons shellcheck-warnings session (2026-04-24). All 332 unit tests pass, CI green.

- Adds **Step 7: Fix REPO_ROOT Resolution in Hooks Installed in Test Repos** — when hook is `.git/hooks/pre-commit`, `SCRIPT_DIR` resolves to `.git/hooks/` and `REPO_ROOT` resolves to `.git/` (not repo root); use `git rev-parse --show-toplevel` to find actual root
- Documents **SKIP_TESTS=1** pattern — bats tests must set this env var before invoking the hook to prevent the hook's test-suite step from running in temp repos
- Documents **Justfile parent-dir guard** — `[[ -f "${REPO_ROOT_HOOK}/Justfile" ]]` prevents `just` from finding Justfile in parent directories
- Documents **`|| true`** fix for short-circuit conditionals under `set -euo pipefail`
- Creates `pre-commit-hook-configuration.history` (first amendment)

## Verification Level

**verified-ci** — 332 unit tests pass, CI green on Myrmidons repo.

## Key Findings

**What Worked**:
- `REPO_ROOT_HOOK="$(git rev-parse --show-toplevel 2>/dev/null || echo "${REPO_ROOT}")"` — immune to hook install location
- `SKIP_TESTS=1` in bats tests prevents hook from running test suite inside temp repos
- `[[ -f "${REPO_ROOT_HOOK}/Justfile" ]]` guard prevents parent-dir Justfile discovery

**What Failed**:
- Using `${REPO_ROOT}` (SCRIPT_DIR-derived) for find paths when hook is in `.git/hooks/` → resolves to `.git/`
- Removing `$# -eq 0` guard from wrong function (`report_unmanaged` not `get_unmanaged_names`) → breaks test 299
- `just test` without Justfile guard → finds and runs parent repo's unrelated test suite
- Short-circuit `&&` without `|| true` under `set -euo pipefail` → false condition aborts script

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (998/998 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test discovery with keywords: pre-commit, REPO_ROOT, hook, bats, test-isolation, SKIP_TESTS

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>