### PR TITLE
feat(skill): pip-cve-fix-requires-override v2.0.0 — two-pass install

### DIFF
--- a/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.history
+++ b/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.history
@@ -1,0 +1,46 @@
+# pip-cve-fix-requires-override-of-upstream-hard-pin — History
+
+## v2.0.0 (2026-05-17)
+
+**Changed by:** AchaeanFleet PR #662 follow-up commit `210735b` (fix(deps): two-pass pip install to clear CVEs)
+**Verification:** verified-ci — full CI watched green on AchaeanFleet PR #662 after the two-pass refactor (Trivy filesystem scan, `security/dependency-scan`, build-and-push all passed).
+
+### What changed (breaking — version bumped MAJOR)
+
+The v1.0.0 workflow — a single `requirements.txt` listing `<upstream>==<latest>` alongside `<transitive>>=<fixed>` overrides — **does not work** with pip's modern resolver. v1.0.0's "verified-local" claim was based on a local install against an already-cached environment; a clean Docker build hits `ResolutionImpossible` and aborts.
+
+v2.0.0 replaces the single-file pattern with a **two-pass pip install**:
+
+1. **`requirements.txt`** contains only the upstream pin (`<upstream>==<latest>`) — resolver-satisfiable on its own.
+2. **`requirements-security-overrides.txt`** contains only the `>=<fixed>` overrides with explanatory header and per-line CVE ids.
+3. The Dockerfile runs **two separate `pip install` invocations**:
+   - Pass 1: `pip install --no-cache-dir -r requirements.txt`
+   - Pass 2: `pip install --no-cache-dir --upgrade -r requirements-security-overrides.txt`
+4. A smoke check (`RUN <binary> --version`) follows pass 2 to catch any breakage from the override.
+
+Also added:
+- New "Why two passes work when one does not" subsection explaining the per-invocation nature of the pip resolver.
+- New failed-attempt rows for the single-file approach (the v1.0.0 pattern), aider downgrade, and forking aider.
+- New tags `two-pass-install` and `ResolutionImpossible`.
+- Verification upgraded from `verified-local` to `verified-ci`.
+- Header description rewritten to describe the two-pass mechanism.
+- Date updated 2026-05-16 → 2026-05-17.
+
+### Why
+
+The original skill's "pip warns but installs" claim was wrong against modern pip (resolver default since 20.3). The actual CI run on AchaeanFleet PR #662 surfaced the `ResolutionImpossible` failure mode, and the two-pass install was the verified fix that produced a green CI. Keeping v1.0.0 advice in circulation would steer future readers into the same broken state.
+
+### Previous version (v1.0.0) snapshot
+
+---
+version: "1.0.0"
+date: 2026-05-16
+verification: verified-local
+---
+
+Content prior to v2.0.0 amendment is preserved in the git history at commit `5fd934b9` on branch `main`. To recover, run:
+
+```bash
+git -C ~/.agent-brain/ProjectMnemosyne show 5fd934b9:skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md \
+  > /tmp/pip-cve-override-v1.0.0.md
+```

--- a/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md
+++ b/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md
@@ -1,11 +1,11 @@
 ---
 name: pip-cve-fix-requires-override-of-upstream-hard-pin
