### PR TITLE
feat: amend ci-cd-dependabot-pixi-lock-drift-fix skill (v1.2.0)

### DIFF
--- a/skills/ci-cd-dependabot-pixi-lock-drift-fix.history
+++ b/skills/ci-cd-dependabot-pixi-lock-drift-fix.history
@@ -1,5 +1,82 @@
 # ci-cd-dependabot-pixi-lock-drift-fix — History
 
+## v1.2.0 (2026-05-03)
+
+**Changed by:** ProjectScylla PR #1861 fix session
+**Verification:** verified-precommit
+
+### What changed
+- Added two new "When to Use" triggers:
+  - Prior regeneration commit exists on branch but CI still fails (main has advanced again)
+  - Local branch and origin branch have diverged in both directions (stale local after prior force-push)
+- Added two new Failed Attempts rows:
+  - "Trusting a prior regeneration commit on the branch" — goes stale if main advances with more pyproject.toml changes
+  - "Not fetching before rebasing due to stale local branch" — local/origin diverged in both directions
+- Updated Quick Reference step 8: auto-merge command now shows both `--squash` and `--rebase` variants with a note that the strategy must match the repo's CLAUDE.md policy
+- Updated step 9 detailed text: same policy note; added ProjectScylla as `--rebase` example
+- Updated `git fetch origin main` → `git fetch origin` throughout (broader fetch is more correct)
+- Added divergence-check guidance in Detailed Steps step 2
+- Updated Multi-PR section to use `git fetch origin` and show `<--squash|--rebase>` placeholder
+- Updated Worktree section: `git fetch origin main` → `git fetch origin`; add policy note on merge flag
+- Added ProjectScylla PR #1861 row to Verified On table
+- Updated frontmatter: version 1.1.0 → 1.2.0; verification → verified-precommit; added triggers (4), (5) to description
+
+### Why
+ProjectScylla PR #1861 (pandas bump >=2.0,<3 → >=2.3.3,<3) had a prior regeneration commit from an
+earlier fix session, but `origin/main` had since accumulated 4 more commits with pyproject.toml changes.
+CI still failed with the identical 6–12s symptom. The local branch and origin branch had also diverged
+(2 vs 3 commits) because the prior session had force-pushed. This session confirmed that the fix is
+idempotent — fetch + rebase + pixi install always works regardless of prior fix attempts — and that
+ProjectScylla uses `--rebase` not `--squash` for auto-merge.
+
+### Previous version (v1.1.0) content snapshot
+
+```
+version: "1.1.0"
+date: 2026-05-03
+verification: verified-local (ProjectScylla multi-PR session 2026-05-02)
+
+When to Use (v1.1.0):
+- A Dependabot PR updates requirements*.txt, pyproject.toml, or other Python constraint files
+- CI fails immediately with lock-file not up-to-date with the workspace
+- CI job duration is 6–12 seconds
+- After rebasing a Dependabot branch, CI still fails even though the rebase was clean
+- The Dependabot PR includes a pixi.lock update commit but it has gone stale after main advanced further
+
+Quick Reference step 8 (v1.1.0):
+  # 8. Re-enable auto-merge (squash only — rebase merging not allowed)
+  gh pr merge <pr-number> --auto --squash
+
+Failed Attempts (v1.1.0): 5 rows (no "trusting prior regen commit" or "stale local branch" rows)
+
+Verified On (v1.1.0): 2 rows (ProjectOdyssey, ProjectScylla multi-PR)
+```
+
+---
+
+## v1.1.0 (2026-05-03)
+
+**Changed by:** ProjectScylla multi-PR Dependabot session (2026-05-02)
+**Verification:** verified-local
+
+### What changed
+- Added rebase-first workflow (fetch → rebase → pixi install)
+- Added pixi.lock conflict resolution pattern (rm + git add + rebase --continue)
+- Added `git fetch origin main` as mandatory step before rebasing (stale cache lesson)
+- Added `git commit --amend --no-edit` case for when pixi.lock is untracked post-conflict
+- Added three new Failed Attempts: skipping fetch, `--rebase` in squash-only repo, separate commit post-conflict
+- Added Multi-PR Sequential Fixing section
+- Updated Worktree section to use rebase pattern
+- Added ProjectScylla multi-PR row to Verified On table
+
+### Why
+Three sequential Dependabot PRs in ProjectScylla revealed that the v1.0.0 pattern (just run pixi install
+after checkout) was incomplete: the pixi.lock conflict during rebase needed explicit rm+add+continue
+handling, and the amend strategy was confirmed for the untracked-post-rebase case. The fetch-first
+requirement was reinforced when stale local cache caused "up to date" false reports.
+
+---
+
 ## v1.0.0 (2026-05-01)
 
 **Changed by:** Initial capture — ProjectOdyssey Dependabot PR session

