### PR TITLE
feat: add github-branch-protection-api-validation skill

### DIFF
--- a/skills/github-branch-protection-api-validation.md
+++ b/skills/github-branch-protection-api-validation.md
@@ -1,0 +1,152 @@
+---
+name: github-branch-protection-api-validation
+description: "GitHub branch protection API enforcement with response validation and synthetic testing. Use when: (1) implementing new branch protection rules, (2) adding API PUT calls that need validation, (3) testing bash scripts with environment fixtures."
+category: ci-cd
+date: 2026-06-03
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags: [github, branch-protection, api, bash-testing, validation]
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-03 |
+| **Objective** | Enforce GitHub branch protection rules with response validation to detect silent API failures, and enable synthetic testing of branch protection scripts |
+| **Outcome** | Successfully implemented for ProjectNestor main branch; all verification criteria passed |
+| **Verification** | verified-ci (PR #108 CI checks passed) |
+
+## When to Use
+
+- Implementing new GitHub branch protection rules via API
+- Adding PUT/PATCH calls to `repos/{owner}/{repo}/branches/{branch}/protection` endpoint
+- Detecting silent failures when API ignores PUT fields (API field names differ from request payload keys)
+- Testing bash governance scripts without hitting live GitHub API
+- Need to allow future tightening of branch protection settings (e.g., 1→2 required reviews) without breaking drift detection
+
+## Verified Workflow
+
+### Quick Reference
+
+**1. Minimize API payload to single field change:**
+```json
+{
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1
+  }
+}
+```
+
+**2. Apply with read-back validation:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+REPO="HomericIntelligence/ProjectNestor"
+CONFIG=".github/branch-protection/main.json"
+
+expected_count=$(jq -r '.required_pull_request_reviews.required_approving_review_count' "$CONFIG")
+
+echo "Applying branch protection..."
+gh api --method PUT "repos/${REPO}/branches/main/protection" --input "$CONFIG" >/dev/null
+
+# READ-BACK: Verify the live state matches expected
+live_count=$(gh api "repos/${REPO}/branches/main/protection" \
+  --jq '.required_pull_request_reviews.required_approving_review_count // 0')
+
+if [ "$live_count" != "$expected_count" ]; then
+  echo "ERROR: PUT ignored field; live=$live_count, expected=$expected_count" >&2
+  exit 1
+fi
+echo "OK: live setting = ${live_count}"
+```
+
+**3. Support synthetic testing via environment variable hook:**
+```bash
+#!/usr/bin/env bash
+# In your verification script
+fetch_rules() {
+  if [ -n "${VERIFY_RULES_FIXTURE:-}" ]; then
+    cat "$VERIFY_RULES_FIXTURE"  # Test mode: use injected fixture
+  else
+    gh api "repos/${REPO}/rules/branches/main"  # Production: call API
+  fi
+}
+rules=$(fetch_rules)
+```
+
+**4. Use >= comparisons for forward-compatible drift detection:**
+```bash
+# Allows 1→2→3 tightening without breaking drift checks
+if ! jq -e '.required_approving_review_count >= 1' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_approving_review_count must be >= 1"
+  exit 1
+fi
+```
+
+### Detailed Steps
+
+1. **Scope API changes narrowly**: Only change field whose semantics are verified by existing code or prior testing. Defer unverified fields (e.g., `require_last_push_approval`) to separate PR with dedicated API validation.
+
+2. **Add GET read-back after PUT**: On same endpoint (`repos/{owner}/{repo}/branches/{branch}/protection`), immediately after PUT, call GET and compare live value to expected config using jq.
+
+3. **Use defensive jq syntax**: Include fallback operator (`// 0` or `// "default"`) to handle missing fields gracefully.
+
+4. **Extract rules-fetch into overridable function**: For bash governance scripts, expose the API call as a function that can be injected via env variable, enabling synthetic testing without network.
+
+5. **Create synthetic test fixtures**: Use `jq -n` to generate test payloads matching the API response format. Example: `[{type:"pull_request",parameters:{required_approving_review_count:1}}]`
+
+6. **Test both pass and fail paths**: Verify script exits 0 with valid payload, exits non-zero with invalid payload.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| No read-back after PUT | Apply script called gh api PUT and exited | Silent failures: API ignores unknown/misspelled fields, script exits 0 but live state unchanged | Always read-back immediately after PUT to detect silent failures |
+| Direct jq assertions in CI | Verified workflow used bare `jq ... < output.json` expression | Doesn't exercise full script logic; synthetic test wasn't executing the actual code path | Extract API calls into overridable functions; inject fixtures via env hooks |
+| Bundled unverified fields | Tried to tighten both `required_approving_review_count` and `require_last_push_approval` in one JSON change | API field name mapping unknown for `require_last_push_approval`; risk of silent failure | Single-field changes only; defer unverified fields to separate PR with explicit API validation |
+| Exact equality for drift detection | Used `required_approving_review_count == 1` assertion | Blocks future tightening to 2 (drift check would fail on valid tightening) | Use `>= min_threshold` instead of `== exact_value` to allow forward evolution |
+
+## Results & Parameters
+
+**Example JSON config** (`.github/branch-protection/main.json`):
+```json
+{
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": false
+  },
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["All Build/Test Checks", "branch-protection-drift"]
+  },
+  "enforce_admins": false,
+  "required_conversation_resolution": true,
+  "required_linear_history": true
+}
+```
+
+**Synthetic test fixture** (pass case):
+```bash
+fixture=$(mktemp)
+jq -n '[{type:"pull_request",parameters:{required_approving_review_count:1,required_review_thread_resolution:true}},{type:"required_status_checks",parameters:{required_status_checks:[{context:"x"}]}}]' > "$fixture"
+VERIFY_RULES_FIXTURE="$fixture" bash scripts/verify-branch-protection.sh
+# Expected: exit 0
+```
+
+**Synthetic test fixture** (fail case):
+```bash
+fixture=$(mktemp)
+jq -n '[{type:"pull_request",parameters:{required_approving_review_count:0}}]' > "$fixture"
+VERIFY_RULES_FIXTURE="$fixture" bash scripts/verify-branch-protection.sh
+# Expected: exit 1, error message about count < 1
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectNestor | Issue #54: Required approving review count | Implemented main branch protection fix; verified with 4 synthesis criteria; PR #108 CI passed |

--- a/skills/github-branch-protection-api-validation.notes.md
+++ b/skills/github-branch-protection-api-validation.notes.md
@@ -1,0 +1,93 @@
+# Implementation Notes: github-branch-protection-api-validation
+
+## ProjectNestor Issue #54 Context
+
+**Issue**: Enforce `required_approving_review_count >= 1` on main branch protection
+**Repository**: HomericIntelligence/ProjectNestor
+**PR**: #108
+**Branch**: 54-auto-impl
+**Commit**: b0d5e77 (fix(#54): require ≥1 approving review on main branch)
+
+## Implementation Details
+
+### Files Modified
+
+1. **`.github/branch-protection/main.json`**
+   - Added JSON configuration file to version control
+   - Single-field approach: only specified `required_pull_request_reviews.required_approving_review_count: 1`
+   - Minimal payload reduces API surface risk
+
+2. **`scripts/apply-branch-protection.sh`**
+   - Read-back validation implemented immediately after PUT
+   - Fetches live state from `repos/{owner}/{repo}/branches/main/protection` endpoint
+   - Compares `live_count` to `expected_count` from config
+   - Exits non-zero if PUT silently failed
+
+3. **`scripts/verify-branch-protection.sh`**
+   - Environment variable hook for synthetic testing: `VERIFY_RULES_FIXTURE`
+   - If set, reads from fixture file (for testing)
+   - If unset, calls `gh api repos/{owner}/{repo}/rules/branches/main` (production)
+   - Uses `>= 1` assertion to allow future tightening (1→2→3)
+
+### API Field Name Mapping
+
+The GitHub REST API for branch protection uses these field names in responses:
+- Endpoint: `GET|PUT /repos/{owner}/{repo}/branches/{branch}/protection`
+- Response field: `.required_pull_request_reviews.required_approving_review_count`
+
+**Critical**: When setting the field via PUT, use same structure as GET response to ensure API recognizes it.
+
+### Synthetic Testing Pattern
+
+```bash
+# Extract API fetch into overridable function
+fetch_protection_rules() {
+  if [ -n "${VERIFY_RULES_FIXTURE:-}" ]; then
+    cat "$VERIFY_RULES_FIXTURE"
+  else
+    gh api "repos/${REPO}/branches/main/protection"
+  fi
+}
+
+# Usage in test
+fixture=$(mktemp)
+jq -n '{required_pull_request_reviews:{required_approving_review_count:1}}' > "$fixture"
+VERIFY_RULES_FIXTURE="$fixture" bash scripts/verify-branch-protection.sh
+```
+
+### Why This Matters
+
+1. **Silent Failures**: GitHub API may accept PUT requests that ignore unknown fields or misspelled keys, returning HTTP 200 but not applying changes. Read-back validation is the only way to detect this.
+
+2. **Forward Compatibility**: Using `>= 1` instead of `== 1` allows branch protection settings to be tightened (1→2 required reviews) without breaking drift detection scripts.
+
+3. **Testability**: Environment variable injection allows bash governance scripts to be tested without network access, accelerating CI/CD feedback.
+
+## Verification Criteria (All Passed)
+
+1. **Syntax Check**: JSON config is valid, jq can parse it
+2. **API Acceptance**: gh api PUT accepts config without errors
+3. **Read-back Match**: Live setting matches config value
+4. **Synthetic Test Pass**: Positive test case exits 0
+5. **Synthetic Test Fail**: Negative test case exits non-zero
+
+## Lessons for Future Branch Protection Changes
+
+| Scenario | Pattern | Evidence |
+|----------|---------|----------|
+| Adding new field to branch protection | Use single-field change in separate PR | Issue #54: `required_approving_review_count` only, deferred `require_last_push_approval` |
+| Changing existing enforcement | Use read-back validation + synthetic tests | apply-branch-protection.sh: GET immediately after PUT; verify-branch-protection.sh: env hook |
+| Detecting drift on tightening rules | Use >= comparisons, not exact equality | verify-branch-protection.sh: `.required_approving_review_count >= 1` allows 1→2→3 |
+| Testing governance scripts in CI | Inject fixture via environment variable | VERIFY_RULES_FIXTURE injected by test harness, script uses fixture-aware function |
+
+## Related Commits in ProjectNestor
+
+- **b0d5e77**: fix(#54): require ≥1 approving review on main branch (implements the pattern)
+- **36cc497**: fix: Address CI failures for PR ProjectNestor#86 (earlier attempt with unverified fields)
+- **cdcb08a**: ci(branch-protection): read effective rules instead of admin endpoint (API endpoint selection)
+
+## References
+
+- GitHub API: [Update branch protection](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection)
+- ProjectNestor governance: `docs/governance/branch-protection.md`
+- gh CLI docs: [gh api](https://cli.github.com/manual/gh_api)


### PR DESCRIPTION
## Summary

Documents GitHub branch protection API enforcement with response validation to detect silent PUT failures and synthetic testing patterns for governance scripts.

## Details

- **Skill**: `github-branch-protection-api-validation`
- **Category**: ci-cd
- **Verification**: verified-ci (ProjectNestor PR #108 CI passed)
- **Date**: 2026-06-03
- **Version**: 1.0.0

## Key Learnings

1. **GET read-back after PUT detects silent API failures** — GitHub API may accept invalid PUT requests (unknown field names, misspelled keys) and return HTTP 200 without applying changes
2. **Environment variable injection enables synthetic testing of bash scripts** — Extract API calls into overridable functions; inject fixtures via env variables to test without network
3. **Single-field JSON changes minimize API surface risk** — Only change one field per PR; defer unverified fields to separate PR with explicit API validation
4. **>= assertions allow future tightening without breaking drift detection** — Use `>= min_threshold` instead of `== exact_value` to allow branch protection settings evolution (1→2→3 required reviews)

## Verified On

- **ProjectNestor** issue #54: Required approving review count on main branch protection
- Implementation: `/scripts/apply-branch-protection.sh` with read-back validation
- Synthetic tests: `/scripts/verify-branch-protection.sh` with fixture injection via `VERIFY_RULES_FIXTURE` env variable

🤖 Generated with Claude Code