### PR TITLE
feat: amend tooling-git-rebase-parallel-merged-branches skill (v1.1.0)

### DIFF
--- a/skills/tooling-git-rebase-parallel-merged-branches.history
+++ b/skills/tooling-git-rebase-parallel-merged-branches.history
@@ -1,0 +1,75 @@
+# tooling-git-rebase-parallel-merged-branches — History
+
+## v1.1.0 (2026-05-17)
+
+**Changed by:** HomericIntelligence/Myrmidons 4-PR stack cleanup (PRs #730, #731, #732, #733 — charter enforcement)
+**Verification:** verified-local
+
+### What changed
+
+- Added a new "Cause B: Stacked-PR squash-merge absorbs ancestors" section to the
+  Detection Signals decision tree, distinguishing it from the original Cause A
+  (parallel/squash-merge of independently authored work).
+- Added the "Stacked PR squash absorption" subsection documenting the rebase-chain
+  mechanism: each branch in a local-rebase chain (C1→C2→C3) carries its ancestors'
+  commits in its history, so a squash-merge of any branch in the chain produces a
+  single commit containing the full diff vs the merge base — absorbing every
+  ancestor PR's diff into that one squash.
+- Added a "Superseded stacked PR" outcome path: when every commit drops as "patch
+  contents already upstream" and `git log origin/main..HEAD` is empty, the PR is
+  fully absorbed and the correct action is `gh pr close <N> --comment "..."` —
+  do NOT re-push.
+- Added two Failed Attempts rows documenting (a) re-pushing the no-op rebase and
+  (b) opening a merge commit to "restore" the absorbed content (both wrong).
+- Updated the description with new trigger conditions (8) and (9) for the
+  stacked-PR squash absorption scenario.
+
+### Why
+
+The v1.0.0 skill covered the case where independently authored work was merged
+upstream via a separate PR (parallel-merge). The Myrmidons cleanup session
+exposed a second, distinct cause of the same rebase signal: stacked PRs created
+via local rebase chain, where the LATER PR squash-merges first and its squash
+diff (vs main) absorbs all ancestor PRs' content. The detection signal is
+identical (every commit drops as "patch contents already upstream") but the
+correct remediation is to CLOSE the absorbed PRs as superseded — not to
+re-push them, not to resolve any conflicts. Without this section, an operator
+seeing the drop signal might try to force-push the no-op rebase or add a merge
+commit, both of which are footguns.
+
+### Previous version (v1.0.0) snapshot
+
+```yaml
+---
+name: tooling-git-rebase-parallel-merged-branches
+description: "Use when: (1) git rebase shows multiple 'dropping <sha> ... patch contents already upstream' messages interleaved with add/add conflicts, (2) a feature branch has been parallel-merged via a separate squash/rewrite PR causing nearly-identical files on both sides, (3) need to batch-rebase many local branches and reconcile with squash-merged history on origin/main, (4) local main is N ahead and M behind origin/main where the N local commits were independently merged upstream via PR, (5) add/add conflicts appear on files that differ only in trivial ways (file mode 100644 vs 100755, slight refinements upstream), (6) `git checkout --ours` is blocked by safety hooks during rebase and you need stage-index extraction (`git show :2:file`) instead, (7) confused about which side of a rebase conflict is 'ours' vs 'theirs' — during rebase ours = HEAD = upstream/rebase-base, theirs = the commit being replayed = your branch's commit (inverted vs merge)."
+category: tooling
+date: 2026-05-06
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - git
+  - rebase
+  - parallel-merge
+  - upstream
+  - drop
+  - supersede
+  - conflicts
+  - add-add
+  - automation
+  - batch
+---
+```
+
+(Full v1.0.0 body covered the parallel-merge case only — no stacked-PR squash
+absorption material. See git history of `tooling-git-rebase-parallel-merged-branches.md`
+at commit prior to this amendment for the full content.)
+
+---
+
+## v1.0.0 (2026-05-06)
+
+**Initial version.** Documented the parallel-merge rebase reconciliation pattern
+(patch-contents-already-upstream + add/add conflicts) verified across 30+ branches
+in ProjectHephaestus.

--- a/skills/tooling-git-rebase-parallel-merged-branches.md
+++ b/skills/tooling-git-rebase-parallel-merged-branches.md
@@ -1,11 +1,12 @@
 ---
 name: tooling-git-rebase-parallel-merged-branches
-description: "Use when: (1) git rebase shows multiple 'dropping <sha> ... patch contents already upstream' messages interleaved with add/add conflicts, (2) a feature branch has been parallel-merged via a separate squash/rewrite PR causing nearly-identical files on both sides, (3) need to batch-rebase many local branches and reconcile with squash-merged history on origin/main, (4) local main is N ahead and M behind origin/main where the N local commits were independently merged upstream via PR, (5) add/add conflicts appear on files that differ only in trivial ways (file mode 100644 vs 100755, slight refinements upstream), (6) `git checkout --ours` is blocked by safety hooks during rebase and you need stage-index extraction (`git show :2:file`) instead, (7) confused about which side of a rebase conflict is 'ours' vs 'theirs' — during rebase ours = HEAD = upstream/rebase-base, theirs = the commit being replayed = your branch's commit (inverted vs merge)."
+description: "Use when: (1) git rebase shows multiple 'dropping <sha> ... patch contents already upstream' messages interleaved with add/add conflicts, (2) a feature branch has been parallel-merged via a separate squash/rewrite PR causing nearly-identical files on both sides, (3) need to batch-rebase many local branches and reconcile with squash-merged history on origin/main, (4) local main is N ahead and M behind origin/main where the N local commits were independently merged upstream via PR, (5) add/add conflicts appear on files that differ only in trivial ways (file mode 100644 vs 100755, slight refinements upstream), (6) `git checkout --ours` is blocked by safety hooks during rebase and you need stage-index extraction (`git show :2:file`) instead, (7) confused about which side of a rebase conflict is 'ours' vs 'theirs' — during rebase ours = HEAD = upstream/rebase-base, theirs = the commit being replayed = your branch's commit (inverted vs merge), (8) a stacked PR (C1→C2→C3) was created via local rebase chain and a LATER PR in the stack squash-merged first, causing earlier PRs to become fully superseded — `git rebase origin/main` drops every commit as 'patch contents already upstream' and `git log origin/main..HEAD` is empty, (9) tempted to re-push or add a merge commit to a no-op rebase result — close as superseded instead."
 category: tooling
-date: 2026-05-06
-version: "1.0.0"
+date: 2026-05-17
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: tooling-git-rebase-parallel-merged-branches.history
 tags:
   - git
   - rebase
@@ -17,6 +18,9 @@ tags:
   - add-add
   - automation
   - batch
+  - stacked-pr
+  - squash-merge
+  - patch-id
 ---
 
 # Git Rebase: Parallel-Merged Branches
@@ -25,10 +29,11 @@ tags:
 
 | Field | Value |
 | ----- | ----- |
-| Date | 2026-05-06 |
-| Objective | Reconcile a local feature branch (or local main) whose commits were independently merged into upstream via a separate squash/rewrite PR, producing a mix of auto-dropped commits and add/add conflicts during rebase |
-| Outcome | Branches collapse to only their genuinely net-new commits; superseded commits drop cleanly |
-| Verification | verified-local — applied across 30+ branches in ProjectHephaestus |
+| Date | 2026-05-17 (v1.1.0); 2026-05-06 (v1.0.0) |
+| Objective | Reconcile a local feature branch (or local main) whose commits were independently merged into upstream via a separate squash/rewrite PR, producing a mix of auto-dropped commits and add/add conflicts during rebase — or detect when a stacked PR has been fully superseded by a later PR's squash-merge absorbing the chain |
+| Outcome | Branches collapse to only their genuinely net-new commits; superseded commits drop cleanly; fully-absorbed stacked PRs are detected (zero commits ahead) and closed as superseded rather than re-pushed |
+| Verification | verified-local — Cause A applied across 30+ branches in ProjectHephaestus; Cause B applied to PR #731 in HomericIntelligence/Myrmidons (4-PR charter cleanup) |
+| History | [changelog](./tooling-git-rebase-parallel-merged-branches.history) |
 
 ## When to Use
 
@@ -123,6 +128,68 @@ git rebase origin/main produces output containing:
 
 If you see only the first signal (drops, no conflicts), the rebase is fine — let it complete normally. If you see only conflicts (no drops), this is a normal rebase conflict and this skill does not apply.
 
+**But** — if you see drops on EVERY commit (no conflicts at all) AND the branch ends up with zero commits ahead of origin/main, you are in **Cause B**: stacked-PR squash absorption. Continue to the next section.
+
+## Cause B: Stacked-PR Squash-Merge Absorbs Ancestors
+
+### The mechanism (non-obvious — engineers commonly misunderstand this)
+
+When a stacked PR series is built via local rebase chain — i.e. `C2` branches off `C1`, `C3` branches off `C2`, `C4` branches off `C3` — each branch's git history **contains all of its ancestor branches' commits**. This is just how branching works, but its interaction with GitHub squash-merge is what trips people up:
+
+> **GitHub's squash-merge collapses the entire diff between the PR head and the merge base (typically `main`) into ONE commit — regardless of how many ancestor PR commits live in the chain history.**
+
+So if PRs are merged out of order — say `C1` then `C3` (skipping `C2`) — the squash-merge of `C3` produces a single commit on `main` containing:
+
+- C3's own diff, PLUS
+- C2's full diff (because C2's commits lived in C3's history as ancestors)
+
+Result: `C2` is now fully absorbed into `main` via the C3 squash. The C2 PR is **superseded** — every byte of its content is already on main, just attributed to the C3 squash commit.
+
+### Detection workflow
+
+```bash
+git fetch origin
+git worktree add /tmp/check-superseded origin/<earlier-stacked-branch> --detach
+cd /tmp/check-superseded
+git rebase origin/main
+# Expected output if fully superseded:
+#   dropping abc1234... -- patch contents already upstream
+#   dropping def5678... -- patch contents already upstream
+#   ... (one drop per commit, NO conflicts)
+#   Successfully rebased and updated HEAD.
+
+git log --oneline origin/main..HEAD
+# Expected: empty output — zero commits ahead.
+```
+
+If **every** commit drops AND `git log origin/main..HEAD` is empty → the PR is fully superseded.
+
+### Correct remediation: close, do not push
+
+```bash
+gh pr close <N> --comment "Superseded by the squash-merge of #<later-PR>, which absorbed this branch's diff via the stacked-rebase chain. When rebased onto current main, every commit drops as 'patch contents already upstream' and the branch has zero commits ahead of main. Closing as no-op."
+```
+
+Do **NOT**:
+
+- Force-push the no-op rebase result — the branch SHA already equals main's SHA, so the push will either no-op or fail trying to update a ref to a value it already has.
+- Add a merge commit to "restore" the absorbed content — the content is not missing, it's on main attributed to the absorbing PR's squash commit.
+- Try to cherry-pick the absorbed commits back onto a fresh branch — they will all be empty (patch-id already present upstream) and `git cherry-pick` will error or produce empty commits.
+
+### How to avoid the situation entirely
+
+Merge stacked PRs **in stack order** (C1 → C2 → C3 → C4). If you must merge out of order, expect — and accept — that intermediate PRs in the chain will be absorbed and need to be closed. This is correct behavior, not a bug.
+
+### Why this differs from Cause A (parallel-merge)
+
+| Aspect                | Cause A: parallel-merge                                      | Cause B: stacked-PR squash absorption                       |
+| --------------------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
+| Origin of duplication | Same logical change authored independently in two branches  | Ancestor commits literally live in the descendant's history |
+| Rebase signal         | Drops **interleaved with add/add conflicts**                 | Drops on EVERY commit, **no conflicts**                     |
+| Net-new commits       | Usually some survive (≥1 ahead)                              | Zero commits ahead — branch collapses entirely              |
+| Remediation           | Take upstream for every conflict (workflow above)            | `gh pr close` as superseded                                 |
+| Common cause          | Someone landed equivalent work upstream via a different PR   | Stacked PR series merged out of order                       |
+
 ## Common Pitfalls
 
 - **Picking theirs by reflex**: in regular merges, "theirs" usually means "the incoming change". During rebase it means "the commit being replayed = your local branch". Always verify with `git show :2:file | head` and `git show :3:file | head` before resolving.
@@ -139,6 +206,9 @@ If you see only the first signal (drops, no conflicts), the rebase is fine — l
 | 3 | `git rebase --skip` on every conflict to bypass duplicates quickly | Skipped genuinely net-new commits whose only overlap with upstream was an add/add file collision, so legitimate work was lost | Use the take-upstream automation loop instead so non-conflicting hunks of net-new commits still apply |
 | 4 | `git rebase --continue` inside an automation loop | Opened an interactive editor for the commit message and blocked the loop indefinitely | Prefix with `GIT_EDITOR=true` so the editor is a no-op in non-interactive contexts |
 | 5 | Trusting the exit code of `git rebase --continue 2>&1 \| tail -3` to decide loop termination | The pipe to `tail` masked the real exit code; loop exited while a conflict was still pending and a force-push pushed a half-rebased branch | Use `git status \| grep -q "rebase in progress"` as the loop condition — it reflects actual rebase state, not piped exit codes |
+| 6 | After a stacked PR (Myrmidons #731 / C2) was absorbed by a later PR's squash-merge (#732 / C3), rebased the C2 branch onto fresh main and tried to `git push --force-with-lease origin C2` | The rebase produced zero net commits (every commit dropped as "patch contents already upstream"). The push either no-ops or attempts to set the ref to the same SHA as main — there is no work to push. Re-pushing also leaves a phantom open PR with a no-op diff confusing reviewers. | When `git rebase origin/main` drops every commit AND `git log origin/main..HEAD` is empty, the PR is fully superseded. `gh pr close <N> --comment "..."` is the correct action — never re-push a no-op branch. |
+| 7 | Assumed GitHub squash-merge of a stacked PR contained "only that PR's commits" and tried to manually re-introduce the "missing" intermediate PR's content via a merge commit or fresh branch | The squash diff of a stacked PR vs `main` includes the full diff of every ancestor branch in the chain — there is no missing content. Trying to "restore" produces empty/no-op commits. | A stacked PR's squash-merge absorbs all ancestor PRs' diffs into one squash commit on main. Verify state with `git diff origin/main..<absorbed-branch>` (will be empty) before assuming work was lost. |
+| 8 | When seeing "patch contents already upstream" drops, applied the Cause A automation loop (take-upstream for conflicts) | There were no conflicts to resolve — the loop ran once, the rebase completed cleanly with zero ahead, and nothing useful was done. The operator was still confused about why the branch had no commits. | Distinguish Cause A (drops + add/add conflicts → take upstream) from Cause B (drops + zero conflicts + zero commits ahead → close as superseded). The presence/absence of conflicts is the disambiguating signal. |
 
 ## Results & Parameters
 
@@ -149,11 +219,16 @@ If you see only the first signal (drops, no conflicts), the rebase is fine — l
 | Conflict resolution rule | always `git show :2:file > file` (take upstream) |
 | Loop termination check | `git status \| grep -q "rebase in progress"` |
 | Editor handling | `GIT_EDITOR=true git rebase --continue` |
-| Verification command | `git log --oneline branch ^origin/main \| wc -l` |
-| Verification level | verified-local (no CI signal — purely local git state) |
+| Verification command (Cause A) | `git log --oneline branch ^origin/main \| wc -l` |
+| Verification command (Cause B) | `git log origin/main..HEAD` (empty = superseded) |
+| Cause B remediation | `gh pr close <N> --comment "Superseded by squash-merge of #<later>..."` |
+| Cause B verified on | HomericIntelligence/Myrmidons PR #731 (2026-05-17) — superseded by squash-merge of #732 |
+| Verification level | verified-local (no CI signal — purely local git state and gh pr state) |
 
 ## Cross-References
 
 - `batch-pr-rebase-workflow.md` — broader playbook for batch-rebasing many PRs (this skill zooms in on the parallel-merged sub-case with stage-index conflict resolution).
 - `git-rebase-stacked-prs-worktree-isolation.md` — when to parallelize rebases across worktrees.
 - `git-commits-on-local-main-recovery.md` — recovering local main commits if you reset by accident.
+- `dataset-repo-charter-stacked-deletion-prs.md` — the Myrmidons charter cleanup that produced the C1–C4 stacked PR series where Cause B was first identified.
+- `merged-pr-noop-detection.md` — sibling detection pattern for already-merged PRs.


### PR DESCRIPTION
## Summary

Amends existing skill from v1.0.0 to v1.1.0. Adds **Cause B: Stacked-PR Squash-Merge Absorbs Ancestors** — a distinct mechanism that produces the same `patch contents already upstream` rebase signal as v1.0.0's parallel-merge cause, but requires entirely different remediation.

- Documents the non-obvious mechanism: a squash-merge of a stacked PR includes ALL ancestor PR diffs because each branch in a local-rebase chain carries its ancestors' commits in its history.
- Detection signal: `git rebase origin/main` drops every commit as "patch contents already upstream" with zero conflicts AND `git log origin/main..HEAD` is empty.
- Correct action: `gh pr close` as superseded. Do NOT re-push (no-op) and do NOT add merge commits (no content is missing — it's on main under the absorbing PR's squash).

## Verification Level

**verified-local** — applied to HomericIntelligence/Myrmidons PR #731 during the 4-PR charter cleanup (C1 #730 → C2 #731 → C3 #732 → C4 #733). C3 squash-merged first; its squash diff vs main absorbed both C3's reconciler removal AND C2's hello-world removal because C3 had been rebased on C2 during local cleanup. Rebasing C2 onto post-merge main produced zero net commits; PR #731 was closed as superseded.

## Key Findings

**What Worked**:

- `git rebase origin/main` + `git log origin/main..HEAD` empty as a binary detection signal for full PR supersession.
- `gh pr close <N> --comment "..."` documenting absorption via patch-id evidence.

**What Failed** (now documented as Failed Attempts rows 6, 7, 8):

- Re-pushing the no-op rebase result — branch SHA equals main's SHA, push no-ops or fails.
- Adding a merge commit to "restore" the absorbed content — content is not missing; merge commit produces empty diff.
- Applying the v1.0.0 (Cause A) take-upstream loop when there are zero conflicts — loop terminates immediately, operator remains confused.

## Why this is a separate amendment, not a new skill

The detection signal (`patch contents already upstream`) is identical between Cause A and Cause B. An operator hitting this signal needs disambiguating guidance in one place, not split across two skills. The v1.1.0 amendment adds a comparison table making the dichotomy explicit.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (1091/1091 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: "stacked PR squash absorb", "patch contents already upstream", "PR superseded"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>