--- a/skills/ci-cd-dependabot-pixi-lock-drift-fix.md
+++ b/skills/ci-cd-dependabot-pixi-lock-drift-fix.md
@@ -1,9 +1,9 @@
 ---
 name: ci-cd-dependabot-pixi-lock-drift-fix
-description: "Use when: (1) a Dependabot PR fails CI with 'lock-file not up-to-date with the workspace', (2) a Dependabot PR updates requirements*.txt or pyproject.toml but pixi.lock was not regenerated, (3) CI on a Dependabot branch completes in 6-12 seconds (pre-flight lock rejection, not a test failure)"
+description: "Use when: (1) a Dependabot PR fails CI with 'lock-file not up-to-date with the workspace', (2) a Dependabot PR updates requirements*.txt or pyproject.toml but pixi.lock was not regenerated, (3) CI on a Dependabot branch completes in 6-12 seconds (pre-flight lock rejection, not a test failure), (4) a prior regeneration commit exists on the branch but CI still fails (main has advanced again), (5) local branch and origin branch have diverged in both directions"
 category: ci-cd
 date: 2026-05-03
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 tags: [pixi, dependabot, lock-file, pip, ci, rebase, squash-merge]
 ---
@@ -25,6 +25,8 @@ tags: [pixi, dependabot, lock-file, pip, ci, rebase, squash-merge]
 - CI job duration is 6–12 seconds (pre-flight `pixi install --locked` rejection — not a test failure)
 - After rebasing a Dependabot branch, CI still fails even though the rebase was clean
 - The Dependabot PR includes a `pixi.lock` update commit but it has gone stale after main advanced further
+- **A prior regeneration commit already exists on the branch, but CI still fails** — main has accumulated more `pyproject.toml`-touching PRs since the last fix; the symptom is identical (6–12s failure); the fix is the same (fetch → rebase → `pixi install`)
+- **Local branch and origin branch have diverged in both directions** (e.g., `local: 2 ahead, origin: 3 ahead`) — a prior session force-pushed a fix to the same Dependabot branch; always start from `git fetch origin` and check out the *remote* state, not a stale local cache
 
 ## Verified Workflow
 
@@ -32,7 +34,7 @@ tags: [pixi, dependabot, lock-file, pip, ci, rebase, squash-merge]
 
 ```bash
 # 1. Fetch first — never skip this; local cache of origin/main may be stale
-git fetch origin main
+git fetch origin
 
 # 2. Check out the Dependabot branch (or use a worktree for isolation)
 git checkout <dependabot-branch>
@@ -60,8 +62,10 @@ SKIP=audit-doc-policy pre-commit run --all-files
 # 7. Force-push to the Dependabot branch
 git push --force-with-lease origin <dependabot-branch>
 
-# 8. Re-enable auto-merge (squash only — rebase merging not allowed)
-gh pr merge <pr-number> --auto --squash
+# 8. Re-enable auto-merge — strategy must match the target repo's merge policy (check CLAUDE.md)
+# --squash vs --rebase depends on repo merge policy (check CLAUDE.md)
+gh pr merge <pr-number> --auto --squash   # for repos that disable rebase merging
+gh pr merge <pr-number> --auto --rebase   # for repos that require rebase merging (e.g. ProjectScylla)
 ```
 
 ### Detailed Steps
