### PR TITLE
feat: amend batch-low-difficulty-issue-impl skill (v1.9.0)

### DIFF
--- a/skills/batch-low-difficulty-issue-impl.history
+++ b/skills/batch-low-difficulty-issue-impl.history
@@ -1,5 +1,61 @@
 # History: batch-low-difficulty-issue-impl
 
+## v1.9.0 (2026-04-26)
+
+**Changed by:** ProjectKeystone parallel-agent CMakeLists contamination incident (2026-04-26)
+**Verification:** verified-local (build failure confirmed in CI; fix confirmed locally)
+
+### What changed
+- Added 1 new Failed Attempts row about CMakeLists cross-branch contamination from two parallel agents
+
+### Why
+Prior v1.8.0 single-anchor rule said "only one agent per wave may touch CMakeLists.txt" but
+didn't document the cross-branch contamination mechanism or the specific error message. In this
+incident, agents for issues #275 (TLS test) and #303 (SIGTERM test) were launched in parallel
+from `origin/main`. The #275 agent's CMakeLists ended up including the `scheduler_sigterm_tests`
+`add_executable()` target from the #303 agent's in-progress edits, causing:
+  `CMake Error: Cannot find source file: tests/integration/test_scheduler_sigterm.cpp`
+The key subtlety: the contamination occurs even when both agents start from the same base commit —
+they appear to share a working copy during the editing phase before diverging into separate branches.
+Fix procedure: rebase contaminated branch, manually remove stray block, force-push.
+
+### Previous version (v1.8.0) snapshot
+
+<details>
+<summary>v1.8.0 frontmatter</summary>
+
+```yaml
+name: batch-low-difficulty-issue-impl
+description: 'Classify, deduplicate, and batch-implement GitHub issues in a large swarm
+  session (24+ waves, 200+ issues). Use when: (1) a large backlog of open issues needs
+  triage, (2) many issues are pure doc/text or infra-only changes, (3) duplicate issues
+  need closing before implementation. Includes worktree-safe grep pattern for ALREADY-DONE
+  verification, correct pre-filter order, ci.yml conflict avoidance, EASY queue exhaustion
+  detection, Docker inline comment parse error pattern, parallel-agent add/add rebase
+  conflict resolution when multiple agents create the same package independently,
+  pre-launch repo-capability checks (autoMergeAllowed, lockfile, pre-commit config),
+  hot-file serialization for shared scripts (apply.sh/reconcile.sh), pre-swarm
+  existing-PR audit, close-before-delegate pattern, and C++20/Conan/pixi-specific
+  guards (libssl-dev, TSan+concurrentqueue blocker, enable_shared_from_this diamond
+  inheritance, CMakeLists.txt single-agent anchor, asyncio_mode auto decorator check).'
+category: tooling
+date: 2026-04-25
+version: 1.8.0
+user-invocable: false
+verification: verified-local
+history: batch-low-difficulty-issue-impl.history
+```
+
+Key state at v1.8.0: Added 7 C++20/Conan/pixi-specific failure modes (libssl-dev Dockerfile
+gap, TSan+concurrentqueue hard blocker, enable_shared_from_this diamond inheritance,
+CMakeLists.txt double-agent anchor rule, asyncio_mode='auto' decorator check, agent PR number
+unreliability). Also added C++20/Conan/pixi Project-Specific Guards checklist in Results &
+Parameters. Single-anchor rule for CMakeLists.txt stated but cross-branch contamination
+mechanism not yet documented.
+</details>
+
+---
+
 ## v1.8.0 (2026-04-25)
 
 **Changed by:** ProjectKeystone 180-issue C++20 myrmidon swarm (7 EASY waves + 9 MEDIUM waves, 2026-04-25)

--- a/skills/batch-low-difficulty-issue-impl.md
+++ b/skills/batch-low-difficulty-issue-impl.md
@@ -11,10 +11,11 @@ description: 'Classify, deduplicate, and batch-implement GitHub issues in a larg
   hot-file serialization for shared scripts (apply.sh/reconcile.sh), pre-swarm
   existing-PR audit, close-before-delegate pattern, and C++20/Conan/pixi-specific
   guards (libssl-dev, TSan+concurrentqueue blocker, enable_shared_from_this diamond
-  inheritance, CMakeLists.txt single-agent anchor, asyncio_mode auto decorator check).'
+  inheritance, CMakeLists.txt single-agent anchor, asyncio_mode auto decorator check,
+  cross-branch CMakeLists contamination from parallel agents starting from same base).'
 category: tooling
-date: 2026-04-25
-version: 1.8.0
+date: 2026-04-26
+version: 1.9.0
 user-invocable: false
 verification: verified-local
 history: batch-low-difficulty-issue-impl.history
@@ -25,7 +26,7 @@ history: batch-low-difficulty-issue-impl.history
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-25 |
+| **Date** | 2026-04-26 |
 | **Objective** | Classify, deduplicate, and batch-implement low-difficulty GitHub issues using worktree-isolated agents |
 | **Outcome** | Verified: worktree isolation works correctly; correct pre-filter order; ALREADY-DONE grep must exclude worktrees; pre-launch repo-capability checks required; C++20/Conan/pixi-specific guards required for C++ projects |
 | **Verification** | verified-local |
