### PR TITLE
Wave 4: amend mojo-jit-crash-and-retry-strategies (v2.0.0 — marked obsolete)

### DIFF
--- a/skills/mojo-jit-crash-and-retry-strategies.history
+++ b/skills/mojo-jit-crash-and-retry-strategies.history
@@ -1,5 +1,51 @@
 # mojo-jit-crash-and-retry-strategies — History
 
+## v2.0.0 (2026-05-26) — Marked OBSOLETE post modular/modular#6413 fix
+
+**Changed by:** ProjectOdyssey JIT-flakiness demolition (PRs #5458 / #5459 / #5460)
+**Verification:** verified-ci (47+ green required-check runs on ProjectOdyssey PR
+#5455 with Mojo `1.0.0b2.dev2026052506`, full heavy Comprehensive Mojo Tests matrix
+passes cleanly with zero `libKGENCompilerRTShared.so` frames anywhere)
+
+### What changed
+
+The skill is now **historical reference only**. The dominant pre-fix JIT crash class
+— Mojo's compiler driver emitting AVX-512 encodings on GHA runners where the
+hypervisor masks AVX-512 CPUID leaves, causing `SIGILL` (signal 4) via the
+in-process libKGEN signal handler — was fixed upstream in
+[modular/modular#6413](https://github.com/modular/modular/issues/6413) on 2026-05-22
+by @dgurchenkov. The fix correctly gates AVX-512 emission on `xgetbv` (the canonical
+OS-enabled-feature check per Intel SDM Vol. 1 §13.3) instead of trusting raw CPUID.
+
+### Anti-recommendations added (DO NOT use in new code)
+
+- Retry wrappers around `pixi run mojo` (any subcommand)
+- `continue-on-error: true` on Mojo CI matrix entries
+- `MOJO_TEST_UNDER_GDB` / coredump-capture composite actions
+- "Transient vs deterministic" classification — all Mojo crashes are now bugs
+- Crash 4 4-hypothesis disproof (was specific to the resolved non-deterministic crash)
+- `MOJO_TARGET_CPU` `--target-features -avx512*` strips outside the narrow
+  sanitizer-only exception (the driver fix does not yet propagate through ASAN/TSAN
+  codegen — see ProjectOdyssey justfile `MOJO_TARGET_CPU` block comment)
+
+### What survives as still-useful methodology
+
+- **Runtime Crash Bisection — Minimal Reproducer**: the binary-reduce flow for
+  isolating a crashing test to a standalone upstream-fileable repro
+- **Closed-Source Boundary**: documents that `libKGEN*.so`, `libAsyncRT*.so`,
+  `libMSupport.so` are NOT in public `modular/modular` — escalation context
+- **libKGEN Stripped-Binary Crash Forensics**: `nm --dynsym` + `objdump` flow for
+  decoding stripped-binary stack offsets (generalizes to any closed-source library)
+- **4-hypothesis disproof meta-pattern**: write down falsifiable hypotheses,
+  dispatch parallel disproofs, escalate if all fail — reusable for any
+  non-deterministic bug
+
+### Body
+
+Body preserved verbatim from v1.0.0. The opening blockquote marks it as historical.
+
+---
+
 ## v1.0.0 (2026-05-18) — Merge of 13 skills (M3 sub-PR 1/4)
 
 **Changed by:** Skill-merge swarm (Phase D, M3 jit-crash-retry sub-cluster / #1772)

--- a/skills/mojo-jit-crash-and-retry-strategies.md
+++ b/skills/mojo-jit-crash-and-retry-strategies.md
@@ -1,16 +1,53 @@
 ---
 name: mojo-jit-crash-and-retry-strategies
-description: "Canonical patterns for Mojo JIT crash recovery and retry wrappers: virtual-address collisions, sequential job wrapping, GDB crash capture, libKGEN JIT crash forensics, transient-vs-deterministic classification, CI retry budgets. Use when: (1) diagnosing a Mojo JIT crash in CI, (2) writing a retry wrapper for flaky Mojo invocations, (3) capturing a libKGEN crash via gdb in a container, (4) auditing CI workflows for missing retry protection, (5) bisecting a Mojo runtime crash to a minimal reproducer, (6) diagnosing wrong ISA emission (AVX-512 on non-AVX-512 CPUs), (7) investigating Mojo serialization or dtype crash in CI."
+description: "HISTORICAL REFERENCE — most patterns OBSOLETE as of Mojo 1.0.0b2.dev2026052506 (modular/modular#6413 fixed upstream). Do NOT use the retry-wrapper, continue-on-error matrix, gdb-coredump-capture, or 4-hypothesis disproof patterns in NEW code. Use when: (1) reading historical PR/issue context that references these patterns, (2) needing the runtime-crash-bisection minimal-reproducer methodology (still useful for future Mojo bugs), (3) understanding the closed-source boundary for libKGEN/libAsyncRT/libMSupport debugging, (4) needing the AVX-512 wrong-ISA forensics for analogous CPU-feature bugs. NOT a guide for treating Mojo crashes as flakes — that posture was wrong and is now removed."
 category: ci-cd
-date: 2026-05-18
-version: "1.0.0"
+date: 2026-05-26
+version: "2.0.0"
 user-invocable: false
-verification: verified-local
+verification: verified-ci
 history: mojo-jit-crash-and-retry-strategies.history
-tags: [merged, mojo, jit, crash, retry, libkgen, forensics, avx512, bisection, ci]
+tags: [obsolete, historical, mojo, jit, crash, libkgen, forensics, avx512, bisection, ci]
 ---
 
 # Mojo JIT Crash and Retry Strategies
+
+> **⚠️ OBSOLETE as of 2026-05-26.** The dominant pre-fix JIT crash class
+> (AVX-512 mis-emission on masked-AVX-512 CPUs, `libKGENCompilerRTShared.so`
+> SIGILLs) was fixed upstream in [modular/modular#6413](https://github.com/modular/modular/issues/6413)
+> on 2026-05-22 and validated on Mojo `1.0.0b2.dev2026052506+`. ProjectOdyssey
+> demolished all retry/coredump/gdb-wrapper infrastructure in PRs #5458, #5459,
+> #5460 (2026-05-26).
+>
+> **DO NOT use in new code:**
+> - Retry wrappers around `pixi run mojo` (any subcommand)
+> - `continue-on-error: true` on Mojo CI matrix entries
+> - `MOJO_TEST_UNDER_GDB` / coredump-capture composite actions
+> - "Transient vs deterministic" classification — all Mojo crashes are now bugs,
+>   not flakes
+> - 4-hypothesis disproof checklist (was specific to the now-resolved
+>   `libKGENCompilerRTShared.so+0x6ef7b` non-deterministic crash)
+> - AVX-512-feature-stripping `--target-features -avx512*` outside the narrow
+>   sanitizer-only exception (the upstream driver fix doesn't yet propagate
+>   through ASAN/TSAN codegen — see ProjectOdyssey justfile `MOJO_TARGET_CPU`)
+>
+> **STILL USEFUL** (extract these patterns for analogous future bugs):
+> - "Runtime Crash Bisection — Minimal Reproducer" section: the methodology
+>   for reducing a crashing test to a standalone upstream-fileable reproducer
+>   remains the canonical approach for ANY future Mojo runtime bug
+> - "Closed-Source Boundary" section: documents that `libKGENCompilerRTShared.so`,
+>   `libAsyncRTMojoBindings.so`, `libMSupport.so` are NOT in the public
+>   `modular/modular` repo — only `mojo/stdlib/` is. Useful escalation context.
+> - "libKGEN Stripped-Binary Crash Forensics" section: the `nm --dynsym` +
+>   `objdump` flow for decoding stripped-binary stack offsets generalizes to
+>   any closed-source library crash
+> - "Crash 4 — 4-Hypothesis Disproof Checklist" structure: the meta-pattern
+>   (write down 4 falsifiable hypotheses, dispatch parallel investigations
+>   to disprove, escalate if all disproved) is reusable for any non-deterministic
+>   bug
+>
+> The body below is preserved verbatim as historical reference. Treat it as
+> archaeology, not as current guidance.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Amends the `mojo-jit-crash-and-retry-strategies` skill to v2.0.0, marking it as
historical reference. The dominant pre-fix JIT crash class (AVX-512 mis-emission
on masked-AVX-512 CPUs, `libKGENCompilerRTShared.so` SIGILLs) was fixed upstream
in [modular/modular#6413](https://github.com/modular/modular/issues/6413) on
2026-05-22 and validated on Mojo `1.0.0b2.dev2026052506+`.

## Companion work in ProjectOdyssey

- **PR #5455** (validation gate): 47+ green required-check runs on the new pin,
  full heavy Comprehensive Mojo Tests matrix passes cleanly with zero libKGEN frames
- **PR #5458** (Wave 1): pin bump + UnsafePointer fix + benchmark/release/gdb-wrapper
  removal + lock cleanup + CLAUDE.md JIT stability note
- **PR #5459** (Wave 1.5): MOJO_TARGET_CPU strip from non-sanitizer paths (sanitizer
  paths retain the strip because the driver fix doesn't yet propagate through
  ASAN/TSAN codegen)
- **PR #5460** (Wave 2): scorched-earth purge of JIT-related ADRs, docs, repros,
  workflows, and 106 stale test-file comments

## What changed in this skill

### Anti-recommendations added (DO NOT use in new code)

- Retry wrappers around `pixi run mojo` (any subcommand)
- `continue-on-error: true` on Mojo CI matrix entries
- `MOJO_TEST_UNDER_GDB` / coredump-capture composite actions
- "Transient vs deterministic" classification — all Mojo crashes are now real bugs
- 4-hypothesis disproof checklist (was specific to the resolved non-determinstic crash)
- `--target-features -avx512*` strips outside the narrow sanitizer-only exception

### What survives as still-useful methodology

- **Runtime Crash Bisection — Minimal Reproducer**: binary-reduce flow for any
  future Mojo runtime bug
- **Closed-Source Boundary**: escalation context for `libKGEN*.so`, `libAsyncRT*.so`,
  `libMSupport.so`
- **libKGEN Stripped-Binary Crash Forensics**: `nm --dynsym` + `objdump` flow for
  decoding stripped-binary stack offsets (generalizes to any closed-source library)
- **4-hypothesis disproof meta-pattern**: write down falsifiable hypotheses,
  dispatch parallel disproofs — reusable for any non-deterministic bug

## Metadata changes

| Field | v1.0.0 | v2.0.0 |
| --- | --- | --- |
| date | 2026-05-18 | 2026-05-26 |
| version | 1.0.0 | 2.0.0 |
| verification | verified-local | verified-ci |
| tags | merged | obsolete, historical (kept the rest) |

## Body

Preserved verbatim from v1.0.0. The new opening blockquote marks it as archaeology.
Future readers can extract the methodology patterns called out above without
re-introducing the obsolete crisis-management infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)