### PR TITLE
feat: amend github-email-privacy-noreply-push-fix skill (v1.1.0)

### DIFF
--- a/skills/github-email-privacy-noreply-push-fix.history
+++ b/skills/github-email-privacy-noreply-push-fix.history
@@ -1,0 +1,50 @@
+# github-email-privacy-noreply-push-fix — History
+
+## v1.1.0 (2026-05-17)
+
+**Changed by:** Myrmidons multi-PR rebase cascade session — agent overrode commit author and hit GH007 across 4 commits before fixing.
+**Verification:** verified-local
+
+### What changed
+
+- Added new Failed Attempts row for the GH007 variant of the rejection ("Block command line pushes that expose my email") — a sibling protection to "email privacy restrictions" that produces a distinct error string.
+- Added a new When-to-Use trigger for the GH007 error code so the skill surfaces on the exact remote string.
+- Added discovery tip: `git log --format=%ae -1 origin/main` reveals what noreply form the user's prior commits used — useful when `gh api users/<USERNAME>` is not available or the username is unknown.
+- Added preferred-approach guidance: **don't override `-c user.email` at all** unless operating in a fresh worktree that doesn't inherit parent git config. The repo's existing `git config user.email` is already correct in nearly every case. Inline `-c` overrides should be reserved for the narrow case where config did not propagate.
+- Added a fourth verified-on row (2026-05-17 Myrmidons rebase cascade, 4 commits amended).
+
+### Why
+
+The v1.0.0 skill described the rejection as "push declined due to email privacy restrictions". The 2026-05-17 session triggered a different but related rejection: `remote: error: GH007: Your push would publish a private email address`. This comes from the GitHub account setting "Block command line pushes that expose my email" (default-on for many users) — a separate toggle from "Keep my email address private" but with the same fix. Without the new error string in the skill, future agents searching for "GH007" or "publish a private email" wouldn't find this skill. The amendment also corrects an antipattern the agent fell into: gratuitously overriding `-c user.email` even when the inherited config was already correct, which is what *introduced* the bad email in the first place.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: github-email-privacy-noreply-push-fix
+description: "Fix GitHub push rejections caused by email-privacy settings when an agent commits with the user's real email. Use when: (1) a push is rejected with 'push declined due to email privacy restrictions', (2) dispatching sub-agents that will commit and push on the user's behalf, (3) configuring orchestrator/swarm prompts that need to override git author email."
+category: tooling
+date: 2026-05-07
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - github
+  - push
+  - email-privacy
+  - noreply
+  - agent-dispatch
+  - swarm
+  - commit
+---
+
+# GitHub Email Privacy: Use Noreply Form for Agent Pushes
+
+(Full v1.0.0 body preserved on git history at commit e7233a50; abbreviated here for brevity. Covered: workflow with `gh api users/<USERNAME> --jq .id` to resolve USER_ID, amend with `--reset-author --no-edit`, force-with-lease push, 4 Failed Attempts rows, orchestrator prompt fragment, verified on Myrmidons PR #481 lint fix.)
+```
+
+---
+
+## v1.0.0 (2026-05-07)
+
+**Initial version.** Documented the email-privacy push rejection mode and the noreply override workflow, derived from the Myrmidons PR #481 orchestrator session.

--- a/skills/github-email-privacy-noreply-push-fix.md
+++ b/skills/github-email-privacy-noreply-push-fix.md
@@ -1,19 +1,22 @@
 ---
 name: github-email-privacy-noreply-push-fix
-description: "Fix GitHub push rejections caused by email-privacy settings when an agent commits with the user's real email. Use when: (1) a push is rejected with 'push declined due to email privacy restrictions', (2) dispatching sub-agents that will commit and push on the user's behalf, (3) configuring orchestrator/swarm prompts that need to override git author email."
+description: "Fix GitHub push rejections (email-privacy / GH007) caused by an agent committing with the user's real email. Use when: (1) push rejected with 'push declined due to email privacy restrictions', (2) push rejected with 'GH007: Your push would publish a private email address', (3) dispatching sub-agents that will commit and push on the user's behalf, (4) configuring orchestrator/swarm prompts that override git author email, (5) deciding whether to override `-c user.email` at all in a worktree."
 category: tooling
-date: 2026-05-07
-version: "1.0.0"
+date: 2026-05-17
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: github-email-privacy-noreply-push-fix.history
 tags:
   - github
   - push
   - email-privacy
   - noreply
+  - gh007
   - agent-dispatch
   - swarm
   - commit
+  - worktree
 ---
 
 # GitHub Email Privacy: Use Noreply Form for Agent Pushes
@@ -22,18 +25,21 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-05-07 |
-| **Objective** | Prevent GitHub from rejecting pushes when an orchestrator or sub-agent commits on behalf of a user whose GitHub account has email-privacy enabled |
-| **Outcome** | Successful — overriding `user.email` to the GitHub noreply form (`<USER_ID>+<USERNAME>@users.noreply.github.com`) and amending the commit lets the push succeed |
+| **Date** | 2026-05-17 |
+| **Objective** | Prevent GitHub from rejecting pushes when an orchestrator or sub-agent commits on behalf of a user whose GitHub account has email-privacy or "block command line pushes that expose my email" (GH007) enabled |
+| **Outcome** | Successful — overriding `user.email` to the GitHub noreply form (`<USER_ID>+<USERNAME>@users.noreply.github.com`) and amending the commit lets the push succeed. **Preferred:** don't override `user.email` at all unless the inherited config is wrong (e.g. fresh worktrees that didn't inherit). |
 | **Verification** | verified-local |
+| **History** | [changelog](./github-email-privacy-noreply-push-fix.history) |
 
 ## When to Use
 
 - A `git push` is rejected with `push declined due to email privacy restrictions`
+- A `git push` is rejected with `remote: error: GH007: Your push would publish a private email address` (the "Block command line pushes that expose my email" account setting — sibling toggle to email-privacy, same fix)
 - The remote message references `https://github.com/settings/emails`
 - You are about to dispatch a sub-agent (Myrmidon swarm worker, code-review fixer, etc.) that will commit and push on the user's behalf
 - You are writing or editing an orchestrator prompt template that controls agent commit author identity
 - Local commits work fine but the first push from a fresh agent dispatch fails
+- You are about to add `-c user.email=...` to a `git commit` invocation — pause and decide whether the override is actually needed (see Step 0 below)
 
 ## Verified Workflow
 
@@ -55,7 +61,27 @@ git push --force-with-lease origin HEAD:<branch>
 
 ### Detailed Steps
 
-1. Confirm the failure mode. The rejected push prints a message that looks like:
+0. **Decide whether to override at all.** The most common cause of GH007 in
+   agent sessions is *gratuitously* overriding `-c user.email` with the user's
+   public personal address when the repo's existing `git config user.email` was
+   already correct (typically already set to the noreply form). Before adding
+   any `-c user.email` flag, run:
+   ```bash
+   git config user.email   # what the repo will use by default
+   git log --format=%ae -1 origin/main  # what the user's prior commits used
+   ```
+   If both already show the noreply form (or any non-public address the user
+   uses), **drop the override entirely** and just `git commit ...`. Inline
+   `-c user.email` is only needed in narrow cases:
+   - Fresh worktrees that didn't inherit the parent repo's config
+   - First commit in a freshly-cloned repo where global config holds the wrong
+     identity
+   - Cross-user impersonation (rare; ask first)
+
+1. Confirm the failure mode. The rejected push prints one of two messages.
+
+   **Variant A — "email privacy restrictions"** (the "Keep my email address
+   private" account setting):
    ```text
    remote: You can make your email public or disable this protection by visiting:
    remote: https://github.com/settings/emails
@@ -63,12 +89,28 @@ git push --force-with-lease origin HEAD:<branch>
     ! [remote rejected] HEAD -> <branch> (push declined due to email privacy restrictions)
    error: failed to push some refs
    ```
-   The `email privacy restrictions` phrase is the unique signal — do not retry naively.
 
-2. Look up the user's numeric GitHub ID. Two reliable sources:
+   **Variant B — "GH007"** (the "Block command line pushes that expose my
+   email" account setting; default-on for many users):
+   ```text
+   remote: error: GH007: Your push would publish a private email address.
+   remote: You can make your email public or disable this protection by visiting:
+   remote: http://github.com/settings/emails
+   ```
+
+   Both variants have the **same fix**. The phrase `email` plus
+   `settings/emails` is the unique signal — do not retry naively.
+
+2. Look up the user's numeric GitHub ID. Three reliable sources, in order of
+   preference:
    ```bash
    # Preferred: the GitHub API
    gh api users/<USERNAME> --jq .id
+
+   # Fast discovery: what email did the user's own latest commit use?
+   # This works without knowing the username and surfaces the exact noreply
+   # form the user prefers (some users use the legacy form without USER_ID).
+   git log --format=%ae -1 origin/main
 
    # Fallback: any prior squash-merged commit on the repo's default branch
    git log --pretty='%aN <%aE>' main | grep noreply | head -1
@@ -109,6 +151,7 @@ git push --force-with-lease origin HEAD:<branch>
 | 2 | Retry the same push without changes after the rejection | Server-side check is deterministic — same email, same rejection | Email-privacy is not a transient error; do not retry without re-authoring. |
 | 3 | `git commit --amend --no-edit` (without `--reset-author`) after changing the email | Amend kept the original author identity; only the committer changed, so the push was rejected again | `--reset-author` is mandatory when fixing the author email on an existing commit. |
 | 4 | Adding the noreply email to a sub-agent's prompt without the numeric `<USER_ID>` prefix (e.g. `mvillmow@users.noreply.github.com`) | GitHub rejects noreply pushes that omit the user-ID prefix because they are ambiguous and not bound to a verified account | Always include `<USER_ID>+` — the numeric ID is what proves account ownership. |
+| 5 | In a Myrmidons rebase-cascade session, overrode the commit author with `git -c user.name="Micah Villmow" -c user.email="villmow.products@gmail.com" commit ...` despite the repo's inherited `git config user.email` already being correct | The user's account has "Block command line pushes that expose my email" enabled, so the remote returned `remote: error: GH007: Your push would publish a private email address`. Had to amend 4 commits with `--reset-author` and force-push each. | Don't override `-c user.email` unless the inherited config is actually wrong. The agent introduced the bad email by overriding gratuitously; the simplest fix is to not override in the first place. Check `git config user.email` and `git log --format=%ae -1 origin/main` before adding any `-c user.email` flag. |
 
 ## Results & Parameters
 
@@ -152,3 +195,4 @@ this every time they try to push.
 | Project | Context | Details |
 |---------|---------|---------|
 | Myrmidons | 2026-05-07 orchestrator session fixing PR #481 lint failure | First push rejected with real email; second push with `4211002+mvillmow@users.noreply.github.com` succeeded |
+| Myrmidons | 2026-05-17 multi-PR rebase cascade — agent gratuitously overrode `-c user.email` with `villmow.products@gmail.com` across 4 commits | All 4 pushes rejected with `GH007: Your push would publish a private email address`; fixed by amending each commit with `--reset-author` and the noreply form, then force-pushing. Root cause: the override was unnecessary — inherited `git config user.email` was already correct. |


### PR DESCRIPTION
## Summary

Amends existing skill from **v1.0.0 → v1.1.0**.

Captures a second variant of the GitHub push-rejection error and codifies the "don't override `-c user.email` gratuitously" preferred approach that would have prevented the failure entirely.

- New trigger: `GH007: Your push would publish a private email address` (the "Block command line pushes that expose my email" account setting — sibling toggle to email-privacy, same fix)
- New Step 0 in the workflow: check `git config user.email` and `git log --format=%ae -1 origin/main` before adding any `-c user.email` flag. Inline overrides are only needed in narrow cases (fresh worktrees that didn't inherit config, etc.)
- New discovery tip: `git log --format=%ae -1 origin/main` reveals the exact noreply form a user prefers — no `gh api` call required
- New Failed Attempts row #5 documenting the 2026-05-17 root cause: gratuitous override of `-c user.email` with the user's public personal address, when the inherited config was already correct

## Verification Level

**verified-local** — Observed across 4 push attempts in a 2026-05-17 Myrmidons multi-PR rebase cascade. All 4 pushes rejected with GH007; all 4 commits amended with `--reset-author` to the noreply form and force-pushed successfully. CI validation of the skill metadata itself is via `scripts/validate_plugins.py` (1091/1091 passing).

## Key Findings

**What Worked**:
- Amending each commit with `git -c user.email="<USER_ID>+<USERNAME>@users.noreply.github.com" commit --amend --reset-author --no-edit`
- Force-pushing with `--force-with-lease`
- Discovering the right noreply form via `git log --format=%ae -1 origin/main` on an unfamiliar repo

**What Failed**:
- `git -c user.email="villmow.products@gmail.com" commit ...` → push rejected with GH007
- The override was unnecessary in the first place — the inherited `git config user.email` was already correct. The root antipattern was adding `-c user.email` when no override was needed.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1091/1091 valid)
- [ ] Verify skill appears in marketplace at v1.1.0
- [ ] Test skill discovery with keywords: "GH007", "publish a private email", "noreply", "user.email override"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>