### PR TITLE
feat: amend tooling-sub-agent-pr-trust-but-verify skill (v1.1.0)

### DIFF
--- a/skills/tooling-sub-agent-pr-trust-but-verify.history
+++ b/skills/tooling-sub-agent-pr-trust-but-verify.history
@@ -1,10 +1,36 @@
+# tooling-sub-agent-pr-trust-but-verify — History
+
+## v1.1.0 (2026-05-07)
+
+**Changed by:** ProjectHermes 31-PR rebase swarm session (caught a Haiku agent corrupting PR #452's content)
+**Verification:** verified-ci
+
+### What changed
+
+- Added new "When to Use" trigger (#3) for content-corruption suspicion
+- Added new section "Verifying Branch Content Against PR Intent" with detection commands and recovery procedure
+- Added Failed Attempts row documenting the PR #452 case
+- Bumped to v1.1.0
+
+### Why
+
+The original v1.0.0 covered verifying GitHub state (PR opened, merged, armed) against
+the API. But sub-agents can also corrupt **commit content** during conflict resolution
+while still producing a clean GitHub state. In the ProjectHermes session, a Haiku agent
+on PR #452 (config DI refactor) produced a force-pushed commit whose content was
+actually from PR #555 (Docker pip pinning). GitHub showed the PR as CLEAN with auto-merge
+armed; only manual `git diff --stat` inspection caught the wrong content. This is a
+distinct failure mode from the GitHub-state mismatches the original skill covered.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
 ---
 name: tooling-sub-agent-pr-trust-but-verify
-description: "Verify sub-agent PR reports against the GitHub API before assuming success. Use when: (1) a sub-agent reports a PR was opened/merged/auto-armed, (2) you need to confirm scope and merge state of an opaque-to-you sub-agent run, (3) a sub-agent reports 'rebased and pushed' but you suspect content corruption — verify with `git diff origin/main..origin/<branch> --stat` that the changed files match the PR's stated intent (e.g., a 'config refactor' PR should not show Dockerfile changes)."
+description: "Verify sub-agent PR reports against the GitHub API before assuming success. Use when: (1) a sub-agent reports a PR was opened/merged/auto-armed, (2) you need to confirm scope and merge state of an opaque-to-you sub-agent run."
 category: tooling
-date: 2026-05-07
-version: "1.1.0"
-history: tooling-sub-agent-pr-trust-but-verify.history
+date: 2026-05-06
+version: "1.0.0"
 user-invocable: false
 verification: verified-local
 tags:
@@ -72,75 +98,6 @@ cd /tmp/<sub-agent-worktree> && git fetch origin && git rebase origin/<base>
 4. If auto-merge silently failed (sub-agent reports armed, but `autoMergeRequest` is `null` in the API): the repo's allowed merge methods don't include the one the sub-agent tried. Re-arm with the right method (`--squash` instead of `--rebase`, etc.).
 5. Only THEN move on to the next dependent task.
 
-## Verifying Branch Content Against PR Intent
-
-Sub-agents can corrupt commit content during conflict resolution while still
-producing a successful push. The git operations succeed; the push succeeds;
-GitHub's mergeable state is fine; CI may even pass — but the branch contains
-the WRONG content. This is invisible to GitHub-state checks.
-
-### When This Happens
-
-- A sub-agent rebases PR A but its conflict resolution pulls in content from
-  sibling PR B (likely if both PRs touch overlapping files and the agent
-  reads the wrong commit during a multi-step resolution)
-- A sub-agent uses `git checkout --theirs` or `--ours` on the wrong file
-- A sub-agent's `git rebase --continue` lands content from an unrelated
-  cherry-pick
-- A sub-agent reuses an existing worktree that was previously checked out
-  to a different branch with similar file paths
-
-### How to Detect
-
-After ANY sub-agent reports "rebased and pushed", run this verification:
-
-```bash
-PR=<pr-number>
-BRANCH=$(gh pr view $PR --json headRefName --jq '.headRefName')
-
-# Fetch the post-push branch tip
-git fetch origin "$BRANCH" 2>/dev/null
-
-# Compare PR title's intent against actual changed files
-echo "--- PR title says: ---"
-gh pr view $PR --json title --jq '.title'
-
-echo "--- Branch's diff stat (changed files) ---"
-git diff origin/main..origin/"$BRANCH" --stat
-
-echo "--- Branch tip commit message ---"
-git log origin/"$BRANCH" -1 --format="%s%n%b"
-```
-
-**Mismatch indicators:**
-
-- A "refactor(config): ..." PR's diff shows `Dockerfile` or `requirements.txt`
-- A "fix(docker): ..." PR's diff shows `tests/test_config.py`
-- The commit message subject line doesn't match the PR title
-
-### How to Recover
-
-When mismatch is detected:
-
-```bash
-# Find the branch's reflog (works if you still have local clone of the branch)
-git reflog "$BRANCH"
-# Identify the SHA of the original PR commit (before sub-agent's rebase)
-# Reset the branch to that SHA
-git checkout "$BRANCH"
-git reset --hard <original-sha>
-# Re-rebase manually, watching for the actual conflict
-git rebase origin/main
-# Resolve conflicts yourself, verify diff matches PR intent, push
-git diff origin/main..HEAD --stat
-git push --force-with-lease origin "$BRANCH"
-```
-
-### Detection Time Cost
-
-This check takes ~2 seconds per PR (one git fetch + one git diff + one gh
-view). Include it in every post-agent-completion sweep — never skip.
-
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -149,7 +106,6 @@ view). Include it in every post-agent-completion sweep — never skip.
 | Trust merge-method hint | Sub-agent ran `gh pr merge --auto --rebase`; the command exited 0 silently | Repo had rebase-merge disabled. `gh` errored once verbosely on the first attempt and then silently no-op'd subsequent ones. The PR was sitting OPEN with no auto-merge configured. | Check `autoMergeRequest` in the API response, not just the gh exit code. `null` means no auto-merge is set, regardless of what the command appeared to do. |
 | Skim file list | Sub-agent reported "modified subscriber.go and added test" without listing exact paths | A sub-agent's understanding of "modified" can include `go.sum` churn or formatter sweep. One sub-agent's PR included an accidental `go.sum` reorder when it ran `go mod tidy`. | The `files: [.files[].path]` array in `gh pr view --json` is the only authoritative scope. Anything not in your brief belongs in the discussion before merge. |
 | Trust "all tests pass" | Sub-agent reports green tests | True at sub-agent's local moment; not necessarily true on origin after a concurrent merge changed shared code. | Re-checking CI status (`statusCheckRollup`) post-rebase is part of verify, not the sub-agent's job. |
-| Trusted "rebased and pushed" report from a Haiku rebase agent | Agent on PR #452 (config DI refactor) reported success; force-push went through; GitHub showed CLEAN state; CI was running | The agent's commit message and content were actually from sibling PR #555 (Docker pip pinning) — completely wrong domain for #452's stated intent. Caught only when orchestrator inspected `git diff --stat` post-push. The push wasn't broken; the conflict resolution silently picked the wrong commit's content during multi-step rebase. **Lesson: every sub-agent rebase needs a post-hoc `git diff origin/main..HEAD --stat` verification against the PR title's domain — git operations succeeding ≠ correct content** |
 
 ## Results & Parameters
 
@@ -183,3 +139,10 @@ Watch fields and what they mean:
 | Project | Context | Details |
 |---------|---------|---------|
 | HomericIntelligence/ProjectArgus | Atlas v0.2.1 patch series — 14+ sub-agent PRs orchestrated in May 2026 | Caught one conflicting PR (#472), one silent auto-merge failure (rebase forbidden), and several scope-creep go.sum churns |
+```
+
+---
+
+## v1.0.0 (2026-05-06)
+
+**Initial version.** Verify sub-agent PR reports against the GitHub API before assuming success.


### PR DESCRIPTION
## Summary

- Amends `tooling-sub-agent-pr-trust-but-verify` to v1.1.0, capturing a new failure class observed in a 31-PR rebase swarm session: sub-agent's git/push operations succeed and GitHub state is clean, but the commit content is from the wrong PR (cross-contamination during multi-step conflict resolution).
- Adds a new "When to Use" trigger (#3) for content-corruption suspicion.
- Adds a new section "Verifying Branch Content Against PR Intent" with a 3-line `git diff --stat`-based detection recipe and a recovery procedure via reflog + manual rebase + `--force-with-lease`.
- Adds a Failed Attempts row documenting the PR #452 case (a Haiku rebase agent silently landed PR #555's Docker pip-pinning content onto PR #452's config DI refactor branch).
- Creates `tooling-sub-agent-pr-trust-but-verify.history` with the v1.1.0 entry and the full verbatim v1.0.0 snapshot.

## Test plan

- [x] `python3 scripts/validate_plugins.py` — 1001/1001 valid
- [x] Frontmatter `version` bumped to `1.1.0`, `date` to `2026-05-07`, `history:` field added
- [x] v1.0.0 content preserved verbatim in `.history`
- [x] No existing skill content removed; only additive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)