### PR TITLE
feat: amend git-rebase-stacked-prs-worktree-isolation skill (v1.1.0)

### DIFF
--- a/skills/git-rebase-stacked-prs-worktree-isolation.history
+++ b/skills/git-rebase-stacked-prs-worktree-isolation.history
@@ -1,0 +1,61 @@
+# git-rebase-stacked-prs-worktree-isolation — History
+
+## v1.1.0 (2026-05-17)
+
+**Changed by:** HomericIntelligence/Myrmidons cascade-rebase session — silent stale-local-branch pickup during `git worktree add`
+**Verification:** verified-local (issue diagnosed and fix applied within the session; CI later confirmed the corrected push was valid)
+
+### What changed
+
+- Added explicit "stale local branch" pitfall to **Failed Attempts** (the bare local-branch form of `git worktree add` silently picked up a stale tip and the subsequent rebase dropped a fix-up commit that lived only on `origin`).
+- Added a **Quick Reference** callout: always pass `origin/<branch> --detach`, never the bare local branch name, and always `git fetch origin --prune` first.
+- Added a **post-rebase detection signal**: `git diff --name-status origin/<base>..HEAD` should show expected file deletions; if missing, the worktree started from a stale ref.
+- Bumped version `1.0.0` → `1.1.0`, updated date to 2026-05-17.
+- Added `history: git-rebase-stacked-prs-worktree-isolation.history` frontmatter field.
+
+### Why
+
+The v1.0.0 Quick Reference already used `origin/$branch --detach` and was correct, but it did
+not explain *why* the bare local branch form is unsafe. A real session in Myrmidons used
+`git worktree add /tmp/wt cleanup/c3-remove-reconciler` (bare local branch). The local branch
+was stale relative to `origin/cleanup/c3-remove-reconciler` (a fix-up commit had been pushed
+but the local pointer was never updated). The rebase "succeeded" but replayed only the stale
+commits, and a `--force-with-lease` push then erased the fix-up commit from the remote. The
+failure took ~15 minutes to detect — only caught by noticing expected file deletions were
+missing from the rebased branch.
+
+Explicitly documenting the pitfall and the post-rebase content check makes the v1.0.0
+workflow's correct-by-construction `origin/<branch> --detach` pattern self-explanatory and
+prevents future regressions.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: git-rebase-stacked-prs-worktree-isolation
+description: "Use git worktrees to rebase a stack of sibling PRs in parallel without cross-iteration corruption. Use when: (1) batch-rebasing many sibling branches onto main after their shared base advanced, (2) a naive in-place rebase loop fails with 'src refspec does not match any' or 'you need to resolve your current index first', (3) parallelizing conflict resolution across sub-agents (one worktree per agent), (4) a force-push pushed a half-rebased branch because exit-code check was masked by a piped tail/grep."
+category: tooling
+date: 2026-05-05
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - git
+  - rebase
+  - worktree
+  - pr-stack
+  - parallelism
+  - conflict-resolution
+---
+
+# Git Rebase Stacked PRs with Worktree Isolation
+
+(See git history for full v1.0.0 body — Quick Reference already used `origin/$branch --detach`,
+but did not document the stale-local-branch failure mode that prompted v1.1.0.)
+```
+
+---
+
+## v1.0.0 (2026-05-05)
+
+**Initial version.** Verified on ProjectCharybdis: 14 sibling auto-impl branches rebased + force-pushed across 5 parallel sub-agents.

--- a/skills/git-rebase-stacked-prs-worktree-isolation.md
+++ b/skills/git-rebase-stacked-prs-worktree-isolation.md
@@ -1,11 +1,12 @@
 ---
 name: git-rebase-stacked-prs-worktree-isolation
-description: "Use git worktrees to rebase a stack of sibling PRs in parallel without cross-iteration corruption. Use when: (1) batch-rebasing many sibling branches onto main after their shared base advanced, (2) a naive in-place rebase loop fails with 'src refspec does not match any' or 'you need to resolve your current index first', (3) parallelizing conflict resolution across sub-agents (one worktree per agent), (4) a force-push pushed a half-rebased branch because exit-code check was masked by a piped tail/grep."
+description: "Use git worktrees to rebase a stack of sibling PRs in parallel without cross-iteration corruption. Use when: (1) batch-rebasing many sibling branches onto main after their shared base advanced, (2) a naive in-place rebase loop fails with 'src refspec does not match any' or 'you need to resolve your current index first', (3) parallelizing conflict resolution across sub-agents (one worktree per agent), (4) a force-push pushed a half-rebased branch because exit-code check was masked by a piped tail/grep, (5) `git worktree add /tmp/wt <branch>` silently picked up a stale local branch tip and the subsequent rebase dropped a commit that lived only on origin."
 category: tooling
-date: 2026-05-05
-version: "1.0.0"
+date: 2026-05-17
+version: "1.1.0"
 user-invocable: false
 verification: verified-ci
+history: git-rebase-stacked-prs-worktree-isolation.history
 tags:
   - git
   - rebase
@@ -24,7 +25,8 @@ tags:
 | **Date** | 2026-05-05 |
 | **Objective** | Rebase a stack of sibling PRs onto an advanced main branch without cross-iteration corruption, by using one git worktree per branch and (optionally) one sub-agent per worktree |
 | **Outcome** | Verified on ProjectCharybdis: 14 sibling auto-impl branches rebased + force-pushed across 5 parallel sub-agents in ~3 minutes wall-clock (vs ~30 minutes sequential). Zero corrupted force-pushes, zero index lock-outs. |
-| **Context** | A naive in-place rebase loop in a single checkout corrupted the repo's index after the first conflicting branch and silently force-pushed a half-rebased branch. The worktree-per-branch pattern eliminates both failure modes. |
+| **Context** | A naive in-place rebase loop in a single checkout corrupted the repo's index after the first conflicting branch and silently force-pushed a half-rebased branch. The worktree-per-branch pattern eliminates both failure modes. v1.1.0 (2026-05-17): documented the stale-local-branch pitfall after a Myrmidons cascade-rebase where `git worktree add /tmp/wt cleanup/c3-remove-reconciler` silently picked up a stale local branch tip and the subsequent rebase dropped a fix-up commit that lived only on `origin`. |
+| **History** | [changelog](./git-rebase-stacked-prs-worktree-isolation.history) |
 
 ## When to Use
 
@@ -45,9 +47,14 @@ Do NOT use this skill if:
 
 ### Quick Reference
 
+**Critical rule:** Always pass `origin/<branch> --detach` to `git worktree add`. Never pass the
+bare local branch name — local branches can be stale relative to `origin/<branch>`, and a rebase
+launched from a stale tip will silently drop commits that exist only on the remote. Always
+`git fetch origin --prune` first.
+
 ```bash
 REPO=/path/to/repo
