### PR TITLE
docs(skills): amend testing-cli-entrypoint-help-smoke to v1.1.0 (editable-install/workflow-parity)

### DIFF
--- a/skills/testing-cli-entrypoint-help-smoke.history
+++ b/skills/testing-cli-entrypoint-help-smoke.history
@@ -1,0 +1,153 @@
+# Changelog: testing-cli-entrypoint-help-smoke
+
+## 1.1.0 — 2026-05-27
+
+**What changed:** Added a new Failed Attempts entry and a Verified Workflow note
+documenting that a subprocess-based `--help` smoke test requires the package to be
+actually installed (editable or regular) into the subprocess's site-packages —
+pytest's `[tool.pytest.ini_options] pythonpath` injection does NOT propagate to a
+freshly-spawned `python` subprocess. Added the diagnostic tell (in-process import
+test passes while the subprocess `--help` test fails with `ModuleNotFoundError`),
+the workflow-parity guidance (every CI workflow that runs the smoke test must
+install the package first), and the editable-install YAML fix. Bumped `verification`
+to `verified-ci` for this new finding (confirmed end-to-end in CI via ProjectHephaestus
+PR #612). Bumped version 1.0.0 → 1.1.0, date → 2026-05-27, added `history` frontmatter
+field and a History row to the Overview table.
+
+**Why:** A real debugging session in ProjectHephaestus surfaced 15 CI failures, all
+`test_script_help_exits_zero[*]` with `ModuleNotFoundError: No module named 'hephaestus'`,
+in the release workflow only. The PR test workflow passed because it ran
+`pip install -e ".[dev]"` first; the release workflow ran `pixi run pytest` without the
+editable-install step (the `hephaestus` package is deliberately kept out of the pixi
+lockfile to avoid hatch-vcs version churn). The original skill (v1.0.0) did not warn
+that subprocess smoke tests have an install prerequisite that must be replicated across
+every CI workflow, so the lesson is worth encoding.
+
+**NOTE on verification honesty:** The original v1.0.0 content (the import + subprocess
+two-pronged test pattern) was `verified-local` only. The NEW finding in this amendment
+(the editable-install / workflow-parity fix) is `verified-ci` — it was confirmed
+end-to-end in CI.
+
+### Previous version snapshot (v1.0.0, verified-local)
+
+```markdown
+---
+name: testing-cli-entrypoint-help-smoke
+description: "Smoke-test Python CLI entry points with --help subprocess calls and import verification. Use when: (1) a package declares [project.scripts] entry points, (2) entry points need regression protection, (3) an issue asks for CLI importability tests."
+category: testing
+date: 2026-03-25
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - python
+  - cli
+  - integration-testing
+  - entry-points
+  - smoke-tests
+---
+
+# Testing CLI Entry Points with --help Smoke Tests
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-03-25 |
+| **Objective** | Verify all `[project.scripts]` entry points are importable and respond to `--help` without crashing |
+| **Outcome** | Success — 8 tests (4 import + 4 subprocess) all pass in 0.39s |
+| **Verification** | verified-local |
+
+## When to Use
+
+- A Python package declares `[project.scripts]` entry points in `pyproject.toml`
+- Entry points need smoke tests to catch import errors, missing dependencies, or broken `main()` signatures
+- An issue explicitly asks for CLI entry point integration tests
+- The existing integration tests only cover module imports, not the `main()` functions that serve as entry points
+
+Do NOT use when:
+- Entry points require real credentials or network access just for `--help` (check first)
+- The package doesn't use argparse/click (custom CLI parsing may not support `--help`)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Run CLI entry point tests
+pixi run pytest tests/integration/test_cli_entry_points.py -v --no-cov
+
+# Verify a single entry point manually
+python -m hephaestus.git.changelog --help
+```
+
+### Detailed Steps
+
+#### 1. Read `pyproject.toml` to find entry points
+
+```bash
+grep -A10 '\[project.scripts\]' pyproject.toml
+```
+
+Example output:
+```toml
+[project.scripts]
+hephaestus-changelog = "hephaestus.git.changelog:main"
+hephaestus-merge-prs = "hephaestus.github.pr_merge:main"
+hephaestus-system-info = "hephaestus.system.info:main"
+hephaestus-download-dataset = "hephaestus.datasets.downloader:main"
+```
+
+#### 2. Verify each module has a `main()` function and `__main__` block
+
+```bash
+grep -n "def main\|if __name__" hephaestus/git/changelog.py
+```
+
+Confirm: each module has `def main()` and `if __name__ == "__main__": main()`.
+
+#### 3. Check for side effects before `--help`
+
+Read each `main()` function to verify `--help` exits cleanly:
+- argparse handles `--help` **before** any business logic runs — `sys.exit(0)` is called by argparse
+- This is safe as long as there are no module-level side effects (network calls, file writes) at import time
+
+#### 4. Create the test file
+
+Key design decisions:
+- **Use `sys.executable -m module.path`** instead of installed script names — avoids depending on pip-installed entry points
+- **Parametrize with ids** matching the script names from `pyproject.toml` for readable test output
+- **Two test classes**: import verification (fast, in-process) + subprocess `--help` (realistic, out-of-process)
+- **Assert usage text** in stdout to confirm argparse actually ran (not just a silent exit 0)
+
+(Test code omitted in snapshot — see git history for full ENTRY_POINTS / TestCLIEntryPointImports / TestCLIEntryPointHelp listing.)
+
+#### 5. Run and verify
+
+```bash
+pixi run pytest tests/integration/test_cli_entry_points.py -v --no-cov
+pixi run ruff check tests/integration/test_cli_entry_points.py
+pixi run ruff format --check tests/integration/test_cli_entry_points.py
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Using installed script names | Tried `subprocess.run(["hephaestus-changelog", "--help"])` | Requires package to be pip-installed with entry points registered; fails in pixi/dev environments | Use `sys.executable -m module.path` — tests the same `main()` code path via `__main__` block without needing pip install |
+| N/A — direct approach worked | Import + subprocess two-pronged strategy succeeded on first try | N/A | For argparse-based CLIs, `--help` is always safe — argparse calls `sys.exit(0)` before any business logic |
+
+## Results & Parameters
+
+**Test file**: `tests/integration/test_cli_entry_points.py`
+**Test count**: 8 (4 import + 4 subprocess)
+**Execution time**: ~0.39s total
+**Pattern for adding new entry points**: Add a tuple to `ENTRY_POINTS` list and a corresponding id string to both `ids=` lists.
+**Key assertion**: Always check for `"usage:"` in stdout — this confirms argparse actually ran, not just a silent exit 0 from some other code path.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| ProjectHephaestus | Issue #52, PR #95 | 4 CLI entry points: changelog, merge-prs, system-info, download-dataset |
+```

--- a/skills/testing-cli-entrypoint-help-smoke.md
+++ b/skills/testing-cli-entrypoint-help-smoke.md
@@ -2,10 +2,11 @@
 name: testing-cli-entrypoint-help-smoke
 description: "Smoke-test Python CLI entry points with --help subprocess calls and import verification. Use when: (1) a package declares [project.scripts] entry points, (2) entry points need regression protection, (3) an issue asks for CLI importability tests."
 category: testing
-date: 2026-03-25
-version: "1.0.0"
+date: 2026-05-27
+version: "1.1.0"
 user-invocable: false
-verification: verified-local
+verification: verified-ci
+history: testing-cli-entrypoint-help-smoke.history
 tags:
   - python
   - cli
@@ -20,10 +21,11 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-03-25 |
+| **Date** | 2026-05-27 |
 | **Objective** | Verify all `[project.scripts]` entry points are importable and respond to `--help` without crashing |
 | **Outcome** | Success — 8 tests (4 import + 4 subprocess) all pass in 0.39s |
-| **Verification** | verified-local |
+| **Verification** | verified-ci (v1.1.0 editable-install finding); v1.0.0 test pattern was verified-local |
+| **History** | [changelog](./testing-cli-entrypoint-help-smoke.history) |
 
 ## When to Use
 
@@ -35,6 +37,26 @@ tags:
 Do NOT use when:
 - Entry points require real credentials or network access just for `--help` (check first)
 - The package doesn't use argparse/click (custom CLI parsing may not support `--help`)
+
+### Install prerequisite for subprocess smoke tests (v1.1.0)
+
+A subprocess-based smoke test (`subprocess.run([sys.executable, ..., "--help"])`)
+requires the package to be **actually installed** (editable or regular) into the
+subprocess's site-packages. A freshly-spawned `python` subprocess does **NOT** inherit
+pytest's `[tool.pytest.ini_options] pythonpath` injection, nor `conftest.py` `sys.path`
+tricks — those only help **in-process** tests. Consequences to plan for:
+
+1. If you write a subprocess CLI smoke test, ensure **every** CI workflow that runs it
+   first installs the package (editable is fine). Do not rely on `pythonpath`/`conftest`
+   sys.path manipulation — it does not cross the subprocess boundary.
+2. Diagnostic tell: if `test_script_is_importable` (in-process) **passes** while
+   `test_script_help_exits_zero` (subprocess) **fails** with `ModuleNotFoundError`, the
+   package isn't installed in that env — it's a missing-install / workflow-parity problem,
+   **not** a code bug. Do NOT "fix" it by weakening or deleting the subprocess test.
+3. When a package is deliberately kept out of the dependency manager's lockfile (e.g.
+   hatch-vcs editable installs causing pixi.lock churn), the editable-install step becomes
+   an explicit, easy-to-forget prerequisite that must be replicated across **all**
+   test-running workflows. Audit every workflow that runs the smoke tests.
 
 ## Verified Workflow
 
