### PR TITLE
feat: amend claude-code-scheduled-tasks-lockfile-gitignore skill (v1.2.0)

### DIFF
--- a/skills/claude-code-scheduled-tasks-lockfile-gitignore.history
+++ b/skills/claude-code-scheduled-tasks-lockfile-gitignore.history
@@ -1,5 +1,47 @@
 # claude-code-scheduled-tasks-lockfile-gitignore — History
 
+## v1.2.0 (2026-05-30)
+
+**Changed by:** ProjectHephaestus PR #816 — same `.claude/scheduled_tasks.lock` file blocked an entirely different tool (`hephaestus-tidy`) that pre-checks `git status --porcelain` before doing any work. Verifies the gitignore fix is the universal remediation, not specific to the `end-of-file-fixer` pre-commit hook.
+**Verification:** verified-ci
+
+### What changed
+
+- Added a third verified-CI data point: ProjectHephaestus PR #816 (2026-05-30). The same lockfile, untracked-and-unignored on a fresh clone, caused `pixi run hephaestus-tidy` to abort immediately on the `_working_tree_clean()` check (hephaestus/github/tidy.py:76-89) which treats any non-empty `git status --porcelain` output as dirty. Adding `.claude/scheduled_tasks.lock` to `.gitignore` immediately unblocked the tool; tidy then ran successfully and deleted 6 stale merged branches without needing the conflict-resolution swarm.
+- Generalized the failure surface in "When to Use": this is NOT only a `pre-commit` / `end-of-file-fixer` problem. ANY tool that checks `git status --porcelain` for cleanliness will refuse to start as long as the lockfile is both present on disk AND untracked-but-not-ignored. `hephaestus-tidy` is the canonical example; the same shape will hit pre-push hooks, CI guard scripts, and `release-please` style checks.
+- Added two new Failed Attempts rows specific to the runtime-process angle of this failure mode:
+  - Tried to stash the file (`git stash push .claude/scheduled_tasks.lock`) → races with the live Claude session that holds the file open; the next scheduled-task acquisition re-creates it within seconds, so stash leaves the working tree dirty again.
+  - Tried to delete the file (`rm .claude/scheduled_tasks.lock`) → the live Claude session re-creates it immediately on next scheduled-task acquisition; you can't out-race a process that owns the lock.
+- Added a "pattern anchoring" note to Results & Parameters: write the gitignore entry as `.claude/scheduled_tasks.lock` (relative path, no leading slash) rather than `/.claude/scheduled_tasks.lock`. The unanchored form matches the file in nested git worktrees and submodules; the anchored form only matches at repo root, which silently fails when the same repo is used as a worktree elsewhere.
+- Updated the description to surface both failure modes (CI pre-commit hook AND CLI dirty-tree guard).
+- Promoted "verify with `git check-ignore -v`" into the Verified Workflow as the universal post-fix sanity check.
+
+### Why
+
+The v1.1.0 skill correctly diagnosed and prescribed the gitignore fix, but framed the problem narrowly as a CI `pre-commit` / `end-of-file-fixer` issue. PR #816 in ProjectHephaestus revealed the same root cause biting a completely different tool (a local CLI tidy utility) through a completely different mechanism (a working-tree cleanliness pre-check, not a normalizing hook). Both failure modes have the same fix because both stem from the lockfile being untracked-but-not-ignored. Generalizing the skill prevents future readers from concluding "this only applies if I see `Fixing .claude/scheduled_tasks.lock` in a pre-commit log" — they should reach for this skill any time a Claude Code-using repo's `git status --porcelain` is unexpectedly non-empty.
+
+Additionally, this wave introduced two new wrong-fix attempts (stash, delete) that v1.1.0 didn't anticipate because the prior context (CI checkout) had no live Claude session writing the file. On a developer's local machine, the file is actively held by the running Claude session and cannot be removed by any client-side trick — only `.gitignore` works.
+
+### Previous version (v1.1.0) snapshot
+
+```markdown
+---
+name: claude-code-scheduled-tasks-lockfile-gitignore
+description: "Untrack and gitignore Claude Code's .claude/scheduled_tasks.lock runtime lockfile to stop end-of-file-fixer pre-commit failures in CI. Use when: (1) CI pre-commit / lint check fails on `Fixing .claude/scheduled_tasks.lock` even though the user's diff didn't touch it, (2) the same failure recurs across unrelated PRs in the same repo, (3) the `/schedule` skill is in use and the lockfile got accidentally committed via `git add .`."
+category: ci-cd
+date: 2026-05-26
+version: "1.1.0"
+user-invocable: false
+verification: verified-ci
+history: claude-code-scheduled-tasks-lockfile-gitignore.history
+tags: [claude-code, gitignore, pre-commit, end-of-file-fixer, lockfile, scheduled-tasks, ci-flake, runtime-state]
+---
+
+(Full v1.1.0 body preserved in git history — see commit predating v1.2.0 amendment. Key shape: durable fix = `git rm --cached .claude/scheduled_tasks.lock` + `.gitignore` entry; triage workaround = `printf '\n' >> .claude/scheduled_tasks.lock`. Failure surface scoped to `end-of-file-fixer` pre-commit hook. Verified on ProjectOdyssey PR #5445 and PR #5457.)
+```
+
+---
+
 ## v1.1.0 (2026-05-26)
 
 **Changed by:** ProjectOdyssey PR #5457 (autograd Phase 2 substrate) — same lockfile churn struck a totally unrelated PR; reinforced that the durable fix is mandatory because the one-line newline workaround regresses on the very next session.