@@ -358,6 +359,7 @@ gh pr list --author "@me" --state all --limit 50
 | TSan build added to project using concurrentqueue (ProjectKeystone 2026-04-25) | Attempted to add `-fsanitize=thread` build to verify thread safety; concurrentqueue (moodycamel) lock-free atomics were in use | concurrentqueue triggers TSan false positives by design — the library uses intentional relaxed-ordering patterns that TSan cannot distinguish from real races. Tests fail spuriously under TSan | TSan + concurrentqueue (or any similar lock-free lib using intentional relaxed ordering) is a hard blocker. Classify any issue requiring TSan + concurrentqueue as HARD — cannot be resolved without replacing the dependency. Never attempt to add TSan builds to projects with concurrentqueue |
 | enable_shared_from_this diamond inheritance on derived class (ProjectKeystone 2026-04-25) | When fixing use-after-free via `weak_ptr` capture, added `std::enable_shared_from_this<T>` to a derived class (e.g., `TaskAgent`) to call `weak_from_this()` | Base class `AgentCore` already inherited `enable_shared_from_this<AgentCore>`. Derived class inheriting it again caused diamond inheritance compile error: "ambiguous base class 'enable_shared_from_this'" | Before adding `enable_shared_from_this<T>` to any class, run `grep -rn enable_shared_from_this` across all base classes in the hierarchy. If base already has it, the derived class can call `weak_from_this()` directly without re-inheriting |
 | Two agents both modifying CMakeLists.txt in the same wave (ProjectKeystone 2026-04-25) | Despite same-file grouping rules, two different agents both modified `CMakeLists.txt` for separate SPDX/spdlog fixes (PRs #392 and #395) in the same wave because the changes appeared unrelated | Second PR could not auto-merge cleanly; one became a duplicate requiring manual resolution | Treat `CMakeLists.txt` as a hard file-grouping anchor: any issue touching it must be batched into ONE agent per wave, regardless of how different the individual changes appear. Apply the same rule as ci.yml: batch all CMakeLists.txt issues into a single Sonnet agent per wave |
+| Two parallel agents modifying CMakeLists.txt in same wave — cross-branch source contamination (2026-04-26) | Launched agents for issues #275 (TLS test) and #303 (SIGTERM test) in parallel from `origin/main`; both added their CMakeLists.txt blocks. The #275 agent's CMakeLists included the `scheduler_sigterm_tests` `add_executable()` target (referencing `test_scheduler_sigterm.cpp`) even though that file only exists on the #303 branch. Build failed: `CMake Error: Cannot find source file: tests/integration/test_scheduler_sigterm.cpp` | Two agents running in parallel, both starting from `origin/main`, independently added their blocks to `CMakeLists.txt`. The agents appear to have written to the same working copy before diverging into their branches, so the #275 agent captured #303's in-progress CMakeLists edits. This is a subtler version of the single-anchor rule: not just "don't both touch the same file" but "if two agents touch the same file in the same wave, one will pick up the other's partial edits even when launched from the same base commit." | CMakeLists.txt is a hard anchor — strictly serialize agents that modify it. Never place two agents in the same wave if both touch CMakeLists.txt, even for purely additive changes. Fix: rebase the contaminated branch, manually remove the stray block, force-push. |
 | Adding @pytest.mark.asyncio when asyncio_mode='auto' set in pyproject.toml (ProjectKeystone 2026-04-25) | Agent wrote new Python test files and added `@pytest.mark.asyncio` decorators to async test functions | `pyproject.toml` already had `asyncio_mode = "auto"` in `[tool.pytest.ini_options]`. With auto mode, pytest-asyncio automatically treats all async test functions as async tests — the decorator is redundant and produces deprecation warnings or errors | Before writing Python test files, check: `grep -A5 "pytest.ini_options" pyproject.toml | grep asyncio_mode`. If `asyncio_mode = "auto"` is present, omit all `@pytest.mark.asyncio` decorators |
 | Trusting agent-reported PR numbers without verification (ProjectKeystone 2026-04-25) | In 3 out of 16 waves, accepted agent's final output ("PR #403") as the authoritative PR number for wave reconciliation | Agents report their in-flight view of PR numbers, which can be stale or incorrect when races occur or the agent mistakes a draft PR number. 3/16 waves had wrong agent-reported PR numbers | After every wave, always verify PR numbers with `gh pr list --author "@me" --state all --limit 50`. Never trust agent-reported PR numbers as ground truth |
 


### PR DESCRIPTION
## Summary

Amends existing skill from v1.8.0 to v1.9.0.

Documents the CMakeLists.txt cross-branch contamination finding from the ProjectKeystone parallel-agent incident (2026-04-26).

- Two parallel agents both starting from `origin/main` contaminated each other's CMakeLists.txt edits
- The #275 agent captured the #303 agent's `add_executable(scheduler_sigterm_tests ...)` block, referencing a source file that only exists on the #303 branch
- Build error: `CMake Error: Cannot find source file: tests/integration/test_scheduler_sigterm.cpp`
- Fix procedure: rebase contaminated branch, manually remove stray block, force-push

## Verification Level

**verified-local** — build failure confirmed in CI; fix confirmed locally

## Key Findings

**What Worked**:
- Rebase + manual stray-block removal + force-push resolved the contaminated branch
- Strict wave serialization for CMakeLists.txt prevents recurrence

**What Failed**:
- Two parallel agents both touching CMakeLists.txt in same wave → cross-branch source contamination even when both start from the same base commit; agents appear to share a working copy during the editing phase before diverging into separate branches

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py` — 1009/1009 skills pass
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: cmake, parallel, contamination, batch, serialization

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>