### PR TITLE
feat: amend parallel-issue-wave-execution skill (v2.6.0)

### DIFF
--- a/skills/parallel-issue-wave-execution.history
+++ b/skills/parallel-issue-wave-execution.history
@@ -1,5 +1,708 @@
 # parallel-issue-wave-execution — History
 
+## v2.6.0 (2026-05-07)
+
+**Changed by:** ProjectScylla 5-PR opus wave session 2026-05-07 (PRs #1927–#1931)
+**Verification:** verified-local
+
+### What changed
+- Added 2 Failed Attempts rows: GitHub auto-merge worker stall, squash-merge keyword auto-close failure
+- Added "Post-Merge Verification" subsection documenting manual `gh issue close` follow-up
+- Added Verified On row for the 2026-05-07 5-PR wave
+- Bumped version to 2.6.0
+
+### Why
+Re-running the wave skill on Scylla surfaced two reliability issues with GitHub's automation: (1) `gh pr merge --auto` did not fire for 12+ min on CLEAN PRs, forcing manual `gh pr merge --squash`; (2) `Closes #1888` keyword in a squash commit body did NOT close the linked issue. Both are now documented as Failed Attempts with the verified workaround (manual merge + manual close).
+
+### Previous version (v2.5.0) snapshot
+
+```markdown
+---
+name: parallel-issue-wave-execution
+description: "Pattern for implementing 20-35 GitHub issues in parallel waves using\
+  \ isolated git worktrees. Use when: (1) backlog of 20+ issues classified as LOW/MEDIUM,\
+  \ (2) issues are independent and touch different files per wave, (3) need 8-10x\
+  \ speedup via myrmidon swarm Agent(isolation:'worktree') calls, (4) CI must be green\
+  \ on main before launching waves."
+category: tooling
+date: 2026-04-26
+version: 2.5.0
+user-invocable: false
+verification: verified-local
+history: parallel-issue-wave-execution.history
+tags:
+  - myrmidon
+  - swarm
+  - parallel-agents
+  - issue-triage
+  - wave-execution
+  - worktree
+  - bulk-pr
+---
+# Parallel Issue Wave Execution
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| Date | 2026-04-26 |
+| Version | 2.5.0 |
+| Objective | Implement 20-35 issues per repo in parallel waves using myrmidon swarm agents, with pre-verification and CI-first strategy |
+| Outcome | SUCCESS — verified across 4 repos and 237 issues: 35 PRs (ProjectScylla), 14 PRs (ProjectMnemosyne), ~34 PRs + 12 closures (ProjectKeystone 180-issue swarm), 17 PRs (ProjectTelemachy per-file mega-agents) |
+
+## When to Use
+
+- Closing a backlog of 20+ issues classified as LOW or MEDIUM difficulty
+- Issues are independent (no shared file conflicts within the same wave)
+- Need 8-10x speedup over sequential implementation
+- After a major config change (e.g. coverage threshold fix) makes all older PRs fail CI
+- Need to rebase a PR that is 50+ commits behind main
+- Multiple issues have detailed implementation plans in comments
+- Each issue touches different files (minimal conflicts)
+- Want to close already-resolved issues first (quick wins that reduce scope before launching agents)
+
+## Verified Workflow
+
+### Phase 0: Fix CI on Main First
+
+**CRITICAL**: Before launching any wave, ensure CI passes on main. If main is red, every agent PR will also fail CI for the same reason, wasting time.
+
+```bash
+# Check CI status on main
+gh run list --branch main --limit 5 --json status,conclusion,name
+# If failing, fix main first before proceeding
+```
+
+### Phase 1: Classify, Verify, and Group Issues
+
+```bash
+# Get all open issues
+gh issue list --state open --limit 100 --json number,title,body
+
+# Read issue with implementation plan (plans are often in comments!)
+gh issue view <number> --comments
+
+# Classify into LOW/MEDIUM/HIGH by:
+# - LOW: single-file or config-only, < 20 LOC
+# - MEDIUM: multi-file, requires pattern understanding
+# - HIGH: architectural, complex refactoring
+```
+
+**Pre-verification step** (added in v2.0.0): Before implementing, verify each issue is still valid. In one session, 6 of 27 issues were already resolved:
+- Feature already existed (justfile, pytest in CI)
+- Validation script already covered the check
+- Referenced file/script did not exist
+
+```bash
+# For each issue, verify it still needs fixing:
+# Check if the file/feature mentioned in the issue already exists
+# Close with comment if resolved: gh issue close <N> --comment "Already resolved: ..."
+```
+
+Group LOW issues into waves of 4-7, ensuring issues that **touch the same file** are in **different waves** to prevent merge conflicts. Also group issues that are duplicates or subsets of each other into a single PR.
+
+**Contended files to watch**: `pyproject.toml`, `pixi.toml`, `docker/Dockerfile`, `retry.py`, `loader.py`, CI workflow files, `marketplace.json`, `scripts/validate_plugins.py`.
+
+### Phase 2: Create Worktrees (for small batches of 2-4 issues)
+
+For smaller parallel batches (2 at a time recommended for direct worktree use):
+
+```bash
+# Create worktrees for first batch
+git worktree add ../<ProjectName>-<issue1> -b <issue1>-<description> main
+git worktree add ../<ProjectName>-<issue2> -b <issue2>-<description> main
+```
+
+**Worktree naming convention**: `../<ProjectName>-<issue-number>` (e.g. `../ProjectScylla-90`)
+
+**Branch naming convention**: `<issue-number>-<kebab-case-description>` (e.g. `90-standardize-runs-per-tier`)
+
+### Phase 3: Launch Parallel Agents Per Wave (for large batches)
+
+Send a **single message** with 4-5 `Agent(isolation="worktree")` calls to run truly in parallel:
+
+```python
+# Each agent receives:
+# - Issue number, title, exact file paths
+# - Pre-written branch name: {issue-number}-{description}
+# - Commit message template
+# - PR title template
+# - Instruction to enable auto-merge
+```
+
+**Agent prompt template** (per issue):
+
+```
+1. gh issue view {N} --comments
+2. git fetch origin && git rebase origin/main  # ALWAYS rebase first (critical for late waves)
+3. Read the relevant files, implement the minimal change
+4. pre-commit run --files <changed-files>  # targeted, not --all-files
+5. pixi install && git add pixi.lock  # REQUIRED if pyproject.toml or pixi.toml changed
+6. git add <files> && git commit -m "type(scope): description"
+7. git push -u origin {N}-description
+8. gh pr create --title "..." --body "Closes #{N}"
+9. gh pr merge --auto --rebase <pr-number>
+```
+
+**Note on step 5**: Even non-dependency changes to `pyproject.toml` (e.g. removing a ruff
+ignore rule) change the scylla package SHA in `pixi.lock`. Always run `pixi install` and
+commit the updated `pixi.lock` if `pyproject.toml` was modified.
+
+### Phase 4: Parallel Implementation (for worktree batches)
+
+1. Read all files needed for BOTH issues simultaneously
+2. Make edits in parallel (use Edit tool on different worktree paths)
+3. Run tests in parallel for both worktrees
+
+```bash
+# Tests in parallel (different terminals or background)
+cd /path/to/worktree-1 && pixi run pytest tests/ -v
+cd /path/to/worktree-2 && pixi run pytest tests/ -v
+```
+
+**Optimal batch size for direct worktrees**: 2 issues at a time — best balance of parallelism vs context.
+
+### Phase 5: Commit, PR Creation, and Cleanup
+
+```bash
+# Commit in each worktree
+cd /path/to/worktree-1 && git add -A && git commit -m "type(scope): description
+
+Closes #<issue>"
+
+# Push and create PR
+git push -u origin <branch>
+gh pr create --title "Title" --body "$(cat <<'EOF'
+## Summary
+...
+
+Closes #<issue>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+# Merge PRs
+gh pr merge <pr-number> --rebase --delete-branch
+
+# After all merged, cleanup worktrees
+git worktree remove /path/to/worktree-1
+git worktree remove /path/to/worktree-2
+git branch -D <branch1> <branch2>
+
+# Update main
+git fetch --prune origin
+git pull --rebase
+```
+
+### Phase 6: Wait and Verify Each Wave
+
+After each wave completes:
+```bash
+gh pr list --state open --author "@me" --json number,title,statusCheckRollup
+```
+
+Only proceed to next wave when all PRs in the current wave are pushed (CI pending or passing).
+
+### Phase 7: Fix CI Failures on Completed PRs
+
+After all waves, check for failures:
+
+```bash
+gh pr list --state open --author "@me" --json number,title,statusCheckRollup | python3 -c "
+import json, sys
+prs = json.load(sys.stdin)
+for pr in sorted(prs, key=lambda x: x['number']):
+    checks = pr.get('statusCheckRollup', [])
+    states = [c.get('state', c.get('conclusion', '')) for c in checks]
+    if any(s in ('FAILURE', 'ERROR') for s in states):
+        print(f'FAILING: PR #{pr[\"number\"]} — {pr[\"title\"]}')
+"
+```
+
+**For each failing PR**: create a fresh branch from current `origin/main`, cherry-pick the commits, resolve conflicts, push, create new PR, close old PR with supersession comment.
+
+### Phase 8: Rebase Stale Pre-existing PRs
+
+For PRs 50+ commits behind main with no CI checks:
+
+```bash
+git fetch origin <old-branch>
+git switch -c <old-branch>-v2 origin/main
+git cherry-pick origin/<old-branch>  # or each commit individually
+# Resolve conflicts — port fixes into refactored code structure
+pre-commit run --files <changed-files>
+pixi install  # if lock file affected
+git push -u origin <old-branch>-v2
+gh pr create ...
+gh pr close <old-pr> --comment "Superseded by #<new-pr>"
+gh pr merge --auto --rebase <new-pr>
+```
+
+### Merge Conflict Resolution (when a PR becomes DIRTY)
+
+When a PR's `mergeStateStatus` is `DIRTY` after another PR merged into the same file:
+
+```bash
+git fetch origin
+git checkout <branch>
+git rebase origin/main           # surfaces conflict markers
+# Edit file: keep BOTH sets of additions, remove all <<<<<<<, =======, >>>>>>> markers
+git add <conflicted-file>
+GIT_EDITOR=true git rebase --continue   # NOTE: --no-edit does NOT exist for git rebase
+git push --force-with-lease origin <branch>
+gh pr merge <PR-number> --auto --rebase  # MUST re-enable — force-push clears it silently
+```
+
+### Per-File Mega-Agent Pattern (for 6+ issues per file)
+
+When file contention analysis shows a single source file touched by 6+ issues,
+strict per-wave single-issue agents waste waves — use a Sonnet mega-agent per file:
+
+**Threshold:**
+- 1-2 issues per file → single-issue agents (normal)
+- 3-5 issues per file → mini-bundle (2 issues per agent)
+- 6+ issues per file → per-file mega-agent (Sonnet, all issues in one PR)
+
+**Agent assignment (example from ProjectTelemachy):**
+- models.py (8 issues) → 1 Sonnet agent, branch `bundle-models-14-19-20-21-51`
+- agamemnon_client.py (6 issues) → 1 Sonnet agent, branch `bundle-client-11-12-23-24-34`
+- cli.py (3 issues) → 1 Sonnet agent, branch `bundle-cli-15-18-43`
+- executor.py (11 issues, also touches cli.py + config.py) → runs ALONE in next wave after others merge
+
+**Result:** 12 planned waves collapsed to Wave D (3 parallel) + Wave E (1 solo) = 2 waves.
+
+**Cross-file ordering rule:**
+If mega-agent X touches files also owned by mega-agents Y and Z, run Y+Z first (parallel),
+then X alone after Y+Z merge. X rebases onto merged Y+Z before starting.
+
+**Branch naming for mega-agents:** `bundle-<file>-<issue1>-<issue2>-...`
+e.g. `bundle-models-14-19-20-21-51`
+
+**PR body for mega-agents:** one `Closes #N` per issue in the set.
+
+**Waves A+B can launch simultaneously with Wave 0:**
+Phase 0 (`gh issue close` for already-done issues) and Waves A+B (docs/config) have zero
+file overlap and can all be dispatched in a single message. Saves ~5 min wall clock.
+
+**Issue bundles for shared config files:**
+Multiple issues touching the same config file (e.g. #22 remove pixi.lock, #28 add entries,
+# 30 add .env) should be bundled into ONE agent/PR — the file-level conflict is unavoidable anyway
+
+## Critical Pitfalls
+
+### Coverage Threshold Cascade Failure
+
+When a PR changes `[tool.pytest.ini_options].addopts` `--cov-fail-under`, **all PRs created before that change will fail CI** if integration tests run with the old threshold.
+
+**Symptom**: Integration test logs show `Coverage failure: total of 12.62 is less than fail-under=75.00`
+
+**Root cause**: `--cov-fail-under` in `addopts` applies to ALL test runs including integration tests that only reach ~12% coverage.
+
+**Fix pattern**:
+1. Land a fix-PR that changes `addopts` to `--cov-fail-under=9` (combined floor)
+2. Add `--override-ini="addopts="` to the unit CI step with explicit `--cov-fail-under=75`
+3. Rebase all pre-fix PRs onto post-fix main
+
+**`pyproject.toml` pattern**:
+```toml
+[tool.pytest.ini_options]
+addopts = [
+    "--cov=scylla",
+    "--cov=scripts",
+    "--cov-fail-under=9",   # Combined floor; unit 75% enforced in CI step
+]
+
+[tool.coverage.report]
+# Combined scylla/+scripts/ floor; scripts/ integration coverage is WIP.
+# Scylla/ 75% enforced in test.yml unit step.
+fail_under = 9
+```
+
+**`test.yml` unit step pattern**:
+```yaml
+- name: Run unit tests
+  run: |
+    pixi run pytest "$TEST_PATH" \
+      --override-ini="addopts=" \
+      -v --strict-markers \
+      --cov=scylla \
+      --cov-report=term-missing \
+      --cov-report=xml \
+      --cov-fail-under=75
+```
+
+### pixi.lock Must Be Regenerated After pyproject.toml Changes
+
+`pixi.lock` contains a SHA256 hash of the local editable package (`./`). Any change to
+`pyproject.toml` — even non-dependency changes like removing a ruff rule from the ignore
+list — changes the package hash. When CI runs `pixi install --locked` with a stale hash,
+it fails with `lock-file not up-to-date with the workspace`.
+
+**This only happens when:**
+- A PR modifies `pyproject.toml` (even metadata-only changes)
+- The pixi environment cache misses in CI (cache is keyed on the lock file hash)
+
+**Symptom**: CI passes when cache hits (old lock file hash still works) but fails on cache
+miss (tries fresh install with `--locked` against the stale SHA).
+
+```bash
+# After any pyproject.toml or pixi.toml change:
+pixi install          # regenerates pixi.lock with correct SHA
+git add pixi.lock && git commit -m "fix(lock): update pixi.lock SHA after pyproject.toml change"
+```
+
+**Quick diagnosis**:
+```bash
+git diff HEAD -- pixi.lock  # if SHA changed, you must commit the updated lock file
+```
+
+### altair Upper Bound and Python 3.14t
+
+`altair = ">=5.0,<6"` resolves to altair 5.5.0 which **fails to import on Python 3.14t**:
+```
+TypeError: _TypedDictMeta.__new__() got an unexpected keyword argument 'closed'
+```
+
+**Fix**: Use `altair = ">=5.0,<7"` AND run `pixi update altair` to force resolution to 6.0.0 (which is 3.14t compatible). Simply editing `pixi.toml` is not enough — `pixi install` will keep the cached 5.5.0 entry.
+
+```bash
+# Wrong:
+altair = ">=5.0,<6"   # resolves to 5.5.0 — broken on Python 3.14t
+
+# Correct:
+altair = ">=5.0,<7"   # must also run:
+pixi update altair    # forces re-solve to 6.0.0
+```
+
+### docker build --check Rejects Multi-line Python in RUN
+
+Multi-line Python in a `RUN $(python3 -c "...")` command is parsed as Dockerfile instructions:
+
+```dockerfile
+# BROKEN — dockerfile parse error: unknown instruction 'import'
+RUN python3 -c "
+import tomllib
+..."
+```
+
+**Fix**: Inline to a single line using semicolons:
+```dockerfile
+# CORRECT
+RUN python3 -c "import tomllib, os; data = tomllib.loads(open('pyproject.toml').read()); ..." \
+    && pip install ...
+```
+
+### Agent Tool Permission Denials in Worktrees
+
+Some agents get `Edit` and `Write` tool calls denied in their worktree paths. This appears to be a sandbox permission issue that affects some worktrees but not others.
+
+**Workaround**: Use bash-based file writing instead of Edit/Write tools:
+
+```bash
+# Heredoc approach (preferred)
+cat > /path/to/file << 'EOF'
+file contents here
+EOF
+
+# Python inline approach (for complex edits)
+python3 -c "
+import pathlib
+p = pathlib.Path('/path/to/file')
+content = p.read_text()
+content = content.replace('old', 'new')
+p.write_text(content)
+"
+```
+
+**Prevention**: If an agent fails with permission denied, handle the fix directly in the main conversation instead of retrying in another worktree.
+
+### Stale Background Agent Contamination
+
+Background agents from previous tasks can outlive their context and leave modifications on main.
+
+**Symptom**: `git status` shows unexpected modifications after switching tasks.
+
+**Recovery**: `git checkout -- .` to discard all modifications, then verify `git status` is clean before starting new work.
+
+**Prevention**: Always run `git status` at the start of a new task to verify a clean working tree.
+
+### Main Worktree Contamination
+
+If an agent runs in the **main worktree** instead of an isolated worktree (missing `isolation="worktree"` parameter), it will leave the repo in a modified state with a switched branch.
+
+**Recovery** (when Safety Net blocks `git restore`):
+```bash
+git show HEAD:<file> > /tmp/<file>_head.bak
+cp /tmp/<file>_head.bak <file>
+# Then switch back to main:
+git switch main
+```
+
+### Pre-commit Environment Mismatch (System Python 3.9 / Go Version)
+
+When the host system uses Debian/Ubuntu Python 3.9 and an older Go version, two pre-commit hooks fail locally:
+
+- **`yamllint`**: Requires Python 3.10+ to install its virtualenv — fails on 3.9
+- **`gitleaks`**: Compiled with Go 1.22 format that mismatches the system Go version
+
+**Symptom**: `pre-commit run --all-files` errors on `yamllint` or `gitleaks` with install failures.
+
+**Fix**: Skip only those two hooks — CI runs them via its own correct environment:
+
+```bash
+SKIP=gitleaks,yamllint pixi run pre-commit run --all-files
+```
+
+**Why this is safe**: CI installs correct Go and uses pixi's Python 3.14+ to run these hooks, so they are enforced in the merge gate. Skipping locally does not bypass the check — it defers it to CI.
+
+### Audit Doc Policy Violations Hook Is Very Slow
+
+The `audit-doc-policy-violations` pre-commit hook can take 5+ minutes to run. Agents waiting for `pre-commit run --all-files` will appear frozen with no output.
+
+**Symptom**: Agent output stops after "Running audit-doc-policy-violations..." with no further progress.
+
+**Fix**: Skip it locally and let CI run it:
+
+```bash
+SKIP=audit-doc-policy-violations pixi run pre-commit run --all-files
+# Or skip both slow/broken hooks at once:
+SKIP=gitleaks,yamllint,audit-doc-policy-violations pixi run pre-commit run --all-files
+```
+
+**Note**: If an agent says "Still waiting on Audit Doc Policy Violations", it has stalled. The safest resolution is to cancel the agent and re-run with the SKIP env var.
+
+### Auto-merge Cleared on Force-Push
+
+GitHub silently clears auto-merge when any `git push --force-with-lease` (or `--force`) is made to the PR branch.
+
+**Symptom**: PR shows "Auto-merge disabled" after a force-push that was needed to update pixi.lock or fix a commit.
+
+**Fix**: Always re-enable after any force-push:
+
+```bash
+gh pr merge <pr-number> --auto --rebase
+```
+
+### GitHub Actions Runner Queue Saturation
+
+Opening too many PRs in a short window causes the GitHub Actions runner pool to fill beyond the org's concurrency limit, stalling all CI for 25+ minutes.
+
+**What happened**: A myrmidon swarm dispatched 10 waves (EASY + MEDIUM) against ProjectKeystone, opening 28 PRs in ~20 minutes. Each PR triggered ~3 workflows (CI, Security Scanning, Dependency Audit) = ~84+ workflow runs queued simultaneously. No runs started for 25+ minutes. The oldest queued run was created at 01:12 UTC; by 01:36 UTC zero had started.
+
+**Mitigation attempts that failed**:
+- `gh run cancel <old-run-id>` — cancel request accepted but runs stayed queued
+- `gh run rerun <run-id>` — failed: "This workflow is already running"
+- `gh workflow run "Security Scanning" --ref <branch>` — new run also immediately queued
+
+**Confirmed ceiling**: ~8 concurrent open PRs is the safe limit for a free-tier GitHub org with 3 workflows per PR.
+
+**Fix**: Rate-limit PR creation across waves:
+
+```bash
+# Open at most 8 PRs per wave window (≤8 PRs × 3 workflows = ≤24 queued runs)
+# After each wave, wait ~2 minutes before the next wave to let runners drain:
+gh pr list --state open --json number,statusCheckRollup | python3 -c "
+import json, sys
+prs = json.load(sys.stdin)
+pending = [p for p in prs if any(
+    c.get('state', c.get('conclusion', '')) in ('PENDING', 'IN_PROGRESS', 'QUEUED')
+    for c in p.get('statusCheckRollup', [])
+)]
+print(f'{len(pending)} PRs with pending/in-progress checks')
+"
+# Only launch next wave when the above count is dropping toward 0
+```
+
+**Prevention rule**: Cap swarm waves to ≤8 PRs per window. Add 120-second pause between waves when total open PRs exceed 8. For repos with 3+ workflows per PR, cap to ≤5 PRs per wave.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Agent Edit/Write in worktree | Agent used Edit and Write tools in its worktree to modify CI workflow files | Permission denied errors from the tool sandbox on some worktree paths | Use bash-based file writing (heredoc, python inline) as fallback when Edit/Write fail in worktrees |
+| Implementing already-resolved issues | Launched agents for issues that were already fixed (justfile existed, pytest already in CI, etc.) | Wasted agent time discovering the issue was moot | Always pre-verify issue state before launching agents; close resolved issues first |
+| Linter reverting file changes | Modified skill files (version bumps, content merges) were silently reverted to git HEAD state | A pre-commit hook or linter was running `git checkout` on tracked files that had been modified | Check for hooks that auto-revert changes; stage changes immediately after editing |
+| Stale background agent contamination | A background agent from a previous task was still running and modifying files on main | Agents outlived their task context and left the working tree dirty | Always verify `git status` is clean before starting a new task; kill stale agents |
+| Marketplace CI with GITHUB_TOKEN | CI workflow tried to create PRs using GITHUB_TOKEN | GitHub Actions GITHUB_TOKEN cannot create PRs (insufficient permissions) | Switch to direct commit to main with a validation gate, or use a PAT/GitHub App token |
+| Merging duplicate issues into one PR | Issues #1110, #928, #914 all covered DRY violations; tried separate PRs | Overlapping file changes would cause merge conflicts | Identify duplicate/subset issues early and merge into a single PR |
+| Waiting on Audit Doc Policy Violations hook | Agent ran `pre-commit run --all-files` and stalled for 5+ minutes — appeared to hang | The "Audit Doc Policy Violations" hook is extremely slow (can exceed 5 min) causing agents to stall and appear frozen | Use `SKIP=audit-doc-policy-violations pixi run pre-commit run --all-files` to skip only this hook; CI runs it in its own environment correctly |
+| Pre-commit hooks fail on system Python 3.9 / Go mismatch | Ran `pre-commit run --all-files` directly on a Debian 3.9 system; yamllint and gitleaks hooks failed | yamllint requires Python 3.10+ virtualenv; gitleaks hook requires Go 1.22 format which mismatches local Go version | Use `SKIP=gitleaks,yamllint pixi run pre-commit run --all-files` — CI runs these via its own correct environment |
+| Ran `git rebase --continue --no-edit` | Used `--no-edit` flag on git rebase | Flag doesn't exist on this git version (it's for `git commit`/`git merge`) | Use `GIT_EDITOR=true git rebase --continue` for non-interactive rebase continuation |
+| Assumed parallel PRs on different issues wouldn't conflict | Two agents independently added tests to `test_cli_report.py` (PRs #1801 and #1803) | Both PRs extended the same test file; #1801 merged first, making #1803 DIRTY | Group agents by file ownership even for test files; when PRs add to shared test helpers/fixtures, they can conflict |
+| Force-pushed rebase resolution and assumed auto-merge persisted | Ran `git push --force-with-lease` after resolving merge conflict, didn't re-enable auto-merge | GitHub silently clears auto-merge on every force-push | Always run `gh pr merge <N> --auto --rebase` immediately after any force-push |
+| Spawned duplicate agent while background agent was still running | Tried to take over branch without checking background agent state | Would have created conflicting commits and wasted work | Read `/tmp/claude-*/tasks/<id>.output`, check `git log origin/<branch>`, and `gh pr list --head <branch>` before touching a branch |
+| Retried agent after BLOCKED report | Agent correctly reported BLOCKED (e.g. coverage threshold below target, cannot implement without breaking changes); orchestrator re-ran with a different prompt | The BLOCKED signal is accurate — the issue requires human architectural review. Re-runs produce the same BLOCKED result or introduce incorrect changes to force past the blocker | When an agent reports BLOCKED with a clear reason, treat it as a signal for human review, not a failure to retry. Label the issue `needs:human-review` and move on. |
+| Strict per-wave for high-contention repos | Applied "≤5 agents, 1 file per wave" to a repo where executor.py had 11 open issues | Required 12+ waves; the contended file serialized everything anyway — no real parallelism | Switch to per-file mega-agent when a file has 6+ issues |
+| Runner queue saturation | Opened 28 PRs across 10 waves in ~20 min, each triggering 3 workflows (CI, Security Scanning, Dependency Audit) = ~84+ workflow runs queued simultaneously on a free-tier GitHub org | GitHub free-tier runner pool exhausted; no runs started for 25+ min. Attempted `gh run cancel` (accepted but runs stayed queued) and `gh run rerun` (failed: "This workflow is already running"); manual `gh workflow run` dispatch also immediately queued | Cap total concurrent PRs to ≤8 per wave window; add 2-min inter-wave delay to let runners drain before opening the next batch |
+
+## Results & Parameters
+
+### Wave Sizing
+
+| Run | Wave | Issues | Result |
+| ----- | ------ | -------- | -------- |
+| ProjectScylla (Mar 2026) | 1-8 | 35 total | 35 PRs created, 31 merged, 4 superseded |
+| ProjectScylla (Mar 2026) | Fix pass | 4 failing + 1 stale | All resolved |
+| ProjectMnemosyne (Apr 2026) | Wave 1 | 7 agents (independent files) | 7 PRs, all CI passing |
+| ProjectMnemosyne (Apr 2026) | Wave 2 | 7 agents (DRY refactors, CI, packaging) | 7 PRs, all CI passing |
+| ProjectMnemosyne (Apr 2026) | Pre-close | 6 issues closed (already resolved) | No PRs needed |
+| ProjectScylla (Apr 2026) | Wave 0 | 20 issues closed (already-done/duplicates) | No PRs, direct gh issue close |
+| ProjectScylla (Apr 2026) | Wave 1 | ~4-5 Haiku doc-only agents | ~5 PRs, auto-merged via rebase |
+| ProjectScylla (Apr 2026) | Wave 2a+2b | ~8-10 Sonnet MEDIUM agents | ~13 PRs, auto-merged; PR #1792 needed pixi.lock after pyproject.toml change |
+| ProjectKeystone (Apr 2026) | 7 EASY waves | 67 EASY issues, ~9-10 per wave | ~34 PRs created, ~12 ALREADY-DONE closures |
+| ProjectKeystone (Apr 2026) | 9 MEDIUM waves | 78 MEDIUM issues, ≤3 Sonnet agents each | All 9 waves at ≤3 agents (C++ compile-time constraint confirmed) |
+| ProjectKeystone (Apr 2026) | HARD deferred | 25 HARD issues | Labeled tier:hard — NATS/JetStream (8), TSan/lock-free (6), circular CMake (5), 4-layer E2E (6) |
+| ProjectTelemachy (Apr 2026) | Wave D (mega-agents) | 3 parallel Sonnet mega-agents (models, client, cli) | 3 PRs, auto-merged; executor.py mega-agent ran solo in Wave E after D merged |
+| ProjectTelemachy (Apr 2026) | Wave E (mega-agent solo) | 1 Sonnet agent for executor.py (11 issues) | 1 PR; rebased onto merged Wave D before starting; 17 total PRs merged |
+
+### HARD Classification Patterns
+
+Use these patterns to immediately classify an issue as HARD (defer to human review, do not send to wave agent):
+
+| Pattern | Trigger Keywords | Why It's HARD |
+| --------- | ----------------- | --------------- |
+| **NATS/JetStream integration** | "JetStream", "real NATS server", "service container", "NATS integration test", "TransparentBridge wiring" | Requires a live NATS server via service containers in CI; nats.c JetStream subscription loops are complex; embedded NATS server in C++ tests is non-trivial. An agent cannot implement this without the full NATS infrastructure present. |
+| **TSan + lock-free queue libraries** | "TSan", "ThreadSanitizer", "concurrentqueue", "moodycamel", "lock-free" (combined with TSan) | Lock-free data structures like `concurrentqueue` use relaxed atomics by design and trigger TSan false positives. These cannot be silenced without replacing the library. Issues like "Add TSan test run for X" where X uses these libraries are fundamentally blocked. |
+| **Circular CMake dependency refactors** | "circular dependency", "CMake target graph", "link dependency cycle" (e.g., `keystone_core ↔ keystone_concurrency`) | Breaking circular link dependencies between CMake targets requires architectural changes to the entire target graph. An agent without full build system understanding can easily break other targets or create new cycles. |
+| **4-layer async hierarchy integration tests** | "L0→L3", "end-to-end hierarchy", "all 4 agent layers", "ChiefArchitect to TaskAgent" | E2E tests spanning all 4 agent layers require each layer to be correctly wired together. Often blocked by prior architectural issues in lower layers that must be resolved first. |
+
+**Rule**: Classify HARD immediately on sight of these keywords — do not attempt to implement in a wave. Label `tier:hard` and defer.
+
+### Optimal Batch Sizes
+
+| Method | Batch Size | Notes |
+| -------- | ----------- | ------- |
+| Direct worktrees | 2 issues | Best balance of parallelism vs context |
+| Agent(isolation="worktree") EASY | 7 issues per wave | Fully parallel, tested successfully |
+| Agent(isolation="worktree") MEDIUM (C++) | 3 issues per wave | C++ compile times mean agents may time out if forced to rebuild from scratch at 5+ agents; confirmed across 9 MEDIUM waves in ProjectKeystone |
+| Agent(isolation="worktree") MEDIUM (Python) | 5 issues per wave | Python rebuild is fast; 5 is safe |
+| Bulk issue filing (Haiku) | 5 agents per wave | GitHub API rate limit safe |
+
+### PR Creation Template
+
+```bash
+gh pr create \
+  --title "[Type] Brief description" \
+  --body "$(cat <<'EOF'
+## Summary
+- Bullet 1
+- Bullet 2
+
+Closes #<N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+gh pr merge --auto --rebase <pr-number>
+```
+
+### Status Polling Script
+
+```bash
+gh pr list --state open --author "@me" --json number,title,statusCheckRollup | python3 -c "
+import json, sys
+prs = json.load(sys.stdin)
+for pr in sorted(prs, key=lambda x: x['number']):
+    checks = pr.get('statusCheckRollup', [])
+    if not checks:
+        status = 'no checks'
+    else:
+        states = [c.get('state', c.get('conclusion', 'UNKNOWN')) for c in checks]
+        if all(s in ('SUCCESS', 'NEUTRAL') for s in states):
+            status = 'PASSING'
+        elif any(s in ('FAILURE', 'ERROR') for s in states):
+            status = 'FAILING'
+        else:
+            status = 'PENDING'
+    print(f'PR #{pr[\"number\"]}: {status} — {pr[\"title\"][:70]}')
+"
+```
+
+### File Contention Analysis Script
+
+Run before wave planning to identify mega-agent candidates:
+
+```bash
+# Identify contended files before wave planning
+gh issue list --state open --json number,body | python3 -c "
+import json,sys,re
+issues=json.load(sys.stdin)
+from collections import Counter
+files=[]
+for i in issues:
+    files += re.findall(r'src/\S+\.py|\.\w+/\S+\.yml', i.get('body',''))
+for f,c in Counter(files).most_common(10): print(c, f)
+"
+# Files with 6+ hits → per-file mega-agent candidates
+# Files with 3-5 hits → consider mini-bundle (2 issues per agent)
+# Files with 1-2 hits → normal single-issue agents
+```
+
+### Background Agent Coordination Checklist
+
+Before taking over a branch that a background agent was working on:
+
+```bash
+# 1. Check the agent output file
+cat /tmp/claude-*/tasks/<agent-id>.output | tail -100
+
+# 2. Check if commits already exist on the remote branch
+git fetch origin
+git log --oneline origin/<branch> | head -5
+
+# 3. Check if a PR already exists
+gh pr list --head <branch> --json number,title,state
+
+# 4. Only take over if remote branch has no useful commits AND no PR exists
+```
+
+### Wave Completion Verification
+
+```bash
+# After all waves complete — empty result means all PRs merged
+gh pr list --state open --json number,title,mergeStateStatus,statusCheckRollup
+
+# If any remain, check mergeStateStatus:
+# DIRTY    → merge conflict, needs rebase resolution
+# BLOCKED  → CI failing or review required
+# UNKNOWN  → CI still running, wait
+```
+
+### Cherry-pick Rebase for Stale PR
+
+```bash
+git fetch origin <old-branch>
+git switch -c <old-branch>-v2 origin/main
+git cherry-pick origin/<old-branch>
+# If conflicts due to refactoring:
+# - Port fixes into new code structure (e.g. ResumeManager, TierActionBuilder)
+# - Use git cherry-pick --continue after resolving
+pre-commit run --files <changed-files> || true
+git add -A && git commit -m "fix: apply pre-commit auto-fixes" 2>/dev/null || true
+pixi install  # if lock files changed
+git push -u origin <old-branch>-v2
+gh pr create ...
+gh pr merge --auto --rebase <new-pr>
+gh pr close <old-pr> --comment "Superseded by #<new-pr>"
+```
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| ProjectScylla | 35 LOW issues, 8 parallel waves, March 2026 | [notes.md](parallel-issue-wave-execution.notes.md) |
+| ProjectScylla | 14 LOW issues, 4 parallel waves, March 2026 (second run) | pyproject.toml change required pixi.lock SHA update; nested worktree carried stale commits |
+| ProjectMnemosyne | 27 open issues triaged, 14 PRs in 2 waves, 6 closed directly, April 2026 | CI gate: pytest + validate_plugins.py (39 tests, 953 skills) |
+| ProjectScylla | 80-issue triage: 20 closed already-done/dup, ~18 PRs in 3 waves, April 2026 | Haiku for LOW, Sonnet for MEDIUM; SKIP=gitleaks,yamllint needed on Debian 3.9 system; Audit Doc Policy hook stalls agents |
+| ProjectScylla | Wave 2b/2c continuation, 6 PRs (#1799-#1804), conflict resolution for PR #1803 | 2026-04-13 |
+| ProjectKeystone | 180-issue C++20/NATS swarm: 7 EASY waves (67 issues) + 9 MEDIUM waves (78 issues) + 25 HARD deferred; confirmed MEDIUM cap at 3 for C++ | 2026-04-25 |
+| ProjectTelemachy | 57 issues, per-file mega-agents collapsed 12 waves → 2; 17 PRs merged | 2026-04-25 |
+```
+
+---
+
+
 ## v2.5.0 (2026-04-26)
 
 **Changed by:** ProjectKeystone myrmidon swarm — runner queue saturation incident (2026-04-26)

--- a/skills/parallel-issue-wave-execution.md
+++ b/skills/parallel-issue-wave-execution.md
@@ -6,8 +6,8 @@ description: "Pattern for implementing 20-35 GitHub issues in parallel waves usi
   \ speedup via myrmidon swarm Agent(isolation:'worktree') calls, (4) CI must be green\
   \ on main before launching waves."
 category: tooling
-date: 2026-04-26
-version: 2.5.0
+date: 2026-05-07
+version: 2.6.0
 user-invocable: false
 verification: verified-local
 history: parallel-issue-wave-execution.history
@@ -26,8 +26,8 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| Date | 2026-04-26 |
-| Version | 2.5.0 |
+| Date | 2026-05-07 |
+| Version | 2.6.0 |
 | Objective | Implement 20-35 issues per repo in parallel waves using myrmidon swarm agents, with pre-verification and CI-first strategy |
 | Outcome | SUCCESS — verified across 4 repos and 237 issues: 35 PRs (ProjectScylla), 14 PRs (ProjectMnemosyne), ~34 PRs + 12 closures (ProjectKeystone 180-issue swarm), 17 PRs (ProjectTelemachy per-file mega-agents) |
 
@@ -516,6 +516,8 @@ print(f'{len(pending)} PRs with pending/in-progress checks')
 | Retried agent after BLOCKED report | Agent correctly reported BLOCKED (e.g. coverage threshold below target, cannot implement without breaking changes); orchestrator re-ran with a different prompt | The BLOCKED signal is accurate — the issue requires human architectural review. Re-runs produce the same BLOCKED result or introduce incorrect changes to force past the blocker | When an agent reports BLOCKED with a clear reason, treat it as a signal for human review, not a failure to retry. Label the issue `needs:human-review` and move on. |
 | Strict per-wave for high-contention repos | Applied "≤5 agents, 1 file per wave" to a repo where executor.py had 11 open issues | Required 12+ waves; the contended file serialized everything anyway — no real parallelism | Switch to per-file mega-agent when a file has 6+ issues |
 | Runner queue saturation | Opened 28 PRs across 10 waves in ~20 min, each triggering 3 workflows (CI, Security Scanning, Dependency Audit) = ~84+ workflow runs queued simultaneously on a free-tier GitHub org | GitHub free-tier runner pool exhausted; no runs started for 25+ min. Attempted `gh run cancel` (accepted but runs stayed queued) and `gh run rerun` (failed: "This workflow is already running"); manual `gh workflow run` dispatch also immediately queued | Cap total concurrent PRs to ≤8 per wave window; add 2-min inter-wave delay to let runners drain before opening the next batch |
+| Relied on `gh pr merge --auto --rebase` to merge wave PRs once CI passes | Enabled auto-merge on all 5 wave PRs (HomericIntelligence/ProjectScylla 2026-05-07: #1927, #1928, #1929, #1930, #1931). After CI went CLEAN/MERGEABLE on every PR, auto-merge did not fire for ~12+ min. | GitHub's auto-merge worker is best-effort, not real-time. Org-level queue saturation or repository-level branch-protection evaluation can delay it indefinitely. Repository also disallowed rebase-merge, so `--auto --rebase` was silently downgraded by GH but still didn't fire. | Auto-merge is fire-and-forget at best. After CI is CLEAN, run `gh pr merge <N> --squash` (or `--rebase` if allowed) MANUALLY to merge immediately. Use auto-merge only as a fallback for PRs you don't need to land on a known timeline. |
+| Used `Closes #1888` in the PR body (and commit message) and squash-merged the PR | PR #1931 squash-merged into HomericIntelligence/ProjectScylla main with `Closes #1888` in the commit body and PR body. Issue #1888 stayed OPEN. | Squash-merge produces a synthetic commit; GitHub's keyword auto-close only reliably fires from the PR description on certain merge methods, and on squash merges the keyword in the synthesized commit body sometimes does not register. Branch-protection workflows that block immediate merge can also strip the closing-keyword grace window. | After a squash-merge with `Closes #N` in the body, always verify with `gh issue view <N> --json state`. If still OPEN, close manually with `gh issue close <N> --comment 'Resolved by #<PR>'`. Treat issue closure as a separate step, not a side-effect of merging. |
 
 ## Results & Parameters
 
@@ -650,6 +652,22 @@ gh pr list --state open --json number,title,mergeStateStatus,statusCheckRollup
 # UNKNOWN  → CI still running, wait
 ```
 
+### Post-Merge Verification
+
+```bash
+# After every wave completes — verify both PRs merged AND linked issues closed
+gh pr list --state open --author "@me" --json number,title  # should be empty
+for issue in <list of issues that should be closed>; do
+  state=$(gh issue view $issue --json state --jq .state)
+  if [ "$state" != "CLOSED" ]; then
+    gh issue close $issue --comment "Resolved by #<PR>"
+  fi
+done
+```
+
+Note: GitHub's "Closes #N" keyword auto-close is unreliable on squash merges
+(see Failed Attempts row B). Always verify and close manually if needed.
+
 ### Cherry-pick Rebase for Stale PR
 
 ```bash
@@ -679,3 +697,4 @@ gh pr close <old-pr> --comment "Superseded by #<new-pr>"
 | ProjectScylla | Wave 2b/2c continuation, 6 PRs (#1799-#1804), conflict resolution for PR #1803 | 2026-04-13 |
 | ProjectKeystone | 180-issue C++20/NATS swarm: 7 EASY waves (67 issues) + 9 MEDIUM waves (78 issues) + 25 HARD deferred; confirmed MEDIUM cap at 3 for C++ | 2026-04-25 |
 | ProjectTelemachy | 57 issues, per-file mega-agents collapsed 12 waves → 2; 17 PRs merged | 2026-04-25 |
+| ProjectScylla | 5-PR opus wave (3 decomp + 2 observability follow-ups), 2026-05-07; surfaced auto-merge stall + squash-close failure modes | PRs #1927-#1931, all merged within ~30 min after manual `gh pr merge --squash` after CI went CLEAN; issue #1888 had to be closed manually despite `Closes #1888` keyword |


### PR DESCRIPTION
## Summary
Amends existing skill v2.5.0 → v2.6.0 with two new failure modes from a 2026-05-07 ProjectScylla 5-PR opus wave:

1. **GitHub auto-merge worker stall**: `gh pr merge --auto` did not fire for 12+ min on CLEAN/MERGEABLE PRs. Workaround: manual `gh pr merge --squash` after CI passes.
2. **Squash-merge keyword auto-close failure**: `Closes #N` in PR/commit body did not close the linked issue. Workaround: explicit `gh issue close` follow-up.

## Verification Level
**verified-local** — observed in this session on PRs #1927-#1931 and issue #1888 in HomericIntelligence/ProjectScylla.

## Test Plan
- [x] Validate with python3 scripts/validate_plugins.py
- [ ] Re-validate on next ProjectScylla wave

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>