### PR TITLE
feat: add code-quality-bot-ignores-noqa skill

### DIFF
--- a/skills/code-quality-bot-ignores-noqa.md
+++ b/skills/code-quality-bot-ignores-noqa.md
@@ -1,0 +1,151 @@
+---
+name: code-quality-bot-ignores-noqa
+description: "GitHub's `github-code-quality[bot]` static analyzer flags imports as 'unused' even when they have explicit `# noqa: F401` markers, blocking PR merge under org rulesets with `required_review_thread_resolution`. The fix isn't to fight the bot or rewrite the imports — it's to resolve the threads via `gh api graphql resolveReviewThread` with one explanatory PR comment. Use when: (1) bot review comments flag deliberate test-patch-seam re-exports as 'unused imports', (2) PR shows `MERGEABLE / BLOCKED` with all CI checks green, (3) `required_review_thread_resolution` is in the org ruleset."
+category: tooling
+date: 2026-05-27
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags: [github, pull-request, code-quality, review-threads, noqa]
+---
+
+# Resolve github-code-quality Bot Threads Without Code Changes
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-27 |
+| **Objective** | Unblock PRs that pass all CI checks but show `MERGEABLE / BLOCKED` because of unresolved bot review threads on deliberate test-patch-seam imports |
+| **Outcome** | Resolved 10 bot threads across two PRs with one explanatory comment per PR; both PRs flipped to `MERGEABLE / CLEAN` and merged via auto-merge |
+| **Verification** | verified-ci (observed unblocking ProjectHephaestus PRs #604 and #606 on 2026-05-27) |
+
+## When to Use
+
+- `github-code-quality[bot]` (or similar static analyzer bot) posts a "Unused import" review comment on a deliberately-preserved import
+- The import has an explicit `# noqa: F401` comment but the bot still flags it
+- `gh pr view <N>` shows `mergeStateStatus: BLOCKED` even though `[.statusCheckRollup[] | select(.conclusion == "FAILURE")]` is empty
+- Your repo's org-level branch protection (or rulesets) has `required_review_thread_resolution: true`
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. List all unresolved review threads with their IDs
+gh api graphql -f query='
+query {
+  repository(owner: "ORG", name: "REPO") {
+    pullRequest(number: <N>) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved path line comments(first: 1) { nodes { author { login } } } }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | "\(.id) \(.path):\(.line) by \(.comments.nodes[0].author.login)"'
+
+# 2. Post a single top-level explanatory comment
+gh pr comment <N> --body-file /tmp/explanation.md
+
+# 3. Resolve every thread you intend to dismiss
+for TID in PRRT_AAA PRRT_BBB PRRT_CCC; do
+  gh api graphql -f query='
+    mutation Resolve($tid: ID!) {
+      resolveReviewThread(input: {threadId: $tid}) {
+        thread { id isResolved }
+      }
+    }' -f tid="$TID" --jq '.data.resolveReviewThread.thread'
+done
+```
+
+### Detailed Steps
+
+**Why the bot doesn't honor `# noqa: F401`.** The `github-code-quality[bot]` (and similar GitHub-Marketplace static analyzers) runs its own AST-based unused-import detection. It is NOT a wrapper around ruff/flake8/pyflakes, so it doesn't read those tools' suppression directives. The same is true for many CodeQL configurations: their queries don't honor `# noqa`.
+
+**Why this matters.** GitHub branch protection / org rulesets can enforce `required_review_thread_resolution: true`. When enabled, ANY unresolved review thread (regardless of who wrote it or whether the review is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED`) blocks the merge. A bot leaving 7 unresolved threads on a PR means 7 blocks, even if every CI check is green and the bot's review state is merely `COMMENTED`.
+
+**Why you should NOT just remove the imports.** Test-patch-seam re-exports preserve the existing test-mock surface after a refactor. Example: when extracting `BaseReviewer.__init__` from `PRReviewer` / `AddressReviewer`, the base class does:
+
+```python
+def _resolve_from_subclass_module(cls: type, name: str):
+    module = importlib.import_module(cls.__module__)
+    return getattr(module, name)
+```
+
+This means `BaseReviewer.__init__` reads `WorktreeManager` from `pr_reviewer`'s OWN namespace — so existing tests doing `patch("hephaestus.automation.pr_reviewer.WorktreeManager", ...)` still intercept. Removing the import per the bot's suggestion breaks `getattr(module, "WorktreeManager")` → `AttributeError`, breaking ~24 existing tests immediately.
+
+**The correct resolution.** Resolve the threads with one explanatory PR comment that:
+1. Names the design intent (test-patch seam) and where it's implemented (e.g. `_resolve_from_subclass_module`).
+2. Names the alternative (removing imports) and why it breaks (`AttributeError` + test count).
+3. Cites the `# noqa: F401` markers as documentation, not enforcement.
+4. States that you're resolving all N threads as won't-fix.
+
+Then use the GraphQL `resolveReviewThread` mutation for each thread. The REST `pulls/<N>/comments/<id>` endpoint's `resolved` field is READ-ONLY; the GraphQL mutation is the only way.
+
+**Order of operations.**
+
+1. Get thread IDs via the GraphQL query above. Each `id` looks like `PRRT_kwDOQww0as6E95j8` (base64-encoded).
+2. Post the explanatory comment FIRST so reviewers see the rationale alongside the resolved threads.
+3. Run the `resolveReviewThread` mutation for each ID.
+4. `gh pr view <N> --json mergeStateStatus` should flip from `BLOCKED` → `UNKNOWN` → `CLEAN` over ~30s as GitHub re-computes mergeability.
+5. If auto-merge was already armed (`gh pr merge --auto --squash`), it fires automatically once `CLEAN`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Add `# noqa: F401` to silence the bot | Annotate the import line so ruff doesn't flag it | The bot isn't ruff. It runs its own AST analysis and ignores comment-based suppressions. | Don't conflate ruff's noqa with arbitrary bots. Each bot has its own rule engine. |
+| Add `__all__ = [...]` listing the re-exports | Make the public API explicit so the bot sees the import as "used" | github-code-quality's "unused import" check tracks symbol usage WITHIN the module, not export visibility. `__all__` does not suppress it. | `__all__` documents intent for humans + `from x import *`, but doesn't change AST-level usage analysis. |
+| Remove the imports as the bot suggests | Take the bot's "best fix" recommendation literally | Breaks 24+ tests that use `patch("hephaestus.automation.X.Y", ...)` where Y is the now-removed re-export. The `getattr(module, "Y")` in the BaseReviewer pattern raises `AttributeError`. | Bots that statically analyze don't know about runtime `getattr` lookups. Reject suggestions that break runtime behavior to satisfy static rules. |
+| Reply to each bot comment individually with a regular `gh pr comment` | Hope GitHub auto-resolves threads on follow-up | A reply is just another comment in the thread. Threads only resolve via the explicit `resolveReviewThread` mutation. | Resolving a thread is a state mutation; commenting in a thread is not. |
+| Force-push to dismiss the bot's review | Hope the bot reposts on the new SHA and the old threads get auto-resolved | Threads pinned to specific lines persist across force-pushes if the lines still exist. New review run posts NEW threads on top of the old unresolved ones. | Force-push doesn't resolve threads. It can multiply them. |
+
+## Results & Parameters
+
+**Specific numbers (ProjectHephaestus 2026-05-27):**
+
+- PR #604: 7 inline comments from `github-code-quality[bot]`, 6 unresolved threads.
+- PR #606: 8 inline comments (2 bot runs), 4 unresolved threads.
+- Resolved with: 1 explanatory PR comment per PR + GraphQL `resolveReviewThread` × {6, 4} = ~10 GraphQL calls total.
+- Time elapsed: ~3 minutes.
+- After resolution, mergeStateStatus on #606: `BLOCKED` → `CLEAN` within 8 seconds. PR #604 took ~30s (GitHub recompute lag, not a real difference).
+
+**Template for the explanatory PR comment:**
+
+```markdown
+The `github-code-quality` bot flagged N imports as "unused" in `<file_paths>`. All N findings
+are intentional and I'm resolving them as won't-fix.
+
+These imports are **deliberate test-patch seams** introduced by <refactor_name>. The base class /
+runner / parent module resolves these symbols from the SUBCLASS's module at instantiation time
+(see `<file>::<function_name>`), which preserves N+ existing test mocks of the form:
+
+    patch("<module_path>.<SymbolName>", ...)
+
+Removing the imports per the bot's suggestion would break those tests immediately, since
+`getattr(module, "<SymbolName>")` would raise `AttributeError`. The `# noqa: F401` markers +
+inline comments document this; the bot doesn't honor `noqa` directives.
+
+Resolving all N unresolved bot threads on this PR.
+```
+
+**Detection one-liner — is your blocked PR a victim of unresolved bot threads?**
+
+```bash
+# Returns the list of unresolved review threads. If the only authors are bots and your CI is green,
+# this skill applies.
+gh pr view <N> --json mergeStateStatus,statusCheckRollup,reviews --jq '{
+  state: .mergeStateStatus,
+  failingChecks: [.statusCheckRollup[] | select(.conclusion == "FAILURE") | .name],
+  reviews: [.reviews[] | {state, author: .author.login}]
+}'
+```
+
+If `state: BLOCKED` + `failingChecks: []` + all reviews are by bots → run the resolveReviewThread loop.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #604 (BaseReviewer dedupe refactor) | 7 bot comments on `pr_reviewer.py` + `address_review.py` flagging re-exports of WorktreeManager / StatusTracker / ThreadLogManager / get_repo_root. Resolved with one PR comment ([4555021222](https://github.com/HomericIntelligence/ProjectHephaestus/pull/604#issuecomment-4555021222)) + 6 GraphQL resolveReviewThread mutations. PR auto-merged. |
+| ProjectHephaestus | PR #606 (IssueImplementer phase-runner split) | 8 bot comments on `implementer.py` flagging re-exports of invoke_claude_with_session / get_repo_slug / is_plan_review_approved / AGENT_IMPLEMENTER. Same resolution: 1 explanatory comment + 4 mutations (4 already resolved from first bot run). PR auto-merged. |


### PR DESCRIPTION
## Summary

Adds a new verified-ci skill `code-quality-bot-ignores-noqa` documenting the workflow to unblock PRs that pass all CI but show `MERGEABLE / BLOCKED` because of unresolved review threads from `github-code-quality[bot]` on deliberate test-patch-seam imports marked with `# noqa: F401`.

Key facts captured:

- `github-code-quality[bot]` runs its own AST-based unused-import detection and does NOT honor `# noqa: F401`, `__all__`, or ruff/pyflakes suppression directives.
- Org rulesets with `required_review_thread_resolution: true` make every unresolved bot thread a merge blocker, regardless of review state or CI status.
- The correct fix is to post one explanatory PR comment, then call the GraphQL `resolveReviewThread` mutation per thread. The REST `resolved` field is read-only.
- Removing the imports per the bot's suggestion breaks ~24 tests because `BaseReviewer.__init__` does `getattr(module, "WorktreeManager")` at runtime — a pattern the static analyzer cannot see.

The skill captures the quick-reference GraphQL queries, the detection one-liner, the explanatory comment template, and five failed-attempts entries with lessons learned.

## Verification

- `python3 scripts/validate_plugins.py` → 408/408 valid.
- Verified-on data: ProjectHephaestus PRs #604 (6 threads resolved) and #606 (4 threads resolved), both auto-merged on 2026-05-27.

## Test plan

- [x] `scripts/validate_plugins.py` reports 100% valid
- [x] Signed commit (`git commit -S`)
- [ ] CI passes on this PR
- [ ] Auto-merge with squash succeeds once green