--- a/skills/claude-code-scheduled-tasks-lockfile-gitignore.md
+++ b/skills/claude-code-scheduled-tasks-lockfile-gitignore.md
@@ -1,13 +1,13 @@
 ---
 name: claude-code-scheduled-tasks-lockfile-gitignore
-description: "Untrack and gitignore Claude Code's .claude/scheduled_tasks.lock runtime lockfile to stop end-of-file-fixer pre-commit failures in CI. Use when: (1) CI pre-commit / lint check fails on `Fixing .claude/scheduled_tasks.lock` even though the user's diff didn't touch it, (2) the same failure recurs across unrelated PRs in the same repo, (3) the `/schedule` skill is in use and the lockfile got accidentally committed via `git add .`."
+description: "Untrack and gitignore Claude Code's .claude/scheduled_tasks.lock runtime lockfile to stop two distinct failure modes: (a) end-of-file-fixer pre-commit failures in CI, (b) CLI tools like hephaestus-tidy that abort because `git status --porcelain` reports the untracked lockfile as dirty. Use when: (1) CI pre-commit / lint check fails on `Fixing .claude/scheduled_tasks.lock`, (2) a CLI tool refuses to run with `Working tree has uncommitted changes` and `git status --porcelain` shows `?? .claude/scheduled_tasks.lock`, (3) the same failure recurs across unrelated PRs in the same repo, (4) the `/schedule` skill is in use."
 category: ci-cd
-date: 2026-05-26
-version: "1.1.0"
+date: 2026-05-30
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
 history: claude-code-scheduled-tasks-lockfile-gitignore.history
-tags: [claude-code, gitignore, pre-commit, end-of-file-fixer, lockfile, scheduled-tasks, ci-flake, runtime-state]
+tags: [claude-code, gitignore, pre-commit, end-of-file-fixer, lockfile, scheduled-tasks, ci-flake, runtime-state, hephaestus-tidy, dirty-working-tree, git-status-porcelain]
 ---
 
 # Claude Code `scheduled_tasks.lock` Gitignore Fix
