### PR TITLE
feat: amend git-worktree-parallel-execution-lifecycle skill (v1.1.0)

### DIFF
--- a/skills/git-worktree-parallel-execution-lifecycle.history
+++ b/skills/git-worktree-parallel-execution-lifecycle.history
@@ -1,7 +1,32 @@
 <!-- markdownlint-disable MD024 -->
-# git-worktree-parallel-execution-lifecycle — Superseded Snapshots
+# git-worktree-parallel-execution-lifecycle — History
 
-This file preserves verbatim content from skills absorbed into the canonical
+## v1.1.0 (2026-05-28)
+
+**Changed by:** ProjectHephaestus PR #635 rebase + review-fix session (Myrmidon swarm worker).
+**Verification:** verified-ci
+
+### What changed
+
+- Added description trigger (14): single-PR fix agent editing in the shared main workdir while a
+  sibling agent stashes + switches the branch out mid-session, discarding unstaged edits.
+- Added 2 Failed Attempts rows: (a) editing in the shared main workdir during a swarm leads to the
+  branch being swapped out from under you; (b) recovering the lost edits from the sibling agent's
+  `git stash` (`WIP on <your-branch>`).
+- Added the `verification: verified-ci` frontmatter field (was missing).
+
+### Why
+
+A single-PR fix agent assumed it was safe to edit in the shared repo because its target branch
+(`613-auto-impl`) was already checked out there. A sibling swarm agent ran `git stash` + `git
+checkout 623-auto-impl` on the same repo, silently dropping the unstaged edits. The fix was to
+locate the WIP stash, create an isolated `/tmp` worktree, `git stash apply` into it, and finish
+the work there. Confirms the existing rule (trigger 7/11): even a SINGLE agent must use its own
+worktree in a shared-repo swarm.
+
+---
+
+This file also preserves verbatim content from skills absorbed into the canonical
 `git-worktree-parallel-execution-lifecycle` skill (M59 merge, 2026-05-19).
 
 ## Superseded from worktree-parallel-agent-execution

--- a/skills/git-worktree-parallel-execution-lifecycle.md
+++ b/skills/git-worktree-parallel-execution-lifecycle.md
@@ -10,10 +10,15 @@ description: "Use when: (1) creating isolated git worktrees for parallel agent e
   main workdir, (8) handling locked worktrees from dead agent PIDs, (9) staged-file two-step
   cleanup (status A lines), (10) cherry=1 rebase-merge artifact classification, (11) inline
   worktree cleanup inside a per-branch rebase loop, (12) fixing stale origin/HEAD or missing
-  origin/main for worktree creation, (13) branch-name collision check before remote push."
+  origin/main for worktree creation, (13) branch-name collision check before remote push, (14)
+  a single-PR fix agent finds the shared main repo checked out to its target branch and starts
+  editing there, but a sibling agent stashes + switches the branch out mid-session, silently
+  discarding the unstaged edits — recover by locating the WIP stash and re-applying into a fresh
+  /tmp worktree."
 category: tooling
-date: 2026-05-19
-version: "1.0.0"
+date: 2026-05-28
+version: "1.1.0"
+verification: verified-ci
 user-invocable: false
 history: git-worktree-parallel-execution-lifecycle.history
 tags: [worktree, git, parallel-agents, wave-execution, cleanup, branch-collision, contamination,
@@ -499,6 +504,8 @@ gh api --method DELETE "repos/$REPO/git/refs/heads/<branch-name>"
 | Post-removal dirty-check via `cd "$WORK_DIR"; git diff-index` | After inline removal, `cd` failed silently; `git diff-index` ran on wrong directory | CWD-based git after possibly-removed directory yields wrong-tree results | Guard with `[ -d "$WORK_DIR" ]` first AND use `git -C "$WORK_DIR" status --porcelain` |
 | End-of-script stale worktree sweep AFTER inline loop cleanup | Sweep re-queried `gh` and re-checked dirtiness on already-classified branches | Pure duplication; doubled `gh` API calls; second silent-failure surface | Replace sweep with `git worktree prune` + printed summary of `CLEANED_WORKTREES` |
 | `gh pr merge --auto --rebase` (default) | Standard merge command | Repo had rebase merging disabled | Detect with `gh repo view --json squashMergeAllowed,rebaseMergeAllowed` once, pass to all briefs |
+| Single-PR fix agent edits in the shared main workdir because its target branch happened to be checked out there | Made review-comment + lint fixes directly in `/home/.../ProjectHephaestus` (not a worktree) while sibling swarm agents ran | A sibling agent ran `git stash` + `git checkout <other-branch>` on the shared repo mid-session; my unstaged edits vanished and `git -C <repo> status` showed a totally different branch (`623-auto-impl`) and different dirty files | NEVER edit in the shared main workdir during a swarm. Even a single-PR agent must `git worktree add /tmp/wt-<pr>-<branch> <branch>` first and work only there. The shared `.git/HEAD` and index belong to everyone |
+| Assume lost unstaged edits are gone after the branch was switched out | Panicked the fixes were lost when the shared repo flipped to another branch | The sibling agent's `git stash` (run before its checkout) captured MY edits as `stash@{0}: WIP on 613-auto-impl` | Before redoing work, run `git stash list` and look for `WIP on <your-branch>`; `git stash apply stash@{N}` into your own fresh worktree to recover verbatim |
 | Both agents append to same docs file end-of-file | Each appended a new H2 section at EOF | Agent A removed a "still out of scope" bullet that B's work made in-scope; rebase produced stale-bullet conflict | "Append-only" necessary but insufficient — also forbid editing "still TODO"/"out of scope" lists |
 | Trusting local pre-commit pass after manual rebase conflict resolution | Resolved markdownlint conflict, force-pushed without rerunning hooks | Manual edit during conflict resolution introduced missing blank line; CI markdownlint failed | Always run `pre-commit run --files <changed>` AFTER manually resolving rebase conflicts |
 | `pixi run -e dev` in split-issue agent brief | Used `dev` env name from instinct | Repo had envs `default`/`lint`/`docs`, no `dev` — agent commands failed | Brief should say "use `pixi run` (default env)" OR grep `pixi.toml` for env names first |


### PR DESCRIPTION
## Summary

Amends the canonical worktree-lifecycle skill from v1.0.0 to v1.1.0.

Captures a contamination variant observed during a ProjectHephaestus PR #635 swarm: a single-PR fix agent edited in the shared main workdir (because its target branch happened to be checked out there), and a sibling swarm agent stashed + switched the branch out mid-session, silently dropping the unstaged edits.

- New trigger (14): branch swapped out from under a single fix agent
- 2 new Failed Attempts rows: shared-workdir edit hazard + WIP-stash recovery
- Added missing `verification: verified-ci` frontmatter field

## Verification Level

**verified-ci** — the recovery (locate `WIP on <branch>` stash, apply into a fresh /tmp worktree, finish + push) was executed and PR #635 went green through fresh CI.

## Key Findings

**What Worked**:
- `git stash list` reveals the sibling agent's pre-checkout stash as `WIP on <your-branch>`
- `git stash apply` into a dedicated `/tmp` worktree recovers edits verbatim

**What Failed**:
- Editing in the shared main workdir during a swarm → branch swapped out, edits gone

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>