@@ -148,6 +170,7 @@ pixi run ruff format --check tests/integration/test_cli_entry_points.py
 | --------- | ---------------- | --------------- | ---------------- |
 | Using installed script names | Tried `subprocess.run(["hephaestus-changelog", "--help"])` | Requires package to be pip-installed with entry points registered; fails in pixi/dev environments | Use `sys.executable -m module.path` — tests the same `main()` code path via `__main__` block without needing pip install |
 | N/A — direct approach worked | Import + subprocess two-pronged strategy succeeded on first try | N/A | For argparse-based CLIs, `--help` is always safe — argparse calls `sys.exit(0)` before any business logic |
+| Relying on pytest `pythonpath` for the subprocess test | ProjectHephaestus release workflow ran `pixi run pytest tests/unit` with no editable-install step; the `hephaestus` package is intentionally excluded from the pixi lockfile (installed via separate `pixi run dev-install` = `pip install -e . --no-deps` to avoid hatch-vcs churn) | 15 failures, all `test_script_help_exits_zero[*]`, each `ModuleNotFoundError: No module named 'hephaestus'`. The in-process import test passed (pytest's `pythonpath` applied), but the spawned `python --help` subprocess did not inherit it. The PR test workflow passed because it ran `pip install -e ".[dev]"` first — a workflow-parity bug | Subprocess smoke tests need the package installed in the env they spawn into; `pythonpath`/`conftest` sys.path tricks only help in-process. Add the editable-install step to EVERY CI workflow that runs the test; don't weaken the test to make it pass |
 
 ## Results & Parameters
 
@@ -167,8 +190,23 @@ pixi run ruff format --check tests/integration/test_cli_entry_points.py
 3. `main()` uses argparse (or click) with `--help` support
 4. No module-level side effects that would crash on import
 
+**CI workflow parity (v1.1.0)**: Every workflow that runs the subprocess smoke test must
+install the package first. The fix that resolved the ProjectHephaestus release-workflow
+failures (PR #612) added an editable-install step before pytest:
+
+```yaml
+- name: Editable install (scripts/ smoke tests spawn subprocesses that import hephaestus)
+  run: pixi run dev-install   # = pip install -e . --no-deps
+- name: Run tests
+  run: pixi run pytest tests/unit
+```
+
+After merging, the release run's test + type-check + build-and-publish jobs all went
+green in CI — hence `verified-ci` for this finding.
+
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
-| ProjectHephaestus | Issue #52, PR #95 | 4 CLI entry points: changelog, merge-prs, system-info, download-dataset |
+| ProjectHephaestus | Issue #52, PR #95 | 4 CLI entry points: changelog, merge-prs, system-info, download-dataset (v1.0.0, verified-local) |
+| ProjectHephaestus | PR #612 | Editable-install / workflow-parity fix: release.yml ran pytest without `pixi run dev-install`, causing 15 `ModuleNotFoundError` failures in subprocess `--help` tests (v1.1.0, verified-ci) |


### PR DESCRIPTION
## Summary

Amends the `testing-cli-entrypoint-help-smoke` skill (1.0.0 -> 1.1.0) with a learning from a ProjectHephaestus debugging session.

- A subprocess-based `--help` smoke test requires the package to be **actually installed** (editable or regular) in the spawned subprocess's env. pytest's `[tool.pytest.ini_options] pythonpath` injection and `conftest.py` sys.path tricks do **not** cross the subprocess boundary — they only help in-process tests.
- Diagnostic tell: in-process import test passes while the subprocess `--help` test fails with `ModuleNotFoundError` => missing-install / workflow-parity problem, not a code bug. Do not weaken the test.
- Concrete failure: ProjectHephaestus `release.yml` ran `pixi run pytest` with no editable-install step (the `hephaestus` package is deliberately kept out of the pixi lockfile to avoid hatch-vcs churn) -> 15 `test_script_help_exits_zero[*]` failures. The PR `test.yml` passed because it ran `pip install -e ".[dev]"` first.
- Fix (verified in CI via ProjectHephaestus PR #612): add `pixi run dev-install` before pytest in the release workflow. Test + type-check + build-and-publish all went green.

## Changes

- Bump version 1.0.0 -> 1.1.0, date -> 2026-05-27
- `verification`: verified-ci for the new finding (text notes the original v1.0.0 pattern was verified-local)
- Add `history` frontmatter field + Overview "History" row + new `testing-cli-entrypoint-help-smoke.history` changelog with full v1.0.0 snapshot
- New Failed Attempts row, a "When to Use" install-prerequisite note, and the editable-install YAML snippet in Results & Parameters
- Validated: `python3 scripts/validate_plugins.py` => 410/410 valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)