### PR TITLE
feat: amend pre-commit-hooks-and-linting-config skill (v1.3.0)

### DIFF
--- a/skills/pre-commit-hooks-and-linting-config.history
+++ b/skills/pre-commit-hooks-and-linting-config.history
@@ -1,5 +1,29 @@
 # pre-commit-hooks-and-linting-config -- History
 
+## v1.3.0 (2026-05-28) -- Document system-installed package shadowing pixi env locally
+
+**Changed by:** ProjectHephaestus PR #652 rebase session (dependency PR onto green main)
+**Verification:** verified-local
+
+### What changed
+
+- Updated description field to add trigger (6): console script false-fails locally due to system-installed package shadowing pixi env.
+- Added new "When to Use" bullet for the `~/.local/bin` shadowing scenario.
+- Added 1 new Failed Attempts row: "System-installed hephaestus shadows pixi default env version locally" — describes how `pixi run --environment default` does NOT prevent `~/.local/bin` from being used when the host package isn't installed into the pixi env via `dev-install`.
+- Bumped version 1.2.0 → 1.3.0.
+
+### Why
+
+During the PR #652 rebase session, `pre-commit run --all-files` failed on `check-dep-sync` with
+"pyproject.toml contains [project.optional-dependencies] — remove it" — an error that does NOT
+exist in the in-tree `dep_sync.py`, but DOES exist in the system-installed `~/.local/bin/hephaestus-check-dep-sync`.
+CI passes because it always runs `pixi run dev-install` first (installing the local package into the
+pixi env, making its console scripts shadow `$PATH`). Locally in a fresh worktree, `dev-install` had
+not been run, so `pixi run --environment default hephaestus-check-dep-sync` resolved to the system
+binary. Fix: `pixi run dev-install` in every new worktree before running pre-commit.
+
+---
+
 ## v1.2.0 (2026-05-28) -- Add bandit severity-level tuning and stray-file MD033 fix
 
 **Changed by:** ProjectHephaestus PR #657 (fix broken main CI)

--- a/skills/pre-commit-hooks-and-linting-config.md
+++ b/skills/pre-commit-hooks-and-linting-config.md
@@ -1,9 +1,9 @@
 ---
 name: pre-commit-hooks-and-linting-config
-description: "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos."
+description: "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes — system-installed package in ~/.local/bin shadows the local dev version."
 category: tooling
 date: 2026-05-28
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
 verification: verified-ci
 history: pre-commit-hooks-and-linting-config.history
@@ -35,6 +35,7 @@ tags: [merged, pre-commit, linting, ruff, mypy, clang-format, yamllint, actionli
 - Adding pygrep hook with exclusion logic (language: system over language: pygrep)
 - Setting up per-directory mypy baseline or per-file invocation for hyphenated dirs
 - Ensuring `pass_filenames:` is correct for hook scripts
+- A pre-commit hook using a pixi console script (`hephaestus-check-dep-sync`, etc.) false-fails locally with stricter errors than CI — system-installed package in `~/.local/bin` shadows the pixi default env version; fix with `pixi run dev-install`
 - Unit-testing pre-commit hook regex logic with pytest
 - Pre-commit hook shells out to `pixi run <task>` and reports `command not found` for a package entry point (pixi environment selection)
 - Designing CI workflow that invokes pre-commit when the repo declares multiple pixi environments (e.g. `default` vs `lint`)
@@ -356,6 +357,7 @@ Verified by ProjectHephaestus PR #657.
 | `entry: pixi run <task>` without `--environment` | Wrote hook entry as `pixi run hephaestus-check-dep-sync` assuming pixi.toml task default env applies | Hook inherited whichever env pre-commit was launched from (e.g. `lint`); console script not installed there -> `command not found` | `pixi run` resolves the environment from current shell state, not from `pixi.toml`. Always write `pixi run --environment default <task>` for hooks that need a package entry point |
 | `pip install -e . --no-deps --no-build-isolation` in CI | Tried to skip build isolation to speed up the editable install | pip subprocess could not locate `hatchling` because `--no-build-isolation` requires the build backend be pre-installed in the same env | Drop `--no-build-isolation`; let pip do standard build isolation — pixi's env already has hatchling available to the pip child |
 | Skip `dev-install` and rely on `pixi install --environment default` | Assumed `pixi install` would install the host package along with its deps | `pixi install` installs declared deps only; once the self-reference is removed from `pyproject.toml` (to stop lockfile churn) it does not install the host package | After removing self-reference, an explicit `pip install -e . --no-deps` (via `pixi run dev-install`) is mandatory in CI before any hook that imports the package or calls a console script |
+| System-installed hephaestus shadows pixi default env version locally | `pixi run --environment default hephaestus-check-dep-sync` ran the binary from `~/.local/bin` (an older/newer system install) instead of the pixi env | When `hephaestus-check-dep-sync` resolves to `~/.local/bin` (user-level pip install), pixi `--environment default` doesn't shadow `$PATH`; the system binary has a different version of `dep_sync.py` with stricter checks that reject `[project.optional-dependencies]` — CI passes green because CI runs `pixi run dev-install` first, installing the local package into the pixi default env and making its console scripts take precedence | Always run `pixi run dev-install` in a fresh worktree before running pre-commit locally. The `~/.local/bin` system install is stale and will diverge from the in-tree version over time. After `dev-install` the local package's console scripts are installed into the pixi env and take priority over `~/.local/bin`. |
 
 ## Results & Parameters
 


### PR DESCRIPTION
## Summary

Amends `pre-commit-hooks-and-linting-config` from v1.2.0 to v1.3.0.

Documents the system-installed package shadowing scenario: `~/.local/bin/hephaestus-check-dep-sync`
(a stale/newer user-level pip install) runs instead of the in-tree version when `pixi run --environment default`
is invoked in a fresh worktree that has not had `pixi run dev-install` run first.

## Verification Level

**verified-local** — observed in ProjectHephaestus PR #652 rebase session. CI always runs `dev-install` so this
is a local-only failure mode; CI itself was confirmed green.

## Key Findings

**What Worked**:
- `pixi run dev-install` in a fresh worktree before running pre-commit installs the local package into the pixi default env, making its console scripts take priority over `~/.local/bin`

**What Failed**:
- `pixi run --environment default hephaestus-check-dep-sync` without prior `dev-install` resolved to the system `~/.local/bin` binary which had stricter checks not present in the in-tree source

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py`
- [x] Skill passes validator

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>