### PR TITLE
feat: amend architecture-shipping-mojo-package-prefix-dev skill (v2.0.0)

### DIFF
--- a/skills/architecture-shipping-mojo-package-prefix-dev.history
+++ b/skills/architecture-shipping-mojo-package-prefix-dev.history
@@ -1,0 +1,104 @@
+# architecture-shipping-mojo-package-prefix-dev — History
+
+## v2.0.0 (2026-05-19)
+
+**Changed by:** ProjectOdyssey issue #5413 end-to-end packaging verification session
+**Verification:** verified-local (recipe build, install-local, wheel, release artifacts verified locally / in the release run; modular-community channel install still unverified pending modular/modular-community#274 merge)
+
+### What changed
+
+- Upgraded verification level `unverified` → `verified-local`. The core workflow (idiomatic
+  `src/<package>/` layout, `conda.recipe/recipe.yaml` rattler-build, `.mojopkg` build, install-local,
+  Python wheel, release-artifact attachment) was executed end-to-end in ProjectOdyssey. The
+  modular-community *channel install* end remains unverified — modular/modular-community#274 is open
+  but not yet merged, so consumers cannot yet `pixi add projectodyssey`.
+- Rewrote the **Publish** step: publishing requires an **org-fork workflow**, not a direct push.
+  `gh repo fork modular/modular-community --org <ORG>`, clone the FORK as `origin`, rely on
+  `gh repo clone`'s auto-added `upstream` remote, hard-sync the fork's main to `upstream/main`,
+  push the branch to the fork, then `gh pr create --repo modular/modular-community --head <ORG>:<branch>`.
+- Added 3 new Failed Attempts rows: (a) the script pushing directly to `modular/modular-community`
+  with no push access, (b) `git remote add upstream` failing with exit 3 because `gh repo clone` of
+  a fork already added `upstream`, (c) `--dry-run` masking the push-access failure entirely.
+- Added the fork-workflow Quick Reference block and a `publish_modular_community.py` notes section.
+- Updated the "Verified On" table with the #5413 session and modular/modular-community#274.
+
+### Why
+
+v1.0.0 was synthesized from surveying published Mojo packages and Modular docs and was never
+executed end-to-end ("Not yet executed end-to-end in any project the author controls"). ProjectOdyssey
+issue #5413 drove the workflow to completion, which (a) confirmed most of the workflow works and
+(b) surfaced that `scripts/publish_modular_community.py` cloned `modular/modular-community` and did
+`git push -u origin <branch>` directly — impossible without push access to Modular's repo. The
+`--dry-run` mode masked the bug because dry-run never pushes. The fix is the standard upstream-fork
+contribution workflow, which v1.0.0 hand-waved as "Fork modular/modular-community" without the
+mechanics.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: architecture-shipping-mojo-package-prefix-dev
+description: "End-to-end pattern for making a Mojo library installable via `pixi add <pkg>` from the modular-community channel: idiomatic `src/<package_name>/` layout, `conda.recipe/recipe.yaml` (rattler-build), PR to `modular/modular-community`, and optional Python wheel that bundles the `.mojopkg`. Use when: (1) planning to publish a Mojo library, (2) converting an in-tree `shared/` directory into a distributable package, (3) replacing fictional `mojo install`/`mojo publish` CLI references in docs, (4) deciding between conda channel vs Python wheel vs git dependency for distribution."
+category: architecture
+date: 2026-05-18
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [mojo-packaging, prefix-dev, modular-community, rattler-build, mojopkg, python-wheel, conda]
+---
+
+# Shipping a Mojo Package via prefix.dev (modular-community)
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-18 |
+| **Objective** | Document the actual, end-to-end pattern for shipping a Mojo library so downstream consumers can `pixi add <pkg>` from the modular-community channel and `from <pkg>.<mod> import <symbol>` in Mojo |
+| **Outcome** | Synthesized plan from surveying NuMojo, decimojo, argmojo, mist, and mojolang.org docs (May 2026). Not yet executed end-to-end in any project the author controls. |
+| **Verification** | unverified |
+
+## When to Use
+
+- Planning to publish a new Mojo library so others can install it with `pixi add`
+- Converting an in-tree `shared/` (or similar) directory into a distributable package
+- Replacing references to the **fictional** `mojo install` / `mojo publish` / `mojo list` / `mojo uninstall` CLI commands in docs or scripts
+- Choosing between three distribution channels for a Mojo library:
+  - **Conda channel** (modular-community on prefix.dev) — recommended default
+  - **Python wheel** (pip-installable) — adds Python interop or loader-only access
+  - **Git dependency** (via `pixi-build` preview or `pixi add -g <git-url>`) — fastest iteration, less discoverable
+
+## CRITICAL — Fictional CLI Commands
+
+These commands **do not exist** in Mojo 1.0 (May 2026). Many tutorials and old INSTALL docs reference them — replace before users try them:
+
+| Old (fictional) | Real (Mojo 1.0, May 2026) |
+|-----------------|---------------------------|
+| `mojo package ... --install` | `pixi add <pkg>` from modular-community channel |
+| `mojo install <file.mojopkg>` | Drop the `.mojopkg` next to `main.mojo`, OR pass `-I /path/to/dir` containing it |
+| `mojo publish` | Open a PR to `modular/modular-community` adding `recipes/<pkg>/recipe.yaml` |
+| `mojo list` | `pixi list` |
+| `mojo uninstall <pkg>` | `pixi remove <pkg>` |
+
+## Verified Workflow
+
+> **Verification status: UNVERIFIED — treat this as a "Proposed Workflow".** This workflow has not been validated end-to-end. It is synthesized from reading real published Mojo packages (decimojo, argmojo, NuMojo, mist) and the official Modular docs at <https://mojolang.org/docs/tools/packaging/>. ProjectOdyssey is partway through implementing it (PR #5414 in flight; recipe + release workflow + wheel PRs queued). Treat as a hypothesis until at least one project completes the full conda-channel publish end-to-end.
+
+### Quick Reference
+
+(see v1.0.0 git history for the full body — layout, build, recipe-test, publish steps,
+detailed steps 1-7, Failed Attempts table with 3 rows, Results & Parameters, Verified On)
+```
+
+> Full v1.0.0 body is preserved in git history at the commit prior to this amendment
+> (branch `skill/amend-shipping-mojo-package-prefix-dev`). The snapshot above captures the
+> frontmatter and the load-bearing sections that changed; the rest of v1.0.0 (layout diagram,
+> recipe skeleton, wheel flavors) is carried forward unchanged into v2.0.0.
+
+---
+
+## v1.0.0 (2026-05-18)
+
+**Initial version.** Synthesized from surveying NuMojo, decimojo, argmojo, mist, and the
+official Modular packaging docs. Verification level: `unverified` — not yet executed
+end-to-end in any project the author controls.

--- a/skills/architecture-shipping-mojo-package-prefix-dev.md
+++ b/skills/architecture-shipping-mojo-package-prefix-dev.md
@@ -2,11 +2,12 @@
 name: architecture-shipping-mojo-package-prefix-dev
 description: "End-to-end pattern for making a Mojo library installable via `pixi add <pkg>` from the modular-community channel: idiomatic `src/<package_name>/` layout, `conda.recipe/recipe.yaml` (rattler-build), PR to `modular/modular-community`, and optional Python wheel that bundles the `.mojopkg`. Use when: (1) planning to publish a Mojo library, (2) converting an in-tree `shared/` directory into a distributable package, (3) replacing fictional `mojo install`/`mojo publish` CLI references in docs, (4) deciding between conda channel vs Python wheel vs git dependency for distribution."
 category: architecture
-date: 2026-05-18
-version: "1.0.0"
+date: 2026-05-19
+version: "2.0.0"
 user-invocable: false
-verification: unverified
-tags: [mojo-packaging, prefix-dev, modular-community, rattler-build, mojopkg, python-wheel, conda]
+verification: verified-local
+history: architecture-shipping-mojo-package-prefix-dev.history
+tags: [mojo-packaging, prefix-dev, modular-community, rattler-build, mojopkg, python-wheel, conda, org-fork, upstream-pr]
 ---
 
 # Shipping a Mojo Package via prefix.dev (modular-community)
@@ -15,10 +16,11 @@ tags: [mojo-packaging, prefix-dev, modular-community, rattler-build, mojopkg, py
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-05-18 |
+| **Date** | 2026-05-19 |
 | **Objective** | Document the actual, end-to-end pattern for shipping a Mojo library so downstream consumers can `pixi add <pkg>` from the modular-community channel and `from <pkg>.<mod> import <symbol>` in Mojo |
-| **Outcome** | Synthesized plan from surveying NuMojo, decimojo, argmojo, mist, and mojolang.org docs (May 2026). Not yet executed end-to-end in any project the author controls. |
-| **Verification** | unverified |
+| **Outcome** | Executed end-to-end in ProjectOdyssey (issue #5413): `src/projectodyssey/` layout, `conda.recipe/recipe.yaml`, `.mojopkg` build, install-local, Python wheel, and release-artifact attachment all verified. The modular-community PR (modular/modular-community#274) is open but **not yet merged**, so the channel-install end is still unverified. |
+| **Verification** | verified-local — recipe build / install-local / wheel / release artifacts verified locally and in the release run; modular-community channel install pending modular/modular-community#274 merge |
+| **History** | [changelog](./architecture-shipping-mojo-package-prefix-dev.history) |
 
 ## When to Use
 
@@ -44,7 +46,14 @@ These commands **do not exist** in Mojo 1.0 (May 2026). Many tutorials and old I
 
 ## Verified Workflow
 
-> **Verification status: UNVERIFIED — treat this as a "Proposed Workflow".** This workflow has not been validated end-to-end. It is synthesized from reading real published Mojo packages (decimojo, argmojo, NuMojo, mist) and the official Modular docs at <https://mojolang.org/docs/tools/packaging/>. ProjectOdyssey is partway through implementing it (PR #5414 in flight; recipe + release workflow + wheel PRs queued). Treat as a hypothesis until at least one project completes the full conda-channel publish end-to-end.
+> **Verification status: VERIFIED-LOCAL.** ProjectOdyssey (issue #5413) executed this workflow
+> end-to-end: the `src/projectodyssey/` layout, `conda.recipe/recipe.yaml`, local `.mojopkg`
+> build, install-local, the Python wheel, and the release-artifact attachment are all verified
+> locally / in the release run. The **one remaining unverified step** is the modular-community
+> *channel install*: modular/modular-community#274 is open but not yet merged, so consumers
+> cannot yet `pixi add projectodyssey` from the channel. Treat steps 1–4 and 7 as verified;
+> treat step 5 (publish) as verified-up-to-PR-open and the consumer experience (step 6) as
+> pending the upstream merge.
 
 ### Quick Reference
 
@@ -64,8 +73,13 @@ pixi exec --spec rattler-build -- rattler-build build \
   -c https://conda.modular.com/max \
   -c https://repo.prefix.dev/modular-community
 
-# 4. Publish: PR to modular/modular-community
-#    Add recipes/<pkg>/recipe.yaml + a test .mojo file
+# 4. Publish via an ORG FORK (you have no push access to modular/modular-community)
+gh repo fork modular/modular-community --org <ORG> --clone=false   # one-time
+gh repo clone <ORG>/modular-community /tmp/mc                       # auto-adds `upstream`
+cd /tmp/mc && git fetch upstream && git checkout main && git reset --hard upstream/main
+git checkout -b add-<pkg>-recipe   # add recipes/<pkg>/, commit
+git push -u origin add-<pkg>-recipe
+gh pr create --repo modular/modular-community --head <ORG>:add-<pkg>-recipe --title "Add <pkg> recipe"
 #    prefix.dev builds & publishes automatically on merge
 ```
 
@@ -119,15 +133,51 @@ pixi exec --spec rattler-build -- rattler-build build \
   -c https://repo.prefix.dev/modular-community
 ```
 
-#### 5. Publish
+#### 5. Publish — via an org fork (NOT a direct push)
 
-Open a PR to <https://github.com/modular/modular-community>. The README's three required steps:
+You almost certainly do **not** have push access to `modular/modular-community`. Publishing is an
+**upstream-fork contribution workflow**. A script (or human) must fork the repo into the publishing
+org once, then always push branches to the *fork* and open PRs against *upstream*.
 
-1. Fork `modular/modular-community`
-2. Add `recipes/<pkg>/` folder containing `recipe.yaml` + the test `.mojo` file
-3. Open the PR
+```bash
+# 5a. ONE-TIME: fork modular/modular-community into your org
+gh repo fork modular/modular-community --org <ORG> --clone=false
 
-Once merged, prefix.dev's build infrastructure builds and publishes automatically. No further action needed.
+# 5b. Clone the FORK as `origin`. `gh repo clone` of a fork AUTO-ADDS `upstream`.
+gh repo clone <ORG>/modular-community /tmp/mc
+cd /tmp/mc
+# DO NOT run `git remote add upstream ...` — it already exists; double-adding errors (exit 3).
+git remote -v   # origin = your fork, upstream = modular/modular-community
+
+# 5c. Hard-sync the fork's main to upstream BEFORE branching (forks drift)
+git fetch upstream
+git checkout main
+git reset --hard upstream/main
+git push origin main
+
+# 5d. Branch, add recipes/<pkg>/, push to the FORK
+git checkout -b add-<pkg>-recipe
+mkdir -p recipes/<pkg>
+cp /path/to/recipe.yaml recipes/<pkg>/recipe.yaml
+cp /path/to/smoke.mojo  recipes/<pkg>/smoke.mojo
+git add recipes/<pkg>
+git commit -m "Add <pkg> recipe"
+git push -u origin add-<pkg>-recipe
+
+# 5e. Open the PR against UPSTREAM with a cross-fork head ref
+gh pr create --repo modular/modular-community \
+  --head <ORG>:add-<pkg>-recipe \
+  --title "Add <pkg> recipe" \
+  --body "Adds recipes/<pkg>/ ..."
+```
+
+Once merged, prefix.dev's build infrastructure builds and publishes automatically. No further action
+needed.
+
+**`--dry-run` trap:** if a publish script has a `--dry-run` mode that skips the `git push`, dry-run
+will report success even when the script is mis-wired to push directly to `modular/modular-community`
+(which has no push access). Always do at least one **real** (non-dry-run) execution against the fork
+before trusting the script.
 
 #### 6. Consumer experience
 
@@ -174,6 +224,9 @@ decimojo demonstrates a working pattern. Two flavors:
 | Believing `mojo install` / `mojo publish` exist | ProjectOdyssey's pre-May-2026 `shared/INSTALL.md` told users to run `mojo install <pkg>.mojopkg` and `mojo publish` | These commands do not exist in Mojo 1.0. They appear in older tutorials and AI-generated docs but have no implementation. Users hit "command not found" or silent no-ops. | Always verify CLI commands against `mojo --help` (Mojo 1.0, May 2026). The real distribution path is conda/prefix.dev via rattler-build — there is no first-party `mojo` publish UX. |
 | Shipping a flat `shared/` directory as the package root | Tried `mojo package shared/ -o shared.mojopkg` and proposing `shared` as the package name | (a) Non-idiomatic — Modular's docs and every major package (decimojo, argmojo) use `src/<package_name>/`. (b) `shared` is a generic name that would collide on prefix.dev's global namespace. (c) Imports become `from shared.x import y` which is ambiguous across projects. | Always use `src/<unique_package_name>/`. The directory name IS the import name AND the prefix.dev package name — they must all match and must be unique globally. |
 | Full Python native-bindings wheel as first attempt | Tried `mojo build --emit shared-lib` with `@export def PyInit_<pkg>` exposing tensor and layer types | Most Mojo stdlib types (Tensor, List, struct types) are not `ConvertibleFromPython` in Mojo 1.0 (May 2026). Bindings work for scalars (`Int`, `Float64`, `String`) but fail to compile or silently lose data for Tensor/List/custom structs without manual `PythonObject` packing/unpacking on every call site. | Start with the loader-only wheel pattern: bundle the `.mojopkg` as package data and expose `mojopkg_path()`. Add native bindings incrementally, per-symbol, only after confirming `ConvertibleFromPython` is implemented for every parameter and return type involved. |
+| Publish script pushed directly to `modular/modular-community` | `scripts/publish_modular_community.py` cloned `modular/modular-community` and ran `git push -u origin <branch>` against it | No push access to Modular's repo — `git push` is rejected (403 / permission denied). Publishing to an upstream you do not own is always a fork-and-PR workflow. | Fork `modular/modular-community` into the publishing org (`gh repo fork --org <ORG>`), clone the FORK as `origin`, push the branch to the fork, and `gh pr create --repo modular/modular-community --head <ORG>:<branch>`. |
+| `git remote add upstream` after `gh repo clone` of a fork | The script ran `git remote add upstream https://github.com/modular/modular-community` to set up the upstream remote | `gh repo clone` of a *fork* already adds an `upstream` remote automatically; adding it again fails with `fatal: remote upstream already exists` (exit 3) and aborts the script | After `gh repo clone <ORG>/<fork>`, the `upstream` remote already exists — do NOT add it. Just `git fetch upstream`. Only add `upstream` manually if you cloned with plain `git clone`. |
+| `--dry-run` masked the broken push | The publish script was exercised only with `--dry-run`, which reported success | Dry-run skips the actual `git push`, so it never exercised the (broken) direct-push-to-upstream code path. The push-access failure only appeared on the first real run. | A `--dry-run` that skips the push gives false confidence. Do at least one real (non-dry-run) execution against the fork before trusting a publish script. |
 
 ## Results & Parameters
 
@@ -251,7 +304,9 @@ channels = [
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | 4-PR plan: rename `shared/` → `src/projectodyssey/` (PR #5414 in flight), then conda.recipe + release workflow + wheel | Plan synthesized from May 2026 survey; end-to-end conda-channel publish not yet completed |
+| ProjectOdyssey | 4-PR implementation merged: rename `shared/` → `src/projectodyssey/` (#5414), conda recipe (#5415), Python wheel (#5416), release.yml (#5417) | Implementation landed; verification done separately under issue #5413 |
+| ProjectOdyssey | Issue #5413 end-to-end verification — recipe build, install-local, wheel, release artifacts all run successfully | 12 follow-up fix PRs (#5419–#5433); release pipeline reached `create-release` for the first time |
+| ProjectOdyssey | modular-community publish via org fork | `gh repo fork` into HomericIntelligence; modular/modular-community#274 opened (not yet merged — channel install unverified) |
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Amends the existing skill from v1.0.0 to v2.0.0. Previous version archived in
`architecture-shipping-mojo-package-prefix-dev.history`.

ProjectOdyssey issue #5413 executed this previously-unverified workflow end-to-end, and the
publish step needed a material rewrite.

- verification `unverified` -> `verified-local`: src layout, conda recipe, .mojopkg build,
  install-local, Python wheel, and release-artifact attachment all verified.
- Rewrote the Publish step: publishing requires an org-fork workflow, not a direct push.
- Added 3 Failed Attempts rows for the publish-script bugs.

## Verification Level

**verified-local** -- recipe build, install-local, wheel, and release artifacts all verified
locally / in the release run. The modular-community **channel install** end remains unverified:
modular/modular-community#274 is open but not yet merged.

## Key Findings

**What Worked**:
- `src/projectodyssey/` layout + `conda.recipe/recipe.yaml` (rattler-build) + loader-only wheel.
- Org-fork publish: `gh repo fork --org`, clone the fork as origin, rely on the auto-added
  `upstream` remote, hard-sync, push to the fork, cross-fork `gh pr create`.

**What Failed**:
- Publish script pushed directly to `modular/modular-community` -> no push access (403).
- `git remote add upstream` after `gh repo clone` of a fork -> remote already exists (exit 3).
- `--dry-run` masked the broken push because dry-run never pushes.

## Test Plan

- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>