-description: "Fix Trivy/pip-audit HIGH/CRITICAL CVEs flagged in transitive pip deps that an upstream package hard-pins with `==`. Bumping the upstream to its latest version usually does NOT clear the CVEs because the new upstream still hard-pins the same vulnerable transitive versions. Force-override the transitive deps post-upstream in `requirements.txt`. Use when: (1) Trivy/pip-audit reports CVEs in transitive deps of a plain pip-installed package (no pixi solver in play), (2) `pip show <upstream> | grep Requires` or PyPI `requires_dist` shows `==` hard-pins on the flagged transitive deps, (3) bumping the upstream alone closes zero or fewer CVEs than expected, (4) `.trivyignore` is undesirable because the CVEs are remotely exploitable or the team has a no-suppressions policy."
+description: "Fix Trivy/pip-audit HIGH/CRITICAL CVEs flagged in transitive pip deps that an upstream package hard-pins with `==`. Bumping the upstream alone does NOT clear the CVEs because the new upstream still hard-pins the same vulnerable transitive versions. Force-override the transitive deps using a TWO-PASS pip install: pass 1 installs the upstream from `requirements.txt` (resolver satisfied), pass 2 installs `requirements-security-overrides.txt` with `--upgrade` (separate resolver invocation deliberately replaces the transitive pins). Use when: (1) Trivy/pip-audit reports CVEs in transitive deps of a plain pip-installed package (no pixi solver in play), (2) `pip show <upstream> | grep Requires` or PyPI `requires_dist` shows `==` hard-pins on the flagged transitive deps, (3) bumping the upstream alone closes zero or fewer CVEs than expected, (4) `.trivyignore` is undesirable because the CVEs are remotely exploitable or the team has a no-suppressions policy."
 category: ci-cd
-date: 2026-05-16
-version: "1.0.0"
+date: 2026-05-17
+version: "2.0.0"
 user-invocable: false
-verification: verified-local
+verification: verified-ci
 tags:
   - trivy
   - pip-audit
@@ -20,6 +20,8 @@ tags:
   - urllib3
   - vulnerability-scan
   - force-override
+  - two-pass-install
+  - ResolutionImpossible
 ---
 
 # pip-cve-fix-requires-override-of-upstream-hard-pin
@@ -28,10 +30,10 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-05-16 |
+| **Date** | 2026-05-17 |
 | **Objective** | Clear Trivy/pip-audit HIGH/CRITICAL CVEs flagged against transitive pip dependencies that an upstream package hard-pins with `==`, when bumping the upstream alone does not close the CVEs. |
-| **Outcome** | Success — appending `>=<fixed-version>` overrides for the flagged transitive deps after the upstream entry in `requirements.txt` produces pip warnings about violated `==` pins but installs the requested versions, clearing the CVEs. |
-| **Verification** | verified-local — applied to `vessels/aider/requirements.txt` on HomericIntelligence/AchaeanFleet PR #662, signed commit `f22ae88`, REST `verified=true reason=valid`. Security CI (Trivy filesystem scan, `security/dependency-scan`) was still QUEUED at skill capture; root-cause analysis was complete and the override is the only path forward because upstream `==` pins block all other approaches. |
+| **Outcome** | Success — splitting the upstream pin and the security overrides into two separate files and running pip install **twice** (a second `--upgrade` pass for the overrides) cleanly replaces the vulnerable transitive deps, clearing the CVEs. A single-file approach is **not viable** because pip's resolver raises `ResolutionImpossible` on the conflicting `==` vs `>=` constraints. |
+| **Verification** | verified-ci — applied to `vessels/aider/` on HomericIntelligence/AchaeanFleet PR #662, signed commit `210735b`. Full CI watched green (Trivy filesystem scan, `security/dependency-scan`, build-and-push). |
 
 ## When to Use
 
