### PR TITLE
feat: amend worktree-parallel-agent-execution skill (v1.3.0)

### DIFF
--- a/skills/worktree-parallel-agent-execution.history
+++ b/skills/worktree-parallel-agent-execution.history
@@ -1,5 +1,68 @@
 # worktree-parallel-agent-execution — History
 
+## v1.3.0 (2026-05-16)
+
+**Changed by:** ProjectAgamemnon Myrmidon-swarm 2026-05-16 (PRs #386 collision recovery + #387-#390 success)
+**Verification:** verified-ci
+
+### What changed
+
+- Added new subsection "Branch collision hardening (v1.3.0)" inside "Verified Workflow":
+  issue-number-suffixed branch naming + mandatory `git ls-remote --exit-code --heads origin`
+  collision check before push
+- Extended frontmatter `description` with trigger (9): parallel worktree agents pushing to
+  overlapping remote branch refs even with correct `isolation: "worktree"`
+- Added 1 new Failed Attempts row: four parallel Haiku bundle agents (4-7) with
+  `isolation: "worktree"` and no branch-name uniqueness guarantee causing 26 commits to collapse
+  onto a single remote branch under one PR (#386)
+- Added 1 new Verified On row for ProjectAgamemnon 2026-05-16 swarm session
+- Bumped version to 1.3.0 (minor — new section, new failure, no breaking changes)
+
+### Why
+
+Phase 0a (v1.2.0) established that `Task isolation=worktree` does NOT prevent index/HEAD
+contention. This amendment documents a second, orthogonal failure mode: even when each agent
+correctly uses its own LOCAL worktree branch, all worktrees share the same remote. If branch
+names collide (e.g., four agents all following the same naming template without an issue-number
+suffix), `git push` from any agent can overwrite or land on top of a sibling's push, collapsing
+N separate branches onto a single remote ref and a single PR. Fix is two-step: (1) require
+issue-number-suffixed branch names, (2) mandate `git ls-remote --exit-code` collision check
+inside every parallel-agent prompt before push.
+
+### Previous version (v1.2.0) snapshot
+
+```markdown
+---
+name: worktree-parallel-agent-execution
+description: "Use when: (1) resolving 3+ independent GitHub issues simultaneously with sub-agents, (2) mass-rebasing many PR branches in parallel without collision, (3) triaging issues by complexity then executing LOW items in a single parallel wave, (4) avoiding merge conflicts when multiple agents work on the same repo, (5) splitting ONE multi-part GitHub issue into N independent parallel sub-tasks with hot-file ownership coordination, (6) `Task isolation=worktree` agents reporting they see stat-cache differences from sibling agents (`please run git restore CLAUDE.md`), (7) parallel haiku/sonnet swarm dispatch on EASY-tier batches where agents commit to the parent repo's checked-out branch instead of their own worktree branch, (8) writing Mnemosyne `/learn` skill amendments in parallel (serialize instead — branch contamination is possible)."
+category: tooling
+date: 2026-05-09
+version: "1.2.0"
+user-invocable: false
+verification: verified-ci
+history: worktree-parallel-agent-execution.history
+tags: [parallel-agents, worktree, wave-execution, batch, rebase, issue-triage, automation, split-issue, hot-file-coordination]
+---
+# Worktree Parallel Agent Execution
+
+## Overview
+
+| Field | Value |
+| ------ | ----------- |
+| **Date** | 2026-05-07 |
+| **Objective** | Launch N parallel sub-agents in isolated worktrees for parallel issue/PR execution AND single-issue splitting |
+| **Outcome** | verified-ci (PRs #1932, #1933 merged from #1887 split); consolidates 5 prior skills |
+| **Verification** | verified-ci |
+| **History** | [changelog](./worktree-parallel-agent-execution.history) |
+
+[... full v1.2.0 body was 568 lines — see git ref prior to this commit for complete snapshot ...]
+```
+
+(Full v1.2.0 markdown was 568 lines. See `git show HEAD~1:skills/worktree-parallel-agent-execution.md`
+for the complete pre-amendment snapshot.)
+
+---
+
 ## v1.2.0 (2026-05-09)
 
 **Changed by:** ProjectOdyssey Phase G EASY-tier consolidation (PR #5363, 8-agent swarm contamination)

--- a/skills/worktree-parallel-agent-execution.md
+++ b/skills/worktree-parallel-agent-execution.md
@@ -1,9 +1,9 @@
 ---
 name: worktree-parallel-agent-execution
-description: "Use when: (1) resolving 3+ independent GitHub issues simultaneously with sub-agents, (2) mass-rebasing many PR branches in parallel without collision, (3) triaging issues by complexity then executing LOW items in a single parallel wave, (4) avoiding merge conflicts when multiple agents work on the same repo, (5) splitting ONE multi-part GitHub issue into N independent parallel sub-tasks with hot-file ownership coordination, (6) `Task isolation=worktree` agents reporting they see stat-cache differences from sibling agents (`please run git restore CLAUDE.md`), (7) parallel haiku/sonnet swarm dispatch on EASY-tier batches where agents commit to the parent repo's checked-out branch instead of their own worktree branch, (8) writing Mnemosyne `/learn` skill amendments in parallel (serialize instead — branch contamination is possible)."
+description: "Use when: (1) resolving 3+ independent GitHub issues simultaneously with sub-agents, (2) mass-rebasing many PR branches in parallel without collision, (3) triaging issues by complexity then executing LOW items in a single parallel wave, (4) avoiding merge conflicts when multiple agents work on the same repo, (5) splitting ONE multi-part GitHub issue into N independent parallel sub-tasks with hot-file ownership coordination, (6) `Task isolation=worktree` agents reporting they see stat-cache differences from sibling agents (`please run git restore CLAUDE.md`), (7) parallel haiku/sonnet swarm dispatch on EASY-tier batches where agents commit to the parent repo's checked-out branch instead of their own worktree branch, (8) writing Mnemosyne `/learn` skill amendments in parallel (serialize instead — branch contamination is possible), (9) parallel worktree agents pushing to overlapping remote branch refs even with correct `isolation: \"worktree\"` — different agents racing on similar branch names produce a single union branch under one PR rather than N separate PRs."
 category: tooling
-date: 2026-05-09
-version: "1.2.0"
+date: 2026-05-16
+version: "1.3.0"
 user-invocable: false
 verification: verified-ci
 history: worktree-parallel-agent-execution.history
@@ -157,6 +157,59 @@ CRITICAL — branch-namespace check before EVERY commit:
 Do NOT trust `cd <worktree>` — always pass `git -C <absolute-worktree-path>` to every git
 command and verify the branch name before commit/push.
 ```
+
+### Branch collision hardening (v1.3.0)
+
+**Failure mode (ProjectAgamemnon swarm 2026-05-16):** Four parallel Haiku bundle agents
+(Bundles 4, 5, 6, 7) each used `isolation: "worktree"` correctly, so their LOCAL working
+trees were separate. But all four followed the same branch-naming template
+(`bundle/simple-sweep-N-2026-05-16`) without an issue-number uniqueness guarantee. The result:
+26 commits from 4 distinct local branches collapsed onto a single remote branch
+(`bundle/simple-sweep-7-2026-05-16`) under one PR (#386), with the PR body listing only
+Bundle 7's 10 issues. Recovery required rewriting the PR body to `Closes #N. Closes #M. …`
+for all 26 actually-delivered issues and deleting an orphan branch.
+
+**Root cause:** Worktrees share the same remote. `git push -u origin <branch>` from agent A
+may land on the same remote ref as agent B if their branch names are identical or if one agent's
+push races and overwrites another's. `Task isolation=worktree` guarantees no LOCAL state
+contamination, but it does NOT guarantee REMOTE branch uniqueness.
+
+**Fix — two-step hardening (verified 2026-05-16 via PRs #387-#390):**
+
+**Step 1 — Issue-number-suffixed branch names.** Every parallel agent must embed the primary
+issue number (and optionally a date) in its branch name to guarantee uniqueness across the wave:
+
+```
+# Pattern: <theme>-<issue-number(s)>-<date>
+medium/clang-tidy-version-info-177-2026-05-16
+medium/cmake-cleanup-182-189-2026-05-16
+medium/tsan-preset-185-2026-05-16
+medium/version-consistency-script-331-2026-05-16
+```
+
+**Step 2 — Mandatory `git ls-remote` collision check inside every agent prompt, BEFORE push:**
+
+```bash
+git ls-remote --exit-code --heads origin <branch> && { echo "FATAL: branch exists on remote"; exit 1; }
+git push -u origin <branch>
+```
+
+**Hard rule for every parallel-agent prompt:**
+
+```text
+CRITICAL — remote branch collision check before push:
+
+  git ls-remote --exit-code --heads origin <my-branch-name> \
+    && { echo "FATAL: branch <my-branch-name> already exists on remote — STOP"; exit 1; }
+  git push -u origin <my-branch-name>
+
+If the collision check fails, STOP and report — do NOT retry with a different name.
+The orchestrator must diagnose why the branch already exists before proceeding.
+```
+
+**Success verification:** After applying v1.3.0 hardening, four parallel Sonnet MEDIUM-Wave-1
+agents (issues #177, #182+189, #185, #331) produced four distinct PRs (#387, #388, #389, #390)
+with zero branch collisions or PR merges.
 
 ### Phase 0: Splitting a Single Issue with Shared Docs/Config Files (v1.1.0)
 
@@ -508,6 +561,7 @@ pixi run mypy <package>/
 | Trusting local pre-commit pass after manual rebase conflict resolution | Resolved markdownlint conflict, force-pushed without rerunning hooks | Manual edit during conflict resolution introduced missing-blank-line; CI markdownlint failed | Always run `pre-commit run --files <changed>` AFTER manually resolving rebase conflicts, BEFORE force-push |
 | Parallel `Task isolation=worktree` on 8 EASY-tier branches (ProjectOdyssey #5363) | Dispatched 8 haiku/sonnet agents simultaneously, each assigned a distinct issue branch | Multiple agents committed to whichever branch the parent repo's working tree had checked out; sibling agents reported `please run git restore CLAUDE.md` from stat-cache deltas | `Task isolation=worktree` is path-isolated but NOT branch/index-isolated when N agents target N distinct branches sharing parent `.git/`. For EASY-tier batches, serialize OR consolidate via cherry-pick into ONE branch (see Phase 0a) |
 | Parallel Mnemosyne `/learn` skill amendments | Launched 5 parallel sub-agents to amend 5 different skills on shared `~/.agent-brain/ProjectMnemosyne` clone | Same branch-namespace contamination pattern as ProjectOdyssey #5363; agents wrote to wrong skill files / wrong branches | Serialize `/learn` invocations OR ensure each agent uses a TRULY independent clone (not just a worktree off the shared clone) |
+| Parallel Haiku bundle agents (4-7) with `isolation: "worktree"`, no branch-name uniqueness guarantee | Four agents used `isolation: "worktree"` correctly; each pushed its own local worktree branch named `bundle/simple-sweep-N-2026-05-16` | 26 commits from 4 distinct branches collapsed onto a single remote branch `bundle/simple-sweep-7-2026-05-16` under one PR (#386); PR body listed only one bundle's issues, leaving 16 silently fixed-but-unclosed | Worktree isolation guarantees no LOCAL state contamination but does NOT guarantee REMOTE branch uniqueness. Always use issue-number-suffixed names + `git ls-remote --exit-code --heads origin <branch>` collision check before push. |
 
 ## Results & Parameters
 
@@ -565,3 +619,4 @@ This ensures agents cannot push directly to main.
 | ProjectOdyssey | 70 PRs rebased (v1.0) and 13 PRs (v1.1) | parallel-rebase-agent-worktree-isolation 2026-03-15/27 |
 | ProjectScylla | Issue #1887 (JSON-logging/tracing/metrics) split into PRs #1932 (squash-merged green, 22 checks) and #1933 (~24 checks after markdownlint fix) | 2026-05-07 — verified-ci foundation for v1.1.0 split-issue pattern |
 | ProjectOdyssey | Phase G EASY-tier 8-issue swarm contamination (PR #5363, 67/68 substantive checks green); recovery via cherry-pick consolidation; close individual worker PRs | 2026-05-09 — verified-ci foundation for v1.2.0 Phase 0a branch-namespace contamination warning |
+| ProjectAgamemnon | 2026-05-16 swarm session (PRs #386 collision recovery + #387-#390 success after fix) | — |


### PR DESCRIPTION
## Summary

- Adds **Branch collision hardening (v1.3.0)** subsection to the Verified Workflow documenting a new failure mode: parallel worktree agents with correct `isolation: "worktree"` can still push to overlapping remote branch refs if their branch names collide
- Mandates issue-number-suffixed branch naming pattern per agent (e.g., `medium/issue-<N>-<date>`) to guarantee uniqueness across parallel waves
- Mandates `git ls-remote --exit-code --heads origin <branch>` collision check inside every parallel-agent prompt before push, with hard-stop if collision detected
- Extends frontmatter `description` with trigger (9) for the new remote-branch-collision scenario
- Adds 1 new Failed Attempts table row (Bundles 4-7 Haiku collapse onto single remote branch, PR #386)
- Adds 1 new Verified On row (ProjectAgamemnon 2026-05-16 PRs #387-#390 success after fix)
- Prepends v1.2.0 → v1.3.0 changelog + v1.2.0 snapshot to `.history` file

## Evidence

**Failure:** ProjectAgamemnon swarm 2026-05-16, four parallel Haiku bundle agents (Bundles 4-7) with `isolation: "worktree"`. 26 commits from 4 distinct local branches collapsed onto a single remote branch `bundle/simple-sweep-7-2026-05-16` under PR #386. Recovery required rewriting PR body and deleting orphan branch.

**Success:** Same session, after applying v1.3.0 hardening: four parallel Sonnet MEDIUM-Wave-1 agents (issues #177, #182+189, #185, #331) produced PRs #387, #388, #389, #390 with zero collisions.

## Validation

`python3 scripts/validate_plugins.py` — 1075/1075 valid.

## Test plan

- [x] `python3 scripts/validate_plugins.py` passes (1075/1075 valid)
- [x] Only `skills/worktree-parallel-agent-execution.md` and `skills/worktree-parallel-agent-execution.history` modified
- [x] Commit is GPG-signed
- [x] Frontmatter `version: "1.3.0"`, `date: "2026-05-16"` updated
- [x] No other skill files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)