### PR TITLE
feat: amend skill-audit-and-merge skill (v2.3.0)

### DIFF
--- a/skills/skill-audit-and-merge.history
+++ b/skills/skill-audit-and-merge.history
@@ -1,5 +1,366 @@
 # skill-audit-and-merge -- History
 
+## v2.3.0 (2026-05-05)
+**Changed by:** 2026-05-04/05 third-pass continuation session (Wave 1c/2c/3c on 786-file unclustered tail)
+**Verification:** verified-ci (PRs landed on feature/myrmidon-merge-triage; commit ff79b3a0 added Wave Nc data + addendum; eaa35680 absorbed C086/C091/C093; marketplace regenerated; CI green)
+
+### What changed
+- Added "Third-Pass Continuation (Wave Nc)" subsection to Verified Workflow with 4 empirical findings:
+  - Wave Nc gap-close mechanics (filter prior fingerprints to alive files; reuse JSONL schema; pass cluster map to coordinator so it produces only C081+ or augmentations)
+  - Cross-category prefix matches verify as 86% false-match (18/21 in Wave 3c); heuristic to require ≥2 strong signals before flagging
+  - Notes-file deletion convention (delete `<name>.notes.md` alongside absorbed parent — content already in canonical's unique_content_per_file inventory)
+  - Diminishing-returns stop rule (41% → 24% → 14% actionable across passes; stop at <15% absent a new clustering signal)
+- Added 1 new Failed Attempts row: cross-category prefix2 matches without secondary signal (86% false-match empirical)
+- Bumped date to 2026-05-05, version to 2.3.0
+
+### Why
+Three new empirical learnings from the third continuation pass that were not in v2.2.0: (1) the gap-close pattern generalizes to a Wave Nc protocol, not just a one-off second pass; (2) cross-category prefix collisions are dominated by false-matches and need a secondary-signal gate before queueing them as merge candidates; (3) the de-duplication yield curve has a measurable floor (<15% actionable) that signals when to stop without losing real merges.
+
+### Previous version (v2.2.0) snapshot
+
+<details><summary>Full v2.2.0 file content</summary>
+
+```markdown
+---
+name: skill-audit-and-merge
+description: "Use when: (1) skills marketplace has 500+ files with visible duplication noise hurting /advise quality, (2) auditing for near-exact duplicates or high-overlap pairs to delete or merge, (3) consolidating topic clusters spanning 3+ files into a single authoritative skill, (4) running a structured deduplication session that must leave all CI tests green"
+category: tooling
+date: '2026-05-04'
+version: 2.2.0
+verification: verified-ci
+history: skill-audit-and-merge.history
+tags:
+  - audit
+  - deduplication
+  - merge
+  - consolidation
+  - marketplace
+  - skills
+  - cleanup
+---
+# Skill Audit and Merge
+
+Systematic audit and consolidation of a skills marketplace to eliminate duplicates, merge related content, and improve `/advise` signal-to-noise ratio.
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-04-12 |
+| **Objective** | Reduce 1,667 → ~1,625 skill files by removing near-exact duplicates and consolidating topic clusters |
+| **Outcome** | 1,667 → 1,625 files (41 removed) across 4 phases; all 98 CI tests passing throughout |
+| **Duration** | ~2 hours (2 conversations) |
+
+## When to Use
+
+- Marketplace has grown organically past ~500 files with visible duplication (similar names, overlapping content)
+- `/advise` returns too many results for a single topic, diluting signal with near-identical entries
+- Multiple skill files form a sequential workflow or cover the same failure from different angles
+- You need to guarantee all CI tests pass after each batch of changes (gate-per-phase)
+- Marketplace has grown organically with overlapping plugins
+- Plugins are missing tags, hurting `/advise` discoverability
+- Plugins are in wrong categories (e.g., workflow tools in debugging/)
+- Need to identify gaps in coverage (empty categories)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Count skills
+ls skills/*.md | wc -l
+
+# Cluster by filename prefix (group by first 3 tokens)
+ls skills/*.md | sed 's|skills/||;s|\.md||' | \
+  python3 -c "
+import sys, collections
+names = [l.strip() for l in sys.stdin]
+clusters = collections.defaultdict(list)
+for n in names:
+    parts = n.split('-')
+    key = '-'.join(parts[:3])
+    clusters[key].append(n)
+for k, v in sorted(clusters.items(), key=lambda x: -len(x[1])):
+    if len(v) > 1:
+        print(f'{len(v):3d}  {k}')
+        for name in v[:6]:
+            print(f'       {name}')
+" | head -80
+
+# Run test gate (must pass between every phase)
+python3 -m pytest tests/ -q --tb=short
+
+# Validate all skill files
+python3 scripts/validate_plugins.py
+```
+
+### Phase 1: Discovery and Triage
+
+1. **Count total files** and snapshot:
+   ```bash
+   ls skills/*.md | wc -l   # e.g. 1667
+   ```
+
+2. **Cluster by prefix** using the command above. Sort clusters by size descending.
+
+3. **Triage clusters into tiers**:
+   | Tier | Criteria | Action |
+   | ------ | ---------- | -------- |
+   | Near-exact | Same workflow, <5% unique content | Delete one immediately |
+   | High-overlap | Same topic, 20-40% unique content each | Merge unique content, delete one |
+   | Topic cluster | Related angles on same domain, 3+ files | Consolidate into 1-2 authoritative files |
+   | Distinct | Different use cases, different audiences | Keep separate |
+
+4. Create a triage table before touching any files:
+   ```
+   | File A | File B | Tier | Decision |
+   ```
+
+5. **For small-scale audits** (under 100 files), also run parallel Explore agents:
+   ```
+   Agent 1: Inventory all plugins by category
+   Agent 2: Assess content quality of each SKILL.md
+   Agent 3: Identify overlaps and merge candidates
+   ```
+
+### Phase 2: Near-Exact Pairs (Tier 1)
+
+- For each pair: open both, confirm <5% unique content
+- Keep the better-named / more-complete file
+- Delete the other: `git rm skills/<name>.md`
+- **No merging needed** — just delete
+- Commit after all Tier 1 deletions: `git commit -m "chore: remove N near-exact duplicate skill files"`
+
+### Phase 3: High-Overlap Pairs (Tier 2)
+
+For each pair:
+1. Read both files fully (use `offset`+`limit` for files >10k tokens)
+2. Identify unique content in the file-to-delete
+3. Absorb unique content into the keeper (add subsections, merge tables)
+4. Delete the absorbed file: `git rm skills/<absorbed>.md`
+5. Batch similar pairs together per commit
+
+**Parallel sub-agent pattern** (when 3+ pairs to process simultaneously):
+```
+# Launch concurrent agents, each handling one pair independently
+# Each agent works on separate files — no git conflicts
+# Collect results, then do one batch commit
+```
+
+### Phase 4: Topic Clusters (Tier 3)
+
+For clusters of 3+ files on the same domain:
+1. Identify the "canonical" file (most complete, best-named)
+2. Read all cluster members
+3. Merge unique sections/findings into canonical
+4. Delete absorbed files
+5. Update canonical's Overview table to reflect merged scope
+
+**Bottom-up merge order** for dependent content:
+```
+domain modules → exports → dependents → tests
+```
+This prevents broken intermediate states where a file references deleted content.
+
+### Gap Recovery Second Pass (when Wave 1 fingerprinting is incomplete)
+
+Use this when a large-scale fingerprinting wave (1,000+ files) hits agent output limits and leaves files unfingerprinted.
+
+**Symptoms**: After Phase 1 merges, some surviving files were never fingerprinted (coverage <100%). Gaps concentrate in letter ranges that were in truncated shards.
+
+**Augment-not-replace approach** — preserve existing fingerprint rows, only add missing ones:
+
+1. Compute the gap:
+   ```bash
+   # Generate sorted list of current skill files
+   ls skills/*.md | sed 's|skills/||;s|\.md||' | sort > current_skills_sorted.txt
+   # Extract fingerprinted skill names from your JSONL/CSV output
+   sort fingerprinted.txt > fingerprinted_sorted.txt
+   # Find files that exist but were never fingerprinted
+   comm -23 current_skills_sorted.txt fingerprinted_sorted.txt > gap_files.txt
+   wc -l gap_files.txt   # e.g. 205 missing
+   ```
+
+2. Re-shard ONLY the gap files into smaller shards (empirical ceiling: **≤103 files per shard**):
+   ```bash
+   # Split gap_files.txt into shards of at most 103 lines
+   split -l 103 gap_files.txt gap_shard_
+   ```
+
+3. Dispatch **`general-purpose`** agents (NOT `Explore`) for the new shards — they can use the Write tool to land JSONL directly on disk.
+
+4. Combine existing + gap fingerprints:
+   ```bash
+   # Filter existing rows to only surviving files (removes absorbed files)
+   python3 - <<'EOF'
+   import json, pathlib
+   surviving = set(pathlib.Path('current_skills_sorted.txt').read_text().split())
+   rows = [r for r in open('wave1_fingerprints.jsonl')
+           if json.loads(r)['name'] in surviving]
+   # Append gap rows
+   rows += list(open('gap_fingerprints.jsonl'))
+   pathlib.Path('combined_fingerprints.jsonl').write_text(''.join(rows))
+   EOF
+   ```
+
+5. Re-cluster globally on the combined set, but **emit only clusters containing ≥1 gap file** — avoids re-discovering already-handled clusters.
+
+6. **Start new cluster IDs at C060** (or whatever is first-pass-max + 1) to avoid collision with first-pass cluster IDs.
+
+7. **Append a "Second Pass Addendum"** to the existing audit report — do not overwrite the first-pass audit trail.
+
+**Result from 2026-05-04 run**: 205 gap files recovered, 21 new clusters (C060–C080), 5 additional merges, 3 false matches caught.
+
+### After Each Phase
+
+```bash
+# Must pass before moving to next phase
+python3 -m pytest tests/ -q --tb=short   # 98 tests, <5s
+
+# One atomic commit per phase
+git add -u
+git commit -m "chore: phase N — <description> (X files removed)"
+```
+
+### Finalize (small-scale audits)
+
+1. Regenerate marketplace.json: `python scripts/generate_marketplace.py`
+2. Verify plugin count matches expectations
+3. Commit all changes
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| No triage step | Started merging immediately without classifying pairs | Wasted time on pairs that turned out to be truly distinct; had to undo work | Always build the full triage table first; 30 min of analysis saves hours of rework |
+| YAML description with unquoted colon | `description: Run pre-commit. Use when: (1) ...` | YAML parser treats `Use when:` as a mapping key; fails in CI (Python 3.11 strict YAML) but not always locally (Python 3.9) | Always quote the entire description value with double quotes when it contains a colon |
+| Pushing directly to main with branch protection | Used `git push origin main` on a branch-protected repo | Remote accepted but logged "bypassed rule violations" warning | For repos with strict protection, use PR-based workflow even if you have bypass permissions |
+| Reading large files without chunking | Called `Read` on a 19,836-token file (`latex-paper-accuracy-review.md`) | Hit the Read tool token limit; partial content returned silently | For files that might be large, read in chunks: `Read(offset=0, limit=500)` then `Read(offset=500, limit=500)` etc. |
+| Worktree not pruned between sub-agent phases | Sub-agents using `isolation="worktree"` left worktrees behind after success | Next sub-agent batch got "worktree already exists" errors | Run `git worktree prune` between phases when using sub-agent worktree isolation |
+| Fixer agents downgraded canonical versions | Dispatched fixer agents to fix content-deficit clusters (E/H/L1); agents re-wrote canonical files from scratch | Agents reverted canonicals to older versions (E: 2.0.0→1.4.0, H: 2.0.0→1.0.0, L1: 2.0.0→1.1.0) and stripped absorbed metadata/descriptions | Fixer agents must be given explicit version floor constraints; provide the pre-fixer commit SHA so the agent can restore from `git show <commit>:skills/<file>.md` if needed |
+| Wave B verifier false FAIL on 8 clusters | Verifier divided fence counts by 2 to get "block pairs" then compared against raw grep-c counts from Phase-0 (labeled "code blocks" but were raw fence markers) | Unit mismatch reported 8 clusters FAILED when only 2 truly had deficits (H: 24 short, L1: 2 short) | Establish a single unit (raw fence count OR block pairs) in Phase 0 and use it consistently through Wave B — never mix counts and pairs in the same comparison |
+| cherry-pick failed for sub-wave integration | Used `git cherry-pick` to integrate cluster B and G commits from worktrees into the integration branch | Worktrees had diverged from a different base than the integration branch, causing cherry-pick conflicts | Use direct file copy from worktrees (`cp worktree/skills/<file>.md integration/skills/`) and manual stage+commit instead of cherry-pick when worktrees were created off a stale base |
+| Fence arithmetic floor was off by absorbed-file overlap | Pre-merge canonical for L1 had 8 fences; absorbed-1 had 14, absorbed-2 had 20; set floor = 42 | Wave A merge produced 40 — fixer merged `fn store` and `fn set` into one code block instead of keeping them separate, losing 2 fences below floor | Floor arithmetic assumes no consolidation of separate code blocks; Wave B verifier must do a content-level diff (not just count comparison) to catch merged blocks that cross cluster-file boundaries |
+| Explore agents for fingerprinting waves | Used `subagent_type: Explore` for fingerprinting shards 2 and 3 in Wave 1 (1,659-file corpus) | `Explore` is a read-only agent type — cannot call `Write` tool. Agents either echoed JSONL as stdout (lost when context cleared) or required complex workarounds to extract output | Any wave whose output must persist to a file (fingerprints, cluster JSON, report files) MUST use `general-purpose` or another writable agent type. Keep shard size ≤103 files (empirical ceiling before output truncation). |
+| Oversized fingerprinting shards causing silent coverage gaps | Wave 1 used 332-file shards, trusting agents to fingerprint the full shard | Explore agents hit output limits partway through each shard, emitting only 838/1024 fingerprints (81.8% coverage); gaps went undetected until post-Phase-1 file count cross-check | Limit fingerprinting shards to ≤103 files; after Wave 1 completes, always `comm -23` surviving files vs. fingerprinted set to detect unfingerprinted files before clustering |
+
+## Results & Parameters
+
+### Scale Achieved (2026-04-12 session)
+
+| Phase | Description | Files Removed |
+| ------- | ------------- | --------------- |
+| 1 | 4 near-exact duplicate pairs — delete one each | 8 |
+| 2 | 9 high-overlap pairs — merge unique content, delete one | 14 |
+| 3a | 4 small paired clusters — merge, delete one each | 6 |
+| 3b | 3 large clusters (academic paper 5→2, CI diagnosis 6→2, Mojo interop 4→2) | 13 |
+| **Total** | **1,667 → 1,625 skill files** | **41** |
+
+### Merge Patterns (small-scale reference)
+
+| Pattern | Example | Structure |
+| --------- | --------- | ----------- |
+| Sequential workflow | worktree-{create,switch,sync,cleanup} | 4 sub-skills in skills/ |
+| Orchestrator + primitives | gh-fix-pr-feedback + get/reply | 3 sub-skills, orchestrator is primary |
+| Analysis + Action | analyze-ci-failure-logs + fix-ci-failures | 2 sub-skills: analyze/ and fix/ |
+
+### Key Commands
+
+```bash
+# Cluster detection (group by first 3 prefix tokens)
+ls skills/*.md | sed 's|skills/||;s|\.md||' | \
+  python3 -c "
+import sys, collections
+names = [l.strip() for l in sys.stdin]
+clusters = collections.defaultdict(list)
+for n in names:
+    parts = n.split('-')
+    key = '-'.join(parts[:3])
+    clusters[key].append(n)
+for k, v in sorted(clusters.items(), key=lambda x: -len(x[1])):
+    if len(v) > 1:
+        print(f'{len(v):3d}  {k}')
+        for name in v:
+            print(f'       {name}')
+"
+
+# Test gate (run after every phase)
+python3 -m pytest tests/ -q --tb=short
+
+# Full skill validator
+python3 scripts/validate_plugins.py
+
+# Prune leftover worktrees
+git worktree prune
+
+# Snapshot file count
+ls skills/*.md | wc -l
+```
+
+### Triage Decision Matrix
+
+| Signal | Likely Tier |
+| -------- | ------------- |
+| Filename differs only in last token | Near-exact (Tier 1) |
+| Same "When to Use" triggers, different examples | High-overlap (Tier 2) |
+| Same domain, different failure modes documented | Topic cluster (Tier 3) |
+| Different primary audience or repo type | Distinct — keep separate |
+
+### CI Check Names
+
+| Check | Command | Threshold |
+| ------- | --------- | ----------- |
+| Validate Plugins | `python3 scripts/validate_plugins.py` | Must pass (0 errors) |
+| Test suite | `python3 -m pytest tests/ -q --tb=short` | 98 tests, all green |
+
+## Key Insights
+
+1. **Triage before touching anything**: Build the full triage table first. Starting merges immediately wastes effort on pairs that turn out to be distinct.
+
+2. **Phase gates prevent cascade failures**: Running the test suite after each phase means you catch YAML/schema errors while the diff is small and obvious.
+
+3. **Parallel sub-agents work when files are independent**: Each merge pair touches different files — no git conflicts. Launch 2-3 concurrent agents per phase for 2-3x speedup.
+
+4. **Large file safety**: Files >~400 lines may exceed Read tool limits. Always check file size with `wc -l` before reading; use `offset`+`limit` for chunked reads.
+
+5. **Cross-references reveal clusters**: If skill A mentions skill B in "See Also", they're merge candidates. If A, B, and C all cross-reference each other, that's a Tier 3 cluster.
+
+6. **Keep better-named file as canonical**: The file with the clearer, more specific name is easier for `/advise` to surface. Keep it; absorb into it.
+
+7. **User decisions matter for scope**: Always ask about merge style, category changes, and scope before starting (especially for small-scale audits where user direction shapes the work).
+
+## Prevention Checklist
+
+Before creating a new skill:
+- [ ] Run `/advise` — if 3+ results return, check for near-duplicates first
+- [ ] Filename follows `<topic>-<subtopic>-<4-word-summary>` convention
+- [ ] Description is quoted (double quotes) if it contains a colon
+- [ ] Failed Attempts table is present (required by CLAUDE.md)
+- [ ] Tags are set for discoverability
+- [ ] Place in correct category (tooling for workflows, ci-cd for Docker fixes, etc.)
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| ProjectMnemosyne | PR #22 (v1.0.0) — 43 → 37 plugins, ~1 hour | [notes.md](skill-audit-and-merge.notes.md) |
+| ProjectMnemosyne | 2026-04-12 session (v2.0.0) — 1,667 → 1,625 files, 41 removed, 98 tests passing | 4-phase deduplication, verified-ci |
+| ProjectMnemosyne | PR #1549 — 12-cluster Myrmidon swarm consolidation, May 2026 (14 canonicals, ~34 absorbed, 967→935 entries) | 4 sub-waves of ≤5 parallel agents with `isolation: worktree`; Wave B verifier; marketplace regen in Wave C |
+| ProjectMnemosyne | 2026-05-04 full-corpus dedup (v2.2.0) — 1,659 → 982 files, 57 absorbed across 2 passes (52 in pass 1 + 5 in gap-recovery pass 2); 171/171 tests passing | Gap-recovery second pass recovered 205/987 unfingerprinted files; `general-purpose` agents used for all write-capable fingerprinting waves; 21 new clusters (C060–C080) found in second pass |
+
+## References
+
+- PR #22: https://github.com/HomericIntelligence/ProjectMnemosyne/pull/22
+- CLAUDE.md plugin standards
+- History: [skill-audit-and-merge.history](skill-audit-and-merge.history)
+- git-worktree-workflow, gh-pr-review-workflow, ci-failure-workflow (examples of merged plugins)
+```
+
+</details>
+
+---
+
+
 ## v2.2.0 (2026-05-04)
 **Changed by:** 2026-05-04 full-corpus Myrmidon deduplication session (1,659 → 982 files, two passes)
 **Verification:** verified-ci (171/171 tests passing, 982/982 plugins valid)

--- a/skills/skill-audit-and-merge.md
+++ b/skills/skill-audit-and-merge.md
@@ -2,8 +2,8 @@
 name: skill-audit-and-merge
 description: "Use when: (1) skills marketplace has 500+ files with visible duplication noise hurting /advise quality, (2) auditing for near-exact duplicates or high-overlap pairs to delete or merge, (3) consolidating topic clusters spanning 3+ files into a single authoritative skill, (4) running a structured deduplication session that must leave all CI tests green"
 category: tooling
-date: '2026-05-04'
-version: 2.2.0
+date: '2026-05-05'
+version: 2.3.0
 verification: verified-ci
 history: skill-audit-and-merge.history
 tags:
@@ -188,6 +188,41 @@ Use this when a large-scale fingerprinting wave (1,000+ files) hits agent output
 
 **Result from 2026-05-04 run**: 205 gap files recovered, 21 new clusters (C060–C080), 5 additional merges, 3 false matches caught.
 
+### Third-Pass Continuation (Wave Nc)
+
+When second-pass merges leave a *further* coverage gap (e.g., files created after the snapshot, or a residual cross-category tail), do a **Wave Nc continuation pass** instead of starting over. Empirically validated 2026-05-04/05 on the same 984-file corpus.
+
+**Continuation mechanics**:
+
+1. Compute the new gap with `comm -23 <current skills sorted> <fingerprinted files sorted>` — only the diff needs new fingerprints.
+2. Reuse the existing fingerprint JSONL schema verbatim — no schema changes between passes.
+3. **Filter prior fingerprints to alive files only** before re-clustering (drop entries for files deleted by prior merges). 2026-05-04 run: 1021 historically fingerprinted, 984 still alive (37 already merged away).
+4. Pass the existing cluster→files map (e.g., C001–C080) to the Wave 2c coordinator so it produces only NEW clusters (C081+) or augmentations to existing clusters — does NOT re-cluster files already triaged.
+
+**Cross-category prefix matches verify as 86% false-match**: After the prior swarm absorbed all single-category prefix2/prefix3 matches, the remaining unclustered tail is dominated by cross-category prefix collisions (e.g., `debugging`+`testing`, `ci-cd`+`tooling`). On the 2026-05-04 run across 786 unclustered files:
+
+- 21 new clusters surfaced (C081–C101), all 2-file pairs.
+- Wave 3c verdicts: **18 false-match (86%), 3 high-overlap, 0 near-exact, 0 topic-cluster**.
+- Pattern: same `prefix2` token (e.g., `pr-review-*`, `python-version-*`, `security-review-*`, `stale-script-*`) but the two files address mutually exclusive operational phases or different deliverables (manual cleanup vs. automated detector; bug fix vs. design pattern; reactive vs. proactive).
+
+**Heuristic for future runs**: weight cross-category 2-file prefix matches as `false-match-likely` by default. Require at least one of these stronger signals to upgrade them to merge-candidate:
+
+- (a) shared tags ≥2,
+- (b) heading-overlap ≥0.75 with same trigger phrases, or
+- (c) explicit `cross_refs` between the two files.
+
+**Notes-file deletion convention**: When deleting an absorbed skill, also delete its `<name>.notes.md` companion. In every 2026-05-04 case (`mojo-boolable-raises-fix.notes.md`, `json-schema-validation-wiring.notes.md`, `config-filename-model-id-audit.notes.md`), the notes file contained raw session timeline + issue/PR numbers + diagnostic process — facts already absorbed (in concentrated form) into the canonical via the Wave 3 unique_content_per_file inventory. Preserving `.notes.md` separately bloats the corpus; the parent skill's "Verified On" section already cites the source PR.
+
+**Diminishing-returns stop rule**: Actionable yield collapses across continuation passes. From the same 984-file corpus:
+
+| Pass | Scope | Clusters | Actionable | Yield |
+| ------ | ------- | ---------- | ------------ | ------- |
+| Wave 3 (first) | full corpus | 59 | 22 high-overlap + 2 near-exact | **41%** |
+| Wave 3b (gap-fill) | 205 gap files | ~21 | 5 confirmed + 3 false-match | **24%** |
+| Wave 3c (cross-cat tail) | 786 unclustered | 21 | 3 high-overlap | **14%** |
+
+**Stop rule**: when a continuation pass yields **<15% actionable**, the corpus is at its de-duplication floor — further passes cost more than they save. Do not run a fourth pass without a new clustering signal (e.g., embedding-based similarity); pure prefix/heading heuristics are exhausted.
+
 ### After Each Phase
 
 ```bash
@@ -220,6 +255,7 @@ git commit -m "chore: phase N — <description> (X files removed)"
 | Fence arithmetic floor was off by absorbed-file overlap | Pre-merge canonical for L1 had 8 fences; absorbed-1 had 14, absorbed-2 had 20; set floor = 42 | Wave A merge produced 40 — fixer merged `fn store` and `fn set` into one code block instead of keeping them separate, losing 2 fences below floor | Floor arithmetic assumes no consolidation of separate code blocks; Wave B verifier must do a content-level diff (not just count comparison) to catch merged blocks that cross cluster-file boundaries |
 | Explore agents for fingerprinting waves | Used `subagent_type: Explore` for fingerprinting shards 2 and 3 in Wave 1 (1,659-file corpus) | `Explore` is a read-only agent type — cannot call `Write` tool. Agents either echoed JSONL as stdout (lost when context cleared) or required complex workarounds to extract output | Any wave whose output must persist to a file (fingerprints, cluster JSON, report files) MUST use `general-purpose` or another writable agent type. Keep shard size ≤103 files (empirical ceiling before output truncation). |
 | Oversized fingerprinting shards causing silent coverage gaps | Wave 1 used 332-file shards, trusting agents to fingerprint the full shard | Explore agents hit output limits partway through each shard, emitting only 838/1024 fingerprints (81.8% coverage); gaps went undetected until post-Phase-1 file count cross-check | Limit fingerprinting shards to ≤103 files; after Wave 1 completes, always `comm -23` surviving files vs. fingerprinted set to detect unfingerprinted files before clustering |
+| Treating cross-category prefix2 matches as merge candidates without secondary signal | Wave 2c surfaced 21 cross-category prefix-collision pairs (e.g., `pr-review-*`, `python-version-*`, `security-review-*`) and queued them all as merge candidates | Wave 3c verified 18/21 (86%) as false-match — same prefix token described mutually exclusive operational phases or different deliverables (manual cleanup vs. automated detector; bug fix vs. design pattern) | Require ≥2 strong signals (shared tags ≥2, heading-overlap ≥0.75 with near-identical trigger phrases, or explicit `cross_refs`) before flagging cross-category prefix matches as merge candidates; default-weight them `false-match-likely` |
 
 ## Results & Parameters
 


### PR DESCRIPTION
## Summary

Amends `skill-audit-and-merge` (v2.2.0 → v2.3.0) with third-pass continuation findings from the 2026-05-04/05 Wave 1c/2c/3c run on the residual cross-category tail.

## What changed

- **New "Third-Pass Continuation (Wave Nc)" subsection** in Verified Workflow:
  - Wave Nc gap-close mechanics: `comm -23` for new gap, reuse JSONL schema, filter prior fingerprints to alive files (1021 → 984), pass existing cluster map so coordinator emits only C081+ or augmentations.
  - **Cross-category prefix matches verify as 86% false-match** (18/21 in Wave 3c). Heuristic: require ≥2 strong signals (shared tags ≥2, heading-overlap ≥0.75, or explicit `cross_refs`) before flagging.
  - Notes-file deletion convention: delete `<name>.notes.md` alongside absorbed parent — content already absorbed in concentrated form.
  - **Diminishing-returns stop rule**: 41% → 24% → 14% actionable across passes; stop at <15% without a new clustering signal.
- **New Failed Attempts row**: treating cross-category prefix2 matches as merge candidates without secondary signal.
- Frontmatter: `version: 2.3.0`, `date: 2026-05-05`.
- v2.2.0 full snapshot archived in `skill-audit-and-merge.history`.

## Verification

- `verified-ci`: derived from PRs landed on `feature/myrmidon-merge-triage` (commits ff79b3a0, eaa35680). Marketplace regenerated; parent project CI green.
- Local: `python3 scripts/validate_plugins.py skills/ plugins/` → 986/986 valid.

## Test plan

- [x] `validate_plugins.py` passes
- [ ] CI on this PR passes
- [ ] Auto-merge on green

🤖 Generated with [Claude Code](https://claude.com/claude-code)