### PR TITLE
feat: amend python-circular-import-symbol-extraction skill (v1.1.0)

### DIFF
--- a/skills/python-circular-import-symbol-extraction.history
+++ b/skills/python-circular-import-symbol-extraction.history
@@ -1,0 +1,92 @@
+# python-circular-import-symbol-extraction — History
+
+## v1.1.0 (2026-04-29)
+
+**Changed by:** ProjectHephaestus PR #308 — eager `__init__.py` re-exports triggering circular import
+**Verification:** verified-local (pre-commit passed, `pixi run pytest tests/unit -v` passed; CI validation pending)
+
+### What changed
+- Added new "When to Use" trigger: `__init__.py` eagerly re-exports CLI entry-point modules that import back into a still-loading package
+- Added new Step 0 to the Verified Workflow: "Check `__init__.py` for eager CLI re-exports" — remove heavy CLI modules from `__all__` and top-level imports
+- Extended Quick Reference with the `__init__.py` pattern summary
+- Added 2 new Failed Attempts rows (delete-only without moving shared symbol; lazy import workaround)
+- Updated description to mention `__init__.py` eager re-export as a distinct trigger
+- Added ProjectHephaestus PR #308 to the "Verified On" table
+- Added `eager-init-exports` tag
+- Added history frontmatter field (first amendment)
+
+### Why
+The existing skill captured the *symbol-extraction* fix pattern but not the *eager `__init__.py` re-export* root cause that commonly produces the same `ImportError`. PR #308 in ProjectHephaestus showed that `github/__init__.py` eagerly importing CLI modules (`fleet_sync`, `tidy`) caused `ImportError: cannot import name '_gh_call' from partially initialized module 'hephaestus.github'` — same error class but with a distinct trigger that warrants an explicit detection step.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: python-circular-import-symbol-extraction
+description: "Fix Python circular import errors caused by partially-initialized modules by extracting the shared symbol into a new lightweight module. Use when: (1) Python raises ImportError or partially-initialized module error on startup, (2) module A imports module B which (lazily) imports module A, (3) the symbol being imported lives in A but A is only partially initialized when B tries to use it, (4) making imports lazy inside functions does not fix the error. After moving symbols, all mock patches must target the new module where the name is looked up at call time."
+category: architecture
+date: 2026-04-23
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - python
+  - circular-imports
+  - symbol-extraction
+  - mock-patch
+  - testing
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-04-23 |
+| **Objective** | Break Python circular import chain `runner.py → tier_action_builder → subtest_executor.__getattr__ → parallel_executor → rate_limit → runner` that caused `ImportError` on startup |
+| **Outcome** | Extracted `ShutdownInterruptedError`, `is_shutdown_requested`, `request_shutdown` into new `scylla/e2e/shutdown.py`; all importers redirected; `runner.py` re-exports symbols for backward compat; 4 test mock patches updated |
+| **Verification** | verified-ci (ProjectScylla PR #1850) |
+
+## When to Use
+
+- Python raises `ImportError: cannot import name 'X' from partially initialized module 'A'` on startup
+- `A → B → A` import cycle where A is only partially initialized when B tries to import from it
+- Making imports lazy (moving `from X import Y` inside function bodies) does **not** fix the error — root cause is that Y is referenced during module init
+- Multiple modules need a shared symbol and the symbol currently lives in a "heavy" module that creates the cycle
+- After moving a symbol, test mock patches stop intercepting calls (patches targeting the old location no longer work)
+
+## Verified Workflow
+
+### Quick Reference
+
+```text
+Circular import diagnosis:
+  1. Read the full ImportError traceback — map the import chain A → B → C → A
+  2. Identify the shared symbol: which name is being imported across the cycle boundary?
+  3. Ask: is this symbol lightweight (no heavy deps of its own)?
+     YES → extract to new module C
+     NO  → consider lazy import OR restructure dependencies
+
+Fix pattern (symbol extraction):
+  A imports C (not B)
+  B imports C (not A)
+  A re-exports from C for backward compat
+  All mock patches updated to target C
+
+Mock patch rule:
+  Patch the module where the name is LOOKED UP at call time — not where it was originally defined.
+  After moving symbol X from module A to module C:
+    WRONG: patch("pkg.A.X", ...)    <- A no longer has X at call time
+    RIGHT: patch("pkg.C.X", ...)    <- callers resolve X from C
+```
+
+### Step 1: Map the full circular import chain
+
+Read the full traceback carefully...
+[... full content truncated for brevity — see git history for complete v1.0.0 content ...]
+```
+
+---
+
+## v1.0.0 (2026-04-23)
+
+**Initial version.** Created from ProjectScylla PR #1850 fix for circular import in `scylla.e2e` package. Covered: symbol extraction to leaf module, backward-compat re-exports, and mock patch retargeting.

--- a/skills/python-circular-import-symbol-extraction.md
+++ b/skills/python-circular-import-symbol-extraction.md
@@ -1,32 +1,36 @@
 ---
 name: python-circular-import-symbol-extraction
-description: "Fix Python circular import errors caused by partially-initialized modules by extracting the shared symbol into a new lightweight module. Use when: (1) Python raises ImportError or partially-initialized module error on startup, (2) module A imports module B which (lazily) imports module A, (3) the symbol being imported lives in A but A is only partially initialized when B tries to use it, (4) making imports lazy inside functions does not fix the error. After moving symbols, all mock patches must target the new module where the name is looked up at call time."
+description: "Fix Python circular import errors caused by partially-initialized modules. Use when: (1) Python raises ImportError or partially-initialized module error on startup, (2) module A imports module B which imports back into A while A is still loading, (3) __init__.py eagerly re-exports heavyweight CLI modules that import back into the same package, (4) making imports lazy inside functions does not fix the error. Fix: remove eager re-exports from __init__.py, extract the shared symbol to a true leaf module, redirect all importers to the leaf. After moving symbols, all mock patches must target the new module where the name is looked up at call time."
 category: architecture
-date: 2026-04-23
-version: "1.0.0"
+date: 2026-04-29
+version: "1.1.0"
 user-invocable: false
-verification: verified-ci
+verification: verified-local
+history: python-circular-import-symbol-extraction.history
 tags:
   - python
   - circular-imports
   - symbol-extraction
   - mock-patch
   - testing
+  - eager-init-exports
 ---
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-23 |
-| **Objective** | Break Python circular import chain `runner.py → tier_action_builder → subtest_executor.__getattr__ → parallel_executor → rate_limit → runner` that caused `ImportError` on startup |
-| **Outcome** | Extracted `ShutdownInterruptedError`, `is_shutdown_requested`, `request_shutdown` into new `scylla/e2e/shutdown.py`; all importers redirected; `runner.py` re-exports symbols for backward compat; 4 test mock patches updated |
-| **Verification** | verified-ci (ProjectScylla PR #1850) |
+| **Date** | 2026-04-29 |
+| **Objective** | Break Python circular import chains that produce `ImportError: cannot import name 'X' from partially initialized module` on startup |
+| **Outcome** | Two verified fixes: (1) ProjectScylla PR #1850 — extract shutdown symbols to leaf module; (2) ProjectHephaestus PR #308 — remove eager CLI re-exports from `__init__.py` + extract `_gh_call` to leaf module |
+| **Verification** | verified-local (PR #308: pre-commit passed, unit tests passed; CI pending) / verified-ci (PR #1850) |
+| **History** | [changelog](./python-circular-import-symbol-extraction.history) |
 
 ## When to Use
 
 - Python raises `ImportError: cannot import name 'X' from partially initialized module 'A'` on startup
 - `A → B → A` import cycle where A is only partially initialized when B tries to import from it
+- `package/__init__.py` eagerly re-exports CLI entry-point modules (via `from pkg.cli_mod import main`) and those CLI modules import back into the same package
 - Making imports lazy (moving `from X import Y` inside function bodies) does **not** fix the error — root cause is that Y is referenced during module init
 - Multiple modules need a shared symbol and the symbol currently lives in a "heavy" module that creates the cycle
 - After moving a symbol, test mock patches stop intercepting calls (patches targeting the old location no longer work)
@@ -36,24 +40,55 @@ tags:
 ### Quick Reference
 
 ```text
+Step 0: Check __init__.py for eager CLI re-exports (new trigger in v1.1.0)
+  - Look for lines like: from pkg.fleet_sync import main as fleet_sync
+  - CLI entry-point modules often import back into the package = instant cycle
+  - Fix: delete those lines and remove names from __all__
+
 Circular import diagnosis:
   1. Read the full ImportError traceback — map the import chain A → B → C → A
   2. Identify the shared symbol: which name is being imported across the cycle boundary?
   3. Ask: is this symbol lightweight (no heavy deps of its own)?
-     YES → extract to new module C
+     YES → extract to new leaf module
      NO  → consider lazy import OR restructure dependencies
 
 Fix pattern (symbol extraction):
-  A imports C (not B)
-  B imports C (not A)
-  A re-exports from C for backward compat
-  All mock patches updated to target C
+  __init__.py   removes eager re-export of CLI modules
+  cli_mod.py    imports from leaf (not from the package being initialized)
+  leaf.py       has NO imports that touch the package being initialized
+  orig.py       re-exports from leaf for backward compat (explicit `as X` form for mypy)
 
 Mock patch rule:
   Patch the module where the name is LOOKED UP at call time — not where it was originally defined.
-  After moving symbol X from module A to module C:
+  After moving symbol X from module A to leaf module C:
     WRONG: patch("pkg.A.X", ...)    <- A no longer has X at call time
     RIGHT: patch("pkg.C.X", ...)    <- callers resolve X from C
+```
+
+### Step 0: Check `__init__.py` for eager CLI re-exports
+
+Before tracing the full chain, check whether the cycle is *triggered by* `__init__.py` loading
+a heavyweight CLI module:
+
+```python
+# hephaestus/github/__init__.py  <-- PROBLEMATIC pattern
+from hephaestus.github.fleet_sync import main as fleet_sync  # CLI module!
+from hephaestus.github.tidy import main as tidy              # CLI module!
+__all__ = [..., "fleet_sync", "tidy"]
+```
+
+CLI modules typically import everything they need, including utilities that live in the same
+package. When `hephaestus.github` is first loaded (e.g., by `from hephaestus.automation.github_api import _gh_call`),
+it triggers loading of `fleet_sync`, which tries `from hephaestus.automation.github_api import _gh_call`
+— but `hephaestus.github` is not yet done initializing at that moment.
+
+**Fix**: delete the eager re-export lines and remove the names from `__all__`. Callers that need the CLI
+modules can import them directly (`from hephaestus.github.fleet_sync import main`).
+
+```python
+# hephaestus/github/__init__.py  <-- FIXED
+# (removed fleet_sync and tidy re-exports)
+__all__ = [...]  # CLI entry points removed
 ```
 
 ### Step 1: Map the full circular import chain
@@ -62,12 +97,19 @@ Read the full traceback carefully. Python's partial-initialization error identif
 module that is being imported while still being initialized:
 
 ```
-ImportError: cannot import name 'is_shutdown_requested' from partially initialized
-module 'scylla.e2e.runner' (most likely due to a circular import)
+ImportError: cannot import name '_gh_call' from partially initialized
+module 'hephaestus.github' (most likely due to a circular import)
 ```
 
 Trace the chain from the error:
 ```
+# ProjectHephaestus PR #308 example:
+hephaestus.github.__init__
+  -> fleet_sync (eagerly imported by __init__)
+  -> from hephaestus.automation.github_api import _gh_call
+  -> github_api imports from hephaestus.github (cycle!)
+
+# ProjectScylla PR #1850 example:
 runner.py
   -> tier_action_builder (imports runner for shutdown symbols)
   -> subtest_executor.__getattr__ triggers import of parallel_executor
@@ -81,55 +123,66 @@ List all symbols being imported across the cycle boundary. Ask for each:
 - Does it have its own heavy dependencies that would re-create the cycle?
 - Is it a pure value, function, or small exception class?
 
+In the ProjectHephaestus case, the shared symbol was:
+- `_gh_call` — subprocess helper function; only deps are `rate_limit.py` + `run_subprocess`
+
 In the ProjectScylla case, the shared symbols were:
 - `ShutdownInterruptedError` — simple Exception subclass, zero deps
 - `is_shutdown_requested` — function reading a threading.Event, no heavy imports
 - `request_shutdown` — function setting a threading.Event, no heavy imports
 
-All three were safe to extract.
+All were safe to extract.
 
-### Step 3: Create the new lightweight module
+### Step 3: Create the new lightweight leaf module
 
 Create a new module at the same package level with only the extracted symbols and
-their minimal dependencies:
+their minimal dependencies. The leaf module must import ONLY stdlib + lower-level helpers —
+never from the package being initialized:
 
 ```python
-# src/scylla/e2e/shutdown.py
-"""Shutdown coordination primitives (extracted to break circular imports).
+# hephaestus/github/gh_subprocess.py — leaf module
+"""gh subprocess helper extracted to break circular imports.
 
 This module intentionally has minimal dependencies so it can be imported by
-any module in the scylla.e2e package without creating cycles.
+any module in the hephaestus.github package without creating cycles.
 """
-from __future__ import annotations
+from hephaestus.github.rate_limit import detect_claude_usage_limit, detect_rate_limit, wait_until
+from hephaestus.utils.helpers import run_subprocess
 
+
+def _gh_call(args, check=True, retry_on_rate_limit=True, max_retries=3):
+    ...
+```
+
+```python
+# src/scylla/e2e/shutdown.py — leaf module
+"""Shutdown coordination primitives (extracted to break circular imports)."""
 import threading
 
 _shutdown_event = threading.Event()
 
-
-class ShutdownInterruptedError(Exception):
-    """Raised when a task is interrupted by a shutdown request."""
-
-
-def is_shutdown_requested() -> bool:
-    """Return True if a shutdown has been requested."""
-    return _shutdown_event.is_set()
-
-
-def request_shutdown() -> None:
-    """Signal that a shutdown has been requested."""
-    _shutdown_event.set()
+class ShutdownInterruptedError(Exception): ...
+def is_shutdown_requested() -> bool: ...
+def request_shutdown() -> None: ...
 ```
 
 **Key principle**: The new module must have NO imports that would re-create the cycle.
 Verify this by checking every `import` in the new file against the existing chain.
 
-### Step 4: Update all importers to use the new module
+### Step 4: Update all importers to use the new leaf module
 
 Redirect every module that was importing the symbols from the original location:
 
 ```python
-# BEFORE (in rate_limit.py, parallel_executor.py, tier_action_builder.py, etc.):
+# fleet_sync.py: BEFORE
+from hephaestus.automation.github_api import _gh_call
+
+# fleet_sync.py: AFTER
+from hephaestus.github.gh_subprocess import _gh_call
+```
+
+```python
+# BEFORE (in rate_limit.py, parallel_executor.py, etc.):
 from scylla.e2e.runner import ShutdownInterruptedError, is_shutdown_requested
 
 # AFTER:
@@ -139,19 +192,21 @@ from scylla.e2e.shutdown import ShutdownInterruptedError, is_shutdown_requested
 Search comprehensively — do not miss any importer:
 
 ```bash
-grep -rn "from scylla.e2e.runner import" src/ tests/ --include="*.py"
-grep -rn "from.*runner import.*shutdown\|from.*runner import.*Shutdown" src/ tests/ --include="*.py"
+grep -rn "from <pkg>.<original_module> import <symbol>" src/ tests/ --include="*.py"
 ```
 
 ### Step 5: Add backward-compat re-exports to the original module
 
-The original module (`runner.py`) should re-export the moved symbols so any code
-that imports them from there still works:
+The original module should re-export the moved symbols so any code that imports them
+from there still works. Use the explicit `as X` form — required by mypy for re-exports:
 
 ```python
-# In runner.py -- add at the top after other imports:
-# Re-export shutdown primitives for backward compatibility.
-# These were extracted to scylla.e2e.shutdown to break a circular import.
+# automation/github_api.py — explicit re-export (mypy requires `as X` form)
+from hephaestus.github.gh_subprocess import _gh_call as _gh_call
+```
+
+```python
+# In runner.py — backward compat re-export block:
 from scylla.e2e.shutdown import (  # noqa: F401  (re-export)
     ShutdownInterruptedError,
     is_shutdown_requested,
@@ -159,8 +214,9 @@ from scylla.e2e.shutdown import (  # noqa: F401  (re-export)
 )
 ```
 
-The `# noqa: F401` suppresses the "imported but unused" linter warning since these
-are intentional re-exports.
+The `# noqa: F401` suppresses the "imported but unused" linter warning. The explicit
+`as _gh_call` form (rather than just `import _gh_call`) signals to mypy that this is
+an intentional public re-export — without it mypy raises `error: Module does not explicitly export attribute`.
 
 ### Step 6: Update all mock patches in tests
 
@@ -170,59 +226,62 @@ the module where the name is **resolved at call time**.
 
 Rule: patch the module that **imports and uses** the symbol, not where it was defined.
 
-In the ProjectScylla case, `is_shutdown_requested` was moved from `runner` to `shutdown`.
-The callers (e.g., `parallel_executor.py`) now import from `shutdown`. The patch target
-changes accordingly:
-
 ```python
-# BEFORE (broken after move -- patches a name that no longer exists in runner at call time):
+# BEFORE (broken after move):
 @patch("scylla.e2e.runner.is_shutdown_requested", return_value=True)
-def test_something(mock_shutdown):
-    ...
 
-# AFTER (correct -- patches the module where callers actually look up the name):
+# AFTER (correct):
 @patch("scylla.e2e.shutdown.is_shutdown_requested", return_value=True)
-def test_something(mock_shutdown):
-    ...
 ```
 
 Find all affected patches:
 ```bash
-grep -rn "patch.*runner.*is_shutdown_requested\|patch.*runner.*request_shutdown\|patch.*runner.*ShutdownInterrupted" tests/ --include="*.py"
+grep -rn "patch.*<original_module>.*<symbol_name>" tests/ --include="*.py"
 ```
-
-Update each one. There may be 4-10 patches depending on test coverage.
 
 ### Step 7: Verify the fix
 
 ```bash
 # Import the package from scratch (no cached modules)
+python -c "from hephaestus.automation.planner import main; print('OK')"
 python -c "from scylla.e2e import runner; print('OK')"
 
 # Run the full test suite
 pytest tests/ -v
 
 # Check no imports still reference the old location for the moved symbols
-grep -rn "from scylla.e2e.runner import.*shutdown\|from scylla.e2e.runner import.*Shutdown" src/ --include="*.py"
-# Should return zero results (only the re-export line in runner.py itself)
+grep -rn "from <pkg>.<original_module> import <symbol>" src/ --include="*.py"
+# Should return zero results (only the re-export line itself)
 ```
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Lazy imports inside function bodies | Moved `from scylla.e2e.runner import is_shutdown_requested` inside function bodies in rate_limit.py and parallel_executor.py | Did not fix the error -- the symbol was referenced during module-level code (class body, module-level constant) in one of the intermediate modules, so deferring the import statement didn't defer the actual resolution | Lazy function-body imports only help if the symbol is used at call time. If any intermediate module in the chain references the symbol during its own initialization (class definition, module constant), lazy imports don't break the cycle |
-| Patching old module location after symbol move | 4 tests continued to use `patch("scylla.e2e.runner.is_shutdown_requested", ...)` after moving the symbol to `shutdown.py` | The patches registered the mock on `runner.is_shutdown_requested` but callers looked up `shutdown.is_shutdown_requested` -- the mock was never invoked, so tests passed without actually testing the behavior | Python mock patches intercept name lookups. After moving a symbol, update ALL patches to target the module where callers actually resolve the name |
+| Lazy imports inside function bodies | Moved `from scylla.e2e.runner import is_shutdown_requested` inside function bodies in rate_limit.py and parallel_executor.py | Did not fix the error — the symbol was referenced during module-level code (class body, module-level constant) in one of the intermediate modules, so deferring the import statement didn't defer the actual resolution | Lazy function-body imports only help if the symbol is used at call time. If any intermediate module in the chain references the symbol during its own initialization, lazy imports don't break the cycle |
+| Patching old module location after symbol move | 4 tests continued to use `patch("scylla.e2e.runner.is_shutdown_requested", ...)` after moving the symbol to `shutdown.py` | The patches registered the mock on `runner.is_shutdown_requested` but callers looked up `shutdown.is_shutdown_requested` — the mock was never invoked | Python mock patches intercept name lookups. After moving a symbol, update ALL patches to target the module where callers actually resolve the name |
+| Delete only `__init__.py` re-exports without moving `_gh_call` | Removed `fleet_sync`/`tidy` from `hephaestus/github/__init__.py` but left `from hephaestus.automation.github_api import _gh_call` in `fleet_sync.py` | The `github → automation` import edge in `fleet_sync.py` remained intact; any future code path touching both packages can re-trigger the same cycle | Must eliminate the layering violation at the source (move the shared symbol to a leaf module), not just remove the eager load from `__init__.py` |
+| Lazy import inside the offending function in fleet_sync.py | Moved `from hephaestus.automation.github_api import _gh_call` inside the function body | Mechanically avoids the startup cycle but leaves a hidden trap — no CI check enforces it; future refactors can promote it back to module level | Use a structural fix (move the symbol to a leaf module) rather than a runtime workaround; structural fixes are enforced by the import graph itself |
 
 ## Results & Parameters
 
-### New file created
+### New leaf modules created
 
 ```
-src/scylla/e2e/shutdown.py   -- 3 symbols, ~40 lines, zero heavy deps
+hephaestus/github/gh_subprocess.py  -- _gh_call only, imports rate_limit + run_subprocess
+src/scylla/e2e/shutdown.py          -- 3 symbols, ~40 lines, zero heavy deps
 ```
 
-### Files updated
+### Files updated (ProjectHephaestus PR #308)
+
+| File | Change |
+|------|--------|
+| `hephaestus/github/__init__.py` | Removed eager re-exports of `fleet_sync` and `tidy`; removed from `__all__` |
+| `hephaestus/github/gh_subprocess.py` | New leaf module containing `_gh_call` |
+| `hephaestus/github/fleet_sync.py` | Updated import to `gh_subprocess` (from `automation.github_api`) |
+| `hephaestus/automation/github_api.py` | Added explicit re-export: `from hephaestus.github.gh_subprocess import _gh_call as _gh_call` |
+
+### Files updated (ProjectScylla PR #1850)
 
 | File | Change |
 |------|--------|
@@ -232,16 +291,16 @@ src/scylla/e2e/shutdown.py   -- 3 symbols, ~40 lines, zero heavy deps
 | `src/scylla/e2e/tier_action_builder.py` | Updated import to `shutdown.py` |
 | `tests/unit/e2e/test_runner.py` | Updated 4 mock patches to target `shutdown` module |
 
-### Dependency graph after fix
+### Dependency graph after fix (ProjectHephaestus)
 
 ```
-shutdown.py       (threading only -- zero scylla deps)
+gh_subprocess.py   (rate_limit + run_subprocess only — no automation deps)
     ^
-rate_limit.py     (imports from shutdown, not runner)
-parallel_executor.py
-tier_action_builder.py
+fleet_sync.py      (imports from gh_subprocess, not automation.github_api)
     ^
-runner.py         (imports from shutdown; re-exports for compat)
+github/__init__.py (no longer eagerly loads fleet_sync or tidy)
+    ^
+automation/github_api.py  (re-exports _gh_call from gh_subprocess for compat)
 ```
 
 ### Mock patch target rule (canonical)
@@ -252,22 +311,21 @@ runner.py         (imports from shutdown; re-exports for compat)
 # Symbol defined in:   shutdown.py
 # Symbol imported by:  parallel_executor.py  ->  from scylla.e2e.shutdown import is_shutdown_requested
 # Correct patch target: "scylla.e2e.shutdown.is_shutdown_requested"
+```
 
-# If parallel_executor.py had done:
-#   from scylla.e2e import shutdown
-#   shutdown.is_shutdown_requested()
-# Then the correct patch target would be:
-#   "scylla.e2e.shutdown.is_shutdown_requested"  (same result here)
+### Explicit re-export form required by mypy
 
-# If parallel_executor.py imports runner and accesses runner.is_shutdown_requested:
-#   from scylla.e2e import runner
-#   runner.is_shutdown_requested()
-# Then the correct patch target would be:
-#   "scylla.e2e.runner.is_shutdown_requested"  (the re-export in runner)
+```python
+# WRONG (mypy error: Module does not explicitly export attribute '_gh_call'):
+from hephaestus.github.gh_subprocess import _gh_call
+
+# RIGHT (mypy accepts explicit re-export):
+from hephaestus.github.gh_subprocess import _gh_call as _gh_call
 ```
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectScylla | PR #1850 -- circular import fix on `scylla.e2e` package | Fixed startup `ImportError`; 4 mock patches updated; CI passed |
+| ProjectScylla | PR #1850 — circular import fix on `scylla.e2e` package | Fixed startup `ImportError`; 4 mock patches updated; CI passed |
+| ProjectHephaestus | PR #308 — eager `__init__.py` re-exports triggering circular import | Removed CLI re-exports from `github/__init__.py`; extracted `_gh_call` to `gh_subprocess.py`; pre-commit passed, unit tests passed locally |


### PR DESCRIPTION
## Summary

Amends existing skill `python-circular-import-symbol-extraction` from v1.0.0 to v1.1.0.

Documents the eager `__init__.py` re-export pattern as a distinct trigger for the same `ImportError: cannot import name 'X' from partially initialized module` class of error — observed in ProjectHephaestus PR #308.

- Added Step 0 to workflow: detect and remove eager CLI re-exports from `__init__.py`
- Added 2 new Failed Attempts rows (delete-only fix without moving symbol; lazy import trap)
- Extended Quick Reference with `__init__.py` trigger pattern summary
- Added mypy explicit re-export note (`from X import Y as Y` form required)
- Added ProjectHephaestus PR #308 to Verified On table
- Created first history file with v1.0.0 snapshot

## Verification Level

**verified-local** — pre-commit hooks passed, `pixi run pytest tests/unit -v` passed on ProjectHephaestus PR #308. CI validation pending.

## Key Findings

**What Worked**:
- Remove eager re-exports of CLI modules from `__init__.py` (removes the load trigger)
- Extract the shared symbol (`_gh_call`) to a true leaf module with no upward deps
- Redirect the CLI module to import from the leaf instead of the parent package
- Use explicit `from X import Y as Y` form for mypy-compatible backward-compat re-exports

**What Failed**:
- Delete `__init__.py` re-exports only (without moving `_gh_call`) → `github → automation` import edge remains; cycle can recur via any future code path
- Lazy import inside function body → mechanically works but leaves a hidden trap with no CI enforcement

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1038/1038 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: `circular`, `import`, `__init__`, `eager`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>