@@ -42,6 +44,7 @@ tags:
   curl -s https://pypi.org/pypi/<upstream>/json | jq '.info.requires_dist' | grep -iE '<dep1>|<dep2>'
   ```
 - You explicitly do NOT want to use `.trivyignore` (CVEs are remotely exploitable, or per-CVE rationale rot is unacceptable). For genuinely unfixable CVEs, see `ci-cd-pip-audit-ignore-vuln-allowlist-with-tracking-issue`.
+- Common targets: AI/ML tooling that pins aggressively (aider-chat, langchain, llama-index, certain HuggingFace tooling).
 
 ## Verified Workflow
 
@@ -53,22 +56,50 @@ curl -s https://pypi.org/pypi/<upstream>/json | jq '.info.requires_dist' \
   | grep -iE '<dep1>|<dep2>|<dep3>'
 # Expect to see lines like "GitPython==3.1.46", "pillow==12.1.1", "urllib3==2.6.3"
 
-# 2. Bump upstream to latest stable (pin to a specific version, not a range)
-#    AND append >= overrides for each flagged transitive dep with the fixed version.
+# 2. Split requirements into TWO files:
+#    requirements.txt — only the upstream pin (resolver-satisfiable on its own)
 cat > requirements.txt <<'EOF'
 <upstream>==<latest>
+EOF
+
+#    requirements-security-overrides.txt — only the upgrade-only overrides
+cat > requirements-security-overrides.txt <<'EOF'
+# Security overrides applied AFTER <upstream> install (two-pass pattern).
+# <upstream> hard-pins these transitive deps at vulnerable versions; pip's
+# resolver cannot satisfy both pins simultaneously, so we install them in
+# a second --upgrade pass that deliberately overwrites the transitive pins.
 GitPython>=<fixed>     # CVE-XXXX-XXXXX, CVE-XXXX-YYYYY
 Pillow>=<fixed>        # CVE-XXXX-ZZZZZ
 urllib3>=<fixed>       # CVE-XXXX-WWWWW
 EOF
 
-# 3. Install — pip will print a warning but honour the >= override
-pip install -r requirements.txt
-# Expect: "pip's dependency resolver does not currently take into account ..."
-# Expect: "<upstream> X.Y.Z requires GitPython==A.B.C, but you have GitPython A.B.D which is incompatible."
+# 3. Install in TWO separate pip invocations (two resolver passes)
+pip install --no-cache-dir -r requirements.txt
+pip install --no-cache-dir --upgrade -r requirements-security-overrides.txt
 
-# 4. Re-run the scanner; CVEs against the overridden deps should be cleared
+# 4. Smoke-test the upstream still runs (catches override-induced breakage)
+<binary> --version   # e.g. `aider --version`
+
+# 5. Re-run the scanner; CVEs against the overridden deps should be cleared
 trivy fs --severity HIGH,CRITICAL .
+```
+
+### Dockerfile snippet (verified on AchaeanFleet `vessels/aider/`)
+
+```dockerfile
+COPY vessels/aider/requirements.txt /tmp/requirements.txt
+COPY vessels/aider/requirements-security-overrides.txt /tmp/requirements-security-overrides.txt
+
+# Pass 1: install aider-chat with its own pin set satisfied
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Pass 2: deliberately upgrade transitive deps with CVE patches.
+# This is a SEPARATE resolver invocation — pip will replace the pins
+# from pass 1 because --upgrade is explicit user intent.
+RUN pip install --no-cache-dir --upgrade -r /tmp/requirements-security-overrides.txt
+
+# Smoke check: if the override broke aider, fail the build now (not at runtime)
+RUN aider --version
 ```
 
 ### Detailed Steps
@@ -81,7 +112,7 @@ trivy fs --severity HIGH,CRITICAL .
      | jq -r '.info.requires_dist[]' \
      | grep -iE '<dep1>|<dep2>|<dep3>'
    ```
-   If you see `==` (not `>=` or `~=`), this skill applies. If you see range constraints, prefer plain upstream bump or `pixi-pip-audit-cve-pinning` (pixi projects).
+   If you see `==` (not `>=` or `~=`), this skill applies. If you see range constraints, prefer a plain upstream bump or `pixi-pip-audit-cve-pinning` (pixi projects).
 
 3. **Check the latest upstream version first to verify it does NOT already include the fix.** Many "latest" releases still hard-pin to vulnerable transitive versions:
    ```bash
