### PR TITLE
feat(skill): add end-to-end convergence tests to gradient-checking skill (v1.1.0)

### DIFF
--- a/skills/gradient-checking-and-backward-pass-testing.history
+++ b/skills/gradient-checking-and-backward-pass-testing.history
@@ -8,6 +8,545 @@ and embedded YAML frontmatter issues.
 
 ---
 
+## v1.1.0 — 2026-05-26
+
+- **Changed by**: ProjectOdyssey PR #5466 — added convergence tests beyond FD checks
+- **Verification**: verified-ci
+
+### What changed
+
+- Extended frontmatter `description` to mention convergence tests as a complementary class.
+- Added new section **"End-to-end Convergence Tests (complementary to FD checks)"** explaining
+  the gap that FD checks cannot catch and the three-tier convergence test pattern (tiny MLP,
+  small conv stack, full production shape).
+- Added 4 new Failed Attempts rows: trusting FD as sufficient, uniform-weight init, constant-fill
+  inputs, and misdiagnosing symmetric-init plateau as conv backward bug.
+- Added `_make_asymmetric` / `_assert_loss_decreased` / `_assert_parameter_changed` helpers and
+  a convergence-test template to **Results & Parameters**.
+- Added Verified On row for PR #5466 with the three tiers' loss trajectories.
+- Bumped version 1.0.0 → 1.1.0; updated date 2026-05-19 → 2026-05-26; flipped Overview
+  Verification field unverified → verified-ci.
+
+### Why
+
+Surfaced in ProjectOdyssey PR #5466: a substrate with passing per-op FD gradient checks
+(`test_variable_layers.mojo`) still produced training that flatlined at chance loss
+(EMNIST 2.76% accuracy across 47 classes). Per-op FD validates *gradient values*, not
+*training dynamics* — the data pipeline can corrupt inputs upstream of where FD probes.
+Pairing FD with end-to-end convergence tests catches this class of failure. The pattern
+also requires asymmetric init/inputs to avoid the dead-symmetry pathology that masks
+substrate bugs as test failures.
+
+### Snapshot of previous version (v1.0.0)
+
+```markdown
+---
+name: gradient-checking-and-backward-pass-testing
+description: "Use when: (1) writing numerical gradient checks for conv2d, depthwise\
+  \ conv2d, batch norm, layer norm, or pooling backward passes in Mojo, (2) a gradient\
+  \ check reports analytical≈0 vs numerical≈nonzero for a normalization layer, (3)\
+  \ migrating from check_gradients() to check_gradient() or choosing tolerances for\
+  \ float32 backward tests, (4) extending backward coverage to inference mode, 4D\
+  \ inputs, multi-channel configs, or all three gradient fields (grad_input, grad_weights,\
+  \ grad_bias), (5) implementing analytically tractable exact-value tests for conv2d\
+  \ backward with all-ones configs"
+category: testing
+date: 2026-05-19
+version: "1.0.0"
+user-invocable: false
+history: gradient-checking-and-backward-pass-testing.history
+tags:
+  - gradient-checking
+  - backward-pass
+  - batch-norm
+  - layer-norm
+  - conv2d
+  - depthwise-conv2d
+  - pooling
+  - finite-differences
+  - float32-precision
+  - mojo
+---
+
+# Gradient Checking and Backward Pass Testing
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| Date | 2026-05-19 |
+| Objective | Numerically correct backward pass tests for all ML layer types in Mojo |
+| Outcome | Consolidated patterns from 10 skills covering conv2d, depthwise conv2d, batch norm, layer norm, and pooling |
+| Verification | unverified |
+
+## When to Use
+
+- Conv2d, depthwise conv2d, batch norm, layer norm, or pooling backward pass lacks gradient-correctness tests
+- Gradient check fails with "analytical ≈ 0 but numerical ≈ 0.009" for a normalization layer
+- Choosing between `check_gradient()` and `check_gradients()` APIs
+- Adding inference-mode (`training=False`) backward tests for batch norm
+- Extending gradient coverage to 4D inputs, multi-channel configs, param gradients (grad_gamma, grad_beta)
+- Writing exact-value analytical tests for conv2d backward (no finite differences needed)
+- Per-file test count is approaching its limit and a new file must be created
+
+## Verified Workflow
+
+### Quick Reference
+
+**Normalization cancellation fix (BatchNorm, LayerNorm — any zero-mean layer):**
+
+```mojo
+# NEVER use ones_like(output) for normalization backward tests!
+# PREFERRED: sum(output^2) loss — closed-form derivative
+var two = full_like(output, 2.0)
+var grad_output = multiply(two, output)  # dL/dY = 2 * output
+
+fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+    var out = batch_norm2d(inp, gamma, beta, running_mean, running_var,
+                           training=True, epsilon=1e-5)[0]
+    var sq = multiply(out, out)
+    var r = sq
+    while r.dim() > 0:
+        r = reduce_sum(r, axis=0, keepdims=False)
+    return r
+
+# ALTERNATIVE: non-uniform cycling pattern (interim approach)
+var grad_output = zeros_like(output)
+for i in range(output.numel()):
+    grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * Float32(0.25) - Float32(0.3)
+# Pattern: [-0.3, -0.05, 0.2, 0.45, ...], mean ≈ 0.075
+```
+
+**check_gradient() vs check_gradients():**
+
+| API | Tolerance model | Use when |
+| --- | --- | --- |
+| `check_gradient(fwd, bwd, x, grad_out, rtol, atol)` | Combined: `abs(diff) ≤ atol + rtol*magnitude` | All gradient checking tests (correct for large magnitudes) |
+| `check_gradients(fwd, bwd, x, eps, tol)` | Pure absolute: `abs(diff) < tol` | ONLY the 2 meta-test files that verify Bool-return semantics |
+
+**Tolerance quick-ref by layer type:**
+
+| Layer | rtol | atol | epsilon |
+| --- | --- | --- | --- |
+| Conv2D backward | `1e-2` | `1e-2` | `1e-4` or `3e-4` |
+| Depthwise Conv2D | `1e-2` | `1e-2` | `3e-4` |
+| BatchNorm training | `2e-2` | `1e-4` | `1e-3` |
+| BatchNorm inference | `1e-2` | `1e-4` | `1e-3` |
+| LayerNorm input | `1e-2` | `1e-5` | `1e-4` |
+| LayerNorm gamma/beta | `1e-2` | `1e-4` | `1e-4` |
+| MaxPool/AvgPool | `1e-3` | `5e-4` | `3e-4` |
+
+### Step 1: Understand the Cancellation Problem
+
+Normalization layers have a structural property:
+
+```text
+x_norm = (x - mean(x)) / std(x)  =>  sum(x_norm) = 0  (always)
+```
+
+BatchNorm backward contains a term `sum(grad_output * x_norm)`. When `grad_output = ones`:
+- `sum(1 * x_norm) = sum(x_norm) = 0` → analytical gradient is **exactly zero**
+- In float32, perturbing `x[i]` by ε=1e-4 produces numerical gradient ≈ 0.009
+- Result: "false failure" — 1000× mismatch, but the implementation is correct
+
+**The same identity holds for LayerNorm and any mean-centering normalization layer.**
+
+### Step 2: Choose the Correct grad_output Strategy
+
+**For normalization layers** — use either:
+
+1. `sum(output^2)` loss (preferred — loss function with closed-form derivative):
+
+   ```mojo
+   var grad_output = multiply(full_like(output, 2.0), output)
+   # forward closure reduces sum(out * out) to scalar
+   ```
+
+2. Non-uniform cycling pattern (interim):
+
+   ```mojo
+   for i in range(output.numel()):
+       grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * Float32(0.25) - Float32(0.3)
+   ```
+
+**For conv2d / depthwise conv2d** — `ones_like(output)` is safe (no zero-mean property).
+With `padding > 0`, prefer non-uniform to be safe at boundary positions.
+
+**For pooling** — use non-uniform for the numerical tier (AvgPool with symmetric inputs
+can cause gradient cancellation).
+
+**Consistency rule**: The `grad_output` and `forward_for_grad` closure MUST derive from the
+same loss function.
+
+### Step 3: Use check_gradient() (Not check_gradients())
+
+```mojo
+from shared.testing.gradient_checker import check_gradient
+
+fn _ones_grad(output: AnyTensor) raises -> AnyTensor:
+    var grad = zeros_like(output)
+    for i in range(output.numel()):
+        grad._set_float64(i, 1.0)
+    return grad^
+
+var output = forward(input)
+var grad_output = _ones_grad(output)
+check_gradient(forward, backward, input, grad_output, rtol=1e-2, atol=1e-2)
+```
+
+Why `check_gradient()` is required: For a gradient of magnitude 32.4 with diff 0.046:
+
+- `check_gradients(tolerance=0.01)`: 0.046 ≥ 0.01 → **FAIL** (false failure)
+- `check_gradient(rtol=1e-2, atol=1e-2)`: 0.046 ≤ 0.01 + 0.01×32.4 = 0.334 → **PASS**
+
+**Tolerance conversion from old check_gradients() calls:**
+
+| Old call | New call |
+| --- | --- |
+| `check_gradients(..., tolerance=0.01)` | `check_gradient(..., rtol=1e-2, atol=1e-2)` |
+| `check_gradients(..., tolerance=0.05)` | `check_gradient(..., rtol=5e-2, atol=1e-4)` |
+| `check_gradients(..., tolerance=0.1)` | `check_gradient(..., rtol=1e-1, atol=1e-2)` |
+
+**Exceptions** (must keep `check_gradients()`):
+- `test_gradient_checker_meta.mojo` — tests Bool-return semantics
+- `test_gradient_checker_noncont_tensors.mojo` — tests Bool-return semantics
+
+### Step 4: Conv2D Gradient Checking
+
+Two gradient checking APIs — pick the one matching existing tests:
+
+```mojo
+# API 1: check_gradient (explicit grad_output)
+fn forward_input(inp: ExTensor) raises -> ExTensor:
+    return conv2d(inp, kernel, bias, stride=1, padding=0)
+
+fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    return conv2d_backward(grad_out, inp, kernel, stride=1, padding=0).grad_input
+
+var output = forward_input(x)
+var grad_output = ones_like(output)
+check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+
+# API 2: check_gradients (internal grad_output, note 'raises escaping' on closures)
+fn forward(x: ExTensor) raises escaping -> ExTensor:
+    return conv2d(x, kernel, bias, stride=stride, padding=padding)
+
+fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    return conv2d_backward(grad_out, x, kernel, stride=stride, padding=padding).grad_input
+
+var passed = check_gradients(forward, backward, input, epsilon=1e-4, tolerance=1e-2)
+assert_true(passed, "Conv2D gradient check failed")
+```
+
+**With padding > 0** — use non-uniform `grad_output`:
+
+```mojo
+var grad_output = zeros_like(output)
+for i in range(output.numel()):
+    grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * Float32(0.25) - Float32(0.3)
+```
+
+**Per-file test count budget:**
+
+```
+test_gradient_checking_basic.mojo:  ≤10 tests
+test_gradient_checking_dtype.mojo:  ≤10 tests
+test_gradient_checking_conv2d.mojo: ≤10 tests (all 3 outputs × 3 configs = 9 tests)
+test_backward_conv_padding.mojo:    ≤10 tests
+```
+
+Check before adding: `grep -c "^fn test_" <file>.mojo`
+
+**Recommended test configurations for conv2d:**
+
+| Config | in\_ch | out\_ch | kernel | stride | padding | input shape |
+| --- | --- | --- | --- | --- | --- | --- |
+| same-padding | 1 | 1 | 3×3 | 1 | 1 | `(1,1,5,5)` |
+| strided | 1 | 1 | 3×3 | 2 | 0 | `(1,1,7,7)` |
+| multi-channel | 2 | 3 | 3×3 | 1 | 0 | `(1,2,5,5)` |
+
+### Step 5: Analytically Exact Conv2D Backward Tests
+
+For all-ones input, all-ones kernel, zero bias, single output position (`input_spatial = kernel_spatial`):
+
+| Gradient | Formula | Example (in\_ch=3, out\_ch=8, batch=1) |
+| --- | --- | --- |
+| `grad_weights[oc,ic,kh,kw]` | `batch × 1.0` | `1.0` |
+| `grad_input[b,ic,ih,iw]` | `out_channels × 1.0` | `8.0` |
+| `grad_bias[oc]` | `batch × out_H × out_W` | `1.0` (single output pos) |
+
+Batched (batch=2): `grad_bias` and `grad_weights` multiply by batch; `grad_input` unchanged.
+
+Padding=1 border pixel formula (all-ones, kernel=3, out\_ch=C, spatial=N):
+
+```text
+grad_input[b,ic,ih,iw] = out_channels × overlap_h(ih) × overlap_w(iw)
+
+corner   (0, 0):   2×2 = 4  →  4×C
+edge  (0, 1):      2×3 = 6  →  6×C
+interior (1, 1):   3×3 = 9  →  9×C
+
+Example (C=8, N=5): corner=32.0, edge=48.0, interior=72.0
+```
+
+### Step 6: Depthwise Conv2D Specifics
+
+**Critical API differences from regular conv2d:**
+
+| Aspect | Regular Conv2D | Depthwise Conv2D |
+| --- | --- | --- |
+| Kernel shape | `(out_channels, in_channels, kH, kW)` | `(channels, 1, kH, kW)` |
+| Gradient field | `.grad_weights` | `.grad_weights` (NOT `.grad_kernel`) |
+| Per-file limit | ≤10 tests | ≤8 tests (stricter) |
+
+```mojo
+# Depthwise kernel shape
+kernel_shape.append(channels)
+kernel_shape.append(1)  # Always 1
+kernel_shape.append(kH)
+kernel_shape.append(kW)
+```
+
+**grad_bias analytical test** (1×1 output per channel):
+
+```mojo
+var grad_output = zeros_like(output)
+grad_output._data.bitcast[Float32]()[0] = Float32(0.5)   # channel 0
+grad_output._data.bitcast[Float32]()[1] = Float32(-0.3)  # channel 1
+var grads = depthwise_conv2d_backward(grad_output, x, kernel, stride=1, padding=0)
+assert_almost_equal(grads.grad_bias._data.bitcast[Float32]()[0], Float32(0.5), tolerance=1e-5)
+```
+
+### Step 7: BatchNorm Gradient Testing
+
+**Training mode (sum(output^2) loss approach):**
+
+```mojo
+var result = batch_norm2d(x, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5)
+var output = result[0]
+var grad_output = multiply(full_like(output, 2.0), output)
+
+fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+    var res = batch_norm2d(inp, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5)
+    var out = res[0]
+    var sq = multiply(out, out)
+    var r = sq
+    while r.dim() > 0:
+        r = reduce_sum(r, axis=0, keepdims=False)
+    return r
+
+var numerical = compute_numerical_gradient(forward_for_grad, x, epsilon=1e-3)
+assert_gradients_close(grad_input, numerical, rtol=2e-2, atol=1e-4, message="...")
+```
+
+**Inference mode (training=False):**
+
+```mojo
+# Non-trivial running stats
+var running_mean = zeros(param_shape, DType.float32)
+running_mean._data.bitcast[Float32]()[0] = 0.3
+var running_var = ones(param_shape, DType.float32)
+running_var._data.bitcast[Float32]()[0] = 0.5
+
+fn forward_for_gamma_infer(g: ExTensor) raises -> ExTensor:
+    var res = batch_norm2d(x, g, beta, running_mean, running_var, training=False, epsilon=1e-5)
+    var out = res[0]
+    var weighted = multiply(out, grad_output)
+    var r = weighted
+    while r.dim() > 0:
+        r = reduce_sum(r, axis=0, keepdims=False)
+    return r
+
+var num_gamma = compute_numerical_gradient(forward_for_gamma_infer, gamma, epsilon=1e-3)
+assert_gradients_close(grad_gamma_analytical, num_gamma, rtol=1e-2, atol=1e-4, message="...")
+```
+
+### Step 8: LayerNorm Parameter Gradient Checks
+
+`layer_norm_backward(grad_output, x, gamma, epsilon)` returns `(grad_input, grad_gamma, grad_beta)`.
+
+```mojo
+# grad_gamma test — perturb gamma, hold x and grad_output fixed
+fn forward_for_gamma(g: ExTensor) raises -> ExTensor:
+    var out = layer_norm(x, g, beta, epsilon=1e-5)
+    var weighted = multiply(out, grad_output)
+    var r = weighted
+    while r.dim() > 0:
+        r = reduce_sum(r, axis=0, keepdims=False)
+    return r
+
+var num_gamma = compute_numerical_gradient(forward_for_gamma, gamma, epsilon=1e-4)
+var grad_gamma_analytical = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)[1]
+assert_gradients_close(grad_gamma_analytical, num_gamma, rtol=1e-2, atol=1e-4, ...)
+
+# grad_beta test — perturb beta (use non-zero beta to document additive shift path)
+fn forward_for_beta(b: ExTensor) raises -> ExTensor:
+    var out = layer_norm(x, gamma, b, epsilon=1e-5)
+    var weighted = multiply(out, grad_output)
+    var r = weighted
+    while r.dim() > 0:
+        r = reduce_sum(r, axis=0, keepdims=False)
+    return r
+```
+
+**Gamma shape for 4D inputs** — flattened over last 3 dims:
+
+| Input shape | Gamma shape |
+| --- | --- |
+| `[B, C, H, W]` | `[C*H*W]` |
+| `[2, 2, 2, 4]` | `[16]` |
+
+### Step 9: Pooling Backward (Three-Tier Pattern)
+
+**Tier 1 — Shape:** `grad_input.shape() == input.shape()`
+
+**Tier 2 — Analytical values:**
+
+```mojo
+# MaxPool: max position receives gradient, others get 0
+var x_known = ExTensor([1, 1, 2, 2], dtype)
+x_known._set_float64(1, 4.0)  # max — receives gradient
+var go = ExTensor([1, 1, 1, 1], dtype)
+go._set_float64(0, 1.0)
+var gi = maxpool2d_backward(go, x_known, 2, 2, 0)
+# gi[1] > 0.5, gi[0] ≈ gi[2] ≈ gi[3] ≈ 0
+
+# AvgPool: each element = 1 / (pool_size^2)
+var gi_avg = avgpool2d_backward(go, x_all_ones, 2, 2, 0)
+# Each gi_avg[k] ≈ 0.25
+```
+
+**Tier 3 — Numerical check (non-uniform grad_output required for AvgPool):**
+
+```mojo
+fn forward_max(x: ExTensor) raises escaping -> ExTensor:
+    var pool_out = maxpool2d(x, pool_size, stride, padding=padding)
+    var result = ExTensor([1], x.dtype())
+    var s: Float64 = 0.0
+    for i in range(pool_out.numel()):
+        s += pool_out._get_float64(i) * grad_out_nu._get_float64(i)
+    result._set_float64(0, s)
+    return result^
+
+var analytical = maxpool2d_backward(grad_out_nu, input_small, pool_size, stride, padding)
+var numerical = compute_numerical_gradient(forward_max, input_small, epsilon)
+assert_gradients_close(analytical, numerical, rtol=1e-3, atol=5e-4, ...)
+```
+
+### Step 10: Commit Pattern (GLIBC Mismatch)
+
+On hosts with GLIBC < 2.32, the mojo-format pre-commit hook will fail:
+
+```bash
+SKIP=mojo-format git commit -m "test(<layer>): add gradient checking tests"
+# CI runs mojo format in Docker with correct GLIBC
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --- | --- | --- | --- |
+| `grad_output = ones_like(output)` for normalization | Uniform upstream gradient for batch norm \| layer norm backward | `sum(x_norm) = 0` by construction; analytical grad is exactly zero; numerical picks up float32 noise ≈ 0.009 | Never use uniform grad_output for any zero-mean normalization layer |
+| Increase atol to hide mismatch | Raised tolerance from 1e-5 to 1e-2 for the failing normalization test | Masks the real issue without validating backward correctness | Fix the test setup, not the threshold |
+| Modify backward formula | Changed grad_input formula to produce non-zero output for uniform grad | The formula IS correct; zero result for uniform grad is mathematically right | Don't change correct code to pass a badly designed test |
+| `epsilon=1e-6` for numerical gradient | Smaller perturbation for more accurate finite differences | Worsens float32 rounding; analytical vs numerical gap grows | Smaller epsilon increases numerical error in float32; use 3e-4 or 1e-3 |
+| `check_gradients()` with conv2d (magnitude 32.4) | Old API kept; only epsilon changed from 1e-4 to 3e-4 | Diff dropped from 0.134 to 0.046 but still failed absolute tolerance 0.01 | The problem was the tolerance model (absolute vs relative), not epsilon |
+| `check_gradients()` with non-uniform inputs for depthwise conv2d | Added non-uniform inputs but kept old API | Diff was 0.0103 at magnitude 126.4 — barely exceeded absolute tolerance 0.01 | Large-magnitude gradients need relative tolerance; `check_gradient()` is required |
+| Tight tolerances (1e-3\|1e-6) copied from linear layer tests | Used linear layer rtol/atol for conv2d tests | Conv2d accumulates more FP error via strided access + multiple passes | Use rtol=1e-2, atol=1e-2 for conv2d; pool tolerances can be tighter (1e-3\|5e-4) |
+| `.grad_kernel` field for depthwise backward | Assumed depthwise returns a field named `.grad_kernel` | Actual return type is `GradientTriple` with `.grad_weights` | Always verify field names from `gradient_types.mojo`, not docstrings |
+| `rtol`/`atol` keyword args in `assert_almost_equal` | Passed `rtol=1e-2, atol=1e-2` | `assert_almost_equal` takes `tolerance: Float32`, not rtol/atol | Check the actual Mojo function signature — differs from PyTorch/numpy |
+| Adding tests to an existing file at capacity | Kept adding to `test_backward_conv_pool.mojo` | File at per-file test limit; CI heap corruption risk | Check `grep -c "^fn test_"` before adding; create new split file when ≥6-8 tests exist |
+| `ones_like(output)` for pooling numerical tier | Passed uniform grad for AvgPool numerical check | AvgPool with symmetric inputs causes gradient cancellation — numerical grad ≈ 0 everywhere | Use non-uniform grad_output for pooling numerical tier |
+| `compute_numerical_gradient` on vector pool output | Called function where forward returned raw pool output | Vector-output path sums all Jacobian elements — can cancel for AvgPool | Wrap forward function to compute weighted dot product and return scalar ExTensor |
+| Non-uniform alternating pattern as final norm solution | Used `grad_output[i] = (i%4)*0.25 - 0.3` as long-term fix | Works but is ad-hoc, not derived from a loss function | Use `sum(output^2)` loss with `grad_output = 2 * output` for principled verification |
+| Single `epsilon=1e-4` for float32 inference mode | Same epsilon as training mode tests | Fixed running stats amplify perturbation sensitivity | Use `epsilon=1e-3` for inference mode batch norm |
+| `full_like` not imported | Used `full_like` without adding to extensor import | Mojo compilation error: `full_like` undefined | Add `full_like` to extensor import before using it |
+| `_make_ones_grad(fwd: NumericalForward, x)` helper | Helper takes NumericalForward trait parameter to compute forward internally | Mojo `def` functions cannot take trait parameters directly | Use `_ones_grad(output: AnyTensor)` taking the already-computed output |
+| Skipping non-uniform pattern for small inputs | Assumed small tensors ([2,4,4,4]) avoid cancellation | Cancellation is structural (math), not statistical — size doesn't matter | The zero-sum property is inherent to batch norm math, not input size |
+| `List[Int](1, 3, 6, 6)` literal syntax for shapes | Used list literal constructor | Deprecated syntax flagged by pre-commit hook | Always use `List[Int]()` + `.append()` calls for shape construction |
+| Reusing conv2d forward closure directly for batch norm | `fn forward(x): return batch_norm2d(x, ...)[0]` returning full tensor | `compute_numerical_gradient` sums all output elements — equivalent to ones upstream (same cancellation) | The closure must compute the scalar loss explicitly |
+| Gamma shape `[C, H, W]` for 4D layer norm | Used 3D gamma for 4D input | Implementation uses flat `[C*H*W]` for 4D inputs | Verify gamma shape convention matches the implementation |
+| Create a new standalone testing doc | Draft new `normalization-testing-guide.md` | Duplication; belongs in the existing shared guide | Extend the existing doc; don't create parallel documentation |
+
+## Results & Parameters
+
+### Required Imports
+
+```mojo
+from shared.testing import (
+    compute_numerical_gradient,
+    assert_gradients_close,
+)
+from shared.testing.gradient_checker import check_gradient
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like, full_like
+from shared.core.normalization import (
+    batch_norm2d, batch_norm2d_backward,
+    layer_norm, layer_norm_backward,
+)
+from shared.core.conv import conv2d, conv2d_backward, depthwise_conv2d, depthwise_conv2d_backward
+from shared.core.pooling import maxpool2d, avgpool2d, maxpool2d_backward, avgpool2d_backward
+from shared.core.arithmetic import multiply
+from shared.core.reduction import sum as reduce_sum
+```
+
+### Gradient Return Types
+
+```text
+GradientTriple (Conv2dBackwardResult, DepthwiseConv2dBackwardResult):
+  .grad_input   → gradient w.r.t. input x
+  .grad_weights → gradient w.r.t. kernel/weights (NOT .grad_kernel for depthwise)
+  .grad_bias    → gradient w.r.t. bias
+
+GradientPair (Conv2dNoBiasBackwardResult):
+  .grad_a → gradient w.r.t. input x
+  .grad_b → gradient w.r.t. kernel
+
+layer_norm_backward / batch_norm2d_backward return tuples:
+  result[0] → grad_input
+  result[1] → grad_gamma
+  result[2] → grad_beta
+```
+
+### Migration Decision Tree
+
+```text
+Writing or migrating a gradient checking test?
+├─ Is this a meta-test that checks Bool return of check_gradients()?
+│   └─ YES → Keep check_gradients() (test_gradient_checker_meta, test_gradient_checker_noncont_tensors)
+└─ NO → Use check_gradient() with:
+    ├─ Normalization layer? → Non-uniform or sum(output^2) grad_output
+    └─ All other layers → _ones_grad(output) helper
+    ├─ Old tolerance=X → rtol=X, atol=1e-2 (normal) or atol=1e-4 (large values)
+    └─ Always: non-uniform inputs (Float32(i) * 0.1)
+```
+
+### CI Workflow Update
+
+```yaml
+- name: "Core Gradient"
+  path: "tests/shared/core"
+  pattern: "... test_gradient_checking_conv2d.mojo test_backward_conv_padding.mojo
+    test_depthwise_conv_grad_check_part1.mojo test_depthwise_conv_grad_check_part2.mojo ..."
+  continue-on-error: true
+```
+
+Insert new test files alphabetically in the `pattern` field.
+
+## Verified On
+
+| Project | Context | Details |
+| --- | --- | --- |
+| ProjectOdyssey | BatchNorm backward gradient tests (PRs #3816, #4780) | Sum-of-squares loss pattern for normalization |
+| ProjectOdyssey | Conv2d gradient checking (PRs #3865, #3772, #4793, #4809) | All 3 outputs × 3 configs |
+| ProjectOdyssey | Depthwise conv2d gradient checking (PR #4794, issue #3775) | Part1+Part2 split files |
+| ProjectOdyssey | check\_gradient migration — PR #5107, PR #5210 (59 calls across 5 files) | Migration complete |
+| ProjectOdyssey | LayerNorm param gradients (PR #4806, issue #3810) | grad\_gamma and grad\_beta |
+| ProjectOdyssey | Pool backward tester (PR #4782, issue #3720) | Three-tier pattern |
+| ProjectOdyssey | Conv2d analytical value tests (PRs #4797, #4799, issue #3235) | Batch+padding formulas |
+```
+
+---
+
 ## Superseded from batch-norm-gradient-testing
 
 ```markdown

--- a/skills/gradient-checking-and-backward-pass-testing.md
+++ b/skills/gradient-checking-and-backward-pass-testing.md
@@ -7,10 +7,12 @@ description: "Use when: (1) writing numerical gradient checks for conv2d, depthw
   \ float32 backward tests, (4) extending backward coverage to inference mode, 4D\
   \ inputs, multi-channel configs, or all three gradient fields (grad_input, grad_weights,\
   \ grad_bias), (5) implementing analytically tractable exact-value tests for conv2d\
-  \ backward with all-ones configs"
+  \ backward with all-ones configs, (6) adding end-to-end convergence tests as a\
+  \ complementary class to per-op finite-difference checks for validating the full\
+  \ forward→backward→optimizer→writeback loop"
 category: testing
-date: 2026-05-19
-version: "1.0.0"
+date: 2026-05-26
+version: "1.1.0"
 user-invocable: false
 history: gradient-checking-and-backward-pass-testing.history
 tags:
@@ -32,10 +34,10 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| Date | 2026-05-19 |
-| Objective | Numerically correct backward pass tests for all ML layer types in Mojo |
-| Outcome | Consolidated patterns from 10 skills covering conv2d, depthwise conv2d, batch norm, layer norm, and pooling |
-| Verification | unverified |
+| Date | 2026-05-26 |
+| Objective | Numerically correct backward pass tests for all ML layer types in Mojo, plus end-to-end convergence tests that validate the full training loop |
+| Outcome | Consolidated patterns from 10 skills covering conv2d, depthwise conv2d, batch norm, layer norm, and pooling; v1.1 adds convergence-test class |
+| Verification | verified-ci |
 
 ## When to Use
 
@@ -400,10 +402,65 @@ SKIP=mojo-format git commit -m "test(<layer>): add gradient checking tests"
 # CI runs mojo format in Docker with correct GLIBC
 ```
 
+## End-to-end Convergence Tests (complementary to FD checks)
+
+Finite-difference (FD) per-op gradient checks validate *gradient values* on isolated layers, but
+they do NOT validate *training dynamics*. A substrate with correct per-op gradients can still
+fail to train if the data pipeline corrupts inputs, the optimizer skips parameters silently,
+or writeback is broken. **Add at least one end-to-end convergence test per autograd substrate.**
+
+### The gap FD checks cannot catch
+
+Surfaced in ProjectOdyssey PR #5466: the existing `test_variable_layers.mojo` validated
+`loss.backward()` populated gradient registry entries and matched analytical values for 3×3 conv
+and 2×3 linear ops. All tests PASSED while `train_autograd.mojo` trained EMNIST to 2.76% accuracy
+(= chance for 47 classes; ln(47)=3.85 loss flatline). Root cause was a 1-byte-per-element batch
+copy upstream of the substrate — not catchable by per-op FD tests because they bypass the data
+pipeline.
+
+### Three-tier convergence test pattern
+
+Each tier runs N training steps on persistent parameters and asserts loss decreased by at least X%.
+Each tier catches a different failure mode:
+
+| Tier | Architecture | Steps | Pass criterion | Catches |
+|------|--------------|-------|----------------|---------|
+| 1 | Tiny MLP (linear → CE) | 20 | loss drops ≥90% | Substrate basics: tape recording, backward dispatch, optimizer step, writeback |
+| 2 | Small conv stack (conv → relu → flatten → linear → CE) | 30 | loss drops ≥70% | Multi-layer gradient propagation; cancellation through chained ops |
+| 3 | Full production shape (e.g. LeNet: conv→relu→maxpool×2, flatten, 3×FC) | 50 | loss drops ≥30% | Exact op stack used in production, at realistic shape |
+
+### Critical implementation details
+
+- **Asymmetric weight init is mandatory** for multi-layer tiers (e.g. `t[i] = base + i*slope`).
+  Uniform fill creates dead-symmetry pathology: every layer output is identical, softmax is uniform,
+  and gradients to earlier layers are algebraically zero (only fp32 cancellation noise survives).
+  Tier 1 (single layer) does not manifest this, but tiers 2+ do.
+- **Asymmetric inputs**, not constant fill. Conv kernels need spatial signal to differentiate
+  pixels; constant inputs produce false-negative "convergence failure" that is actually input
+  deficiency.
+- **Loss-decrease threshold must be relative** (`(first - last) / first ≥ target`) so the test
+  is scale-invariant.
+- **Also assert ≥1 trainable parameter changed** by some `min_abs_delta` to catch silent
+  optimizer no-ops (e.g. `has_gradient()` returning False and SGD skipping the param).
+- **Persist parameter state across steps** by reassigning from `parameters[i].data` after each
+  `optimizer.step()`.
+
+### When a convergence test fails AND a magnitude test shows weird-small gradients
+
+Before blaming the substrate: (a) rerun with asymmetric init, (b) compare gradients directly with
+a manual chain. L2 difference between manual and autograd grads should be exactly 0.0 if the
+substrate is correct. Symmetric init + a real upstream data bug produce identical symptoms
+(chance-loss plateau + tiny gradients), so direct manual-vs-autograd comparison is the only way
+to disambiguate.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --- | --- | --- | --- |
+| Trusting FD gradient checks as sufficient validation | Existing `test_variable_layers.mojo` checked gradients against analytical values on isolated 3×3 ops; all tests passed | Per-op FD validates *gradient values*, not *training dynamics*. A correct-gradient substrate can still produce a training loop that never converges if the data pipeline corrupts inputs upstream | Pair every per-op gradient test with at least one end-to-end convergence test that runs ≥20 SGD steps on persistent params and asserts loss decreased by a relative threshold |
+| Writing the first draft of the convergence tests with uniform weight init | All weights filled with constant 0.05 to keep the test self-contained | Uniform init = mathematical pathology: every layer output is identical, softmax is uniform, gradient back through the layer is algebraically zero (only fp32 cancellation noise survives) | Convergence tests MUST use asymmetric init (e.g., `t[i] = base + i*slope`). Tier 1 (single layer) doesn't manifest the pathology, but tiers 2+ (multi-layer) do |
+| Using constant-fill inputs in the convergence tests | Input `t[i] = 0.3` for all pixels | Conv kernels have no spatial signal to differentiate; even when grads flow, the kernel can't learn a meaningful pattern. False-negative "convergence failure" that's actually input deficiency | Convergence-test inputs should vary across the spatial dimensions. Use `_make_asymmetric` not `_make_tensor(fill=const)` for both weights and inputs |
+| Test 2 plateau at ln(2)=0.694 initially diagnosed as conv backward bug | Saw loss flatline at chance loss for 2 classes, plus a buggy magnitude test showing 1e-8 conv grads | Misdiagnosis: this combination of symptoms (chance-loss plateau + tiny conv grads) is exactly what symmetric init produces, AND it's what a real substrate bug would produce. Required direct manual-vs-autograd gradient comparison to disambiguate | When a convergence test fails AND a magnitude test shows weird-small gradients, before blaming the substrate: (a) rerun with asymmetric init, (b) compare gradients directly with a manual chain |
 | `grad_output = ones_like(output)` for normalization | Uniform upstream gradient for batch norm \| layer norm backward | `sum(x_norm) = 0` by construction; analytical grad is exactly zero; numerical picks up float32 noise ≈ 0.009 | Never use uniform grad_output for any zero-mean normalization layer |
 | Increase atol to hide mismatch | Raised tolerance from 1e-5 to 1e-2 for the failing normalization test | Masks the real issue without validating backward correctness | Fix the test setup, not the threshold |
 | Modify backward formula | Changed grad_input formula to produce non-zero output for uniform grad | The formula IS correct; zero result for uniform grad is mathematically right | Don't change correct code to pass a badly designed test |
@@ -478,6 +535,60 @@ Writing or migrating a gradient checking test?
     └─ Always: non-uniform inputs (Float32(i) * 0.1)
 ```
 
+### Convergence Test Helpers
+
+```mojo
+# Asymmetric tensor init — eliminates the dead-symmetry pathology
+def _make_asymmetric(shape: List[Int], base: Float64, slope: Float64) raises -> AnyTensor:
+    var t = zeros(shape, DType.float32)
+    var n = 1
+    for d in shape: n *= d
+    for i in range(n):
+        t._set_float64(i, base + Float64(i) * slope)
+    return t^
+
+# Loss-decrease assertion (relative, scale-invariant)
+def _assert_loss_decreased(name: String, losses: List[Float32], min_relative_drop: Float64) raises:
+    var first = Float64(losses[0])
+    var last = Float64(losses[len(losses) - 1])
+    var drop = (first - last) / first
+    if drop < min_relative_drop:
+        raise Error(name + ": loss drop " + String(drop) + " < required " + String(min_relative_drop))
+
+# Parameter-changed sanity check — catches silent optimizer no-ops
+def _assert_parameter_changed(name: String, before: Float64, after: Float64, min_abs_delta: Float64) raises:
+    var delta = before - after if before > after else after - before
+    if delta < min_abs_delta:
+        raise Error(name + ": parameter unchanged (delta=" + String(delta) + ")")
+```
+
+### Convergence Test Template
+
+```mojo
+def test_my_convergence() raises:
+    var optimizer = SGD(learning_rate=0.01)
+    var w = _make_asymmetric([out, in], 0.05, 0.003)  # NOT _make_tensor(fill=const)
+    var b = _make_tensor([out], 0.0)
+    var losses = List[Float32]()
+    var w_before_0 = w._get_float64(0)
+    for step in range(N):
+        var tape = GradientTape()
+        tape.enable()
+        var x = Variable(_make_asymmetric([batch, in], 0.1, 0.01), False, tape)  # asymmetric input too
+        var v_w = Variable(w, True, tape)
+        var v_b = Variable(b, True, tape)
+        # ... forward → loss → backward ...
+        losses.append(loss_val)
+        var params: List[Variable] = []
+        params.append(v_w^); params.append(v_b^)
+        optimizer.step(params, tape)
+        w = params[0].data  # persist for next step
+        b = params[1].data
+        optimizer.zero_grad(tape)
+    _assert_loss_decreased("name", losses, 0.30)
+    _assert_parameter_changed("w[0]", w_before_0, w._get_float64(0), 0.0001)
+```
+
 ### CI Workflow Update
 
 ```yaml
@@ -501,3 +612,4 @@ Insert new test files alphabetically in the `pattern` field.
 | ProjectOdyssey | LayerNorm param gradients (PR #4806, issue #3810) | grad\_gamma and grad\_beta |
 | ProjectOdyssey | Pool backward tester (PR #4782, issue #3720) | Three-tier pattern |
 | ProjectOdyssey | Conv2d analytical value tests (PRs #4797, #4799, issue #3235) | Batch+padding formulas |
+| ProjectOdyssey | PR #5466 — added `tests/projectodyssey/autograd/test_autograd_convergence.mojo` | All 3 convergence tiers pass after upstream data-copy fix; previously RED due to combined test-init + data-copy bugs. Caught a class of training-pipeline failures that per-op FD tests missed for months. Tier 1 loss 1.39→0.022 (20 steps); Tier 2 loss 1.41→0.099 (30 steps); Tier 3 loss 7.16e7→2.23 (50 steps) |


### PR DESCRIPTION
## Summary

Amend `skills/gradient-checking-and-backward-pass-testing.md` (1.0.0 -> 1.1.0) to document
**end-to-end convergence tests** as a complementary test class to per-op finite-difference
(FD) gradient checks.

Surfaced in ProjectOdyssey PR #5466: the existing autograd test suite (`test_variable_layers.mojo`)
validated gradients against analytical values on isolated 3x3 ops and all tests passed, yet
`train_autograd.mojo` trained EMNIST to 2.76% accuracy (= chance for 47 classes) due to a
1-byte-per-element batch copy upstream of the substrate. Per-op FD validates *gradient values*,
not *training dynamics* — and it does not exercise the data pipeline. Pairing FD with an
end-to-end convergence test class catches this failure mode.

### What changed

- New section **"End-to-end Convergence Tests (complementary to FD checks)"** with three-tier
  pattern (tiny MLP / small conv stack / full production shape), pass criteria, and critical
  implementation details (asymmetric init/inputs, relative loss-decrease threshold,
  parameter-changed sanity check, parameter persistence across steps).
- 4 new **Failed Attempts** rows: trusting FD as sufficient validation, uniform-weight init
  pathology, constant-fill input deficiency, and misdiagnosing symmetric-init plateau as a
  conv backward bug.
- Helper snippets (`_make_asymmetric`, `_assert_loss_decreased`, `_assert_parameter_changed`)
  and a convergence-test template in **Results & Parameters**.
- New **Verified On** row for PR #5466 with all three tiers' loss trajectories (Tier 1
  1.39 -> 0.022 over 20 steps; Tier 2 1.41 -> 0.099 over 30 steps; Tier 3 7.16e7 -> 2.23
  over 50 steps).
- Frontmatter: version 1.0.0 -> 1.1.0; date 2026-05-19 -> 2026-05-26; extended `description`
  to mention convergence tests.
- Overview: Verification field unverified -> verified-ci.
- History file: new entry at top with full v1.0.0 snapshot.

## Test plan

- [x] `python3 scripts/validate_plugins.py` -> **401/401 valid**
- [x] Frontmatter version bump and date updated
- [x] History file has new entry at top with v1.0.0 snapshot
- [x] All existing content preserved; only additions made

🤖 Generated with [Claude Code](https://claude.com/claude-code)