@@ -71,12 +75,20 @@ gh pr merge <pr-number> --auto --squash
 
 2. **Always fetch before rebasing** — local `origin/main` may be stale cached data:
    ```bash
-   git fetch origin main
+   git fetch origin
    ```
    Skipping this step causes `git rebase origin/main` to report "Current branch is up to date"
    even when main has actually advanced 10+ commits. After fetching, the rebase sees the real
    divergence (including recently merged PRs that modify `pyproject.toml`, which cause genuine
    pixi.lock conflicts).
+
+   Also check whether the local branch and origin branch have diverged — a prior fix session may
+   have force-pushed to the same Dependabot branch, leaving the local checkout stale:
+   ```bash
+   git status   # or: git log --oneline origin/<branch>..HEAD && git log --oneline HEAD..origin/<branch>
+   ```
+   If local and remote are diverged in both directions, reset to the remote state or start fresh
+   from `origin/<branch>`.
 
 3. Fetch and check out the Dependabot branch locally:
    ```bash
@@ -126,10 +138,11 @@ gh pr merge <pr-number> --auto --squash
    git push --force-with-lease origin <dependabot-branch>
    ```
 
-9. Re-enable auto-merge — GitHub silently clears it on force-push. Use `--squash` (rebase merging
-   is disabled in this repository):
+9. Re-enable auto-merge — GitHub silently clears it on force-push. The merge strategy must match
+   the target repository's policy (check CLAUDE.md for that repo):
    ```bash
-   gh pr merge <pr-number> --auto --squash
+   gh pr merge <pr-number> --auto --squash   # repos that disable rebase merging (e.g. ProjectOdyssey)
+   gh pr merge <pr-number> --auto --rebase   # repos that require rebase merging (e.g. ProjectScylla)
    ```
 
 ### Multi-PR Sequential Fixing
@@ -139,10 +152,10 @@ earlier may merge to main while you're working on the next branch, invalidating 
 
 ```bash
 # Pattern for each PR in sequence:
-git fetch origin main          # always re-fetch before each rebase
+git fetch origin          # always re-fetch before each rebase
 git checkout <next-branch>
 git rebase origin/main
-# ... pixi install, commit, push, gh pr merge --auto --squash ...
+# ... pixi install, commit, push, gh pr merge --auto <--squash|--rebase> ...
 ```
 
 ### Using a Worktree for Isolation
@@ -154,7 +167,7 @@ BRANCH="$(gh pr view <pr-number> --json headRefName --jq '.headRefName')"
 WORKTREE="/tmp/dep-$(echo "$BRANCH" | tr '/' '-')"
 REPO_DIR="<project-root>"
 
-git -C "$REPO_DIR" fetch origin main
+git -C "$REPO_DIR" fetch origin
 git -C "$REPO_DIR" worktree add "$WORKTREE" "origin/$BRANCH"
 cd "$WORKTREE"
 git rebase origin/main
@@ -165,7 +178,7 @@ git commit -m "chore: update pixi.lock for dependabot constraint change"
 # OR: git commit --amend --no-edit  (if pixi.lock was deleted during conflict resolution)
 SKIP=audit-doc-policy pre-commit run --all-files
 git push --force-with-lease origin "HEAD:$BRANCH"
