### PR TITLE
feat: amend pip-cve-override skill (v2.1.0) — escalation rule

### DIFF
--- a/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.history
+++ b/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.history
@@ -1,5 +1,32 @@
 # pip-cve-fix-requires-override-of-upstream-hard-pin — History
 
+## v2.1.0 (2026-05-18)
+
+**Changed by:** AchaeanFleet PR #662 follow-up commits `13d906a` (added litellm override) and `30aab3e` (disabled aider vessel via `if: false` + matrix removal, filed tracking issue HomericIntelligence/AchaeanFleet#665).
+**Verification:** verified-ci — the two-pass override pattern itself remained green on PR #662; the v2.1.0 amendment codifies the escalation rule that emerged when chasing a 4th override line for one upstream (`aider-chat`) proved untenable.
+
+### What changed (MINOR — two-pass pattern unchanged, additive guidance only)
+
+- New top-level section **"When to stop chasing and disable the vessel instead"** before "Failed Attempts". Codifies the rule: cap override attempts at ~3 deps per upstream; beyond that, gate the vessel out of CI (`if: false` on build matrix + remove from hardcoded vessel lists/shell arrays), open a GH tracking issue, leave the Dockerfile + override file in place for one-revert re-enable when upstream ships a clean release. Includes the worked AchaeanFleet PR #662 example (commits 210735b → 13d906a → 30aab3e, tracking issue #665).
+- New **Failed Attempts** row: "Chase CVEs indefinitely instead of disabling" — explains why each CI roundtrip cost (5+ min, matrix fail-fast cascade) compounded past the cadence of new CVE disclosures in aider's dep tree (GitPython → Pillow → urllib3 → litellm).
+- New **Verified On** rows for commit `13d906a` (litellm addition as the 4th override line / warning signal) and commit `30aab3e` (the disable surgery + tracking issue).
+- New tags: `escalation-policy`, `disable-vessel-tracking`.
+- Frontmatter `description` extended with a sentence summarising the escalation rule so future skill-search hits surface it.
+- `date` bumped 2026-05-17 → 2026-05-18, `version` 2.0.0 → 2.1.0.
+
+### Why
+
+The two-pass pattern is correct and stays. But applying it without a stop-rule produced exactly the failure mode the new section warns against on AchaeanFleet `vessels/aider/`: a fourth override line (litellm) shipped, then more CVE disclosures threatened a fifth, and the team disabled the vessel rather than continue. Codifying the escalation rule prevents future readers from repeating that arc.
+
+### Previous version (v2.0.0) snapshot
+
+Content prior to this amendment is preserved in the git history at commit `ae55d5f21bb7cdbde1e35cc487361be222e590f8` on branch `main`. To recover, run:
+
+```bash
+git -C ~/.agent-brain/ProjectMnemosyne show ae55d5f21bb7cdbde1e35cc487361be222e590f8:skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md \
+  > /tmp/pip-cve-override-v2.0.0.md
+```
+
 ## v2.0.0 (2026-05-17)
 
 **Changed by:** AchaeanFleet PR #662 follow-up commit `210735b` (fix(deps): two-pass pip install to clear CVEs)

--- a/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md
+++ b/skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md
@@ -1,9 +1,9 @@
 ---
 name: pip-cve-fix-requires-override-of-upstream-hard-pin
-description: "Fix Trivy/pip-audit HIGH/CRITICAL CVEs flagged in transitive pip deps that an upstream package hard-pins with `==`. Bumping the upstream alone does NOT clear the CVEs because the new upstream still hard-pins the same vulnerable transitive versions. Force-override the transitive deps using a TWO-PASS pip install: pass 1 installs the upstream from `requirements.txt` (resolver satisfied), pass 2 installs `requirements-security-overrides.txt` with `--upgrade` (separate resolver invocation deliberately replaces the transitive pins). Use when: (1) Trivy/pip-audit reports CVEs in transitive deps of a plain pip-installed package (no pixi solver in play), (2) `pip show <upstream> | grep Requires` or PyPI `requires_dist` shows `==` hard-pins on the flagged transitive deps, (3) bumping the upstream alone closes zero or fewer CVEs than expected, (4) `.trivyignore` is undesirable because the CVEs are remotely exploitable or the team has a no-suppressions policy."
+description: "Fix Trivy/pip-audit HIGH/CRITICAL CVEs flagged in transitive pip deps that an upstream package hard-pins with `==`. Bumping the upstream alone does NOT clear the CVEs because the new upstream still hard-pins the same vulnerable transitive versions. Force-override the transitive deps using a TWO-PASS pip install: pass 1 installs the upstream from `requirements.txt` (resolver satisfied), pass 2 installs `requirements-security-overrides.txt` with `--upgrade` (separate resolver invocation deliberately replaces the transitive pins). **Escalation rule (v2.1.0):** cap override attempts at ~3 deps per upstream — if the scanner keeps surfacing new HIGH CVEs in *different* transitive deps from the same upstream after 3 override lines, the upstream's dep tree is the problem; disable the vessel out of CI (gated `if: false` / matrix removal) and open a tracking issue rather than chase the chain indefinitely. Use when: (1) Trivy/pip-audit reports CVEs in transitive deps of a plain pip-installed package (no pixi solver in play), (2) `pip show <upstream> | grep Requires` or PyPI `requires_dist` shows `==` hard-pins on the flagged transitive deps, (3) bumping the upstream alone closes zero or fewer CVEs than expected, (4) `.trivyignore` is undesirable because the CVEs are remotely exploitable or the team has a no-suppressions policy."
 category: ci-cd
