### PR TITLE
feat: amend verify-audit-findings-before-acting skill (v1.2.0)

### DIFF
--- a/skills/verify-audit-findings-before-acting.history
+++ b/skills/verify-audit-findings-before-acting.history
@@ -1,5 +1,57 @@
 # verify-audit-findings-before-acting -- History
 
+## v1.2.0 (2026-05-31)
+
+**Changed by:** ProjectHephaestus `/repo-analyze-strict-full` 15-section audit (Opus 4.7 auditor; 3 CRITICAL + 26 MAJOR + 40 MINOR; B- 82.5% overall). Phase 1 Explore agent verified findings against live repo before remediation planning. 10 PRs landed; 9 already merged with green CI on first attempt; 1 in CI with auto-merge armed.
+**Verification:** verified-ci (third corroborating session; 3 of 29 findings = 10.3% refuted by Phase 1 + 1 root-cause finding the audit missed surfaced by inverse-hypothesis search)
+
+### What changed
+
+- **Promoted verification level from `verified-local` → `verified-ci`.** Three sessions of corroborating evidence, and the 2026-05-31 session's plan + 10 PRs landed with 9 already merged green on first attempt (and 1 in CI with auto-merge armed). The skill's discipline is no longer hypothesis — it is the workflow that shipped.
+- **Added "Phase 1 verification BEFORE remediation planning"** as a new When-to-Use trigger and as a dedicated workflow section. Previous versions framed Phase 1 as "before issue filing"; the correct framing is "before drafting the remediation plan." Drafting a plan against unverified findings means PRs that fix non-issues AND leaves actual root causes untouched.
+- **Added "Inverse-Hypothesis Search Catalog"** as a new workflow section with a 7-row table mapping "audit says X is missing" → "also check: is X present but WRONG?" The 2026-05-31 session demonstrated the audit class is biased toward absence findings and systematically misses presence-but-wrong root causes. Catching the `doc_policy.py` linter REJECTING `--squash` was a direct application of this search.
+- **Added "AUDIT CORRECTIONS Section in the Remediation Plan"** as a required structural element of any audit-driven remediation plan. Includes a worked-example table format showing how to enumerate REFUTED findings with evidence AND NEW-FINDING discoveries from inverse-hypothesis search. Reviewers can immediately see why the plan's PR count differs from the audit's finding count.
+- **Added 2 new false-positive classes to Detailed Steps:**
+  - Class 6: "Already-fixed-state hallucination" — auditor flagged `_version.py` CRITICAL "tracked despite .gitignore"; `git ls-files` returned empty. Auditor flagged `dist/` MAJOR "contains stale dev wheels"; directory did not exist. Audit invented bad states the repo had never been in. Run `git ls-files`, `ls -d`, `find` to confirm claimed bad state before believing it.
+  - Class 7: "Cross-file collision hallucination" — auditor flagged `security.yml` MAJOR "duplicates `_required.yml` security jobs"; `_required.yml` contains no security jobs. Audit invented a structural overlap that did not exist. When an audit claims "file A duplicates file B", read both files; do not trust prose summaries.
+- **Added 3 new Failed Attempts rows:**
+  - Trusting strict audit findings without verification before remediation planning (10.3% refutation rate in this session).
+  - Skipping the inverse-hypothesis check (audit missed the `doc_policy.py` linter root cause).
+  - Omitting AUDIT CORRECTIONS section from the remediation plan (downstream agents re-introduce refuted findings).
+- **Added "Missed-finding rate" to Results & Parameters** — N=1 across one session is not yet a stable estimate; conjecture: 1–3 missed root causes per strict audit, with the inverse-hypothesis class being the most common.
+- **Updated "Verified On"** with the 2026-05-31 ProjectHephaestus session including concrete refutation evidence and the root-cause-discovery worked example.
+- **Updated description, tags, version, date.** Description now names the inverse-hypothesis search and the AUDIT CORRECTIONS pattern. Tags add `phase-1-verification`, `inverse-hypothesis-search`, `audit-corrections-section`, `root-cause-discovery`, `remediation-plan-corrections`. Version 1.1.0 → 1.2.0. Date → 2026-05-31.
+
+### Why
+
+A third strict-full audit corroborated the skill's thesis AND surfaced a critical methodology gap the previous versions did not name: Phase 1 verification was framed as "before issue filing" when the correct point of insertion is "before drafting the remediation plan." The 2026-05-31 session would have wasted ~3 PRs fixing non-issues AND left the actual root cause (the `doc_policy.py` linter) untouched if I had not run Phase 1 before planning. The corrected sequence (PR1 = fix linter, PR2+ = fix skills) is why all 10 PRs landed and 9 merged green on first attempt.
+
+Three sharper failure classes are now named:
+
+1. **Already-fixed-state hallucination** — auditor describes a violation in a state the repo has never been in. Verify with `git ls-files`/`ls -d`/`find` before believing.
+2. **Cross-file collision hallucination** — auditor describes structural duplication that doesn't exist. Read both files before believing.
+3. **Inverse-hypothesis blind spot** — audit is biased toward absence findings ("X is missing") and systematically misses presence-but-wrong findings ("X is present but enforces the wrong rule"). The inverse-hypothesis class is often the actual root cause of the symptoms the audit named.
+
+The AUDIT CORRECTIONS section is the bridge: reviewers see "audit said 3 CRITICAL, plan has 1 PR" and immediately read the evidence-backed refutation. Without this section, the discrepancy looks like the implementer dropped findings without justification.
+
+### Previous version (v1.1.0) snapshot
+
+---
+name: verify-audit-findings-before-acting
+description: "Strict-mode repo audits routinely hallucinate critical findings (references to nonexistent files, claims of missing CI checks that already exist). Verify each finding against current filesystem state BEFORE filing issues or fixing. Use when: (1) consuming output from /repo-analyze-strict or any swarm-audit, (2) about to bulk-file remediation issues, (3) deciding which audit majors are real."
+category: documentation
+date: 2026-05-27
+version: "1.1.0"
+user-invocable: false
+verification: verified-local
+history: verify-audit-findings-before-acting.history
+tags: [audit, code-review, fact-checking, remediation]
+---
+
+(Full v1.1.0 body preserved in git history at commit immediately preceding the v1.2.0 amendment; v1.0.0 snapshot remains below in this file.)
+
+---
+
 ## v1.1.0 (2026-05-27)
 
 **Changed by:** ProjectHephaestus `/repo-analyze-strict-full` session (15 Sonnet section agents, full file coverage, B+ ~86% GO)

