### PR TITLE
feat: amend llm-output-verdict-parse-last-line-not-substring skill (v1.2.0)

### DIFF
--- a/skills/llm-output-verdict-parse-last-line-not-substring.history
+++ b/skills/llm-output-verdict-parse-last-line-not-substring.history
@@ -1,5 +1,93 @@
 # llm-output-verdict-parse-last-line-not-substring — History
 
+## v1.2.0 (2026-05-28)
+
+**Changed by:** ProjectHephaestus GO/NOGO verdict unification (PR #679 / issue #678)
+**Verification:** verified-ci (skill overall, from prior #670 validation) — the v1.2.0 work itself is verified-local with CI in flight (full local suite of 845 automation tests passed, mypy clean, pre-commit all-files green; PR #679 in CI with auto-merge enabled)
+
+### What changed
+
+- New finding: a single pipeline can legitimately need **TWO different verdict parsers**, and conflating them is a real regression.
+  - **Persisted-comment GATE parser → must be LAST-match-wins.** A gate that reads a stored GitHub `## 🔍 Plan Review` comment to decide "may the implementer proceed?" must scan for the LAST `Verdict: GO|NOGO` line, because a long-lived comment may accumulate an earlier draft verdict before the reviewer's final word. Failing toward NOGO is safe (re-review); failing toward GO implements an unreviewed plan (the #455/#468/#484 bug class). Implemented as a dedicated `_GATE_VERDICT_RE` with `findall(...)[-1]`.
+  - **In-loop / fresh-output parser → first-match is fine.** The reviewer running inside the loop emits exactly one verdict line per the prompt contract ("end your response with EXACTLY ONE verdict line, emit NOTHING after it"). Its parser (`parse_review_verdict`, `.search()` = first match) decides loop termination and fails safe to NOGO on AMBIGUOUS. First-match is correct because the contract guarantees one line.
+- Extended `description` with triggers (8) first-match vs last-match parser selection and (9) auditing a "parser unification" refactor that may have silently dropped a last-wins safety guarantee.
+- Added a new `### Two Parsers: Gate (last-match) vs In-Loop (first-match)` subsection under Verified Workflow with the `_GATE_VERDICT_RE` snippet, GO/NOGO vocabulary, and the input-contract decision table.
+- Added 1 new `Failed Attempts` row (8) for the gate-onto-first-match unification regression.
+- Updated `Verified On` with the GO/NOGO unification context (PR #679, issue #678).
+- Bumped `version` 1.1.0 → 1.2.0 (MINOR — new finding + new failed attempt).
+
+### Why
+
+During a refactor that unified the verdict vocabulary to GO/NOGO, the persisted-comment
+gate was "simplified" to reuse the in-loop first-match `parse_review_verdict`. This SILENTLY
+broke the last-wins safety guarantee: a posted review reading
+`Verdict: GO … on reflection … Verdict: NOGO` (reviewer changed its mind to REJECT) now
+parsed as GO → a rejected plan would be implemented. The regression was caught only because
+a sub-agent's trust-but-verify flagged two failing regression tests
+(`test_false_when_go_precedes_nogo_in_same_body`, `test_true_when_nogo_precedes_go_in_same_body`)
+whose docstrings explicitly guard the last-wins contract. Lesson: when unifying parsers,
+check whether each call site's INPUT contract differs — "exactly one line" (fresh output)
+vs "may accumulate lines" (persisted state) demand different match semantics; do NOT collapse
+them. Keep two parsers, document why. (Clarification: the anchored `^\s*\**\s*Verdict:` regex
+already ignores mid-sentence mentions like "we did not pick Verdict: GO here" because such a
+line does not START with `Verdict:` — inline-prose false positives are handled by
+line-anchoring regardless of first/last.)
+
+### Previous version (v1.1.0) snapshot
+
+```markdown
+---
+name: llm-output-verdict-parse-last-line-not-substring
+description: "Parse discrete LLM-emitted verdicts (APPROVED/REVISE/BLOCK, GO/NOGO, SAFE/UNSAFE) using last-line regex extraction, not substring `in` checks. Use when: (1) adding a Python/shell consumer that reads a classification marker from LLM output, (2) the prompt instructs the LLM that 'readers take the LAST matching line', (3) the LLM may discuss multiple options before settling on a verdict, (4) a substring-in check would fire on quoted/discussed markers, (5) auditing an existing parser for false-positive verdict reads, (6) a reviewer comment exists but its verdict is never parsed — causing the pipeline to re-review the same issue every pass forever (#615 infinite loop), (7) diagnosing a re-review loop where the log gives no clue what the reviewer wrote."
+category: architecture
+date: 2026-05-28
+version: "1.1.0"
+user-invocable: false
+verification: verified-ci
+history: llm-output-verdict-parse-last-line-not-substring.history
+tags:
+  - llm-output-parsing
+  - verdict-gate
+  - regex
+  - last-line-wins
+  - claude-output
+  - prompt-parser-contract
+  - false-positive
+  - substring-vs-regex
+  - bounded-retry
+  - infinite-loop
+  - observability
+---
+
+# LLM Output Verdict Parse: Last-Line Regex, Not Substring
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-28 |
+| **Objective** | Prevent false-positive verdict reads when a Python/shell consumer parses a discrete classification marker (`**Verdict: APPROVED**` etc.) from LLM output. Also prevent the complementary infinite-re-review loop when the verdict is malformed and never parseable. |
+| **Outcome** | SUCCESS — regex fix shipped in PR #552; bounded-retry cap + WARNING diagnostic logging shipped in PR #670 (Issues #615/#616). 53-pass infinite loop for issues #455/#468/#484 eliminated. |
+| **Verification** | verified-ci — PR #670 passed all pre-commit hooks and CI. |
+| **History** | [changelog](./llm-output-verdict-parse-last-line-not-substring.history) |
+
+## When to Use
+
+- You are adding a Python or shell consumer that reads a classification marker (verdict, severity, action, command) from LLM output.
+- The prompt that generated the output explicitly says "readers take only the LAST matching line" (or equivalent).
+- The LLM is permitted to discuss multiple options before settling — multiple matching markers may legitimately appear.
+- A substring `in` check would fire on a quoted/discussed marker.
+- You are auditing an existing parser (skip-gate, finalize-gate, ship-gate) for false-positive reads.
+- **A plan-review loop re-reviews the same issue every pass without ever terminating** — symptom of a malformed verdict that regex cannot parse.
+- **The pipeline log gives no clue what the reviewer wrote** — only says "verdict is None" or "not APPROVED" at DEBUG level.
+
+(Verified Workflow, Failed Attempts rows 1–7, Results & Parameters, and Verified On
+follow as in v1.1.0; full v1.1.0 body preserved in git history at the commit prior to
+the v1.2.0 amendment.)
+```
+
+---
+
 ## v1.1.0 (2026-05-28)
 
 **Changed by:** PR #670 — Issues #615/#616 (verdict-loop fix + batch comment fetch)

--- a/skills/llm-output-verdict-parse-last-line-not-substring.md
+++ b/skills/llm-output-verdict-parse-last-line-not-substring.md
@@ -1,9 +1,9 @@
 ---
 name: llm-output-verdict-parse-last-line-not-substring
-description: "Parse discrete LLM-emitted verdicts (APPROVED/REVISE/BLOCK, GO/NOGO, SAFE/UNSAFE) using last-line regex extraction, not substring `in` checks. Use when: (1) adding a Python/shell consumer that reads a classification marker from LLM output, (2) the prompt instructs the LLM that 'readers take the LAST matching line', (3) the LLM may discuss multiple options before settling on a verdict, (4) a substring-in check would fire on quoted/discussed markers, (5) auditing an existing parser for false-positive verdict reads, (6) a reviewer comment exists but its verdict is never parsed — causing the pipeline to re-review the same issue every pass forever (#615 infinite loop), (7) diagnosing a re-review loop where the log gives no clue what the reviewer wrote."
+description: "Parse discrete LLM-emitted verdicts (APPROVED/REVISE/BLOCK, GO/NOGO, SAFE/UNSAFE) using last-line regex extraction, not substring `in` checks. Use when: (1) adding a Python/shell consumer that reads a classification marker from LLM output, (2) the prompt instructs the LLM that 'readers take the LAST matching line', (3) the LLM may discuss multiple options before settling on a verdict, (4) a substring-in check would fire on quoted/discussed markers, (5) auditing an existing parser for false-positive verdict reads, (6) a reviewer comment exists but its verdict is never parsed — causing the pipeline to re-review the same issue every pass forever (#615 infinite loop), (7) diagnosing a re-review loop where the log gives no clue what the reviewer wrote, (8) deciding whether a verdict parser should be first-match or last-match — persisted/accumulating comment gates need last-match-wins, single-line fresh-output parsers can use first-match, (9) auditing a 'parser unification' refactor that may have silently dropped a last-wins safety guarantee."
 category: architecture
 date: 2026-05-28
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
 history: llm-output-verdict-parse-last-line-not-substring.history
@@ -19,6 +19,9 @@ tags:
   - bounded-retry
   - infinite-loop
   - observability
+  - first-match-vs-last-match
+  - parser-unification-regression
+  - input-contract
 ---
 
 # LLM Output Verdict Parse: Last-Line Regex, Not Substring
@@ -28,9 +31,9 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-05-28 |
-| **Objective** | Prevent false-positive verdict reads when a Python/shell consumer parses a discrete classification marker (`**Verdict: APPROVED**` etc.) from LLM output. Also prevent the complementary infinite-re-review loop when the verdict is malformed and never parseable. |
-| **Outcome** | SUCCESS — regex fix shipped in PR #552; bounded-retry cap + WARNING diagnostic logging shipped in PR #670 (Issues #615/#616). 53-pass infinite loop for issues #455/#468/#484 eliminated. |
-| **Verification** | verified-ci — PR #670 passed all pre-commit hooks and CI. |
+| **Objective** | Prevent false-positive verdict reads when a Python/shell consumer parses a discrete classification marker (`**Verdict: APPROVED**` etc.) from LLM output. Also prevent the complementary infinite-re-review loop when the verdict is malformed and never parseable, and the inverse regression where a persisted-comment gate's last-wins guarantee is silently dropped by collapsing it onto a first-match parser. |
+| **Outcome** | SUCCESS — regex fix shipped in PR #552; bounded-retry cap + WARNING diagnostic logging shipped in PR #670 (Issues #615/#616); two-parser distinction (gate last-match vs in-loop first-match) preserved during the GO/NOGO vocabulary unification in PR #679 (issue #678). 53-pass infinite loop for issues #455/#468/#484 eliminated. |
+| **Verification** | verified-ci — PR #670 passed all pre-commit hooks and CI. (v1.2.0 two-parser content: verified-local — 845 automation tests + mypy + pre-commit green; PR #679 CI in flight.) |
 | **History** | [changelog](./llm-output-verdict-parse-last-line-not-substring.history) |
 
 ## When to Use
@@ -42,6 +45,8 @@ tags:
 - You are auditing an existing parser (skip-gate, finalize-gate, ship-gate) for false-positive reads.
 - **A plan-review loop re-reviews the same issue every pass without ever terminating** — symptom of a malformed verdict that regex cannot parse.
 - **The pipeline log gives no clue what the reviewer wrote** — only says "verdict is None" or "not APPROVED" at DEBUG level.
+- **You must decide whether a verdict parser should be first-match or last-match.** Persisted / accumulating comment gates (long-lived GitHub comments that may collect an earlier draft verdict before the final one) need last-match-wins; single-line fresh-output parsers whose prompt contract guarantees exactly one verdict line can use first-match.
+- **You are auditing a "parser unification" refactor** (e.g. unifying verdict vocabulary to GO/NOGO) that may have silently collapsed a persisted-comment gate onto a first-match parser, dropping its last-wins safety guarantee.
 
 ## Verified Workflow
 
@@ -102,6 +107,60 @@ Three guarantees the regex provides that `MARKER in body` does not:
 2. **Last-match wins**: early APPROVED then later BLOCK → BLOCK wins.
 3. **Strict token equality**: `matches[-1] == "APPROVED"` rejects look-alikes like `APPROVED_WITH_CHANGES`.
 
+### Two Parsers: Gate (last-match) vs In-Loop (first-match)
+
+A single pipeline can legitimately need **two different verdict parsers**. Whether a parser
+should take the **first** or the **last** match is dictated by the **INPUT contract** of the
+text it reads, not by stylistic preference. Conflating them is a real regression (see Failed
+Attempt 8).
+
+| Parser | Input it reads | Input contract | Match semantics | Fail-safe direction |
+|---|---|---|---|---|
+| **Persisted-comment GATE** (`is_*_approved` on a stored `## 🔍 Plan Review` comment) | A long-lived GitHub comment that decides "may the implementer proceed?" | **May accumulate lines** — discussion + an earlier draft verdict before the reviewer's FINAL word | **LAST-match-wins** (`findall(...)[-1]`) | Fail toward **NOGO** (re-review is safe; GO would implement an unreviewed plan — the #455/#468/#484 bug class) |
+| **In-loop / fresh-output** (`parse_review_verdict` on the reviewer's just-emitted reply) | The reviewer's reply produced inside the loop, per the prompt contract "end your response with EXACTLY ONE verdict line, emit NOTHING after it" | **Exactly one line** (prompt-guaranteed) | **First-match is fine** (`.search()`) | Fail to **NOGO** on AMBIGUOUS |
+
+The persisted-comment gate must use a **dedicated** last-match regex — do NOT reuse the
+in-loop first-match parser for it:
+
+```python
+import re
+
+# Dedicated GATE regex: persisted comment may accumulate an earlier draft verdict
+# before the reviewer's FINAL one. The reviewer's LAST word must win.
+# `\**` tolerates optional markdown bold; line-anchored via re.MULTILINE.
+_GATE_VERDICT_RE = re.compile(
+    r"^\s*\**\s*Verdict\s*:\s*\**\s*(GO|NO[\s-]?GO)\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+def gate_allows_proceed(persisted_comment_body: str) -> bool:
+    """Return True iff the LAST Verdict line in the persisted review is GO."""
+    matches = _GATE_VERDICT_RE.findall(persisted_comment_body)
+    if not matches:
+        return False  # no parseable verdict → fail safe (re-review)
+    last = matches[-1].upper().replace(" ", "").replace("-", "")
+    return last == "GO"  # NOGO (or anything else) → do not proceed
+```
+
+The in-loop parser, reading fresh single-line output, may use first-match safely because the
+prompt contract guarantees exactly one verdict line:
+
+```python
+def parse_review_verdict(fresh_reply: str) -> str:
+    """First-match is correct: the prompt guarantees exactly one verdict line."""
+    m = _GATE_VERDICT_RE.search(fresh_reply)  # .search() = first match
+    if m is None:
+        return "NOGO"  # AMBIGUOUS / missing → fail safe to NOGO
+    return "GO" if m.group(1).upper().replace(" ", "").replace("-", "") == "GO" else "NOGO"
+```
+
+**Clarification — line-anchoring already handles inline prose for BOTH parsers.** The anchored
+`^\s*\**\s*Verdict\s*:` pattern ignores mid-sentence mentions like
+`we did not pick Verdict: GO here` because that line does not START with `Verdict:`. So
+inline-prose false positives are handled by line-anchoring **regardless** of first-vs-last
+choice. The first-vs-last decision is purely about which of *several legitimately-anchored*
+verdict lines wins.
+
 ### Detailed Steps
 
 1. **Read the prompt template used to generate the LLM output.** Find the explicit "format" instruction. Example from `hephaestus/automation/prompts.py:474-475`: *"End your response with exactly one of the following verdict lines … readers take only the LAST matching line."*
@@ -153,6 +212,7 @@ Three guarantees the regex provides that `MARKER in body` does not:
 | 5 | Log malformed verdict at DEBUG level | When verdict returned None, only DEBUG log emitted — no clue what the reviewer wrote; loop ran 12+ times per issue unseen | Malformed verdict is an actionable operator alert: log at WARNING with first line of offending comment body + URL. |
 | 6 | No retry cap on malformed verdicts | Loop called re-review every pass when verdict was None | Same issues re-reviewed 12× across loops 2–5 (#455/#468/#484). Add `count_unparseable_verdict_passes()` + `exceeds_unparseable_verdict_cap()` with cap=3. |
 | 7 | Loosen the strict regex to catch more variants | Considered removing `^...$` anchoring to tolerate whitespace/markdown decorators | Strict anchoring is intentional — it prevents the false-positive substring matches that caused #551/#552. NEVER loosen VERDICT_LINE_RE; fix the LLM prompt output instead. |
+| 8 | Unify the persisted-comment gate onto the in-loop first-match parser during a vocabulary refactor (GO/NOGO unification, PR #679) | First-match silently broke last-wins → a `Verdict: GO … on reflection … Verdict: NOGO` review (reviewer changed its mind to REJECT) parsed as GO, would implement a rejected plan. Caught only by two failing regression tests (`test_false_when_go_precedes_nogo_in_same_body`, `test_true_when_nogo_precedes_go_in_same_body`) whose docstrings guard the last-wins contract. | Match semantics follow the INPUT contract — "exactly one line" (fresh output) vs "may accumulate lines" (persisted state); keep two parsers, do NOT collapse them. |
 
 ## Results & Parameters
 
@@ -176,6 +236,17 @@ is_approved = verdict == "APPROVED"
 MAX_UNPARSEABLE_VERDICT_PASSES: int = 3  # surface for human after 3 failed parses
 ```
 
+**GO/NOGO gate regex (persisted-comment gate, last-match-wins):**
+
+```python
+_GATE_VERDICT_RE = re.compile(
+    r"^\s*\**\s*Verdict\s*:\s*\**\s*(GO|NO[\s-]?GO)\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+# Gate (persisted comment, may accumulate lines): findall(...)[-1]  → last-match-wins
+# In-loop (fresh single-line reply, prompt guarantees one line): .search() → first-match
+```
+
 **Cross-language equivalents:**
 
 | Language | Pattern | Notes |
@@ -195,6 +266,9 @@ MAX_UNPARSEABLE_VERDICT_PASSES: int = 3  # surface for human after 3 failed pars
 5. `body = "No verdict here."` → None / False.
 6. `body = ""` → None / False.
 7. 3 review comments with no parseable verdict → `count_unparseable_verdict_passes == 3`, `exceeds_cap True`.
+8. **Gate, GO precedes NOGO** (`test_false_when_go_precedes_nogo_in_same_body`): `body = "Verdict: GO\non reflection…\nVerdict: NOGO\n"` → gate returns **False** (last-match-wins; reviewer's final NOGO must win).
+9. **Gate, NOGO precedes GO** (`test_true_when_nogo_precedes_go_in_same_body`): `body = "Verdict: NOGO\non reflection…\nVerdict: GO\n"` → gate returns **True** (last GO wins).
+10. **In-loop, single line** (fresh reply, prompt-guaranteed one line): `reply = "…\nVerdict: NOGO\n"` → `parse_review_verdict` returns `"NOGO"`; first-match is safe because exactly one line is present.
 
 **Cross-reference these related skills:**
 
@@ -209,3 +283,4 @@ MAX_UNPARSEABLE_VERDICT_PASSES: int = 3  # surface for human after 3 failed pars
 | ProjectHephaestus | `hephaestus/automation/prompts.py:474-475` | Prompt source — explicit "readers take only the LAST matching line" instruction. |
 | ProjectHephaestus | `hephaestus/automation/plan_reviewer.py:342` | Originating defect — `_FINAL_VERDICT_MARKER in latest_review_body`. Fixed in #552. |
 | ProjectHephaestus | Issue #552 (epic #550) | Originating issue under the 1.0 audit remediation epic. |
+| ProjectHephaestus | Issue #678 / PR #679 | GO/NOGO verdict unification — preserved the two-parser distinction (`_GATE_VERDICT_RE` last-match gate vs `parse_review_verdict` first-match in-loop). Regression where the gate was collapsed onto first-match caught by `test_false_when_go_precedes_nogo_in_same_body` / `test_true_when_nogo_precedes_go_in_same_body`. Verified-local: 845 automation tests + mypy + pre-commit green; CI in flight. |


### PR DESCRIPTION
## Summary

Amends the `llm-output-verdict-parse-last-line-not-substring` skill from **v1.1.0 → v1.2.0** (MINOR — new finding + new failed attempt).

Documents that a single pipeline can legitimately need **TWO different verdict parsers**, and that conflating them is a real regression.

- **Persisted-comment GATE parser must be LAST-match-wins.** A gate that reads a stored GitHub `## 🔍 Plan Review` comment to decide "may the implementer proceed?" must scan for the LAST `Verdict: GO|NOGO` line (`_GATE_VERDICT_RE` + `findall(...)[-1]`). A long-lived comment may accumulate an earlier draft verdict before the reviewer's final word; the final word must win. Failing toward NOGO is safe (re-review); failing toward GO implements an unreviewed plan (the #455/#468/#484 bug class).
- **In-loop / fresh-output parser may use first-match.** The reviewer running inside the loop emits exactly one verdict line per the prompt contract ("end your response with EXACTLY ONE verdict line, emit NOTHING after it"). Its parser (`parse_review_verdict`, `.search()` = first match) decides loop termination and fails safe to NOGO on AMBIGUOUS. First-match is correct because the contract guarantees one line.

## Verification Level

**verified-ci** for the skill overall (carried from the prior PR #670 validation).

The **v1.2.0 content itself is verified-local, CI in flight**: the originating ProjectHephaestus GO/NOGO verdict unification (issue #678 / PR #679) passed the full local suite (845 automation tests), `mypy` clean, and `pre-commit run --all-files` green; PR #679 is in CI with auto-merge enabled. This is stated honestly in the skill's Overview, Verified On, and `.history`, rather than overclaiming CI completion.

This skills-repo PR itself: `validate_plugins.py` 418/418 valid, `pytest tests/` 219 passed, `markdownlint-cli2` 0 errors, `pre-commit` green on the changed files.

## Key Findings

**What Worked**:
- Keeping two dedicated parsers — `_GATE_VERDICT_RE` (last-match) for the persisted gate and `parse_review_verdict` (first-match) for fresh single-line output.
- Line-anchoring (`^\s*\**\s*Verdict\s*:`) already neutralizes inline-prose false positives for BOTH parsers, so the first-vs-last choice is purely about which of several *legitimately-anchored* verdict lines wins.

**What Failed** (new Failed Attempts row 8):
- During a vocabulary refactor unifying verdicts to GO/NOGO, the persisted gate was "simplified" to reuse the in-loop first-match parser → silently broke last-wins: `Verdict: GO … on reflection … Verdict: NOGO` (reviewer changed its mind to REJECT) parsed as GO, which would implement a rejected plan. Caught only by two failing regression tests (`test_false_when_go_precedes_nogo_in_same_body`, `test_true_when_nogo_precedes_go_in_same_body`) whose docstrings guard the last-wins contract.
- Lesson: match semantics follow the INPUT contract — "exactly one line" (fresh output) vs "may accumulate lines" (persisted state); keep two parsers, do NOT collapse them.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (418/418 valid)
- [x] `pytest tests/` (219 passed)
- [x] `markdownlint-cli2` on the edited skill (0 errors)
- [ ] Verify skill appears in marketplace after merge
- [ ] Test skill discovery with keywords "first-match vs last-match", "verdict parser unification"

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>