@@ -16,45 +16,77 @@ tags: [claude-code, gitignore, pre-commit, end-of-file-fixer, lockfile, schedule
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-05-26 |
-| **Objective** | Stop CI `pre-commit` / `end-of-file-fixer` failures caused by Claude Code's `/schedule` skill writing a runtime lockfile (`.claude/scheduled_tasks.lock`) that is tracked in git but rewritten at runtime without a trailing newline. The failure bites every PR in the repo, not just the one that "broke" it, because whichever Claude session most recently wrote the file determines the on-disk EOL state at CI checkout time. |
-| **Outcome** | Two-part durable fix: `git rm --cached` the file and add it to `.gitignore`. Verified twice: ProjectOdyssey PR #5445 (2026-05-24, commit 702a5a2e) and the recurrence on PR #5457 (2026-05-26) — both unblocked CI. The one-line newline workaround works for the current PR but regresses on the next session. |
+| **Date** | 2026-05-30 |
+| **Objective** | Stop two related failure modes caused by Claude Code's `/schedule` skill writing a per-machine, per-process runtime lockfile (`.claude/scheduled_tasks.lock`) that is NOT in the default `.gitignore` of most repositories: (a) CI `pre-commit` / `end-of-file-fixer` rewrites the lockfile (no trailing newline) and the hook fails on every PR; (b) any local CLI tool that gates on `git status --porcelain` (canonical example: `hephaestus-tidy` via `_working_tree_clean()` in `hephaestus/github/tidy.py`) refuses to start, treating the untracked lockfile as a dirty working tree. Both failures share one root cause: the lockfile is held open by a live Claude session, is regenerated on every scheduled-task acquisition, and must not be tracked, stashed, or deleted. |
+| **Outcome** | Two-part durable fix: `git rm --cached` the file (if tracked) AND add `.claude/scheduled_tasks.lock` to `.gitignore`. Verified three times: ProjectOdyssey PR #5445 (2026-05-24, commit 702a5a2e), ProjectOdyssey PR #5457 (2026-05-26), and ProjectHephaestus PR #816 (2026-05-30). The Hephaestus run is the strongest evidence — immediately after the gitignore landed on main, `pixi run hephaestus-tidy` ran cleanly and deleted 6 stale merged branches without needing the conflict-resolution swarm. |
 | **Verification** | verified-ci |
 | **History** | [changelog](./claude-code-scheduled-tasks-lockfile-gitignore.history) |
 
 ## When to Use
 
+**CI pre-commit / lint failures:**
+
 - CI `pre-commit` workflow or `lint` job fails with `Fix End of Files....Failed` and the log shows `Fixing .claude/scheduled_tasks.lock`.
 - The pre-commit hook reports a file was "modified" but the user's commit/diff did not touch that file (giveaway signature).
 - Your PR shows status `BLOCKED` despite touching no `.claude/` files at all.
 - The same `end-of-file-fixer` failure on `.claude/scheduled_tasks.lock` recurs across multiple unrelated PRs in the same repo (durable fix was never landed to main).
+
+**Local CLI tools that gate on a clean working tree:**
+
+- `pixi run hephaestus-tidy` (or `hephaestus-tidy --dry-run`) aborts with:
+
+  ```text
+  ERROR - Working tree has uncommitted changes. Commit or stash them before running hephaestus-tidy.
+  ```
+
+  and `git status --porcelain` reports `?? .claude/scheduled_tasks.lock`. The check lives in `hephaestus/github/tidy.py:76-89` (`_working_tree_clean()`) and treats any non-empty porcelain output as dirty.
+- Any other tool that gates on `git status --porcelain == ""` before running (release scripts, pre-push hooks, `release-please`-style guards) refuses to proceed on a freshly cloned Claude Code-active repo.
+- You catch yourself wanting to `git stash` or `rm` the lockfile to make a tool happy — DON'T. The live Claude session re-creates it within seconds.
+
+**Preemptive setup:**
+
 - The `/schedule` skill (Claude Code scheduled tasks / routines) is in use on the project.
-- Setting up a new repo or template that will be used with Claude Code — preempt the issue by adding the gitignore entry up front.
+- Setting up a new repo or template that will be used with Claude Code — preempt both failure modes by adding the gitignore entry up front, BEFORE the file is ever created.
 
 ## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# Durable fix (REQUIRED — land to main to stop recurrence)
-# 1. Untrack the lockfile from git (keeps the working copy on disk)
+# Durable fix — covers BOTH failure modes (CI pre-commit AND dirty-tree CLI guards)
+# Required steps depend on whether the file is currently tracked:
+
+# Case A: file is TRACKED on main (CI pre-commit failure scenario)
 git rm --cached .claude/scheduled_tasks.lock
 
-# 2. Add it to .gitignore (next to the existing .claude/worktrees/ line)
+# Case B: file is UNTRACKED but on disk (dirty-tree CLI guard scenario, e.g. hephaestus-tidy)
+# No `git rm --cached` needed — just add to .gitignore
+
+# Both cases: append the gitignore entry (relative path, no leading slash — matches in any worktree)
 cat >> .gitignore <<'EOF'
+
+# Claude Code scheduled-task runtime lock (per-machine, per-process — not source)
 .claude/scheduled_tasks.lock
 EOF
 
-# 3. Commit and push
+# Post-fix sanity check — MUST report the file as ignored before committing
+git check-ignore -v .claude/scheduled_tasks.lock
+# Expected: .gitignore:N:.claude/scheduled_tasks.lock  .claude/scheduled_tasks.lock
+
+# Confirm `git status --porcelain` is now empty (with the lockfile still on disk)
+git status --porcelain
+# Expected: (empty)
+
+# Commit and push (sign per repo convention)
 git add .gitignore
-git commit -m "chore: untrack and gitignore .claude/scheduled_tasks.lock"
+git commit -S -m "chore: gitignore .claude/scheduled_tasks.lock"
 git push
 ```
 
 ```bash
-# Triage workaround (ACCEPTABLE for unblocking a single PR fast, but DOES NOT prevent recurrence)
-# Use ONLY when you need the current PR unblocked immediately and cannot wait
-# for the durable fix to merge to main. Follow up with the durable fix.
+# Triage workaround for CI pre-commit failures ONLY
+# (ACCEPTABLE for unblocking a single PR fast, DOES NOT fix the dirty-tree CLI failure mode)
+# Use ONLY when the durable fix can't land immediately. Follow up with the durable fix.
 printf '\n' >> .claude/scheduled_tasks.lock
 git add .claude/scheduled_tasks.lock
 git commit -m "chore: add trailing newline to .claude/scheduled_tasks.lock"
@@ -63,7 +95,9 @@ git push
 
 ### Detailed Steps
 
-1. **Confirm the diagnostic signature.** In the failing CI log, look for:
+1. **Confirm the diagnostic signature.** Two distinct shapes — pick the one that matches your failure:
+
+   **Shape A — CI pre-commit (`end-of-file-fixer`) failure.** In the failing CI log:
 
    ```text
    Fix End of Files.............................................................................Failed
@@ -76,32 +110,65 @@ git push
 
    If the user's diff doesn't touch this file but the hook keeps rewriting it, you've found it.
 
-2. **Verify the file is tracked on `main`** (root cause of the recurrence):
+   **Shape B — CLI tool refuses to start on a "dirty" working tree.** Tool reports:
 
-   ```bash
-   git ls-tree -r origin/main --name-only | grep scheduled_tasks.lock
+   ```text
+   ERROR - Working tree has uncommitted changes. Commit or stash them before running <tool>.
    ```
 
-   If this returns a hit, every CI run on every PR is vulnerable — the durable fix MUST land to main.
-
-3. **Apply the durable fix.** Untrack the file from git's index (do NOT delete the working copy — `/schedule` will keep using it) and add it to `.gitignore`:
+   and:
 
    ```bash
+   git status --porcelain
+   # ?? .claude/scheduled_tasks.lock
+   ```
+
+   Canonical example: `pixi run hephaestus-tidy` aborts via `_working_tree_clean()` in `hephaestus/github/tidy.py:76-89`.
+
+2. **Determine tracked vs untracked.** This decides whether you need `git rm --cached`:
+
+   ```bash
+   # Is it tracked on main? (Shape A scenario)
+   git ls-tree -r origin/main --name-only | grep scheduled_tasks.lock
+
+   # Is it tracked in your branch's index?
+   git ls-files --error-unmatch .claude/scheduled_tasks.lock 2>/dev/null && echo TRACKED || echo UNTRACKED
+   ```
+
+   If tracked anywhere → use `git rm --cached` AND `.gitignore`. If untracked but present → just `.gitignore` (Shape B is usually this).
+
+3. **Apply the durable fix.** Do NOT delete the working copy — `/schedule` will keep using it, and a live Claude session will re-create it within seconds anyway.
+
+   ```bash
+   # Only if currently tracked:
    git rm --cached .claude/scheduled_tasks.lock
    ```
 
-   Place the gitignore entry next to the existing `.claude/worktrees/` line so the Claude-Code-runtime ignores are grouped:
+   Anchor the gitignore pattern with `.claude/` (no leading slash) so it matches the file in any worktree of this repo, not just at the top-level checkout. Group it with other Claude-Code-runtime ignores:
 
    ```gitignore
+   # Claude Code runtime state — never commit
    .claude/worktrees/
    .claude/scheduled_tasks.lock
    ```
 
-4. **Commit both changes in the same commit** so the next checkout of this branch has the file untracked AND ignored simultaneously.
+4. **Verify the ignore took effect — BEFORE committing.** This is the universal post-fix sanity check that catches anchoring mistakes (`/.claude/...` vs `.claude/...`) and typos:
 
-5. **Land the durable fix to `main` ASAP.** A feature branch fix only unblocks one PR. If you only apply the workaround (or the durable fix) to your own feature branch, the failure will recur on the next PR opened in this repo by anyone else.
+   ```bash
+   git check-ignore -v .claude/scheduled_tasks.lock
+   # Expected: .gitignore:N:.claude/scheduled_tasks.lock  .claude/scheduled_tasks.lock
 
-6. **Verify in CI.** Push the branch and confirm the `pre-commit` and `lint` checks pass.
+   git status --porcelain
+   # Expected: (empty, with the lockfile still on disk and held by the live session)
+   ```
+
+   If `git check-ignore` prints nothing, the pattern is wrong — fix the gitignore line and re-run before committing.
+
+5. **Commit both changes in the same commit** so the next checkout of this branch has the file untracked AND ignored simultaneously. Sign per repo convention (`git commit -S`).
+
+6. **Land the durable fix to `main` ASAP.** A feature branch fix only unblocks one PR. If you only apply the workaround (or the durable fix) to your own feature branch, the failure will recur on the next PR opened in this repo by anyone else.
+
+7. **Verify the fix works.** For Shape A: push and confirm CI `pre-commit` / `lint` go green. For Shape B: re-run the blocked tool (e.g. `pixi run hephaestus-tidy`) and confirm it now starts and completes successfully.
 
 ## Failed Attempts
 
@@ -112,6 +179,8 @@ git push
 | Add `.claude/scheduled_tasks.lock` to `.gitignore` without `git rm --cached` | Just gitignored, no index removal | `.gitignore` does NOT untrack files already in the index; the file stays tracked and CI keeps failing | Both steps are required: `git rm --cached` AND `.gitignore` entry |
 | Ignore the failure as "unrelated to my PR — someone else will fix it" | Left the PR `BLOCKED`, hoped repo maintainers would land the durable fix | Nobody owns the durable cleanup unless you do; the PR stays blocked indefinitely while the same failure hits every other PR in the repo | If the failure is blocking your PR, it's yours to fix. The durable fix is one commit — land it |
 | Apply the durable fix only to a feature branch (PR #5445), assuming it would propagate | Landed `git rm --cached` + `.gitignore` on the AnyTensor repro branch, expected the cleanup to "stick" | If the durable fix branch is rebased / squashed / abandoned before merging to main, the file stays tracked on main and the failure recurs on the next PR (PR #5457, two days later) | The durable fix MUST merge to main. Until it does, every PR in the repo remains vulnerable |
+| Stash the untracked lockfile to make a dirty-tree CLI happy | `git stash push -u .claude/scheduled_tasks.lock` to clear `git status --porcelain` so `hephaestus-tidy` would run | Stashing races with the live Claude session that holds the file open; the next scheduled-task acquisition writes the file again within seconds, so `git status --porcelain` re-populates and the next CLI invocation re-fails | Don't fight the live session. The file is held open by a long-running process — only `.gitignore` actually makes it disappear from `git status` output |
+| Delete the lockfile to clear the dirty-tree check | `rm .claude/scheduled_tasks.lock` then re-run `hephaestus-tidy` | The live Claude session re-creates the file immediately on its next scheduled-task acquisition (typically within seconds); there's no way to out-race a process that owns the lock from the client side | The only durable answer is to make git stop reporting the file at all — that requires `.gitignore`, not deletion |
 
 ## Results & Parameters
 
@@ -131,9 +200,34 @@ No trailing newline. Written by Claude Code's `/schedule` skill to coordinate sc
 .claude/scheduled_tasks.lock
 ```
 
-**General pattern — tracked runtime-mutable files cause CI flakes:**
+**Pattern anchoring matters.** Write the entry as `.claude/scheduled_tasks.lock` (no leading slash), NOT `/.claude/scheduled_tasks.lock`. The unanchored form matches the file in any worktree of this repo (including `.git/worktrees/<branch>/.claude/scheduled_tasks.lock` and nested submodules). The anchored form only matches at the repo root, which silently fails when the same repo is used via `git worktree add` — and that's the common Claude Code workflow.
 
-Any file that satisfies all three of (a) tracked in git, (b) rewritten at runtime by a tool, (c) subject to a normalizing pre-commit hook (end-of-file-fixer, trailing-whitespace, mixed-line-ending) will cause this exact failure mode. The fix is always the same: `git rm --cached` + `.gitignore`. Watch for:
+**Two failure-mode shapes — same fix.**
+
+| Shape | Trigger | Diagnostic |
+|-------|---------|------------|
+| **A — CI hook rewrites the file** | Lockfile is tracked in git; `end-of-file-fixer` (or any normalizing pre-commit hook) rewrites the no-trailing-newline contents on every CI checkout | `Fixing .claude/scheduled_tasks.lock` in pre-commit log; PR `BLOCKED` despite unrelated diff |
+| **B — Local CLI sees dirty tree** | Lockfile is untracked but on disk; tool gates on `git status --porcelain == ""` | `git status --porcelain` returns `?? .claude/scheduled_tasks.lock`; tool prints `Working tree has uncommitted changes` and refuses to start |
+
+Both shapes are fixed by the same gitignore entry. Shape A additionally requires `git rm --cached` if the file was ever tracked.
+
+**Canonical Shape B example: `hephaestus-tidy`.** The pre-check lives in `hephaestus/github/tidy.py:76-89`:
+
+```python
+def _working_tree_clean() -> bool:
+    """Return True only if the working tree has no uncommitted changes."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip() == ""
+```
+
+Any non-empty `git status --porcelain` output aborts the run. A single untracked lockfile is enough.
+
+**General pattern — runtime-mutable files cause both CI flakes AND local-tool guard failures.**
+
+Any file that satisfies (a) created/rewritten at runtime by a long-running tool, (b) NOT in `.gitignore` of the repo where it lives, will hit at least one of these failure modes. The fix is always the same: add to `.gitignore` (and `git rm --cached` if tracked). Watch for:
 
 - `.claude/scheduled_tasks.lock` (Claude Code `/schedule`)
 - `.idea/workspace.xml` (JetBrains workspace state)
@@ -143,12 +237,14 @@ Any file that satisfies all three of (a) tracked in git, (b) rewritten at runtim
 
 **Verification evidence:**
 
-- ProjectOdyssey PR #5445, commit 702a5a2e (2026-05-24) — `pre-commit` and `lint` Required Checks transitioned FAILURE → SUCCESS after applying durable fix.
-- ProjectOdyssey PR #5457 (2026-05-26) — same failure recurred on unrelated autograd Phase 2 work because the durable fix from PR #5445 had not landed to main. One-line newline workaround unblocked the PR; durable fix landing tracked separately.
+- ProjectOdyssey PR #5445, commit 702a5a2e (2026-05-24) — `pre-commit` and `lint` Required Checks transitioned FAILURE → SUCCESS after applying durable fix. (Shape A)
+- ProjectOdyssey PR #5457 (2026-05-26) — same failure recurred on unrelated autograd Phase 2 work because the durable fix from PR #5445 had not landed to main. One-line newline workaround unblocked the PR; durable fix landing tracked separately. (Shape A recurrence)
+- ProjectHephaestus PR #816, merged 2026-05-30 — `pixi run hephaestus-tidy --dry-run` was permanently aborting with `Working tree has uncommitted changes` because `.claude/scheduled_tasks.lock` was untracked-but-not-ignored on main. Adding the path to `.gitignore` (`git check-ignore -v` confirmed) made `git status --porcelain` return empty with the file still on disk. Tidy then ran successfully and deleted 6 merged branches without needing the conflict-resolution swarm. (Shape B — first verified case)
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | PR #5445 (AnyTensor overload repro branch, 2026-05-24) — CI `pre-commit` and `lint` checks failing every push on `Fixing .claude/scheduled_tasks.lock` despite unrelated diff | Two-part fix (`git rm --cached` + `.gitignore` entry) on commit 702a5a2e unblocked CI; both checks went FAILURE → SUCCESS |
-| ProjectOdyssey | PR #5457 (autograd Phase 2 substrate, 2026-05-26) — same failure recurred on totally unrelated branch because the durable fix from PR #5445 had not merged to main | One-line `printf '\n' >> .claude/scheduled_tasks.lock` workaround unblocked the PR; CI then passed. Demonstrates that the durable fix MUST land to main, not just a feature branch |
+| ProjectOdyssey | PR #5445 (AnyTensor overload repro branch, 2026-05-24) — CI `pre-commit` and `lint` checks failing every push on `Fixing .claude/scheduled_tasks.lock` despite unrelated diff (Shape A — tracked lockfile) | Two-part fix (`git rm --cached` + `.gitignore` entry) on commit 702a5a2e unblocked CI; both checks went FAILURE → SUCCESS |
+| ProjectOdyssey | PR #5457 (autograd Phase 2 substrate, 2026-05-26) — same Shape A failure recurred on totally unrelated branch because the durable fix from PR #5445 had not merged to main | One-line `printf '\n' >> .claude/scheduled_tasks.lock` workaround unblocked the PR; CI then passed. Demonstrates that the durable fix MUST land to main, not just a feature branch |
+| ProjectHephaestus | PR #816 (merged 2026-05-30) — Shape B failure: `pixi run hephaestus-tidy` aborted with `Working tree has uncommitted changes`; `git status --porcelain` reported `?? .claude/scheduled_tasks.lock`. The lockfile was untracked but held open by the live Claude session that issued the tidy command, so stash/delete attempts immediately regressed | Added `.claude/scheduled_tasks.lock` to `.gitignore` (no leading slash, anchored with `.claude/` so it matches in any worktree). `git check-ignore -v` confirmed the rule applied. Post-merge, `pixi run hephaestus-tidy` ran cleanly and deleted 6 stale merged branches without needing the conflict-resolution swarm |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.1.0 to v1.2.0.

Generalizes the skill from a single CI-pre-commit failure mode to two distinct failure modes sharing one root cause: Claude Code's `.claude/scheduled_tasks.lock` is per-machine, per-process runtime state held open by the live session. It must not be tracked, stashed, or deleted — only `.gitignore` works.

- Adds Shape B failure mode: any CLI gating on `git status --porcelain` (canonical: `hephaestus-tidy` via `_working_tree_clean()` in `hephaestus/github/tidy.py:76-89`) aborts when the untracked lockfile is reported as dirty.
- Adds third verified-CI data point: ProjectHephaestus PR #816 (merged 2026-05-30). Post-merge, `pixi run hephaestus-tidy` ran cleanly and deleted 6 stale merged branches without needing the conflict-resolution swarm.
- Adds pattern-anchoring guidance (no leading slash) so the gitignore matches in `git worktree`-managed directories.
- Promotes `git check-ignore -v` post-fix sanity check into the verified workflow.

## Verification Level

**verified-ci**

The failure mode AND the fix were observed live in the same session that produced this skill amendment:

- `pixi run hephaestus-tidy --dry-run` failed pre-fix with `ERROR - Working tree has uncommitted changes. Commit or stash them before running hephaestus-tidy.` and `git status --porcelain` returning `?? .claude/scheduled_tasks.lock`.
- After PR #816 merged to ProjectHephaestus main, fetching to a fresh clone gave `git check-ignore -v .claude/scheduled_tasks.lock` → `.gitignore:84:.claude/scheduled_tasks.lock` and `git status --porcelain` returned empty (lock file still on disk, held by live session).
- `pixi run hephaestus-tidy` then ran successfully end-to-end and deleted 6 merged branches without needing the conflict-resolution swarm.

## Key Findings

**What Worked**:

- Adding `.claude/scheduled_tasks.lock` to `.gitignore` (no leading slash — matches inside worktrees).
- `git check-ignore -v <path>` is the universal post-fix sanity check that catches anchoring mistakes before commit.
- A skill that names BOTH failure shapes is searchable from either entry point: pre-commit logs OR dirty-tree CLI errors.

**What Failed**:

- `git stash push -u .claude/scheduled_tasks.lock` → races with the live Claude session that holds the file open; lock re-populates within seconds.
- `rm .claude/scheduled_tasks.lock` → live session re-creates it on the next scheduled-task acquisition; you can't out-race a process that owns the lock.
- Both wrong attempts reinforce the lesson: the file IS supposed to exist on disk for the running session — the fix is to make git stop reporting it, not to make it stop existing.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — 438/438 valid (including the amended file).
- [x] Verify commit is GPG-signed (`git log --show-signature -1` → `Good signature from "Micah Villmow"`).
- [x] Verify v1.1.0 snapshot preserved in `claude-code-scheduled-tasks-lockfile-gitignore.history`.
- [ ] Verify skill appears in marketplace after merge.
- [ ] Test discovery with keywords: `hephaestus-tidy`, `Working tree has uncommitted changes`, `scheduled_tasks.lock`, `git status --porcelain`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>