--- a/skills/verify-audit-findings-before-acting.md
+++ b/skills/verify-audit-findings-before-acting.md
@@ -1,13 +1,13 @@
 ---
 name: verify-audit-findings-before-acting
-description: "Strict-mode repo audits routinely hallucinate critical findings (references to nonexistent files, claims of missing CI checks that already exist). Verify each finding against current filesystem state BEFORE filing issues or fixing. Use when: (1) consuming output from /repo-analyze-strict or any swarm-audit, (2) about to bulk-file remediation issues, (3) deciding which audit majors are real."
+description: "Strict-mode repo audits routinely hallucinate critical findings (references to nonexistent files, claims of missing CI checks that already exist) AND miss real ones (linter bugs, root causes). Verify each finding against current filesystem state BEFORE writing a remediation plan, and search for inverse hypotheses (what the audit MISSED) before acting. Use when: (1) consuming output from /repo-analyze-strict or any swarm-audit, (2) about to write a remediation plan from audit output, (3) about to bulk-file remediation issues, (4) deciding which audit majors are real, (5) the audit's CRITICAL/MAJOR count differs from what you can verify on disk."
 category: documentation
-date: 2026-05-27
-version: "1.1.0"
+date: 2026-05-31
+version: "1.2.0"
 user-invocable: false
-verification: verified-local
+verification: verified-ci
 history: verify-audit-findings-before-acting.history
-tags: [audit, code-review, fact-checking, remediation]
+tags: [audit, code-review, fact-checking, remediation, phase-1-verification, inverse-hypothesis-search, audit-corrections-section, root-cause-discovery, remediation-plan-corrections]
 ---
 
 # Verify Each Audit Finding Against the Filesystem Before Acting
