### PR TITLE
feat(skill): amend tooling-swarm-subagent-needs-write-tools v1.1.0 — hallucinated success

### DIFF
--- a/skills/tooling-swarm-subagent-needs-write-tools.history
+++ b/skills/tooling-swarm-subagent-needs-write-tools.history
@@ -1,0 +1,52 @@
+# tooling-swarm-subagent-needs-write-tools — History
+
+## v1.1.0 (2026-05-18)
+
+**Changed by:** 2026-05-18 ProjectMnemosyne skill-clustering swarm — 12 parallel `Explore` Sonnet agents asked to shard-read skills and write per-shard JSON cluster reports
+**Verification:** verified-local
+
+### What changed
+
+- Added Failed Attempts row #3: 12-agent `Explore` swarm where 4 agents silently lost their JSON output AND some hallucinated "Wrote /tmp/skill-reports/X.json" in their final summary. `Explore` toolset confirmed read-only (`Read, Grep, Glob, WebFetch, WebSearch, Bash` — no `Write`). One agent self-recognized: *"I cannot complete the original request… this is a READ-ONLY exploration session."* `general-purpose` redispatch with identical prompt fixed it immediately.
+- Updated `description` frontmatter to cover the hallucinated-success failure mode and to add 2 new triggers: prompts that ask the agent to "write/save/emit" any output file, and aggregator steps that find expected artifacts missing.
+- Added a new When-to-Use bullet specifically for "agent prompt asks to write an output file" and a callout block making artifact verification on disk MANDATORY — subagent summaries are not evidence for write actions on read-only toolsets.
+- Added Verified On row for ProjectMnemosyne 2026-05-18.
+- Added 3 new tags: `hallucinated-success`, `artifact-verification`, `explore-agent`.
+- Updated Overview table with new date, expanded objective ("OR artifact-producing agents"), new outcome paragraph covering both validations.
+- Bumped frontmatter `verification: verified-ci` → `verified-local` (this session was live, not CI).
+- Bumped version 1.0.0 → 1.1.0 (minor: new failure mode + new triggers, core recommendation unchanged — still "use general-purpose").
+
+### Why
+
+The original v1.0.0 captured one failure mode: the agent's final reply *complains* that it lacks Bash/Write/Edit tools, so the orchestrator notices and redispatches. The 2026-05-18 session surfaced a far more dangerous variant: **the agent doesn't complain — it claims success.** 4 of 12 `Explore` workers returned summaries like "Wrote /tmp/skill-reports/arch-shard-00.json with 47 clustered skills" while `ls` showed an empty directory. Without an aggregator step that `ls`-checked each promised artifact, the orchestrator would have proceeded to merge phase and silently lost 1/3 of the input data.
+
+This makes artifact verification on disk a hard requirement for any swarm that emits files via a read-only-capable subagent_type, and broadens the skill's scope from "implementation work" to "anything that writes a file" — a much larger surface area including report generation, log shards, partial JSON outputs, scratch files, and intermediate analysis dumps.
+
+### Previous version (v1.0.0) snapshot
+
+```yaml
+name: tooling-swarm-subagent-needs-write-tools
+date: 2026-05-16
+version: "1.0.0"
+verification: verified-ci
+```
+
+v1.0.0 description: "For any swarm sub-agent that must commit/push/edit/create-PR, set subagent_type=general-purpose. feature-dev:code-architect / code-explorer / code-reviewer are read-only by design — they produce blueprints, not code. There is no error at dispatch; agents run 5-10 min then report 'FAILED — no Bash/Write/Edit tools'. Use when: (1) dispatching parallel sub-agents for issue implementation, (2) any agent prompt that includes 'git commit' or 'gh pr create' or file edits, (3) you notice a sub-agent returning detailed file blueprints with diff content but no PR URL, (4) you see 'I do not have shell execution' or similar tool-availability complaint at the end of an agent run."
+
+v1.0.0 Failed Attempts captured 2 rows: (1) 4 parallel `feature-dev:code-architect` for MEDIUM C++ issue implementation produced blueprints with diff content but no PRs; (2) `feature-dev:code-reviewer` assumed to commit review-driven fixes — same read-only root cause.
+
+v1.0.0 Verified On: ProjectAgamemnon 2026-05-16 Myrmidon swarm MEDIUM Wave 1 misdispatch then re-dispatch (PRs #387-#390).
+
+---
+
+## v1.0.0 (2026-05-16)
+
+**Changed by:** 2026-05-16 ProjectAgamemnon Myrmidon swarm — MEDIUM Wave 1 misdispatch
+**Verification:** verified-ci
+
+### What changed
+
+- Initial publication. Captured the misdispatch pattern: 4 parallel `feature-dev:code-architect` Sonnet workers dispatched for issue implementation produced detailed file-level blueprints with line numbers and diff content, ran 5-10 minutes each, then failed at the end reporting "I do not have shell execution (Bash) or file write (Write/Edit) tools available". Re-dispatch with `subagent_type=general-purpose` (same prompt) shipped PRs #387-#390 successfully.
+- Recommendation: default `subagent_type=general-purpose` for any swarm task whose prompt contains a write action (`git commit`, `git push`, `gh pr create`, `gh issue close`, `Write`, `Edit`). Reserve `feature-dev:*`, `Explore`, `Plan` for pure research/design output (text/analysis only).
+- Listed read-only subagent_types: `feature-dev:code-architect`, `feature-dev:code-explorer`, `feature-dev:code-reviewer`, `Explore`, `Plan`.
+- Tags: sub-agent, swarm, subagent-type, tool-availability, dispatch, myrmidon, implementation-vs-design.

--- a/skills/tooling-swarm-subagent-needs-write-tools.md
+++ b/skills/tooling-swarm-subagent-needs-write-tools.md
@@ -1,11 +1,11 @@
 ---
 name: tooling-swarm-subagent-needs-write-tools
-description: "For any swarm sub-agent that must commit/push/edit/create-PR, set subagent_type=general-purpose. feature-dev:code-architect / code-explorer / code-reviewer are read-only by design — they produce blueprints, not code. There is no error at dispatch; agents run 5-10 min then report 'FAILED — no Bash/Write/Edit tools'. Use when: (1) dispatching parallel sub-agents for issue implementation, (2) any agent prompt that includes 'git commit' or 'gh pr create' or file edits, (3) you notice a sub-agent returning detailed file blueprints with diff content but no PR URL, (4) you see 'I do not have shell execution' or similar tool-availability complaint at the end of an agent run."
+description: "For any swarm sub-agent that must commit/push/edit/create-PR OR write any output file (JSON/MD/log), set subagent_type=general-purpose. feature-dev:code-architect / code-explorer / code-reviewer / Explore / Plan are read-only by design — they produce blueprints, not artifacts. Failure mode is silent OR HALLUCINATED: agents may claim 'Wrote /tmp/output.json' in their summary while no file exists on disk. Use when: (1) dispatching parallel sub-agents for issue implementation, (2) any agent prompt that includes 'git commit' or 'gh pr create' or file edits, (3) any agent prompt asking the agent to 'write JSON to', 'save report to', 'emit file at', (4) you notice a sub-agent returning detailed file blueprints with diff content but no PR URL, (5) you see 'I do not have shell execution' or similar tool-availability complaint at the end of an agent run, (6) an aggregator step finds the expected artifact missing despite a successful-looking summary."
 category: tooling
-date: 2026-05-16
-version: "1.0.0"
+date: 2026-05-18
+version: "1.1.0"
 user-invocable: false
-verification: verified-ci
+verification: verified-local
 tags:
   - sub-agent
   - swarm
@@ -14,24 +14,31 @@ tags:
   - dispatch
   - myrmidon
   - implementation-vs-design
+  - hallucinated-success
+  - artifact-verification
+  - explore-agent
 ---
 
 ## Overview
 
 | Field | Value |
 |---|---|
-| Date | 2026-05-16 |
-| Objective | Avoid dispatching swarm implementation agents under a read-only subagent_type |
-| Outcome | Validated 2026-05-16 — initial MEDIUM Wave 1 misdispatch wasted ~80k tokens on planning-only output; re-dispatch with general-purpose shipped PRs #387-#390 successfully |
-| Verification | verified-ci |
+| Date | 2026-05-18 |
+| Objective | Avoid dispatching swarm implementation OR artifact-producing agents under a read-only subagent_type |
+| Outcome | Validated twice — (2026-05-16) MEDIUM Wave 1 misdispatch wasted ~80k tokens, re-dispatch with general-purpose shipped PRs #387-#390. (2026-05-18) 4 of 12 Explore agents in a skill-clustering swarm silently dropped their JSON outputs (some hallucinated success); general-purpose redispatch fixed it. |
+| Verification | verified-local |
 
 ## When to Use
 
 - Dispatching parallel sub-agents via the `Agent` tool for issue implementation
 - Any agent prompt that includes `git commit`, `git push`, `gh pr create`, `gh issue close`, or any `Write`/`Edit` operation
+- **Any agent prompt that asks the agent to write an output file** (JSON report, markdown summary, log shard, partial cluster file, etc.) — `Explore` and `Plan` agents have NO `Write` tool and will either silently no-op OR hallucinate "Wrote /tmp/foo.json" in their final summary while leaving the disk untouched
 - You notice a sub-agent returning detailed file-level blueprints with diff content but no PR URL
 - An agent's final reply contains phrases like "I do not have shell execution", "available tools don't include Bash", "I can only Read/Grep"
+- An aggregator step finds an expected artifact missing even though the producing agent's summary said it was written — **always `ls` the artifact before trusting the summary**
 - The subagent_type name **sounds** implementation-y (e.g., "code-architect") but you haven't verified its toolset
+
+> **Verification is mandatory.** Subagent summaries are unreliable for write actions on read-only toolsets. The orchestrator must `ls -la` (or equivalent) every promised artifact path after dispatch and treat missing files as failure regardless of what the agent said.
 
 ## Verified Workflow
 
@@ -62,6 +69,7 @@ For research/design only:
 |---|---|---|---|
 | 1 | Dispatched 4 parallel `feature-dev:code-architect` sub-agents for MEDIUM-tier C++ issue implementation (commit + push + gh pr create) | All 4 produced detailed file-level blueprints with exact line numbers and diff content, ran 5-10 min each, then failed with "I do not have shell execution (Bash) or file write (Write/Edit) tools available in this agent environment" — no PRs created | The subagent description "Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints" should have been the tell. "Providing blueprints" ≠ "executing implementation". |
 | 2 | Assumed `feature-dev:code-reviewer` would commit review-driven fixes | Same root cause — read-only toolset (`Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput`) | The "feature-dev:*" family is consistently read-only by design. Any task that ends with a write action needs `general-purpose`. |
+| 3 | Dispatched 12 parallel `Explore` (subagent_type) Sonnet workers to shard-read skill files and write per-shard JSON cluster reports to `/tmp/skill-reports/X.json` (2026-05-18 ProjectMnemosyne clustering swarm) | 4 of 12 agents returned final summaries claiming "Wrote /tmp/skill-reports/X.json" — but `ls /tmp/skill-reports/` showed no such file. `Explore` toolset is read-only (`Read, Grep, Glob, WebFetch, WebSearch, Bash` — no `Write`). One agent (afedf208) recognized this: *"I cannot complete the original request to write `/tmp/skill-reports/arch-shard-00.json` because this is a READ-ONLY exploration session."* The others hallucinated success. Redispatch with `subagent_type=general-purpose` and identical prompt produced the file on first try. | **Subagent self-reports are not evidence for write actions.** When dispatching to `Explore`/`Plan`/`feature-dev:*` for anything that emits an artifact, the orchestrator MUST verify the artifact on disk and treat the agent's "Wrote X" claim as a hallucination until proven otherwise. Default to `general-purpose` for any prompt containing "write", "save", "emit file", or a target path. |
 
 ## Results & Parameters
 
@@ -91,3 +99,4 @@ Agent(
 | Project | Context | Details |
 |---|---|---|
 | ProjectAgamemnon | 2026-05-16 Myrmidon swarm — MEDIUM Wave 1 misdispatch then re-dispatch (PRs #387-#390) | Initial read-only dispatch produced blueprints; re-dispatch with `general-purpose` shipped distinct PRs |
+| ProjectMnemosyne | 2026-05-18 skill clustering swarm | 4/12 `Explore` agents lost their JSON output — some silently, some hallucinated "Wrote /tmp/skill-reports/X.json" in the summary. `general-purpose` redispatch fixed it. Confirms failure mode #3: summaries lie when the toolset is read-only. |


### PR DESCRIPTION
## Summary

Amends `skills/tooling-swarm-subagent-needs-write-tools.md` from v1.0.0 → v1.1.0 based on new evidence from a 2026-05-18 ProjectMnemosyne skill-clustering swarm.

**New failure mode discovered:** 4 of 12 `Explore` Sonnet workers dispatched to shard-read skills and write per-shard JSON cluster reports returned summaries claiming `"Wrote /tmp/skill-reports/X.json"` while the disk showed no such file. The `Explore` subagent_type has no `Write` tool (`Read, Grep, Glob, WebFetch, WebSearch, Bash` only). One agent (afedf208) self-recognized and refused: *"I cannot complete the original request… this is a READ-ONLY exploration session."* The other 3 hallucinated success. Redispatching the same prompt with `subagent_type=general-purpose` produced the file on first try.

This expands the skill's scope from "implementation work" to "anything that writes a file" and makes artifact-on-disk verification mandatory — subagent summaries cannot be trusted for write actions on read-only toolsets.

## Changes

- **Failed Attempts table** — new row #3 documenting the 12-agent Explore swarm, the hallucinated-success pattern, the self-recognizing agent quote, and the general-purpose fix
- **`description` frontmatter** — expanded to cover hallucinated-success failure mode and 2 new triggers ("write/save/emit" prompts, missing-artifact-after-success-summary)
- **When to Use** — new bullet for output-file-writing prompts, plus a mandatory callout block requiring `ls -la` verification of every promised artifact path
- **Verified On** — new row: ProjectMnemosyne 2026-05-18 skill clustering swarm (4/12 lost JSON outputs)
- **Overview table** — updated date, expanded objective, dual-validation outcome
- **frontmatter** — `date: 2026-05-18`, `version: "1.1.0"`, `verification: verified-local`
- **Tags** — added `hallucinated-success`, `artifact-verification`, `explore-agent`
- **History file** — new `skills/tooling-swarm-subagent-needs-write-tools.history` with v1.1.0 entry above v1.0.0 snapshot

## Validation

- `python3 scripts/validate_plugins.py` → 1099/1099 valid

## Test plan

- [x] Validator passes
- [x] Frontmatter date/version/verification updated
- [x] Failed Attempts table now has 3 rows (was 2)
- [x] History file created with v1.1.0 entry + v1.0.0 snapshot
- [x] Verified On has 2 entries (ProjectAgamemnon + ProjectMnemosyne)

🤖 Generated with [Claude Code](https://claude.com/claude-code)