### PR TITLE
feat: amend stale-plan-already-resolved skill (v1.1.0)

### DIFF
--- a/skills/stale-plan-already-resolved.history
+++ b/skills/stale-plan-already-resolved.history
@@ -1,3 +1,52 @@
+# stale-plan-already-resolved — History
+
+## v1.1.0 (2026-05-20) — Add close-directly-no-PR case and git log -S diagnostic
+
+**Changed by:** Session context (ProjectHephaestus#422 — CHANGELOG criterion already removed by PR #357)
+**Verification:** verified-local
+
+### What changed
+
+A user invoked "fix this issue" against ProjectHephaestus#422. The issue asked to remove a
+`CHANGELOG.md or equivalent release notes` line from the Documentation `<criteria>` blocks of
+four `repo-analyze*/SKILL.md` files, citing exact line numbers (`:107`, `:109`, `:133`, `:132`).
+
+Investigation found the work was already fully done:
+
+- The exact phrase did not appear anywhere in those files.
+- `git log -S "CHANGELOG.md or equivalent release notes" -- 'skills/repo-analyze*/SKILL.md'`
+  showed it had ALREADY been removed by commit `76b46c9` (PR #357,
+  "chore: remove CHANGELOG.md and changelog tooling", 2026-05-07), which dropped the whole
+  CHANGELOG pipeline ecosystem-wide.
+- The cited line numbers were stale — they predated PR #357.
+- The issue's optional "fold into Section 10" ask was already satisfied: Section 10 already
+  had a generic `Release management: versioning strategy (SemVer), release process documented`
+  criterion.
+- Correct outcome: NOTHING to change in code, docs, or comments. The issue was closed directly
+  as `completed` with an explanatory comment citing PR #357 — NO PR, because there was no diff
+  to make.
+
+This amendment adds, on top of v1.0.0:
+
+1. **New When-to-Use trigger** — an issue cites exact line numbers / a code snippet that does
+   not appear anywhere in the current files; the issue likely predates a merged fix.
+2. **New diagnostic** in Verified Workflow — `git log -S "<exact phrase or snippet from the
+   issue>" -- '<glob>'` is a fast, decisive way to find the commit/PR that already made the
+   change. Real example: `git log -S "CHANGELOG.md or equivalent release notes" --
+   'skills/repo-analyze*/SKILL.md'` surfaces PR #357 / commit `76b46c9`.
+3. **New decision case** — when there is NO functional change AND no comment/doc change to make,
+   close the issue DIRECTLY with `gh issue close <N> --reason completed --comment "<cites the
+   PR/commit that already did it>"`, no PR. The existing comment-only-PR guidance is kept for
+   the case where a clarifying comment IS warranted in a file.
+4. **New Failed Attempts row** — assuming a PR is always needed to close the issue.
+5. **New Verified On row** — ProjectHephaestus#422.
+
+Frontmatter: `version` bumped 1.0.0 → 1.1.0, `date` 2026-03-15 → 2026-05-20, added
+`verification: verified-local` and `history: stale-plan-already-resolved.history`.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
 ---
 name: stale-plan-already-resolved
 description: 'Detect when an issue''s implementation plan is stale because the fix
@@ -5,11 +54,9 @@ description: 'Detect when an issue''s implementation plan is stale because the f
   match current code, or the requested change is already satisfied by a broader fix
   already in place.'
 category: ci-cd
-date: 2026-05-20
-version: 1.1.0
+date: 2026-03-15
+version: 1.0.0
 user-invocable: false
-verification: verified-local
-history: stale-plan-already-resolved.history
 ---
 ## Overview
 
@@ -19,8 +66,6 @@ history: stale-plan-already-resolved.history
 | **Key insight** | Always verify actual current state before applying a plan — plans can become stale after other PRs merge |
 | **Impact** | Prevents unnecessary changes and incorrect "fixes" that would revert progress |
 | **Context** | Issue #4280: plan said change `test_*_layers.mojo` → `test_*_layers*.mojo`, but code already used `test_*.mojo` |
-| **Verification** | verified-local |
-| **History** | [changelog](./stale-plan-already-resolved.history) |
 
 ## When to Use
 
@@ -29,7 +74,6 @@ history: stale-plan-already-resolved.history
 3. A follow-up issue references a prior fix (e.g., "follow-up from #3458") and the code may have evolved
 4. The plan was written weeks ago and many PRs have merged since
 5. CI pattern change issues where the pattern may have been updated as part of a broader consolidation
-6. An issue cites exact line numbers or a code snippet that does not appear anywhere in the current files — the issue likely predates a merged fix that already removed or moved the target
 
 ## Verified Workflow
 
@@ -60,29 +104,7 @@ grep -n "test_\*_layers\.mojo" .github/workflows/comprehensive-tests.yml
 grep -A3 '"Models"' .github/workflows/comprehensive-tests.yml
 ```
 
-### 4. Find the commit/PR that already made the change (decisive diagnostic)
-
-When the plan's "before" state is gone, `git log -S` pinpoints exactly which commit removed
-or changed it. Search for the **exact phrase or code snippet quoted in the issue**:
-
-```bash
-# git log -S finds commits that ADDED or REMOVED the given string
-git log -S "<exact phrase or snippet from the issue>" -- '<glob>'
-```
-
-Real example — issue #422 asked to remove a `CHANGELOG.md or equivalent release notes`
-criterion line from four `repo-analyze*/SKILL.md` files:
-
-```bash
-git log -S "CHANGELOG.md or equivalent release notes" -- 'skills/repo-analyze*/SKILL.md'
-# → surfaces commit 76b46c9 (PR #357, "chore: remove CHANGELOG.md and changelog tooling")
-#   which already removed the line ecosystem-wide weeks before the issue was actioned.
-```
-
-If `git log -S` shows the string was already removed by a merged commit, the issue's cited
-line numbers are stale and the requested change is already done.
-
-### 5. Determine if the issue's goal is already satisfied
+### 4. Determine if the issue's goal is already satisfied
 
 The key question: does the current state **achieve the same objective** as the planned change?
 
@@ -92,16 +114,12 @@ The key question: does the current state **achieve the same objective** as the p
 | Add explicit filenames | Wildcard already present | Goal already met — no change needed |
 | Remove explicit filenames | Already using wildcard | Goal already met — document only |
 
-### 6. Apply the minimal appropriate change
+### 5. Apply the minimal appropriate change
 
-Pick the action based on whether **any file** still needs to change:
+If the goal is already met, the appropriate fix is:
 
-| Situation | Correct action |
-| ----------- | ---------------- |
-| Functional fix already exists, but a comment/doc would clarify current intent | Update the comment/doc, then create a comment-only PR with `Closes #<issue>` |
-| Goal is fully met AND no comment/doc change belongs in any file (the change is genuinely zero-diff) | Close the issue directly — **no PR** |
-
-When a clarifying comment IS warranted:
+- Update the **comment** to reflect current intent clearly
+- Create a PR that closes the issue by documenting the already-correct state
 
 ```diff
 - # test_googlenet_layers.mojo split into 3 parts (≤8 tests each)
@@ -109,41 +127,25 @@ When a clarifying comment IS warranted:
 + # (e.g., test_googlenet_layers_part1.mojo) without requiring manual CI updates.
 ```
 
-When there is genuinely **nothing to change** — no functional change and no comment/doc
-edit belongs anywhere — do not open an empty PR. Close the issue directly and cite the
-commit/PR that already did the work:
-
-```bash
-gh issue close <N> --reason completed \
-  --comment "Already resolved by PR #357 (commit 76b46c9, 'chore: remove CHANGELOG.md
-and changelog tooling'), which removed this line ecosystem-wide on 2026-05-07. The line
-numbers in this issue predate that merge. Section 10 already covers release management
-generically. No code change needed."
-```
-
-### 7. Verify with the project's validation command
+### 6. Verify with validate_test_coverage.py
 
 ```bash
 python3 scripts/validate_test_coverage.py
-# Must exit 0 before committing — only when a file actually changed
+# Must exit 0 before committing
 ```
 
-### 8. Close the issue
+### 7. Close the issue via PR
 
-- If a file changed: create the PR with `Closes #<issue>` (even a pure comment update) so
-  the issue closes on merge and the already-correct state is documented.
-- If nothing changed: the `gh issue close --reason completed --comment` from step 6 already
-  closed it — no PR exists or is needed.
+Create the PR with `Closes #<issue>` even if the change is purely a comment update — this
+formally closes the issue and documents that the goal was already achieved.
 
 ## Results & Parameters
 
 | Parameter | Value |
 | ----------- | ------- |
 | Key diagnostic | `grep -n "<pattern from plan>" <file>` — if empty, plan is stale |
-| Decisive diagnostic | `git log -S "<exact phrase from issue>" -- '<glob>'` — finds the commit/PR that already made the change |
 | Validation command | `python3 scripts/validate_test_coverage.py` |
-| Correct change scope | Comment-only update when the functional fix already exists; zero change when nothing needs editing |
-| Close when zero diff | `gh issue close <N> --reason completed --comment "<cites the PR/commit>"` — no PR |
+| Correct change scope | Comment-only update when the functional fix already exists |
 | PR label | `cleanup` |
 
 ## Failed Attempts
@@ -153,11 +155,20 @@ python3 scripts/validate_test_coverage.py
 | Applying plan verbatim | Would have changed `test_*.mojo` back to `test_*_layers*.mojo` | This would have been a regression — narrowing a working broad pattern | Always read actual file before applying a "before → after" from a plan |
 | Skipping verification | Assuming plan's "before" state was current | Plan said line 234 had `test_*_layers.mojo`; actual line 283 had `test_*.mojo` | Verify anchors (line numbers, patterns) before touching anything |
 | Treating as no-op | Issue already resolved, do nothing | Issue remains open; no PR closes it | Even when goal is met, create a PR with a comment clarification to formally close |
-| Assuming a PR is always needed to close the issue | Planning a comment-only PR even though no file needed any change | There was literally no diff to make — a PR would be empty | When the goal is fully met and no clarifying comment belongs in any file, close the issue directly with `gh issue close --reason completed --comment` |
 
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
 | ProjectOdyssey | Issue #4280 (follow-up from #3458) | [notes.md](../references/notes.md) |
-| ProjectHephaestus | Issue #422 — CHANGELOG criterion already removed by PR #357 (commit 76b46c9) | Closed directly as completed; no PR (zero diff) |
+```
+
+---
+
+## v1.0.0 (2026-03-15) — Initial version
+
+**Initial version.**
+
+First release. Detect when an issue's implementation plan is stale because the fix was already
+applied — verify actual current state before applying a plan, recognize when a broader merged
+change already satisfies the goal, and close the issue with a comment-only PR.


### PR DESCRIPTION
## Summary

Amends the `stale-plan-already-resolved` skill (v1.0.0 → v1.1.0) with a new resolution case and a decisive diagnostic, learned from ProjectHephaestus#422.

A user invoked "fix this issue" against ProjectHephaestus#422, which asked to remove a `CHANGELOG.md or equivalent release notes` criterion line from four `repo-analyze*/SKILL.md` files, citing exact line numbers. Investigation found the line had already been removed ecosystem-wide by PR #357 (commit `76b46c9`, 2026-05-07) — the cited line numbers were stale. The correct outcome was to close the issue directly as `completed` with an explanatory comment — no PR, because there was zero diff to make.

The pre-existing skill always recommended a comment-only PR to close such issues. This amendment adds the genuinely-zero-change case and the `git log -S` diagnostic.

## Verification Level

**verified-local** — the `git log -S` diagnostic was confirmed locally against ProjectHephaestus git history; `python3 scripts/validate_plugins.py` exits 0 (378/378 valid). No CI run.

## Key Findings

### What Worked

- `git log -S "<exact phrase from issue>" -- '<glob>'` decisively pinpoints the commit/PR that already added or removed a string — far faster than scanning history manually.
- When an issue is fully satisfied and no file needs any edit, closing directly with `gh issue close <N> --reason completed --comment "<cites the PR/commit>"` is the correct, honest outcome.

### What Failed

- Assuming a PR is always needed to close the issue: planning a comment-only PR when no file needed any change would have produced an empty PR. When the goal is fully met and no clarifying comment belongs in any file, close the issue directly.

## Changes

- New file `skills/stale-plan-already-resolved.history` (v1.1.0 + v1.0.0 entries, full v1.0.0 snapshot)
- Frontmatter: `version` 1.0.0 → 1.1.0, `date` → 2026-05-20, added `verification: verified-local` and `history:`
- Overview table: added Verification and History rows
- New When-to-Use trigger (stale line numbers / snippet not present)
- New Verified Workflow step: `git log -S` diagnostic with the real PR #357 example
- "Apply the minimal appropriate change" now distinguishes comment-only-PR vs. close-directly-no-PR
- New Failed Attempts row and Verified On row (ProjectHephaestus#422)

## Test Plan

- [x] `python3 scripts/validate_plugins.py` exits 0 (378/378 valid)
- [x] `.history` file is append-only, newest first, with full v1.0.0 snapshot
- [x] Frontmatter version bumped to 1.1.0, date 2026-05-20
- [x] All required sections present (Overview, When to Use, Verified Workflow, Failed Attempts, Results & Parameters)