@@ -90,22 +121,22 @@ trivy fs --severity HIGH,CRITICAL .
    ```
    If the latest upstream's transitive pins are still vulnerable: this skill is required. If patched: a plain bump suffices.
 
-4. **Bump the upstream AND append `>=` overrides** in `requirements.txt`. Order matters: list the upstream first, then the overrides below it. Add a trailing comment with the CVE id(s) for traceability:
-   ```
-   <upstream>==<latest>
-   <dep1>>=<fixed-1>     # CVE-XXXX-XXXXX
-   <dep2>>=<fixed-2>     # CVE-XXXX-YYYYY
-   ```
+4. **Split into two requirements files.** Do NOT attempt a single-file `==` + `>=` override — pip's modern resolver (2020+ resolver, default since 20.3) raises `ResolutionImpossible` and refuses to install anything. The two-pass pattern works because **each `pip install` invocation runs the resolver independently**, and the second invocation with `--upgrade` is explicit user intent that overrides the transitive pins installed in pass 1.
 
-5. **Install locally and observe pip's behaviour.** pip emits a warning that the `==` pin from upstream is violated, but it still installs the requested override version. This is intentional and correct — pip's resolver is "best-effort" for conflicting constraints and prefers the explicit `requirements.txt` entry.
+   - `requirements.txt`: just `<upstream>==<latest>`. The resolver succeeds because there are no conflicts.
+   - `requirements-security-overrides.txt`: only the `>=<fixed>` overrides. Include a header comment explaining the two-pass dependency and listing the CVE ids per line for traceability.
 
-6. **Re-run the scanner.** Verify the CVEs against the overridden deps are cleared. Any remaining CVEs are either (a) in deps the upstream does not hard-pin (covered by `pixi-pip-audit-cve-pinning` / plain bumps), or (b) genuine no-fix-yet cases for `ci-cd-pip-audit-ignore-vuln-allowlist-with-tracking-issue`.
+5. **Install in two separate `pip install` commands.** Pass 1 establishes the upstream. Pass 2 (`--upgrade`) deliberately replaces the transitive deps. The second pass emits no error — pip happily honours the upgrade request.
 
-7. **Open an upstream issue/PR to get the pins natively bumped.** The override is a downstream workaround; the durable fix is for the upstream maintainer to relax their pins. This avoids drift between your override and upstream's pin going forward.
+6. **Add a smoke check (`<binary> --version` or `python -c "import <upstream>; ..."`) immediately after pass 2.** This catches the case where the override actually breaks the upstream at runtime. If the smoke check fails, the build fails — exactly what we want for a CI-gated image.
 
-8. **Sign the commit and verify post-push** per the ecosystem signed-commits rule:
+7. **Re-run the scanner.** Verify the CVEs against the overridden deps are cleared. Any remaining CVEs are either (a) in deps the upstream does not hard-pin (covered by `pixi-pip-audit-cve-pinning` / plain bumps), or (b) genuine no-fix-yet cases for `ci-cd-pip-audit-ignore-vuln-allowlist-with-tracking-issue`.
+
+8. **Open an upstream issue/PR to get the pins natively bumped.** The override is a downstream workaround; the durable fix is for the upstream maintainer to relax their pins. This avoids drift between your override and upstream's pin going forward.
+
+9. **Sign the commit and verify post-push** per the ecosystem signed-commits rule:
    ```bash
-   git commit -S -m "fix(deps): bump <upstream> + override transitive pins to clear CVEs"
+   git commit -S -m "fix(deps): two-pass pip install to clear CVEs in <upstream> transitive pins"
    git push
    gh api repos/<owner>/<repo>/commits/<sha> --jq '.commit.verification'
    # Expect: {"verified": true, "reason": "valid", ...}
