### PR TITLE
feat: amend hatch-vcs-pyproject-auto-versioning-setup skill (v1.1.0)

### DIFF
--- a/skills/hatch-vcs-pyproject-auto-versioning-setup.history
+++ b/skills/hatch-vcs-pyproject-auto-versioning-setup.history
@@ -1,0 +1,46 @@
+# hatch-vcs-pyproject-auto-versioning-setup — History
+
+## v1.1.0 (2026-05-24)
+
+**Changed by:** ProjectHephaestus PRs #434, #436, #438 — post-migration gotchas surfaced when downstream tooling assumed the old static-version world
+**Verification:** verified-ci
+
+### What changed
+- Added a new "Four-piece coordination" Quick Reference checklist enumerating the pyproject, `__init__.py`, consistency-script, and single-source-check pieces that must all change together
+- Added three new Failed Attempts rows covering: `importlib.metadata.version("hephaestus")` failing because the distribution name is `HomericIntelligence-Hephaestus`; consistency scripts grepping `pyproject.toml` for a version that no longer exists; verifying script output via `tail -3` and missing the relevant line
+- Extended Step 4 with an explicit warning that `importlib.metadata` does NOT normalize import-name → distribution-name; the dist name from `[project].name` must be used literally
+- Added a new Step 8 "Update downstream consistency checks" — covers rewriting drift checks to derive the canonical version from `git describe --tags --abbrev=0 --match 'v[0-9]*'` with `importlib.metadata` fallback, and validating the single-source invariant via `tomllib` (presence of `dynamic = ["version"]` and `[tool.hatch.version].source == "vcs"`)
+- Bumped verification from `verified-precommit` to `verified-ci` (PRs #434, #436, #438 all merged via CI)
+
+### Why
+The original v1.0.0 covered the migration itself (pyproject, gitignore, ruff exclude, CI workflow). It did not warn about downstream code that assumed the static-version world:
+
+- `hephaestus/__init__.py` used `_pkg_version("hephaestus")` (import name) and broke with `PackageNotFoundError` because the installed dist is `HomericIntelligence-Hephaestus`
+- `scripts/check_version_single_source.py` still grepped `pyproject.toml` for a `version = "..."` line that no longer exists
+- `hephaestus/version/consistency.py` had a `_get_pyproject_version` helper that returned `None` once the field went dynamic, breaking drift detection
+
+All three failure modes are caught in CI now, so the verification level is upgraded.
+
+### Previous version (v1.0.0) snapshot
+
+```yaml
+---
+name: hatch-vcs-pyproject-auto-versioning-setup
+description: "Migrate a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags. Use when: (1) the version string is hardcoded in pyproject.toml and a CI auto-tag workflow must bump it, (2) you want the version derived automatically from git tags at build/install time with no file edits needed, (3) an auto-tag workflow is creating bot commits on main that trigger infinite CI loops, (4) hatch-vcs is being added to pixi.toml pypi-dependencies unnecessarily."
+category: ci-cd
+date: "2026-04-21"
+version: "1.0.0"
+user-invocable: false
+verification: verified-precommit
+tags:
+  - hatch-vcs
+  - hatchling
+  - pyproject
+  - auto-versioning
+  - git-tags
+  - dynamic-version
+  - ci-cd
+---
+```
+
+The full v1.0.0 body covered: pyproject.toml updates, .gitignore for `_version.py`, ruff exclude, `importlib.metadata` pattern in `__init__.py`, removal of `hatch-vcs` from `pixi.toml`, simplified auto-tag CI workflow, and install verification. It did NOT cover downstream consistency-script breakage or the distribution-name vs import-name gotcha.

--- a/skills/hatch-vcs-pyproject-auto-versioning-setup.md
+++ b/skills/hatch-vcs-pyproject-auto-versioning-setup.md
@@ -1,11 +1,12 @@
 ---
 name: hatch-vcs-pyproject-auto-versioning-setup
-description: "Migrate a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags. Use when: (1) the version string is hardcoded in pyproject.toml and a CI auto-tag workflow must bump it, (2) you want the version derived automatically from git tags at build/install time with no file edits needed, (3) an auto-tag workflow is creating bot commits on main that trigger infinite CI loops, (4) hatch-vcs is being added to pixi.toml pypi-dependencies unnecessarily."
+description: "Migrate a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags, and update downstream tooling that assumed the static-version world. Use when: (1) the version string is hardcoded in pyproject.toml and a CI auto-tag workflow must bump it, (2) you want the version derived automatically from git tags at build/install time with no file edits needed, (3) an auto-tag workflow is creating bot commits on main that trigger infinite CI loops, (4) hatch-vcs is being added to pixi.toml pypi-dependencies unnecessarily, (5) post-migration, importlib.metadata.version() raises PackageNotFoundError because the import name differs from the distribution name, (6) a version-consistency or single-source check script grep's pyproject.toml for a version field that no longer exists."
 category: ci-cd
-date: "2026-04-21"
-version: "1.0.0"
+date: "2026-05-24"
+version: "1.1.0"
 user-invocable: false
-verification: verified-precommit
+verification: verified-ci
+history: hatch-vcs-pyproject-auto-versioning-setup.history
 tags:
   - hatch-vcs
   - hatchling
@@ -13,6 +14,9 @@ tags:
   - auto-versioning
   - git-tags
   - dynamic-version
+  - importlib-metadata
+  - distribution-name
+  - single-source-versioning
   - ci-cd
 ---
 
@@ -22,10 +26,11 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-04-21 |
-| **Objective** | Replace a hardcoded `version = "X.Y.Z"` in `pyproject.toml` with `hatch-vcs` dynamic versioning so the auto-tag CI workflow only needs to push a git tag — no file edits, no bot commits. |
-| **Outcome** | hatch-vcs generates `_version.py` at install time from the most recent git tag; pyproject.toml declares `dynamic = ["version"]`; CI auto-tag workflow simplified to tag-push only. |
-| **Verification** | verified-precommit |
+| **Date** | 2026-05-24 |
+| **Objective** | Replace a hardcoded `version = "X.Y.Z"` in `pyproject.toml` with `hatch-vcs` dynamic versioning so the auto-tag CI workflow only needs to push a git tag — no file edits, no bot commits — AND update downstream tooling (`__init__.py`, drift-check scripts, single-source-of-truth validators) that previously assumed the static-version world. |
+| **Outcome** | hatch-vcs generates `_version.py` at install time from the most recent git tag; pyproject.toml declares `dynamic = ["version"]`; CI auto-tag workflow simplified to tag-push only; `__init__.py` looks up version by distribution name; consistency checks derive canonical version from `git describe`; single-source check validates the hatch-vcs invariant via `tomllib`. |
+| **Verification** | verified-ci |
+| **History** | [changelog](./hatch-vcs-pyproject-auto-versioning-setup.history) |
 
 ## When to Use
 
@@ -33,8 +38,21 @@ tags:
 - Auto-tag CI workflow is producing infinite trigger loops (commit triggers CI, CI commits, triggers CI...)
 - You want `pip show <pkg>` / `importlib.metadata.version()` to reflect the latest git tag automatically
 - A `hatch-vcs` entry was added to `pixi.toml [pypi-dependencies]` and needs to be removed (it's a build-time dep only)
+- After migrating to hatch-vcs, `import yourpackage` raises `PackageNotFoundError` because `__version__` is looking up the import name instead of the distribution name
+- A drift-detection or single-source-of-truth script greps `pyproject.toml` for a version field that no longer exists once `dynamic = ["version"]` is set
 
 ## Verified Workflow
+
+### Quick Reference
+
+The four pieces that MUST change together when migrating to hatch-vcs:
+
+- [ ] **1. `pyproject.toml`** — declare `dynamic = ["version"]`, add `[tool.hatch.version] source = "vcs"`, add `[tool.hatch.build.hooks.vcs] version-file = "<pkg>/_version.py"`, add `hatch-vcs` to `[build-system].requires`
+- [ ] **2. `<pkg>/__init__.py`** — `_pkg_version("<distribution-name>")` (case-sensitive value from `[project].name`), **NOT** `_pkg_version("<import-name>")`. importlib.metadata does NOT normalize between the two
+- [ ] **3. Drift / consistency scripts** — derive the canonical version from `git describe --tags --abbrev=0 --match 'v[0-9]*'` with `importlib.metadata` fallback. **Never** parse `pyproject.toml` for `[project].version` — the field is gone
+- [ ] **4. Single-source-of-truth checks** — validate the invariant (`dynamic = ["version"]` present AND `[tool.hatch.version].source == "vcs"`) via `tomllib`, **NOT** by comparing version strings across files
+
+Also: add `<pkg>/_version.py` to `.gitignore` and `[tool.ruff] exclude`. Remove `hatch-vcs` from `pixi.toml [pypi-dependencies]` if present.
 
 ### 1. Update `pyproject.toml`
 
@@ -83,22 +101,23 @@ exclude = [
 
 Without this, ruff will lint or format the generated file and may fail CI.
 
-### 4. Verify `__init__.py` already uses `importlib.metadata`
-
-If the package already reads version from installed metadata, no changes are needed:
+### 4. Update `__init__.py` to use the DISTRIBUTION NAME (not import name)
 
 ```python
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 try:
-    __version__ = _pkg_version("your-dist-name")
+    # CRITICAL: This is the [project].name value from pyproject.toml,
+    # NOT the import package directory name.
+    __version__ = _pkg_version("HomericIntelligence-Hephaestus")
 except PackageNotFoundError:
     __version__ = "unknown"
 ```
 
-If `__init__.py` hardcodes `__version__ = "X.Y.Z"`, switch it to the pattern above.
-The dist name matches the `name` field in `pyproject.toml` (case-insensitive, hyphens/underscores normalized).
+**The most common mistake:** using the import name (e.g. `"hephaestus"`) instead of the distribution name (e.g. `"HomericIntelligence-Hephaestus"`). `importlib.metadata.version()` does NOT normalize between PyPI distribution names and import package names. It performs a PEP 503 normalized lookup against installed `*.dist-info` directories — and there is no such directory for the import name. You will get `PackageNotFoundError` and `__version__ == "unknown"` at every import.
+
+The dist name is the **exact** value of the `name` field in `[project]` in `pyproject.toml` (PEP 503 normalization is applied, so case and `-`/`_` differences are tolerated, but the name itself must match).
 
 ### 5. Remove hatch-vcs from `pixi.toml` (if added by mistake)
 
@@ -151,6 +170,67 @@ python -c "import yourpackage; print(yourpackage.__version__)"
 ls yourpackage/_version.py
 ```
 
+### 8. Update downstream consistency / single-source checks
+
+Any pre-existing tooling that assumed `pyproject.toml` holds a static `[project].version` will break. Update each pattern:
+
+**Pattern A — Drift/consistency check that compared `pyproject.toml` version to `__init__.py` / `VERSION` / `SECURITY.md`:**
+
+```python
+# OLD — broken after hatch-vcs migration
+# def _get_pyproject_version() -> str:
+#     data = tomllib.loads(Path("pyproject.toml").read_text())
+#     return data["project"]["version"]   # KeyError — field is dynamic now
+
+# NEW — derive canonical version from git, with importlib.metadata fallback
+import subprocess
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+def _get_canonical_version(dist_name: str) -> str:
+    """Canonical version: latest git tag, or installed dist metadata as fallback."""
+    try:
+        tag = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        return tag.lstrip("v")
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        return _pkg_version(dist_name)
+    except PackageNotFoundError:
+        return "unknown"
+```
+
+**Pattern B — "Single source of truth" check that previously asserted one literal version string:**
+
+After hatch-vcs, the "single source" is the **invariant** that pyproject delegates to VCS, not a string match. Validate via `tomllib`:
+
+```python
+import tomllib
+from pathlib import Path
+
+def check_single_source_invariant() -> None:
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    project = data.get("project", {})
+    dynamic = project.get("dynamic", [])
+    assert "version" in dynamic, (
+        "pyproject.toml [project].dynamic must include 'version' "
+        "(hatch-vcs single-source invariant violated)"
+    )
+    assert "version" not in project, (
+        "pyproject.toml [project] must NOT define a static 'version' "
+        "field once 'version' is in [project].dynamic"
+    )
+    hatch_version = data.get("tool", {}).get("hatch", {}).get("version", {})
+    assert hatch_version.get("source") == "vcs", (
+        "[tool.hatch.version] source must be 'vcs' for hatch-vcs single-source versioning"
+    )
+```
+
+**Pattern C — verification of script output.** When a check script prints a status line, verify it by reading the FULL output. Do not `tail -3` and claim a line is missing — earlier lines get truncated and you'll falsely report regressions. Quote the actual line from the script's stdout when claiming success or failure.
+
 ## Key Insight: `_version.py` is generated at install time
 
 When `pip install -e .` or `pixi install` runs, hatch-vcs writes `yourpackage/_version.py`
@@ -169,6 +249,9 @@ in the source tree containing the current version string. This file:
 | Keep auto-tag workflow with `pyproject.toml` bump steps | Left steps in CI that read the version, incremented it, rewrote `pyproject.toml`, and committed back to `main` | Creates a bot commit on `main` on every CI pass, triggers infinite loop potential, and defeats the purpose of auto-versioning | With `hatch-vcs`, the workflow only needs to push a git tag — all file-edit/commit steps must be removed |
 | Not adding `_version.py` to `.gitignore` | Omitted `yourpackage/_version.py` from `.gitignore` | Generated file gets accidentally staged and committed; ruff lints it on next pre-commit run and fails CI | Always add the generated `_version.py` to `.gitignore` immediately when enabling `hatch-vcs` |
 | Not adding `_version.py` to ruff `exclude` | Left `_version.py` out of `[tool.ruff] exclude` | ruff reformats the generated file on every pre-commit run, causing spurious diffs or CI failures | Add `yourpackage/_version.py` to `[tool.ruff] exclude` alongside the `.gitignore` entry |
+| Use the **import name** with `importlib.metadata.version()` | `__version__ = _pkg_version("hephaestus")` in `hephaestus/__init__.py` when the installed distribution is `HomericIntelligence-Hephaestus` | `PackageNotFoundError`: `importlib.metadata` performs a PEP 503 normalized lookup against installed `*.dist-info` directories. The import package name is not the distribution name; there is no `hephaestus-*.dist-info` to find. `__version__` silently becomes `"unknown"` at every import. | `importlib.metadata.version()` requires the **distribution name** (the literal value of `[project].name`), not the import package directory name. The two are unrelated — never assume normalization across them |
+| Parse `pyproject.toml` for `[project].version` in a drift-check script | `_get_pyproject_version()` did `tomllib.load(...)["project"]["version"]` after the migration | `KeyError`/`None` — once `dynamic = ["version"]` is set, `[project].version` no longer exists in pyproject.toml. Hatch-vcs deliberately removes it because the field is computed at build time. | After hatch-vcs migration, derive canonical version from `git describe --tags --abbrev=0 --match 'v[0-9]*'` with `importlib.metadata.version("<dist-name>")` as fallback. Never grep pyproject for a field hatch-vcs deliberately removed |
+| Verify "the script printed line X" by reading `tail -3` of stdout | Claimed a single-source check was missing an output line based on the last 3 lines of its output | The relevant line was earlier in the output and got truncated by `tail`. I reported a false regression on a working script. | Verify script output by reading the FULL stdout (or grep for the expected line explicitly). Never assert a line is missing based on a truncated tail. Quote the actual matching line when claiming success or failure |
 
 ## Results & Parameters
 
@@ -177,10 +260,11 @@ in the source tree containing the current version string. This file:
 | Parameter | Description | Example |
 | ----------- | ------------- | --------- |
 | `yourpackage` | The package directory (contains `__init__.py`) | `hephaestus` |
-| `your-dist-name` | The `name` field in `pyproject.toml` | `HomericIntelligence-Hephaestus` |
+| `your-dist-name` | The `name` field in `pyproject.toml` — **use this literal value in `importlib.metadata.version()`** | `HomericIntelligence-Hephaestus` |
 | Bootstrap version | Last known release version for tag-list fallback | `"0.7.0"` |
 | `hatchling` version pin | Tested range | `>=1.27.0,<2` |
 | `hatch-vcs` version pin | Tested range | `>=0.4.0,<1` |
+| Canonical version source (post-migration) | git tag, parsed with `git describe --tags --abbrev=0 --match 'v[0-9]*'` | `v0.7.1` → `0.7.1` |
 
 ### Expected Outcomes
 
@@ -189,9 +273,12 @@ After completing the migration:
 - `pyproject.toml` has `dynamic = ["version"]` and no `version = "X.Y.Z"` line
 - `[tool.hatch.version]` and `[tool.hatch.build.hooks.vcs]` sections added
 - `yourpackage/_version.py` exists locally after `pixi install` / `pip install -e .` but is NOT committed
-- `importlib.metadata.version("your-dist-name")` returns the version from the most recent git tag
+- `importlib.metadata.version("<your-dist-name>")` returns the version from the most recent git tag
+- `import yourpackage; print(yourpackage.__version__)` prints the same version (NOT `"unknown"`)
 - Auto-tag CI workflow no longer commits to `main` — only pushes a tag
 - `hatch-vcs` is NOT present in `pixi.toml [pypi-dependencies]`
+- Drift/consistency scripts derive the canonical version from git, not from `pyproject.toml`
+- Single-source-of-truth check validates the hatch-vcs invariant via `tomllib`, not a string compare
 
 ## Relationship to `versioning-consistency-release-workflow`
 
@@ -201,10 +288,15 @@ skill covers the static versioning pattern: `pyproject.toml` holds the canonical
 
 This skill replaces the "canonical version lives in `pyproject.toml`" part: with `hatch-vcs`,
 the canonical version lives in git tags and `pyproject.toml` declares `dynamic = ["version"]`.
-The `importlib.metadata` runtime pattern stays the same.
+The `importlib.metadata` runtime pattern stays the same — but the lookup argument MUST be
+the distribution name, and any drift check must derive its canonical from `git describe`,
+not from parsing `pyproject.toml`.
 
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
 | ProjectHephaestus | Branch `5047-separate-dev-production-deps` | `version = "0.7.0"` removed; `dynamic = ["version"]` added; auto-tag workflow simplified to tag-push; pre-commit passes locally |
+| ProjectHephaestus | PR #434 | Fixed `hephaestus/__init__.py` to use distribution name `"HomericIntelligence-Hephaestus"` in `importlib.metadata.version()` instead of import name `"hephaestus"`; resolved `PackageNotFoundError`; merged via CI |
+| ProjectHephaestus | PR #436 | Rewrote `scripts/check_version_single_source.py` to validate the hatch-vcs invariant (`dynamic = ["version"]` + `[tool.hatch.version].source == "vcs"`) via `tomllib` instead of comparing version strings across files; merged via CI |
+| ProjectHephaestus | PR #438 | Replaced `_get_pyproject_version` in `hephaestus/version/consistency.py` with `_get_canonical_version` deriving from `git describe --tags --abbrev=0 --match 'v[0-9]*'` with `importlib.metadata` fallback; merged via CI |


### PR DESCRIPTION
## Summary

Amends existing skill `hatch-vcs-pyproject-auto-versioning-setup` from v1.0.0 to v1.1.0.

Documents the downstream-tooling pitfalls that surfaced AFTER the initial hatch-vcs migration in ProjectHephaestus — pitfalls v1.0.0 didn't cover because they only emerge when other code in the repo (init module, drift checkers, single-source validators) is exercised post-migration.

- Distribution-name vs import-name gotcha in `importlib.metadata.version()` — PEP 503 lookup is against installed `*.dist-info` dirs, NOT import package directories
- Consistency-check scripts must derive canonical version from `git describe --tags --abbrev=0 --match 'v[0-9]*'` (with `importlib.metadata` fallback), NEVER parse `pyproject.toml` for `[project].version` (the field is gone)
- Single-source-of-truth check must validate the hatch-vcs invariant (`dynamic = [\"version\"]` + `[tool.hatch.version].source == \"vcs\"`) via `tomllib`, not by comparing version strings across files

Closes #N/A

## Verification Level

**verified-ci** (upgraded from `verified-precommit` in v1.0.0)

All three downstream fixes shipped via merged PRs in ProjectHephaestus:

- PR #434 — `__init__.py` distribution-name lookup
- PR #436 — `scripts/check_version_single_source.py` invariant via tomllib
- PR #438 — `hephaestus/version/consistency.py` git-describe canonical version

## Key Findings

**What Worked**:
- Looking up version by the literal `[project].name` value (`HomericIntelligence-Hephaestus`)
- `git describe --tags --abbrev=0 --match 'v[0-9]*'` as the canonical-version source
- Validating the hatch-vcs invariant via `tomllib` rather than string compare

**What Failed**:
- `_pkg_version(\"hephaestus\")` (import name) → `PackageNotFoundError`
- Parsing `pyproject.toml` for `[project].version` after `dynamic = [\"version\"]` was set → KeyError, dropped to None
- Verifying script output via `tail -3` → claimed a working check was broken because the relevant line was earlier in stdout

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py` (382/382 valid)
- [ ] Verify skill appears in marketplace after merge
- [ ] Test skill discovery with keywords: hatch-vcs, importlib.metadata, distribution name, single source versioning

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>