@@ -16,20 +16,23 @@ tags: [audit, code-review, fact-checking, remediation]
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-05-27 |
-| **Objective** | Catch hallucinated audit findings before they become wasted remediation work |
-| **Outcome** | Saved 3 false-positive PRs in one session by verifying each finding against `ls` / `grep` |
-| **Verification** | verified-local (≈20% false/stale across two strict-full sessions: 3 of 11, then ~3 of ~16) |
+| **Date** | 2026-05-31 |
+| **Objective** | Catch hallucinated audit findings before they become wasted remediation work AND discover root-cause findings the audit missed by searching the inverse hypothesis space |
+| **Outcome** | Saved 3 false-positive PRs AND discovered 1 root-cause finding the audit missed; 10 PRs landed, 9 already merged with green CI on first attempt |
+| **Verification** | verified-ci (10 PRs merged with green CI in 2026-05-31 session; ≈10–25% false-positive rate corroborated across three strict-full sessions) |
 | **History** | [changelog](./verify-audit-findings-before-acting.history) |
 
 ## When to Use
 
 - Receiving output from `/repo-analyze-strict`, `/repo-analyze-strict-full`, or any swarm-of-15 audit
+- **About to write a remediation plan from audit output** *(added v1.2.0)* — Phase 1 verification MUST run before plan generation, not after issue filing. Drafting a plan against unverified findings means writing PRs that fix non-issues.
 - About to bulk-file `gh issue create` for every flagged finding
 - Reviewing a "missing X" finding before adding X to the codebase
 - A new auditor (model or human) makes a sweeping "you don't have Y" claim about your repo
 - **Any "missing control / no Y in CI" claim** — controls often live in an aggregator/required workflow, not the file named after them. Grep the WHOLE `.github/` before believing absence.
 - **Two swarm section agents disagree on the same checkable fact** — the disagreement itself is the verification trigger; grep the fact before filing either way.
+- **Before claiming the audit is "complete enough" to drive remediation** *(added v1.2.0)* — search the INVERSE hypothesis space: if the audit says "linter is MISSING", ALSO check "is the linter PRESENT but WRONG?" The inverse class is the most common audit blind spot and is often the actual root cause.
+- **The audit's CRITICAL/MAJOR count differs from your independent count** *(added v1.2.0)* — a 1- or 2-finding gap is normal noise; a 3+ finding gap means either you or the audit is wrong about ground truth. Verify before believing either side.
 
 ## Verified Workflow
 
@@ -59,6 +62,8 @@ Each is a structurally plausible failure. None of them was true in the verified 
 3. **Documentation reading error** — pixi.toml comments warned about `dev-install` being required, but the agent inferred this meant the `bootstrap` justfile recipe was broken. The recipe was incomplete but pixi's editable build did make the package importable for most CLIs; the audit's "imports fail" claim was wrong.
 4. **Control exists in a DIFFERENT file than the agent read** *(new class, 2026-05-27)* — the Security agent (S8) reported "no secrets-scanning in CI" after reading only `.github/workflows/security.yml` (which runs pip-audit only). Gitleaks IS present and is a REQUIRED check at `.github/workflows/_required.yml:478-497` with a SHA-pinned binary download. When an audit says "missing X", grep the WHOLE `.github/` (or whole repo) — controls live in aggregator/required workflows, not the file named after the control. (A real gap did remain — no SAST/CodeQL — so verification separates the true gap from the false one.)
 5. **Line-number drift even in TRUE findings** *(new class, 2026-05-27)* — the issue-filing swarm re-verified every cited file:line and found refs stale even when the finding was real: `.claude/workflows/development.md` "rebase merge" was line 19 not 18; `runtime.py:93` already had `timeout=10` (excluded, though :77/:244 were genuinely unbounded); README had 2 version-pin lines not the 3 claimed. A finding can be real while its cited location is stale — re-verify exact file:line at fix/file time.