-date: 2026-05-17
-version: "2.0.0"
+date: 2026-05-18
+version: "2.1.0"
 user-invocable: false
 verification: verified-ci
 tags:
@@ -22,6 +22,8 @@ tags:
   - force-override
   - two-pass-install
   - ResolutionImpossible
+  - escalation-policy
+  - disable-vessel-tracking
 ---
 
 # pip-cve-fix-requires-override-of-upstream-hard-pin
@@ -142,6 +144,28 @@ RUN aider --version
    # Expect: {"verified": true, "reason": "valid", ...}
    ```
 
+## When to stop chasing and disable the vessel instead
+
+The two-pass override pattern works per CVE chain, but it has a ceiling. If you find yourself appending a 4th, 5th, or Nth `>=` override line for the **same upstream** because Trivy keeps surfacing fresh HIGH CVEs in *different* transitive deps from the same upstream's dep tree, **stop**. The upstream's dependency graph is itself the liability, and your CI roundtrip cost (5+ minutes per attempt, matrix fail-fast cascading into every downstream PR) will exceed the rate at which the upstream patches.
+
+**Escalation rule (verified on AchaeanFleet `vessels/aider/`):**
+
+- **Cap:** ~3 override lines per upstream package. Beyond that, the override file becomes a moving target.
+- **Trigger:** scanner surfaces a new HIGH CVE in a *fourth* transitive dep from the same upstream after pass 2 already cleared 3 deps.
+- **Action sequence (one PR):**
+  1. Open a tracking GitHub issue titled e.g. "Re-enable `<vessel>` vessel after upstream CVE chain is resolved" describing the chain, the override file's final state, and the upstream's relevant tracker. Reference example: [HomericIntelligence/AchaeanFleet#665](https://github.com/HomericIntelligence/AchaeanFleet/issues/665).
+  2. Gate the vessel out of CI: set `if: false` on its build job (or comment out the matrix entry) in `.github/workflows/ci.yml`. Remove the vessel from any hardcoded vessel arrays / shell loops / compose includes.
+  3. **Leave the Dockerfile, `requirements.txt`, and `requirements-security-overrides.txt` in place** so re-enable is a single revert when the upstream ships a clean release.
+  4. Cross-link the tracking issue from the disable commit message and from the override file header comment.
+- **Re-enable trigger:** upstream releases a version whose `requires_dist` no longer hard-pins any of the formerly vulnerable deps (verify with the PyPI `requires_dist` curl above). Revert the gating commit, drop the override file if no longer needed, close the tracking issue.
+
+**Worked example:** AchaeanFleet PR #662 went through three escalation steps before disabling `vessels/aider/`:
+- Commit `210735b` — first override pass (GitPython, Pillow, urllib3 — 3 deps, cleared cleanly).
+- Commit `13d906a` — added `litellm>=1.83.10` after Trivy surfaced a new HIGH CVE chain (3 CVEs) in litellm 1.81.10, an aider transitive. This is the warning signal — we are now at 4 override lines for one upstream.
+- Commit `30aab3e` — disable surgery: `if: false` on the aider build matrix, vessel removed from build arrays, tracking issue [#665](https://github.com/HomericIntelligence/AchaeanFleet/issues/665) filed. Dockerfile + override file preserved for one-revert re-enable.
+
+The rule of thumb: **3 override lines is the budget per upstream**. Past that, you are doing the upstream maintainer's job for them on every CI run, and the cost compounds.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -152,6 +176,7 @@ RUN aider --version
 | Downgrade aider-chat to a pre-vulnerable version | Considered pinning to an aider release that predated the vulnerable transitive pins | Would re-introduce the original CVEs (older aider depended on even older, also-vulnerable, transitive versions). Net CVE count would not improve. | Downgrade-to-escape is rarely a win for security CVEs in long-lived dep chains. |
 | Fork aider with bumped transitive pins | Considered maintaining a `homericintelligence/aider-chat` fork with relaxed pins | Excessive maintenance burden — every upstream release requires re-rebasing the fork; CI must build from the fork; provenance gets murky for downstream consumers. | Forking for a 3-line override is not proportional. Reserve forks for cases where you need to patch upstream code, not just pins. |
 | Wait for upstream to bump pins | Considered filing only an upstream issue and accepting CI failure until upstream releases | Upstream cadence is days-to-weeks; CI stays red and blocks unrelated PRs. | File the upstream issue/PR in parallel, but unblock CI immediately with the two-pass override. |
+| Chase CVEs indefinitely instead of disabling | Kept appending override lines as Trivy surfaced new HIGH CVEs in successive transitive deps (GitPython → Pillow → urllib3 → litellm) from the same upstream (`aider-chat`) | Each CI roundtrip is 5+ minutes and blocks every downstream PR via matrix fail-fast cascade; the cadence of new CVE disclosures in the upstream's dep tree exceeded our patch cadence, so the override file became a moving target. | Cap override attempts at ~3 deps per upstream. Beyond that, disable the vessel (`if: false` on the build matrix + remove from hardcoded vessel lists) and file a GH tracking issue (e.g. AchaeanFleet#665). Leave Dockerfile + override file in place for a one-revert re-enable when upstream ships a clean release. |
 
 ## Results & Parameters
 
@@ -217,6 +242,8 @@ pip's resolver runs **per-invocation**. Within a single `pip install`, all const
 | --------- | --------- | --------- |
 | AchaeanFleet | PR #662 — `vessels/aider/` Trivy CVE fix, two-pass pip install pattern | Signed commit `210735b`. Full CI green (Trivy filesystem scan, `security/dependency-scan`, build-and-push). The earlier single-file attempt on the same branch had failed with `ResolutionImpossible` and motivated this v2.0.0 rewrite. |
 | AchaeanFleet | PR #662 — initial single-file attempt (v1.0.0 of this skill) | Signed commit `f22ae88`, REST `verified=true reason=valid`. Resolver failed at Docker build time; superseded by `210735b`. |
+| AchaeanFleet | PR #662 — litellm override added after Trivy surfaced a new HIGH CVE chain (3 CVEs) in `litellm 1.81.10`, an aider transitive | Signed commit `13d906a`. Added `litellm>=1.83.10` to `requirements-security-overrides.txt`. This was the 4th override line for one upstream — the warning signal that triggered the escalation rule (see "When to stop chasing"). |
+| AchaeanFleet | PR #662 — vessel disable decision (v2.1.0 escalation policy applied) | Signed commit `30aab3e`. `vessels/aider/` build gated with `if: false` on the CI matrix and removed from hardcoded vessel arrays; Dockerfile + override file preserved for one-revert re-enable. Tracking issue [HomericIntelligence/AchaeanFleet#665](https://github.com/HomericIntelligence/AchaeanFleet/issues/665) filed to re-enable once upstream resolves its dep chain. |
 
 ## References
 


### PR DESCRIPTION
## Summary

Amend `skills/pip-cve-fix-requires-override-of-upstream-hard-pin.md` from v2.0.0 → **v2.1.0** (MINOR — additive, two-pass pattern unchanged).

The two-pass pip install pattern from v2.0.0 worked on AchaeanFleet `vessels/aider/` (cleared GitPython, Pillow, urllib3 CVEs cleanly). But Trivy then surfaced a 4th HIGH CVE chain in litellm (an aider transitive). After adding the litellm override (PR #662, commit `13d906a`), the team disabled the aider vessel entirely (commit `30aab3e`, tracking issue [AchaeanFleet#665](https://github.com/HomericIntelligence/AchaeanFleet/issues/665)) rather than chase the next layer. v2.1.0 codifies that escalation rule.

### What changed

- New section **"When to stop chasing and disable the vessel instead"** — cap override attempts at ~3 deps per upstream; beyond that, gate the vessel out of CI (`if: false` on build matrix + remove from hardcoded vessel arrays), open a GH tracking issue, leave the Dockerfile + override file in place for one-revert re-enable. Includes worked AchaeanFleet #662 / #665 example.
- New **Failed Attempts** row: "Chase CVEs indefinitely instead of disabling" — CI roundtrip cost (5+ min, matrix fail-fast cascade) compounded past upstream CVE-disclosure cadence.
- New **Verified On** rows for commits `13d906a` (litellm override = warning signal) and `30aab3e` (disable surgery + issue #665).
- Tags: `+escalation-policy`, `+disable-vessel-tracking`.
- `description` extended with escalation-rule sentence.
- `date` 2026-05-17 → 2026-05-18, `version` 2.0.0 → 2.1.0.
- History: v2.1.0 entry prepended with snapshot reference to sha `ae55d5f21bb7cdbde1e35cc487361be222e590f8`.

## Test plan

- [x] `python3 scripts/validate_plugins.py` → 1091/1091 valid
- [x] Signed commit (`-S`) per repo convention
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)