@@ -115,16 +146,30 @@ trivy fs --severity HIGH,CRITICAL .
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | ---------------- | --------------- | ---------------- |
-| Bump upstream to latest only | Bumped `aider-chat==0.82.3` → `aider-chat==0.86.2` in `requirements.txt` expecting transitive pins to be patched | aider 0.86.2 still hard-pins `gitpython==3.1.46`, `pillow==12.1.1`, `urllib3==2.6.3` — Trivy still flagged all 7 HIGH CVEs. Closed 0 of 7. | Do not assume "latest = patched". Always check PyPI's `requires_dist` for the actual pinned versions before relying on a bump. |
-| `.trivyignore` for the 7 CVEs | Considered as a fast path to unblock CI | Papers over real vulnerabilities, requires per-CVE rationale that rots fast, and is dishonest when CVEs are remotely exploitable. Conflicts with no-silent-failures policy. | `.trivyignore` is a fallback for genuinely-unfixable-locally CVEs (kernel-side, by-design). For pip hard-pins, force-override is the right tool. |
-| Wait for upstream to bump pins | Considered filing only an upstream issue and accepting CI failure until upstream releases | Upstream cadence is days-to-weeks; CI stays red and blocks unrelated PRs. | File the upstream issue/PR in parallel, but unblock CI immediately with the downstream override. |
+| Bump upstream to latest only | Bumped `aider-chat==0.82.3` → `aider-chat==0.86.2` expecting transitive pins to be patched | aider 0.86.2 still hard-pins `gitpython==3.1.46`, `pillow==12.1.1`, `urllib3==2.6.3` — Trivy still flagged all 7 HIGH CVEs. Closed 0 of 7. | Do not assume "latest = patched". Always check PyPI's `requires_dist` for the actual pinned versions before relying on a bump. |
+| Single-file `==` upstream + `>=` overrides (v1.0.0 of this skill) | Listed `aider-chat==0.86.2` and `GitPython>=3.1.49`, `Pillow>=12.2.0`, `urllib3>=2.7.0` together in one `requirements.txt`; expected pip to warn-but-install | pip's modern resolver raised `ResolutionImpossible` and refused to install anything. The CI Docker build failed at the `pip install -r requirements.txt` step. The v1.0.0 claim that "pip warns but installs" was based on a local install where an older transitive was already cached; a clean resolver pass cannot satisfy both `==3.1.46` and `>=3.1.49` simultaneously. | The modern pip resolver is strict, not best-effort. A single resolver invocation will reject conflicting `==`/`>=` constraints on the same package. Must split into two invocations. |
+| `.trivyignore` for the 7 CVEs | Considered as a fast path to unblock CI | Papers over real vulnerabilities, requires per-CVE rationale that rots fast, and is dishonest when CVEs are remotely exploitable. Conflicts with no-silent-failures policy. | `.trivyignore` is a fallback for genuinely-unfixable-locally CVEs (kernel-side, by-design). For pip hard-pins, two-pass override is the right tool. |
+| Downgrade aider-chat to a pre-vulnerable version | Considered pinning to an aider release that predated the vulnerable transitive pins | Would re-introduce the original CVEs (older aider depended on even older, also-vulnerable, transitive versions). Net CVE count would not improve. | Downgrade-to-escape is rarely a win for security CVEs in long-lived dep chains. |
+| Fork aider with bumped transitive pins | Considered maintaining a `homericintelligence/aider-chat` fork with relaxed pins | Excessive maintenance burden — every upstream release requires re-rebasing the fork; CI must build from the fork; provenance gets murky for downstream consumers. | Forking for a 3-line override is not proportional. Reserve forks for cases where you need to patch upstream code, not just pins. |
+| Wait for upstream to bump pins | Considered filing only an upstream issue and accepting CI failure until upstream releases | Upstream cadence is days-to-weeks; CI stays red and blocks unrelated PRs. | File the upstream issue/PR in parallel, but unblock CI immediately with the two-pass override. |
 
 ## Results & Parameters
 
-### `requirements.txt` snippet (verified on AchaeanFleet `vessels/aider/`)
+### Two-file layout (verified on AchaeanFleet `vessels/aider/`)
 
