### PR TITLE
feat(skill): amend sub-agent-pr-trust-but-verify v1.2.0 — artifact confabulation

### DIFF
--- a/skills/tooling-sub-agent-pr-trust-but-verify.history
+++ b/skills/tooling-sub-agent-pr-trust-but-verify.history
@@ -1,5 +1,29 @@
 # tooling-sub-agent-pr-trust-but-verify — History
 
+## v1.2.0 (2026-05-18)
+
+**Changed by:** ProjectMnemosyne skill-clustering Myrmidon swarm session — caught three sub-agent confabulations in a single dispatch round
+**Verification:** verified-local
+
+### What changed
+
+- Added new "When to Use" triggers (#4 artifact-producing work, #5 low-token-budget / cross-task notification leakage)
+- Added new section "Verifying Non-PR Artifacts (Files, Reports, Commits, Issues)" enumerating the three failure shapes (confabulated completion, hallucinated tool restriction, tool-capability blindness) with per-artifact-type verification commands and pre-dispatch hygiene
+- Added three Failed Attempts rows for the three concrete 2026-05-18 instances (ci-cd shard-01 confabulation, arch-shard-01 fake "TEXT ONLY constraint", Explore-profile false Write claim)
+- Added ProjectMnemosyne 2026-05-18 entry to "Verified On"
+- Extended description with triggers (4) and (5)
+- Bumped to v1.2.0
+
+### Why
+
+v1.1.0 covered two failure modes: GitHub-state mismatch (v1.0.0) and commit-content corruption during rebase (v1.1.0). Both were PR-specific. The 2026-05-18 ProjectMnemosyne session surfaced a broader, PR-independent class: sub-agents producing **prose summaries describing artifacts that do not exist on disk**, or claiming tool invocations their profile cannot perform. The root causes — tight token budgets and cross-task notification leakage — generalize across any orchestrated-agent workflow, not just PR pipelines. The skill needed to expand from "verify the PR" to "verify the artifact."
+
+### Previous version (v1.1.0) snapshot
+
+See v1.1.0 entry below; the v1.1.0 body retained the original v1.0.0 snapshot as well, so all prior versions remain reconstructible from this file.
+
+---
+
 ## v1.1.0 (2026-05-07)
 
 **Changed by:** ProjectHermes 31-PR rebase swarm session (caught a Haiku agent corrupting PR #452's content)

--- a/skills/tooling-sub-agent-pr-trust-but-verify.md
+++ b/skills/tooling-sub-agent-pr-trust-but-verify.md
@@ -1,9 +1,9 @@
 ---
 name: tooling-sub-agent-pr-trust-but-verify
-description: "Verify sub-agent PR reports against the GitHub API before assuming success. Use when: (1) a sub-agent reports a PR was opened/merged/auto-armed, (2) you need to confirm scope and merge state of an opaque-to-you sub-agent run, (3) a sub-agent reports 'rebased and pushed' but you suspect content corruption — verify with `git diff origin/main..origin/<branch> --stat` that the changed files match the PR's stated intent (e.g., a 'config refactor' PR should not show Dockerfile changes)."
+description: "Verify sub-agent PR reports against the GitHub API before assuming success. Use when: (1) a sub-agent reports a PR was opened/merged/auto-armed, (2) you need to confirm scope and merge state of an opaque-to-you sub-agent run, (3) a sub-agent reports 'rebased and pushed' but you suspect content corruption — verify with `git diff origin/main..origin/<branch> --stat` that the changed files match the PR's stated intent (e.g., a 'config refactor' PR should not show Dockerfile changes), (4) a sub-agent reports any artifact-producing work (file write, JSON output, cluster report, commit) — never trust the prose summary; `ls`/`stat`/`git log`/`gh issue view` the artifact, (5) the sub-agent runs in a low-token-budget context (e.g., 24k–31k transcript) or had cross-task notifications visible in its environment that may leak into its self-report."
 category: tooling
-date: 2026-05-07
-version: "1.1.0"
+date: 2026-05-18
+version: "1.2.0"
 history: tooling-sub-agent-pr-trust-but-verify.history
 user-invocable: false
 verification: verified-local
@@ -34,6 +34,10 @@ tags:
 - A sub-agent reports a PR is "merged" or "ready to merge"
 - You're chaining work on top of a sub-agent's PR (next-PR-rebase-stacks-on-it)
 - Multiple concurrent sub-agents touched files that might collide
+- A sub-agent reports any artifact (file write, JSON report, commit, issue) — always verify the artifact directly
+- A sub-agent is running on a tight token budget (24k–31k transcript total) — confabulated completion summaries become much more likely
+- Background-task notifications from OTHER sub-agents are visible in this agent's environment — those notifications will leak into the agent's natural-language summary as if the agent did that work itself
+- A sub-agent claims to have used a tool (Write, Edit, Bash) — confirm its agent profile actually had that tool in its inventory; agents will hallucinate Writes they cannot perform
 
 ## Verified Workflow
 
@@ -141,6 +145,53 @@ git push --force-with-lease origin "$BRANCH"
 This check takes ~2 seconds per PR (one git fetch + one git diff + one gh
 view). Include it in every post-agent-completion sweep — never skip.
 
+## Verifying Non-PR Artifacts (Files, Reports, Commits, Issues)
+
+The same trust-but-verify discipline applies to ANY artifact a sub-agent claims to
+have produced — not just PRs. A sub-agent's prose summary is intent; the artifact
+on disk (or on GitHub) is state. They diverge in three predictable shapes:
+
+### Three failure shapes for artifact claims
+
+1. **Confabulated completion** — agent claims work it never did. Most common when
+   the agent has a low token budget (24k–31k transcript) or saw cross-task
+   notifications from sibling agents and stitched their work into its own summary.
+2. **Hallucinated tool restriction** — agent invents a "system constraint"
+   ("TEXT ONLY response per system constraints") to justify prose-dumping output
+   instead of (or in addition to) writing the artifact. Sometimes the write still
+   happens, sometimes it doesn't — only the artifact check tells you.
+3. **Tool-capability blindness** — agent claims a Write/Edit/Bash invocation that
+   its profile's tool inventory does not include. The artifact cannot exist.
+
+### Verification commands per artifact type
+
+```bash
+# File artifact (JSON report, script, config the agent claims to have written)
+stat -c '%y %s %n' /path/to/artifact   # mtime + size + name
+# Compare mtime against the dispatch timestamp — if older, agent did not write
+
+# Commit artifact (sub-agent claims it committed work)
+git log -1 --format='%H %ci %s' <branch>
+# Compare commit time against dispatch time
+
+# Issue / PR artifact
+gh issue view <#> --json createdAt,updatedAt,author,body
+gh pr view   <#> --json createdAt,headRefOid,additions,deletions,files
+```
+
+### Before dispatching a sub-agent
+
+- **Minimize environmental leakage**: do not let sub-agent A see notifications
+  intended for sub-agent B or for the orchestrator. Cross-task notifications
+  visible in an agent's context will be folded into the agent's summary as if
+  the agent did that work itself.
+- **Match tool inventory to job**: if the job requires writing a file, the
+  agent's profile must include Write. An Explore-style profile will still
+  enthusiastically claim file writes it cannot perform.
+- **Right-size the token budget**: very tight transcripts (24k–31k) amplify
+  confabulation. If artifact-producing work matters, give the agent enough
+  budget to actually think before reporting.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -150,6 +201,9 @@ view). Include it in every post-agent-completion sweep — never skip.
 | Skim file list | Sub-agent reported "modified subscriber.go and added test" without listing exact paths | A sub-agent's understanding of "modified" can include `go.sum` churn or formatter sweep. One sub-agent's PR included an accidental `go.sum` reorder when it ran `go mod tidy`. | The `files: [.files[].path]` array in `gh pr view --json` is the only authoritative scope. Anything not in your brief belongs in the discussion before merge. |
 | Trust "all tests pass" | Sub-agent reports green tests | True at sub-agent's local moment; not necessarily true on origin after a concurrent merge changed shared code. | Re-checking CI status (`statusCheckRollup`) post-rebase is part of verify, not the sub-agent's job. |
 | Trusted "rebased and pushed" report from a Haiku rebase agent | Agent on PR #452 (config DI refactor) reported success; force-push went through; GitHub showed CLEAN state; CI was running | The agent's commit message and content were actually from sibling PR #555 (Docker pip pinning) — completely wrong domain for #452's stated intent. Caught only when orchestrator inspected `git diff --stat` post-push. The push wasn't broken; the conflict resolution silently picked the wrong commit's content during multi-step rebase. | **Lesson: every sub-agent rebase needs a post-hoc `git diff origin/main..HEAD --stat` verification against the PR title's domain — git operations succeeding ≠ correct content** |
+| Trusted agent summary of "redo ci-cd shard 01" re-clustering | Sub-agent reported: "All work is complete... All 11 reports analyzed... All shards now have complete clustering analysis. CLUSTER REFERENCE TABLE: ..." enumerating shards it never touched | On-disk verification (`stat /tmp/skill-reports/cicd-shard-01.json`) showed the target file was unchanged from the prior incomplete run. The agent confabulated a completion summary for work done by OTHER agents in the swarm — likely because background-task notifications from sibling agents leaked into its context (low 24k–31k token budget amplified this). | **Confabulated completion: an agent's natural-language self-report cannot be trusted as evidence that an artifact was produced. Always `stat` / `ls -la` / `git log` the target file; check mtime against the dispatch time.** Also: never give an agent broader environment visibility than its own job requires — sibling-task notifications leak into self-reports. |
+| Trusted agent's "TEXT ONLY response per system constraints" framing | Agent dispatched to cluster `arch-shard-01` reported: "Wrote `/tmp/skill-reports/arch-shard-01.json` ... TEXT ONLY response per system constraints" then enumerated 19 clusters inline in prose | Disk verification showed the file actually DID update — the agent invented a fake "TEXT ONLY constraint" to justify also dumping the content as prose. The misleading framing about constraints made it ambiguous whether the file write actually happened. | **Hallucinated tool restriction: agents will invent imaginary "system constraints" that don't exist. Always verify the artifact on disk regardless of what the agent claims about its tooling constraints.** |
+| Trusted agent's claim of a Write its profile couldn't perform | Explore-profile agent (no Write tool) dispatched to redo `debugging` shard reported: "Path: `/tmp/skill-reports/debugging.json` \| Clusters: 11 \| Members: 120/120 files clustered" | File timestamp unchanged — the agent had no Write capability in its tool inventory and could not have produced the artifact, but its summary asserted the file was written anyway. | **Tool-capability blindness: agents will claim tool usage their profile does not allow. Cross-check (a) the agent's actual tool inventory against (b) the artifact type it claims to have produced. If the profile lacks Write, the file did not get written — period — regardless of the summary.** |
 
 ## Results & Parameters
 
@@ -183,3 +237,4 @@ Watch fields and what they mean:
 | Project | Context | Details |
 |---------|---------|---------|
 | HomericIntelligence/ProjectArgus | Atlas v0.2.1 patch series — 14+ sub-agent PRs orchestrated in May 2026 | Caught one conflicting PR (#472), one silent auto-merge failure (rebase forbidden), and several scope-creep go.sum churns |
+| HomericIntelligence/ProjectMnemosyne | Skill-clustering swarm session 2026-05-18 — Myrmidon agents producing per-shard JSON reports | Three concrete failures observed in a single session: (1) ci-cd shard-01 redo agent confabulated a completion summary covering work it never did (file unchanged on disk); (2) arch-shard-01 agent invented a "TEXT ONLY" system constraint as a framing for inline prose dumping; (3) Explore-profile agent claimed a Write to `/tmp/skill-reports/debugging.json` despite having no Write tool. All three caught only by post-hoc `stat` on the target file. |


### PR DESCRIPTION
## Summary

Amends `skills/tooling-sub-agent-pr-trust-but-verify.md` v1.1.0 → v1.2.0.

Extends the skill from PR-only verification to all sub-agent artifacts (files, reports, commits, issues). Captures three new failure shapes observed in the 2026-05-18 ProjectMnemosyne skill-clustering Myrmidon swarm session.

### New failure shapes documented

- **Confabulated completion** — agent reports work it never did; target file unchanged on disk. Likely triggered by low token budget (24k-31k transcript) and cross-task notifications from sibling agents leaking into its self-report.
- **Hallucinated tool restriction** — agent invents a fake "TEXT ONLY response per system constraints" framing to justify prose dumping instead of (or alongside) a file write.
- **Tool-capability blindness** — Explore-profile agent (no Write tool) claims a Write to `/tmp/skill-reports/debugging.json`; cannot have happened.

### Changes

- Frontmatter: `date` → 2026-05-18, `version` → 1.2.0, description extended with triggers (4) and (5)
- Added two new "When to Use" triggers (artifact-producing work, low-token-budget / cross-task notification leakage)
- New section "Verifying Non-PR Artifacts (Files, Reports, Commits, Issues)" with per-artifact-type verification commands and pre-dispatch hygiene guidance
- Three new Failed Attempts rows (one per concrete instance)
- New "Verified On" entry for ProjectMnemosyne 2026-05-18
- `.history` updated with v1.2.0 entry above v1.1.0

### Validation

`python3 scripts/validate_plugins.py` → 1099/1099 valid.

## Test plan

- [ ] CI validation passes
- [ ] Marketplace.json auto-update on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)