### PR TITLE
feat: amend audit-strict-full-swarm-coverage skill (v1.1.0)

### DIFF
--- a/skills/audit-strict-full-swarm-coverage.history
+++ b/skills/audit-strict-full-swarm-coverage.history
@@ -1,0 +1,48 @@
+# audit-strict-full-swarm-coverage — History
+
+## v1.1.0 (2026-05-17)
+
+**Changed by:** ProjectAgamemnon 2026-05-17 audit session
+**Verification:** verified-local
+
+### What changed
+
+- Added second project verification entry: ProjectAgamemnon 2026-05-17 (B- 78% CONDITIONAL GO; 1 critical / 19 major / ~15 minor).
+- Added new Failed Attempt row: choosing `feature-dev:code-reviewer` subagent type fails because it lacks Bash (cannot run `find`, `gh`, `git log` for evidence gathering). Must use `subagent_type: general-purpose`.
+- Added new Failed Attempt row: running the audit as a single sequential agent overflows context partway through Section 8 — the per-section swarm is the only working approach.
+- Added Step 3 note: when the swarm runtime allows it, all 15 sections can be dispatched in a single message (one parallel batch); 3 waves of 5 remain the conservative fallback when concurrency caps apply.
+- Added Step 4 note: subagent type must be `general-purpose` (read-only review subagents like `feature-dev:code-reviewer` lack the Bash tool needed for evidence gathering).
+- Confirmed strict rubric prevents grade inflation on a second project (Agamemnon's B- matches Scylla's pattern).
+
+### Why
+
+The original v1.0.0 was verified on a single project (ProjectScylla). Re-running the
+methodology on ProjectAgamemnon surfaced two new gotchas that would otherwise be
+re-discovered the hard way: (a) sequential single-agent attempts blow context, and
+(b) `feature-dev:code-reviewer` is the wrong subagent type despite being a natural
+first guess. Both lessons are now captured in Failed Attempts.
+
+### Previous version (v1.0.0) snapshot
+
+```
+---
+name: audit-strict-full-swarm-coverage
+description: "Methodology for running a strict, full-coverage repository audit by dispatching one swarm agent per audit section in waves of 5. Use when: (1) running /hephaestus:repo-analyze-strict-full or equivalent full-coverage audit on a repo with >500 files, (2) bug-finding completeness matters and sampling is unsafe, (3) you need pre-release readiness review with strict grading (default F, evidence required), (4) single-agent audits are overflowing context or producing shallow results."
+category: tooling
+date: 2026-05-07
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [audit, repo-analyze, swarm, myrmidon, strict-grading, full-coverage, wave-dispatch, bucketing, go-no-go]
+---
+
+(Body identical to v1.0.0 — see git history at commit f890f900 for full text.
+ProjectScylla verification: 1821 files, 168 src .py; B- (82%); CONDITIONAL GO;
+3 critical / 19 major / 3 grouped minor; issues #1934-#1959.)
+```
+
+---
+
+## v1.0.0 (2026-05-07)
+
+**Initial version.** Verified on ProjectScylla.

--- a/skills/audit-strict-full-swarm-coverage.md
+++ b/skills/audit-strict-full-swarm-coverage.md
@@ -2,10 +2,11 @@
 name: audit-strict-full-swarm-coverage
 description: "Methodology for running a strict, full-coverage repository audit by dispatching one swarm agent per audit section in waves of 5. Use when: (1) running /hephaestus:repo-analyze-strict-full or equivalent full-coverage audit on a repo with >500 files, (2) bug-finding completeness matters and sampling is unsafe, (3) you need pre-release readiness review with strict grading (default F, evidence required), (4) single-agent audits are overflowing context or producing shallow results."
 category: tooling
-date: 2026-05-07
-version: "1.0.0"
+date: 2026-05-17
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: audit-strict-full-swarm-coverage.history
 tags: [audit, repo-analyze, swarm, myrmidon, strict-grading, full-coverage, wave-dispatch, bucketing, go-no-go]
 ---
 