+`vessels/aider/requirements.txt`:
 ```text
 aider-chat==0.86.2
+```
+
+`vessels/aider/requirements-security-overrides.txt`:
+```text
+# Security overrides applied AFTER aider-chat install (two-pass pattern).
+# aider-chat 0.86.2 hard-pins these transitive deps at vulnerable versions;
+# pip's resolver cannot satisfy both pins simultaneously, so we install them
+# in a second --upgrade pass that deliberately overwrites the transitive pins.
+# The `RUN aider --version` smoke check in the Dockerfile catches any breakage
+# introduced by this override.
 GitPython>=3.1.49     # CVE-2026-42215, CVE-2026-42284, CVE-2026-44243, CVE-2026-44244
 Pillow>=12.2.0        # CVE-2026-42311
 urllib3>=2.7.0        # CVE-2026-44431
@@ -138,27 +183,45 @@ urllib3>=2.7.0        # CVE-2026-44431
 | Pillow | 11.2.1 | 12.1.1 | >=12.2.0 | CVE-2026-42311 |
 | urllib3 | 2.4.0 | 2.6.3 | >=2.7.0 | CVE-2026-44431 |
 
-### Expected pip output
+### Expected pip output (two-pass)
 
+Pass 1 (clean install of upstream — resolver satisfied):
 ```
