### PR TITLE
feat: amend audit-driven-remediation-workflow skill (v1.1.0)

### DIFF
--- a/skills/audit-driven-remediation-workflow.history
+++ b/skills/audit-driven-remediation-workflow.history
@@ -1,5 +1,27 @@
 # audit-driven-remediation-workflow — History
 
+## v1.1.0 (2026-05-25)
+
+**Changed by:** ProjectHephaestus PR #567 + epic #550 (run_automation_loop.sh silent-abort + plan-reviewer verdict gate)
+**Verification:** verified-local
+
+### What changed
+- Added "Downstream-Consumer Drift Audit" section between Verified Workflow and Failed Attempts
+- Added 2 new Failed Attempts rows (trust-self-review, producer-tests-not-enough)
+- Added new "When to Use" trigger (producer-side signal)
+- Updated description and tags
+- Internal cross-reference to [[debugging-silent-pipeline-stage-via-argparse-required-grep]] (which now also amended to v1.1.0 in the same session)
+
+### Why
+Session showed an implementing agent claiming work was complete based on 2362 passing unit tests + ruff clean + manual smoke. A strict audit dispatched as a separate sub-agent found 13 findings in <10 minutes, including 3 CRITICALs. The load-bearing finding was downstream-consumer drift: a new verdict marker was added to plan_reviewer.py, with full producer-side unit-test coverage, but the implementer.py consumer never read the marker. The user's stated workflow was silently broken. This pattern — producer tested, consumer unaware — is the single most common gap in audit-driven remediation and was not documented in v1.0.0.
+
+### Previous version (v1.0.0) snapshot
+
+The v1.0.0 entry remains immediately below this entry (unchanged) and continues to document the
+2026-05-18 14-skills merge. No content was deleted in v1.1.0 — only additive changes.
+
+---
+
 ## v1.0.0 (2026-05-18) — Merge of 14 skills
 
 **Changed by:** Skill-merge swarm (Phase B Wave 1, M8 / #1777)

--- a/skills/audit-driven-remediation-workflow.md
+++ b/skills/audit-driven-remediation-workflow.md
@@ -1,13 +1,13 @@
 ---
 name: audit-driven-remediation-workflow
-description: "Canonical end-to-end audit-driven remediation workflow: audit pass → severity classification → batch fix planning → PR generation → verification. Use when: (1) running a strict audit across a repo or ecosystem, (2) reconciling audit-finding issue counts against open issues, (3) generating remediation PRs from audit findings, (4) coordinating audit + fix + verification across multiple repos, (5) deciding fix vs accept/suppress for findings."
+description: "Canonical end-to-end audit-driven remediation workflow: audit pass → severity classification → batch fix planning → PR generation → verification. Use when: (1) running a strict audit across a repo or ecosystem, (2) reconciling audit-finding issue counts against open issues, (3) generating remediation PRs from audit findings, (4) coordinating audit + fix + verification across multiple repos, (5) deciding fix vs accept/suppress for findings, (6) you added a new producer-side signal and must verify every downstream consumer reads it."
 category: tooling
-date: 2026-05-18
-version: "1.0.0"
+date: 2026-05-25
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
 history: audit-driven-remediation-workflow.history
-tags: [merged, audit, remediation, ecosystem-audit, strict-audit, repo-hygiene]
+tags: [merged, audit, remediation, ecosystem-audit, strict-audit, repo-hygiene, downstream-consumer-drift, strict-audit-self-review, producer-consumer-pattern]
 ---
 
 # Audit-Driven Remediation Workflow
@@ -32,6 +32,7 @@ tags: [merged, audit, remediation, ecosystem-audit, strict-audit, repo-hygiene]
 - You are running parallel Myrmidon fixer agents against a large document corpus (20+ files)
 - You need to grade AI architecture research documents for structural/citation compliance
 - A skills marketplace has grown past ~500 files and `/advise` is returning too many near-duplicate results
+- You added a new producer-side signal (verdict marker, state flag, dispatch event) — audit MUST trace every downstream consumer and confirm the signal is read, not just emitted.
 
 ## Verified Workflow
 
@@ -378,6 +379,37 @@ gh pr create \
 gh pr merge --auto --rebase
 ```
 
+## Downstream-Consumer Drift Audit (added v1.1.0)
+
+When an audit-driven remediation introduces a new producer-side signal (a marker in a comment, a state field, a dispatched event), the remediation is INCOMPLETE until every downstream consumer is verified to read the signal correctly. Producer-side unit tests pass without proving the signal is honored. This is the most common gap a strict audit catches.
+
+### Detection workflow
+
+1. Identify the signal: marker constant, state enum value, event topic, etc.
+2. Grep for the signal's contract:
+   ```bash
+   # If signal is a string marker:
+   grep -rn '<marker-substring>' --include='*.py' --include='*.sh' --include='*.ts'
+   # If signal is a state field:
+   grep -rn 'state\.<field>' --include='*.py'
+   # If signal is an event topic:
+   grep -rn 'subscribe.*<topic>\|listen.*<topic>' --include='*.py'
+   ```
+3. For each match outside the producer module, verify the consumer reads + acts on the signal — not just receives it.
+4. Add at least one integration test that exercises the producer → consumer flow end-to-end (not mocked at the consumer boundary).
+
+### Real example (2026-05-25)
+
+Producer: `plan_reviewer.py` posts `**Verdict: APPROVED**` markers in GitHub issue comments. Skip-gate `_latest_review_is_final` works correctly in isolation.
+
+Consumer: `implementer.py:583` calls `_has_plan(issue_number)` which only checks for substring `"Implementation Plan"`. It NEVER scans for the verdict marker. A `**Verdict: BLOCK**` plan would still be implemented.
+
+Test coverage gap: 530 automation unit tests pass. None exercise the producer → consumer flow. The bug shipped through self-review.
+
+Strict audit caught this in <10 minutes by reading both files in parallel via `pc-research-reviewer` agents. Cost of the audit: trivial. Cost of the bug landing on main: blocked plans implemented automatically.
+
+See [[debugging-silent-pipeline-stage-via-argparse-required-grep]] for the related "silent-pipeline-stage" pattern when the consumer is silent due to argparse-time failures rather than missing logic.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -407,6 +439,8 @@ gh pr merge --auto --rebase
 | Explore agents for fingerprinting waves | Used `subagent_type: Explore` for fingerprinting shards | Explore agents are read-only — cannot call Write tool | Any wave whose output must persist to a file MUST use `general-purpose` or another writable agent type |
 | Oversized fingerprinting shards | Used 332-file shards for Wave 1 | Agents hit output limits; 81.8% coverage with silent gaps | Limit fingerprinting shards to ≤103 files; cross-check surviving files vs fingerprinted set after Wave 1 |
 | Fixer agents downgrade canonical versions | Dispatched fixer agents to fix content-deficit clusters | Agents rewrote canonical files from scratch, reverting to older versions | Fixer agents must be given explicit version floor constraints; provide pre-fixer commit SHA for recovery |
+| Trust the implementer's self-review of "all tests pass" without dispatching a strict audit | Implementer (me) reported `pixi run pytest tests/unit: 2362 passed; ruff clean; manual smoke OK` and treated the work as done. Did NOT dispatch a strict review. | A reviewer agent (`pc-research-reviewer`) scoped to the diff caught 13 findings including 3 CRITICALs. Self-review by the implementing model under-weights "did I solve the user's actual intent" vs "did the code I wrote pass its own tests" | Always run `repo-analyze-strict-full` (or equivalent) scoped to the diff before claiming work is complete. Dispatch as a separate sub-agent — the implementing agent has cognitive bias toward justifying its own choices. |
+| Add a producer-side signal (`**Verdict: APPROVED**` marker in plan-reviewer) and verify only the producer's tests pass | Plan-reviewer's `_latest_review_is_final` gate was tested in isolation. 10 new unit tests, all green. PR opened. | The implementer.py phase that runs AFTER plan-reviewer never read the verdict. `_has_plan(issue_number)` only checks for substring `"Implementation Plan"`. A BLOCK plan got implemented. The user's stated workflow was silently broken. | When adding a producer-side signal, grep for EVERY downstream consumer and add an integration test that exercises the full pipeline. Use `grep -rn "<consumer-marker-pattern>" --include='*.py'` to find them. |
 
 ## Results & Parameters
 


### PR DESCRIPTION
## Summary

Amends the `audit-driven-remediation-workflow` skill from v1.0.0 to v1.1.0. Additive only — no v1.0.0 content was removed.

## What changed

- **New section** "Downstream-Consumer Drift Audit" (between Verified Workflow and Failed Attempts) with a detection workflow and a real 2026-05-25 example (ProjectHephaestus `plan_reviewer.py` → `implementer.py` verdict-marker gap).
- **2 new Failed Attempts rows**:
  - Trust the implementer's self-review of "all tests pass" without dispatching a strict audit.
  - Add a producer-side signal and verify only the producer's tests pass.
- **New "When to Use" trigger**: producer-side signal added → audit must trace every downstream consumer.
- **Description updated**: appended trigger (6).
- **Tags added**: `downstream-consumer-drift`, `strict-audit-self-review`, `producer-consumer-pattern`.
- **History entry** prepended (newest-first) documenting the v1.0.0 → v1.1.0 delta.
- **Cross-reference** added to `[[debugging-silent-pipeline-stage-via-argparse-required-grep]]`.

## Why

A ProjectHephaestus session showed an implementing agent claiming work was complete based on 2362 passing unit tests + ruff clean + manual smoke. A strict audit dispatched as a separate sub-agent found 13 findings in under 10 minutes, including 3 CRITICALs. The load-bearing finding was downstream-consumer drift: a new `**Verdict: APPROVED**` marker was added to `plan_reviewer.py` with full producer-side unit-test coverage, but the `implementer.py` consumer never read the marker. A `**Verdict: BLOCK**` plan would still be implemented. The user's stated workflow was silently broken.

This pattern — producer tested, consumer unaware — is the single most common gap in audit-driven remediation and was not documented in v1.0.0.

## Verification

- `python3 scripts/validate_plugins.py` → 386/386 valid.
- Signed commit verified locally (`git log --show-signature -1`).
- Required sections preserved: Overview, When to Use, Verified Workflow, Failed Attempts, Results & Parameters. The new "Downstream-Consumer Drift Audit" section is additional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)