@@ -15,10 +16,11 @@ tags: [audit, repo-analyze, swarm, myrmidon, strict-grading, full-coverage, wave
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-05-07 |
-| **Objective** | Run a strict, evidence-based full-coverage repository audit by bucketing files per audit section and dispatching one swarm agent per section in waves of 5. |
-| **Outcome** | Successful on ProjectScylla (1821 files, 168 src .py): overall B- (82%), CONDITIONAL GO, 3 critical / 19 major / 3 grouped minor findings filed as issues #1934-#1959. |
+| **Date** | 2026-05-17 |
+| **Objective** | Run a strict, evidence-based full-coverage repository audit by bucketing files per audit section and dispatching one swarm agent per section (in waves of 5 if concurrency is capped, or all 15 in parallel if not). |
+| **Outcome** | Verified on two projects. ProjectScylla 2026-05-07: B- (82%), CONDITIONAL GO, 3 critical / 19 major / 3 grouped minor (issues #1934-#1959). ProjectAgamemnon 2026-05-17: B- (78%), CONDITIONAL GO, 1 critical (triple-copy Python orchestration) / 19 major / ~15 minor, all with file:line citations. Wall-clock ~10-15 min when 15 agents run in parallel. |
 | **Verification** | verified-local |
+| **History** | [changelog](./audit-strict-full-swarm-coverage.history) |
 
 ## When to Use
 
@@ -77,21 +79,25 @@ Bucketing rules:
 - Every file appears in exactly one bucket. Some files (e.g., `pyproject.toml`) span concerns — assign to the dominant one (packaging) and let other sections cross-reference.
 - Save bucket lists as `/tmp/audit-section-NN.txt` so each agent gets a precise, finite worklist.
 
-### Step 3 — Dispatch in waves of 5
+### Step 3 — Dispatch the agents
 
-Swarm runtime caps at 5 concurrent agents. Use 3 waves:
+Two valid topologies, depending on the harness's concurrency cap:
 
-- Wave 1: sections 1–5
-- Wave 2: sections 6–10
-- Wave 3: sections 11–15
+- **Single parallel batch (preferred when concurrency allows):** issue all 15 Agent tool calls in a **single assistant message**. Verified on ProjectAgamemnon 2026-05-17 — completed in ~10-15 min wall-clock.
+- **3 waves of 5 (fallback when the swarm runtime caps at 5 concurrent agents):**
+  - Wave 1: sections 1–5
+  - Wave 2: sections 6–10
+  - Wave 3: sections 11–15
+  - Launch each wave by issuing 5 Agent tool calls in a single assistant message with `run_in_background=true`. Wait for all 5 to complete before launching the next wave.
 
-Launch each wave by issuing 5 Agent tool calls in a **single assistant message** with `run_in_background=true`. Wait for all 5 to complete before launching the next wave (avoid overlap so context budgets stay clean).
+Either way, every section MUST get its own dedicated agent — never collapse multiple sections into one prompt or the agent will run out of context (see Failed Attempts).
 
 ### Step 4 — Per-agent prompt template
 
 Every dispatched agent receives all of:
 
-1. **Section criteria verbatim** — copy the rubric for that section from the parent skill (`/hephaestus:repo-analyze-strict-full`).
+0. **Subagent type: `general-purpose`.** Do NOT use `feature-dev:code-reviewer` despite the natural fit — review subagents are read-only and lack the Bash tool. Audit agents need `Bash` to run `find`, `gh issue list`, `git log`, `grep`, etc. for evidence gathering. `general-purpose` has the full tool palette and is the only working choice.
+1. **Section criteria verbatim** — copy the rubric for that section from the parent skill (`/hephaestus:repo-analyze-strict-full`). Every agent gets the SAME grading rubric + anti-inflation rules so the output format is identical and synthesis is mechanical.
 2. **Strict grading rubric:**
    - Default grade is **F**.
    - **A** requires 0 critical + 0 major + ≤2 minor findings.
@@ -143,8 +149,10 @@ Always file critical and major findings as GitHub issues before merging the audi
 | ------- | -------------- | ------------- | -------------- |
 | Single-agent full audit | One agent reads every file in the repo | Context overflow on >500-file repos; quality drops sharply | Per-section swarm with bucketing keeps each agent's context tight |
 | Sampling-based strict audit | Default `repo-analyze-strict` (10 random + 5 largest + 5 smallest per section) | Misses bugs in unsampled files; cannot honestly claim full coverage | Use the FULL variant when bug-finding completeness matters |
-| Launching all 15 agents at once | Single message with 15 Agent tool calls | Swarm runtime caps at 5 concurrent — extras queue or fail | 3 sequential waves of 5 |
+| Launching all 15 agents at once | Single message with 15 Agent tool calls | On harnesses that cap at 5 concurrent agents, extras queue or fail. On uncapped harnesses (verified ProjectAgamemnon 2026-05-17), this is the FASTEST topology (~10-15 min wall-clock). | Check harness limits first: use single-batch when allowed, fall back to 3 waves of 5 otherwise. |
 | Letting agents pick their own files | No bucketed list; agents discover files via `find` | Overlap (same file audited twice) and gaps (files audited zero times) | Pre-bucket every file into exactly one section list |
+| Sequential single-agent strict-full audit | One agent walks all 15 sections in a single prompt | Ran out of context partway through Section 8 (Security) on ProjectAgamemnon 2026-05-17. Output was truncated and several sections never produced findings. | Strict-full MUST be split per-section — there is no working single-agent variant. |
+| `subagent_type: feature-dev:code-reviewer` | Natural first guess: it's literally a code reviewer | Code-reviewer subagents are read-only and lack the Bash tool. They cannot run `find` to enumerate files, `gh issue list` to check planning state, `git log` for history evidence, or `grep` for cross-cutting concerns. Outputs ended up shallow and citation-free. | Use `subagent_type: general-purpose` for audit agents — the full tool palette is non-negotiable for evidence-based grading. |
 
 ## Results & Parameters
 
@@ -163,6 +171,21 @@ Audit run on ProjectScylla 2026-05-07:
 | Overall weighted grade | B- (82%) |
 | Verdict | CONDITIONAL GO |
 | Issues filed | #1934-#1959 |
+
+Audit run on ProjectAgamemnon 2026-05-17:
+
+| Parameter | Value |
+| --------- | ----- |
+| Audit sections | 15 |
+| Topology | Single parallel batch (15 Agent calls in one message) |
+| Subagent type | `general-purpose` (Sonnet) |
+| Wall-clock duration | ~10-15 min |
+| Critical findings | 1 (triple-copy Python orchestration code) |
+| Major findings | 19 |
+| Minor findings | ~15 |
+| Overall weighted grade | B- (78%) |
+| Verdict | CONDITIONAL GO |
+| All findings cited | file:line citations throughout |
 
 Tunable parameters when applying this skill to other repos:
 
@@ -200,6 +223,7 @@ wc -l /tmp/repo-files.txt
 | Project | Context | Details |
 | ------- | ------- | ------- |
 | ProjectScylla | 2026-05-07 audit | 1821 files, 168 src .py; overall B- (82%); CONDITIONAL GO; 3 critical / 19 major / 3 grouped minor findings filed as issues #1934-#1959 |
+| ProjectAgamemnon | 2026-05-17 audit | Single-batch (15 parallel `general-purpose` Sonnet agents); ~10-15 min wall-clock; overall B- (78%); CONDITIONAL GO; 1 critical (triple-copy Python orchestration) / 19 major / ~15 minor; all findings with file:line citations |
 
 ## Cross-References
 


### PR DESCRIPTION
## Summary

Amends existing skill `audit-strict-full-swarm-coverage` from v1.0.0 to v1.1.0.

Adds a second-project verification (ProjectAgamemnon 2026-05-17) and two new Failed Attempts rows discovered during that audit run.

- New verification entry: ProjectAgamemnon 2026-05-17 (B- 78%, CONDITIONAL GO, 1 critical / 19 major / ~15 minor; ~10-15 min wall-clock for 15 parallel general-purpose Sonnet agents)
- Documented single parallel batch topology (all 15 agents in one assistant message) as the preferred dispatch shape when the swarm runtime has no concurrency cap; 3-waves-of-5 remains the fallback
- Captured `subagent_type` lesson explicitly

## Verification Level

**verified-local**

Methodology executed end-to-end on ProjectAgamemnon on 2026-05-17 and produced a usable B- CONDITIONAL GO report with file:line citations across all 15 sections.

## Key Findings

**What Worked**:
- Single parallel batch of 15 `general-purpose` Sonnet agents (one per audit section) completed in ~10-15 min wall-clock
- Identical rubric per agent made synthesis mechanical
- Strict rubric prevented grade inflation on a second project (Agamemnon B- matches Scylla's B- pattern)

**What Failed**:
- Sequential single-agent strict-full audit → ran out of context partway through Section 8 (must split per-section)
- `subagent_type: feature-dev:code-reviewer` → lacks Bash, cannot run `find`/`gh`/`git log` for evidence; outputs ended up shallow and citation-free (must use `general-purpose`)

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1083/1083 valid)
- [ ] Verify skill appears in marketplace at v1.1.0
- [ ] Test skill discovery with keywords: audit, strict, swarm, repo-analyze, parallel-audit

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>