-git -C "$REPO" fetch origin
+git -C "$REPO" fetch origin --prune   # required — refresh remote refs before any worktree add
 mkdir -p /tmp/rebases
 
 for branch in branch-a branch-b branch-c; do
@@ -114,6 +121,33 @@ if [ "$(git -C "$wtpath" merge-base origin/main HEAD)" = "$(git -C "$wtpath" rev
 fi
 ```
 
+### Step 4b — Content-check the rebased branch (catches stale-local-branch pickup)
+
+`merge-base` only confirms the rebase landed on top of `origin/main`. It does NOT confirm the
+worktree started from the canonical remote tip of the branch being rebased. If `git worktree add`
+silently picked up a stale local branch, the rebased history will be missing commits that exist
+only on `origin/<branch>` — and `--force-with-lease` will erase them on push.
+
+After the rebase succeeds, sanity-check the branch content against `origin/<branch>`:
+
+```bash
+# Expected commits/files from origin must be present in the rebased branch.
+# Any commit reachable from origin/<branch> but missing from HEAD is a red flag.
+missing=$(git -C "$wtpath" log --oneline "origin/$branch" --not HEAD)
+if [ -n "$missing" ]; then
+  echo "ABORT $branch — worktree started from stale ref; missing commits:"
+  echo "$missing"
+  # Do NOT force-push. Re-create the worktree with origin/<branch> --detach and retry.
+fi
+```
+
+If you have a known content invariant (e.g. "this branch must delete file X"), assert it directly:
+
+```bash
+git -C "$wtpath" diff --name-status "origin/main..HEAD" | grep -q '^D\s.*path/to/X' \
+  || { echo "ABORT $branch — expected deletion of path/to/X missing"; exit 1; }
+```
+
 ### Step 5 — Parallelize across sub-agents (optional)
 
 With one worktree per branch, dispatch one sub-agent per worktree (or batch 2-3 per agent). Each agent operates on its own `git -C <wtpath>` and cannot collide with siblings. We verified 5 agents handling 14 ProjectCharybdis branches in ~3 min.
@@ -135,6 +169,7 @@ If the Safety Net hook blocks `--force` removal, push first (no dirty state rema
 | Trusting `$?` after piped command | `git rebase origin/main 2>&1 \| tail -3; if [ $? -eq 0 ]` | `tail` clobbers `$?` — the check evaluates `tail`'s exit code, not git's | Capture rebase output to a variable first: `result=$(... 2>&1); if echo "$result" \| grep -q CONFLICT` |
 | Force-push without verifying rebase succeeded | Pushed branch immediately after rebase command, no exit-code or content check | Pushed a half-rebased / unrebased state to remote; PR remained DIRTY because merge-base was unchanged | Verify `git log origin/main..HEAD` is non-empty AND `git merge-base origin/main HEAD` equals `origin/main`'s tip before pushing |
 | `git worktree remove` blocked by Safety Net `--force` | Tried `git worktree remove <path> --force` to clean up after push | Safety Net hook blocks the flag because it can drop uncommitted work | Push first, then `git worktree prune` and `git worktree remove <path>` without `--force` (no dirty state once pushed) |
+| Bare local branch name passed to `git worktree add` (Myrmidons cascade-rebase, 2026-05-17) | `git worktree add /tmp/wt cleanup/c3-remove-reconciler` (no `origin/` prefix, no `--detach`) — the local branch pointer was stale relative to `origin/cleanup/c3-remove-reconciler`, which had a newer fix-up commit. The rebase replayed only the stale commits and `--force-with-lease` then erased the fix-up commit from the remote. | `git worktree add <branch>` uses whatever the local branch tip is; a previous push had updated the remote ref but not the local pointer (the local branch had last been touched in a different worktree). Took ~15 min to detect — only caught by noticing expected file deletions were missing from the rebased branch. | Always `git fetch origin --prune` first, then `git worktree add <path> origin/<branch> --detach`. After rebasing, run `git diff --name-status origin/<base>..HEAD` and confirm the expected files (e.g. recent deletions) are present — if missing, the worktree was created from a stale ref and the push must be aborted. |
 
 ## Results & Parameters
 
@@ -154,3 +189,4 @@ If the Safety Net hook blocks `--force` removal, push first (no dirty state rema
 | Project | Context | Details |
 |---------|---------|---------|
 | HomericIntelligence/ProjectCharybdis | 2026-05-05: 14 sibling auto-impl branches rebased onto main after 23 sibling PRs were merged. 5 sub-agents in parallel, one worktree per branch. All 14 successfully pushed. | Wall-clock ~3 min vs ~30 min sequential |
+| HomericIntelligence/Myrmidons | 2026-05-17: cascade-rebase session — `git worktree add /tmp/wt cleanup/c3-remove-reconciler` picked up a stale local branch tip, dropping a fix-up commit on force-push. Detected after ~15 min via missing expected file deletions. Fix: re-run with `origin/<branch> --detach` after `git fetch origin --prune`. | verified-local; CI confirmed corrected push valid |


### PR DESCRIPTION
## Summary

Amends `git-rebase-stacked-prs-worktree-isolation` from v1.0.0 to v1.1.0.

Documents the stale-local-branch pitfall encountered during a HomericIntelligence/Myrmidons cascade-rebase: `git worktree add /tmp/wt <branch>` (bare local branch name, no `origin/` prefix, no `--detach`) silently picked up a stale local branch tip. The subsequent rebase replayed only the stale commits, and `--force-with-lease` then erased a fix-up commit that lived only on `origin/<branch>`. Took ~15 minutes to detect — only caught by noticing expected file deletions were missing.

- Adds explicit Quick Reference callout: always pass `origin/<branch> --detach`, never the bare local branch name; always `git fetch origin --prune` first.
- Adds Step 4b "Content-check the rebased branch" with `git log origin/<branch> --not HEAD` and `git diff --name-status` detection signals.
- Adds new Failed Attempts row covering the Myrmidons incident.

## Verification Level

**verified-local** — the issue was diagnosed and the fix applied successfully within the session; CI later confirmed the corrected push was valid. Not promoted to verified-ci because the new content-check step has not yet been exercised by a fresh CI run on a new stacked rebase; it is a strict superset of v1.0.0's `merge-base` check.

## Key Findings

**What Worked**:
- `git fetch origin --prune` followed by `git worktree add <path> origin/<branch> --detach` — never starts from a stale local branch tip.
- Post-rebase `git log origin/<branch> --not HEAD` detects missing commits before `--force-with-lease` can erase them on the remote.
- Content-invariant assertions (e.g. "branch must delete file X") catch the failure even when commit counts look superficially correct.

**What Failed**:
- `git worktree add /tmp/wt cleanup/c3-remove-reconciler` (bare local branch) → the local pointer was stale relative to `origin/cleanup/c3-remove-reconciler`; rebase + force-push silently erased a fix-up commit on the remote.
- `merge-base` check alone (v1.0.0 Step 4) — confirms rebase landed on `origin/main`, but does not confirm the worktree started from the canonical remote tip of the branch being rebased.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1091/1091 valid)
- [ ] Verify amended skill renders correctly in marketplace
- [ ] Verify history file is linked from main skill via `history` frontmatter field
- [ ] Test skill discovery with keywords: "worktree stale branch", "git worktree origin ref", "rebase dropped commit"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>