+6. **Already-fixed-state hallucination** *(new class, 2026-05-31)* — `hephaestus/_version.py` was flagged CRITICAL "tracked in git despite `.gitignore`". `git ls-files hephaestus/_version.py` returned empty — the file was already gitignored AND not tracked. The audit hallucinated the violation. `dist/` was flagged MAJOR "contains stale dev wheels" — the directory did not exist. The audit invented a state the repo had never been in. Run `git ls-files`, `ls -d`, and `find` to confirm the claimed bad state before believing it.
+7. **Cross-file collision hallucination** *(new class, 2026-05-31)* — `security.yml` was flagged MAJOR "duplicates `_required.yml` security jobs". Reading `_required.yml` revealed it contains NO security jobs (gitleaks notwithstanding — that's a separate job, not a duplicate). `security.yml` is standalone. The audit invented a structural overlap that did not exist. When an audit claims "file A duplicates file B", read both files; do not trust prose summaries.
 
 **Verification protocol (per finding, 30s budget):**
 
@@ -72,6 +77,70 @@ Each is a structurally plausible failure. None of them was true in the verified 
 
 **Triage rule:** If verification shows the finding is wrong, log it but DO NOT file an issue or open a PR. Track stale-finding rate per audit run; if it exceeds 20%, escalate to question the audit methodology, not the codebase.
 
+### Phase 1 Verification BEFORE Remediation Planning *(added v1.2.0)*
+
+Run Phase 1 verification BEFORE drafting the remediation plan — not before issue filing, not before PR creation. The plan must be written against verified findings, not raw audit output. Drafting a plan against unverified findings produces PRs that fix non-issues, and (worse) leaves the actual root causes untouched.
+
+**Workflow:**
+
+1. Run the 15-section strict audit via swarm.
+2. **Dispatch ONE Explore agent with the full audit findings list. Ask: "verify or refute each finding using `gh api`, `git ls-files`, and direct file reads — NOT just `grep`."**
+3. The Explore agent returns a STATUS table:
+
+   | Finding | Audit Claim | Verification Method | Status | Evidence |
+   |---------|-------------|---------------------|--------|----------|
+   | F1 | "_version.py tracked despite .gitignore" | `git ls-files hephaestus/_version.py` | **REFUTED** | empty output → not tracked |
+   | F2 | "no pr-policy required check" | `gh api repos/.../rulesets/RULESET_ID` | **CONFIRMED** | ruleset omits pr-policy |
+   | F3 | "security.yml duplicates _required.yml" | Read both files | **REFUTED** | _required.yml has no security jobs |
+   | F4 | "stale CLAUDE.md version section :411-413" | Read :411-413 | **PARTIAL** | section exists but at :409-413 (line drift) |
+
+4. **Search the inverse hypothesis space (Phase 1.5):** for every finding of the form "X is missing", spend an extra 30s asking the dual question: "is X present but WRONG?" The audit is structurally biased toward absence-class findings and misses presence-but-incorrect findings.
+5. Write the plan against the CORRECTED finding list — not the raw audit. Drop REFUTED findings; promote NEW-FINDING discoveries; adjust file:line for PARTIAL findings.
+
+### Inverse-Hypothesis Search Catalog *(added v1.2.0)*
+
+| Audit Says | ALSO Check |
+|------------|------------|
+| "linter is MISSING" | "linter is PRESENT but enforcing the WRONG rule" |
+| "no test for X" | "test for X exists but mocks the contract X promises" |
+| "no CI gate for Y" | "CI gate for Y exists but `continue-on-error: true` makes it noop" |
+| "no doc for Z" | "doc for Z exists but contradicts the implementation" |
+| "no policy enforcing P" | "policy file exists but its checker function is wrong" |
+| "no integration test for E2E" | "integration test exists but skips the real network path" |
+| "no error handling for E" | "error handler exists but swallows the exception silently" |
+
+**Worked example (2026-05-31, ProjectHephaestus):** The audit flagged "skills mandate `--rebase` despite squash-only policy" as a content bug in two skill files. The inverse hypothesis check asked: "is there a linter ENFORCING `--rebase` somewhere?" Answer: yes — `hephaestus/validation/doc_policy.py` was REJECTING `--squash` and requiring `--rebase`. That linter was the ROOT CAUSE of the skill content. Fixing the skills first (without fixing the linter) would have been blocked by the linter the audit missed. Phase 1 sequenced PR1 = fix linter, PR2+ = fix skills. The 9 merged PRs all passed CI on first attempt because the corrected sequence was used.
+
+### AUDIT CORRECTIONS Section in the Remediation Plan *(added v1.2.0)*
+
+Every remediation plan generated from a strict audit MUST contain an explicit "AUDIT CORRECTIONS" section listing what Phase 1 refuted, with evidence. Without it, reviewers cannot tell why the plan's finding count differs from the audit's count, and downstream agents will re-introduce the refuted findings.
+
+**Required structure:**
+
+```markdown
+## AUDIT CORRECTIONS
+
+Phase 1 ground-truth verification refuted the following audit findings. They are
+NOT addressed by any PR in this plan.
+
+| Audit Finding | Audit Severity | Verification | Reason for Drop |
+|---------------|----------------|--------------|-----------------|
+| `_version.py` tracked despite `.gitignore` | CRITICAL | `git ls-files hephaestus/_version.py` returned empty | Not tracked. `.gitignore` and hatch-vcs config already correct. |
+| `dist/` contains stale dev wheels | MAJOR | `ls -d dist/` → "No such file or directory" | Directory does not exist. Already gitignored. |
+| `security.yml` duplicates `_required.yml` security jobs | MAJOR | Read both files | `_required.yml` has no security jobs. `security.yml` is standalone. |
+
+## AUDIT-MISSED FINDINGS (NEW)
+
+Phase 1 inverse-hypothesis search discovered findings the audit did not flag.
+These ARE addressed by PRs in this plan.
+
+| Inverse Question | Finding | Severity | PR |
+|------------------|---------|----------|-----|
+| "Is the squash-only linter present but enforcing `--rebase`?" | `hephaestus/validation/doc_policy.py` REJECTS `--squash` and requires `--rebase`, contradicting CLAUDE.md squash-only policy. Root cause of `--rebase` text in skills. | CRITICAL | PR1 |
+```
+
+This section is the bridge between the audit's reported finding count and the plan's PR count. Reviewers can immediately see "audit said 3 CRITICAL, plan has 1 PR — why?" and read the evidence-backed refutation.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -81,10 +150,15 @@ Each is a structurally plausible failure. None of them was true in the verified 
 | Believe "CRITICAL" severity tags | Defer to the audit's own ranking | The "CRITICAL: missing hook" was hallucinated. Severity tag doesn't correlate with finding accuracy | Severity is a model's prediction, not a filesystem fact |
 | Trust "missing control" from the obviously-named file | S8 read only `security.yml`, declared "no secrets-scanning in CI" | Gitleaks was a REQUIRED check in `_required.yml:478-497`, a file the agent never grepped | For any "missing X" claim, grep the WHOLE `.github/`/repo — controls live in aggregator/required workflows |
 | File/fix at the audit's cited file:line without re-checking | Open the issue/PR at the exact line the audit reported | Line refs were stale even in TRUE findings (line 18 vs 19; `runtime.py:93` already had `timeout=10`; 3 vs 2 README pins) → wrong line or already-fixed | Re-verify exact file:line at fix/file time; a finding can be real while its location is stale |
+| Trust strict audit findings without verification before remediation planning | Auditor (Opus 4.7) flagged 3 CRITICAL + 26 MAJOR + 40 MINOR; I started drafting the remediation plan from the raw list | 3 of 29 findings (10.3%) were factually refuted by Phase 1: `_version.py` not tracked, `dist/` did not exist, `security.yml` did not duplicate `_required.yml`. Drafting against the raw list would have produced 3 PRs that fix non-issues | Phase 1 verification MUST run BEFORE remediation planning, not before issue filing. The plan must be written against the corrected finding list, not raw audit output |
+| Skip the inverse-hypothesis check ("audit says missing — also check is it present but wrong?") | Treat the audit's hypothesis space as complete | The audit missed `hephaestus/validation/doc_policy.py` linter that was REJECTING `--squash` and requiring `--rebase`. That linter was the ROOT CAUSE of `--rebase` text in skill files (myrmidon-swarm:318, learn:422). Fixing skills without fixing the linter would have blocked the very PRs the plan generated | For every "X is missing" finding, also ask "is X present but wrong?" — the inverse class is the most common audit blind spot and is often the root cause |
+| Omit AUDIT CORRECTIONS section from the remediation plan | Hand the plan to reviewers without explaining why the PR count differs from the audit's finding count | Reviewers ask "audit said 3 CRITICAL, plan has 1 PR — what happened?" Downstream agents re-introduce the refuted findings in subsequent rounds because the refutation evidence is not preserved | Every audit-driven remediation plan MUST include an AUDIT CORRECTIONS section listing what was refuted, with evidence. Reviewers must be able to immediately see why the plan's count differs |
 
 ## Results & Parameters
 
-**Stale-finding rate observed:** 3/11 majors in the 2026-05-26 ProjectHephaestus audit (27%), then ~3 of ~16 findings false/stale in the 2026-05-27 strict-full audit (≈20%). Consistent ≈20% false-positive rate across two sessions. Likely range across audits: 10–30%.
+**Stale-finding rate observed:** 3/11 majors in the 2026-05-26 ProjectHephaestus audit (27%), ~3/~16 findings false/stale in the 2026-05-27 strict-full audit (≈20%), and 3/29 findings (10.3%) refuted in the 2026-05-31 strict-full audit. Consistent 10–25% false-positive rate across three sessions. Likely range across audits: 10–30%.
+
+**Missed-finding rate observed (added v1.2.0):** In the 2026-05-31 session, Phase 1's inverse-hypothesis search discovered 1 root-cause finding the audit missed (the `doc_policy.py` `--rebase`-enforcing linter). N=1 across one session is not yet a stable estimate; conjecture: 1–3 missed root causes per strict audit, with the inverse-hypothesis class being the most common.
 
 **Grep-the-whole-`.github/` tip:** Before believing any "no Y in CI" / "missing control" finding, grep the entire `.github/` tree, not just the file named after the control. Controls are commonly wired into an aggregator or `_required.yml` workflow rather than the obviously-named file (e.g. Gitleaks lived in `_required.yml:478-497`, not `security.yml`):
 
@@ -133,3 +207,4 @@ done
 |---------|---------|---------|
 | ProjectHephaestus | 2026-05-26 strict-mode full-coverage audit (B+ 84%) | 3 of 11 majors were stale: hallucinated `.claude/hooks/learn-trigger.py` reference (S11 critical), claim of "no gitleaks in CI" (S8 major) when gitleaks v8.30.0 was already wired, partially-wrong claim that `bootstrap` recipe was broken (S13 major). Caught all 3 in under 5 minutes of `ls`/`grep` verification before filing issues. |
 | ProjectHephaestus | 2026-05-27 `/repo-analyze-strict-full` (15 Sonnet agents, full coverage, B+ ~86% GO) | ~3 of ~16 findings false/stale (≈20%). New classes: S8 "no secrets-scanning in CI" was false — Gitleaks REQUIRED at `_required.yml:478-497` (S6 said present, S8 said absent → inter-agent disagreement was the trigger). Line drift in TRUE findings: development.md line 19 not 18; `runtime.py:93` already had `timeout=10`; README 2 pins not 3. Verified MAJORs held: stale CLAUDE.md `:411-413`, pr-policy absent from live ruleset, broken `just watch` reproduced live. |
+| ProjectHephaestus | 2026-05-31 `/repo-analyze-strict-full` 15-section audit (Opus 4.7 auditor, 3 CRITICAL + 26 MAJOR + 40 MINOR, B- 82.5% overall) | **3 of 29 findings (10.3%) REFUTED by Phase-1 Explore agent before remediation:** (1) `hephaestus/_version.py` CRITICAL "tracked despite .gitignore" — `git ls-files` returned empty, not tracked, gitignore + hatch-vcs already correct; (2) `dist/` MAJOR "contains stale dev wheels" — directory did not exist, already gitignored; (3) `security.yml` MAJOR "duplicates `_required.yml` security jobs" — `_required.yml` has NO security jobs, `security.yml` is standalone. **Phase-1 also DISCOVERED 1 root-cause finding the audit missed:** `hephaestus/validation/doc_policy.py` was REJECTING `--squash` and requiring `--rebase`, contradicting CLAUDE.md squash-only policy. This linter was the ROOT CAUSE of `--rebase` text in skill files (myrmidon-swarm:318, learn:422). Phase 1 sequenced PR1=fix linter first, PR2+=fix skills. **10 PRs landed; 9 already merged with green CI on first attempt; 1 in CI with auto-merge armed.** Without Phase 1, ~3 PRs would have fixed non-issues AND the next PR after skill fixes would have been blocked by the unfixed linter. Verification level upgraded to verified-ci. |


### PR DESCRIPTION
## Summary

Amends `verify-audit-findings-before-acting` from v1.1.0 to v1.2.0.

Third corroborating session of the skill's core thesis. Adds three methodology elements that v1.1.0 did not name:

1. **Phase 1 verification BEFORE remediation planning** (not "before issue filing"). Drafting a plan against unverified findings means PRs that fix non-issues AND leaves actual root causes untouched.
2. **Inverse-Hypothesis Search Catalog** — for every "audit says X is missing" finding, ALSO ask "is X present but enforcing the WRONG rule?" The audit class is biased toward absence findings and systematically misses presence-but-wrong root causes (which are often the actual root cause of the symptoms the audit named).
3. **AUDIT CORRECTIONS section** — a required structural element of any audit-driven remediation plan. Reviewers can immediately see why the plan's PR count differs from the audit's finding count.

## Verification Level

**verified-ci** (promoted from verified-local).

The 2026-05-31 ProjectHephaestus session applied the v1.2.0 workflow live:

- Strict-full audit: 3 CRITICAL + 26 MAJOR + 40 MINOR (B- 82.5%)
- Phase 1 Explore agent **refuted 3 of 29 findings** (10.3%):
  - `hephaestus/_version.py` CRITICAL "tracked despite .gitignore" — `git ls-files` empty, not tracked
  - `dist/` MAJOR "contains stale dev wheels" — directory does not exist
  - `security.yml` MAJOR "duplicates `_required.yml` security jobs" — `_required.yml` has no security jobs
- Phase 1 inverse-hypothesis search **discovered 1 root-cause finding the audit missed**: `hephaestus/validation/doc_policy.py` was REJECTING `--squash` and requiring `--rebase`, contradicting CLAUDE.md. This was the ROOT CAUSE of `--rebase` text in skill files. The audit named the symptom (skill content) without finding the cause (the linter enforcing the wrong rule).
- Corrected sequence: **PR1 = fix linter first; PR2+ = fix skills.** 10 PRs landed; 9 already merged with green CI on first attempt; 1 in CI with auto-merge armed.

Without Phase 1, ~3 PRs would have fixed non-issues AND the skill-fix PRs would have been blocked by the unfixed linter the audit missed.

## Key Findings

**What Worked:**

- Phase 1 dispatched as ONE Explore agent with the full audit findings list, instructed to "verify or refute each using `gh api`, `git ls-files`, and direct file reads — NOT just `grep`."
- Inverse-hypothesis search ran on the same agent's pass; cheap (~30s per absence finding) and caught the linter root cause.
- AUDIT CORRECTIONS section in the plan let reviewers see the refutation evidence immediately.

**What Failed (now documented in Failed Attempts):**

- Trusting strict audit findings without verification before remediation planning -> 10.3% of findings would have produced no-op PRs.
- Skipping the inverse-hypothesis check -> would have missed the `doc_policy.py` linter root cause, and subsequent skill-fix PRs would have been blocked.
- Omitting the AUDIT CORRECTIONS section -> reviewers can't see why the plan's PR count differs from the audit's finding count, and downstream agents re-introduce refuted findings.

## Stale-finding rate across three sessions

| Session | Audit | False/Stale Rate |
|---------|-------|------------------|
| 2026-05-26 | ProjectHephaestus strict-full | 3/11 (27%) |
| 2026-05-27 | ProjectHephaestus strict-full | ~3/~16 (~20%) |
| 2026-05-31 | ProjectHephaestus strict-full | 3/29 (10.3%) |

Consistent 10–25% false-positive rate. Likely range across audits: 10–30%.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (all 455 skills pass)
- [x] Commit GPG-signed
- [ ] Verify skill renders correctly in marketplace after merge
- [ ] Test skill discovery with keywords "audit verify", "phase 1 verification", "inverse hypothesis"

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>