-gh pr merge <pr-number> --auto --squash
+gh pr merge <pr-number> --auto --squash   # or --rebase per repo policy
 git -C "$REPO_DIR" worktree remove "$WORKTREE"
 ```
 
@@ -175,9 +188,11 @@ git -C "$REPO_DIR" worktree remove "$WORKTREE"
 | --------- | ---------------- | --------------- | ---------------- |
 | Rebasing without regenerating `pixi.lock` | Clean `git rebase origin/main` with no conflicts | `pixi.lock` still encodes constraint hashes from before the Dependabot bump; CI immediately rejects it | A clean rebase is not enough — always run `pixi install` after rebasing a Dependabot branch |
 | Relying on Dependabot's included `pixi.lock` commit | Dependabot sometimes regenerates `pixi.lock` in its own commit | That commit goes stale once `main` advances past it; the hash no longer matches | Never trust Dependabot's `pixi.lock` commit after main has moved; always regenerate locally |
-| Skipping `git fetch origin main` before rebase | Ran `git rebase origin/main` directly | Reported "Current branch is up to date" — stale local cache; main had actually advanced 10+ commits including a just-merged pytest-asyncio PR that caused a real pixi.lock conflict | Always run `git fetch origin main` first; the rebase command uses locally cached ref data |
-| `gh pr merge --auto --rebase` | Attempted rebase-style auto-merge | GraphQL error: "Merge method rebase merging is not allowed on this repository" | Use `--squash` instead of `--rebase` for auto-merge in repositories that disable rebase merging |
+| Skipping `git fetch origin` before rebase | Ran `git rebase origin/main` directly | Reported "Current branch is up to date" — stale local cache; main had actually advanced 10+ commits including a just-merged pytest-asyncio PR that caused a real pixi.lock conflict | Always run `git fetch origin` first; the rebase command uses locally cached ref data |
+| `gh pr merge --auto --rebase` in a squash-only repo | Attempted rebase-style auto-merge | GraphQL error: "Merge method rebase merging is not allowed on this repository" | Use `--squash` instead of `--rebase` for auto-merge in repositories that disable rebase merging |
 | Adding a separate commit for pixi.lock after conflict resolution | Ran `git add pixi.lock && git commit -m "..."` after `rm pixi.lock ... git rebase --continue` | Creates an extra commit in history; the rebase commit already recorded pixi.lock as deleted — the regenerated file belongs in that same commit | Use `git commit --amend --no-edit` after `pixi install` when pixi.lock shows as untracked post-conflict |
+| Trusting a prior regeneration commit on the branch | A prior fix session had already committed a regenerated pixi.lock; assumed CI would pass | `origin/main` had accumulated 4 more commits with `pyproject.toml` changes since the prior fix; the lock was stale again with the identical 6–12s CI symptom | A regeneration commit does not stay valid indefinitely — if main advances with more `pyproject.toml` changes, re-fetch and re-regenerate |
+| Not fetching before rebasing due to stale local branch | Local branch appeared to be at the correct commit; skipped `git fetch origin` | Local branch and origin branch had diverged in both directions (local: 2 ahead, origin: 3 ahead) from a prior force-push session; rebasing off stale `origin/main` produced a duplicate-commit history | Always run `git fetch origin` first and verify the local/remote state matches before rebasing |
 
 ## Results & Parameters
 
@@ -193,7 +208,7 @@ This is a pre-flight check — `pixi install --locked` runs before any tests and
 ### Expected Output After Fix
 
 ```
-$ git fetch origin main
+$ git fetch origin
 From https://github.com/<org>/<repo>
  * branch              main       -> FETCH_HEAD
 
@@ -216,6 +231,7 @@ CI will restart and complete the full test matrix (not 6–12 seconds).
 | --------- | --------- | --------- |
 | ProjectOdyssey | Dependabot PR updating Python package constraints in pyproject.toml; CI failed with lock-file not up-to-date; pixi install succeeded; CI pending after force-push | Local verification 2026-05-01 |
 | ProjectScylla | Three sequential Dependabot PRs (pandas, vl-convert-python, matplotlib); pixi.lock conflict during rebase when main had advanced; resolved with rm+add+continue pattern; squash auto-merge used | verified-local 2026-05-02 |
+| ProjectScylla | PR #1861 pandas bump (>=2.0,<3 → >=2.3.3,<3); prior regeneration commit existed but was stale (main had advanced 4 commits); local/origin branches diverged; fetch + rebase + pixi install + amend + force-push; rebase auto-merge (ProjectScylla policy) | verified-precommit 2026-05-03 |
 
 ## References
 


### PR DESCRIPTION
## Summary

- Add two new \"When to Use\" triggers: prior regen commit on branch but CI still fails; local/origin branch diverged in both directions
- Add two new Failed Attempts: trusting prior regeneration commit; not fetching before rebasing
- Clarify auto-merge strategy is repo-specific (`--rebase` vs `--squash`) — ProjectScylla uses `--rebase`
- Backfill missing v1.1.0 history entry; add v1.2.0 entry at top of history file
- Update `git fetch origin main` → `git fetch origin` throughout

## Test plan
- [x] `python3 scripts/validate_plugins.py` — 1021/1021 valid

Source: ProjectScylla PR #1861 fix session (pandas bump >=2.0,<3 → >=2.3.3,<3)