-ERROR: pip's dependency resolver does not currently take into account all the packages that are installed.
-aider-chat 0.86.2 requires GitPython==3.1.46, but you have GitPython 3.1.49 which is incompatible.
-aider-chat 0.86.2 requires pillow==12.1.1, but you have pillow 12.2.0 which is incompatible.
-aider-chat 0.86.2 requires urllib3==2.6.3, but you have urllib3 2.7.0 which is incompatible.
-Successfully installed GitPython-3.1.49 Pillow-12.2.0 aider-chat-0.86.2 urllib3-2.7.0
+Successfully installed aider-chat-0.86.2 GitPython-3.1.46 pillow-12.1.1 urllib3-2.6.3 ...
 ```
 
-The `ERROR:` line is a warning in pip's vocabulary — exit code is 0 and the requested versions are installed.
+Pass 2 (`--upgrade` of the security overrides — separate resolver invocation):
+```
+Collecting GitPython>=3.1.49 ...
+Collecting Pillow>=12.2.0 ...
+Collecting urllib3>=2.7.0 ...
+Installing collected packages: urllib3, Pillow, GitPython
+  Attempting uninstall: urllib3
+    Successfully uninstalled urllib3-2.6.3
+  Attempting uninstall: Pillow
+    Successfully uninstalled Pillow-12.1.1
+  Attempting uninstall: GitPython
+    Successfully uninstalled GitPython-3.1.46
+Successfully installed GitPython-3.1.49 Pillow-12.2.0 urllib3-2.7.0
+```
+
+Exit code 0 from both passes. The smoke check (`aider --version`) then prints aider's version string and exits 0, confirming the override did not break the upstream at import time.
+
+### Why two passes work when one does not
+
+pip's resolver runs **per-invocation**. Within a single `pip install`, all constraints are unified into one solve and `==3.1.46` (from aider's metadata) conflicts with `>=3.1.49` (from your overrides file) — `ResolutionImpossible`. Across two `pip install` invocations, the second resolver pass has no knowledge of the conflicting upstream `==` pin from pass 1; it sees only its own `requirements-security-overrides.txt` (plus `--upgrade`) and happily uninstalls + reinstalls the transitive deps. The trade-off: you have violated upstream's tested pin set, so the post-pass smoke check is non-negotiable.
 
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
-| AchaeanFleet | PR #662 — `vessels/aider/requirements.txt` Trivy CVE fix | Signed commit f22ae88, REST `verified=true reason=valid`. Trivy security CI was QUEUED at skill capture; root-cause analysis complete (upstream `==` pins block any other approach). |
+| AchaeanFleet | PR #662 — `vessels/aider/` Trivy CVE fix, two-pass pip install pattern | Signed commit `210735b`. Full CI green (Trivy filesystem scan, `security/dependency-scan`, build-and-push). The earlier single-file attempt on the same branch had failed with `ResolutionImpossible` and motivated this v2.0.0 rewrite. |
+| AchaeanFleet | PR #662 — initial single-file attempt (v1.0.0 of this skill) | Signed commit `f22ae88`, REST `verified=true reason=valid`. Resolver failed at Docker build time; superseded by `210735b`. |
 
 ## References
 
 - [pixi-pip-audit-cve-pinning](pixi-pip-audit-cve-pinning.md) — sibling skill for pixi-managed projects where the solver respects lower-bound constraints (no force-override needed)
 - [ci-cd-pip-audit-ignore-vuln-allowlist-with-tracking-issue](ci-cd-pip-audit-ignore-vuln-allowlist-with-tracking-issue.md) — fallback when a CVE has no upstream fix at all
-- [pip docs — dependency resolver](https://pip.pypa.io/en/stable/topics/dependency-resolution/) — confirms pip honours explicit `requirements.txt` constraints even when they conflict with installed package metadata
+- [pip docs — dependency resolver](https://pip.pypa.io/en/stable/topics/dependency-resolution/) — explains why a single resolver pass with conflicting `==`/`>=` constraints raises `ResolutionImpossible`
+- [pip docs — `--upgrade`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-U) — explicit user intent to replace installed versions, which is what makes pass 2 succeed
 - [PyPI JSON API — requires_dist](https://warehouse.pypa.io/api-reference/json.html) — used to inspect upstream hard-pins without installing


### PR DESCRIPTION
## Summary

Amends `pip-cve-fix-requires-override-of-upstream-hard-pin` from v1.0.0 → v2.0.0 (breaking workflow change).

The v1.0.0 single-file `==` upstream + `>=` overrides pattern was reported as `verified-local` but fails with `ResolutionImpossible` under modern pip resolver in clean CI environments (no pre-cached transitive). v2.0.0 replaces it with the **two-pass pip install** pattern actually verified on AchaeanFleet PR #662:

1. `requirements.txt` — just the upstream pin (resolver-satisfiable on its own)
2. `requirements-security-overrides.txt` — `>=<fixed>` overrides, installed with `pip install --upgrade` in a separate resolver invocation
3. Smoke check (`RUN <binary> --version`) after pass 2 catches override-induced breakage

## Why two passes work when one does not

pip's resolver runs per-invocation. A single solve cannot satisfy both `==3.1.46` (from aider's metadata) and `>=3.1.49` (from overrides). A second `pip install --upgrade` sees only its own file and happily replaces the transitive deps — explicit user intent.

## Changes

- `skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md` — rewritten Verified Workflow with Dockerfile snippet, new "Why two passes work" subsection, three new Failed Attempts rows (single-file v1.0.0, aider downgrade, fork aider), tags `two-pass-install` + `ResolutionImpossible`, verification upgraded `verified-local` → `verified-ci`
- `skills/pip-cve-fix-requires-override-of-upstream-hard-pin.history` — new file documenting v1.0.0 → v2.0.0 rationale, links v1.0.0 snapshot at git sha `5fd934b9`

## Verified On

- **AchaeanFleet PR #662**, signed commit `210735b` — full CI green (Trivy filesystem scan, `security/dependency-scan`, build-and-push)
- Earlier single-file attempt at commit `f22ae88` on the same branch failed at Docker build time with `ResolutionImpossible` — this is the failed-attempt evidence motivating the rewrite

## Test plan

- [x] `python3 scripts/validate_plugins.py` — 1083/1083 valid
- [x] Commit signed (`-S`); `gh api .../commits/<sha> --jq .commit.verification` expected `verified=true reason=valid` after push
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)