### PR TITLE
feat(skills): amend squash-only-repo-merge-method-docs to v1.2.0 (settings-aware merge flag)

### DIFF
--- a/skills/squash-only-repo-merge-method-docs.history
+++ b/skills/squash-only-repo-merge-method-docs.history
@@ -1,5 +1,39 @@
 # squash-only-repo-merge-method-docs -- History
 
+## v1.2.0 (2026-06-03)
+
+**Changed by:** ProjectHephaestus issue #911 — settings-aware merge-method selection; /learn skill stale --rebase
+**Verification:** verified-ci
+
+### What changed
+- Added the second-order lesson that the reactive fix of swapping a hardcoded `--rebase` to a hardcoded `--squash` is itself fragile — it merely assumes a different fixed method. The robust fix is **settings-aware merge-method selection**: query the target repo's allowed methods via `gh api repos/<repo>` and choose dynamically (preference order rebase -> squash -> merge), erroring if none are allowed.
+- Extended `description` and `## When to Use` with two new triggers: (a) a skill/plugin instruction file (e.g. `/learn`, `/finish-branch` `SKILL.md`) hardcodes `gh pr merge --auto --rebase` against a squash-only target repo, and (b) deciding the merge method for a cross-repo `gh pr merge` — detect allowed methods instead of hardcoding.
+- Added the reusable `choose_merge_flag` Bash snippet to the Verified Workflow `### Quick Reference` and to Results & Parameters, with the rebase->squash->merge preference explanation and the ERROR-on-no-methods guard.
+- Added two Failed Attempts rows: (1) swapping hardcoded `--rebase` to hardcoded `--squash` (e.g. learn skill #867) still being wrong for a rebase-only/merge-only target, and (2) the `/learn` skill plugin instruction running `--auto --rebase` against squash-only ProjectMnemosyne (three sub-agents each hit `Merge method rebase merging is not allowed on this repository`), establishing that a tooling skill's OWN instructions are a place this bug hides.
+- Added a Verified On row for ProjectHephaestus issue #911 (supersedes the narrower #721 static-swap issue and the static `--squash` swap from #867).
+- Bumped `version` 1.1.0 -> 1.2.0 and `date` to 2026-06-03.
+
+### Why
+The v1.1.0 skill covered the wrong-merge-method bug in DOCS and in PyGithub CODE, but its fix was still "use `--squash` on this repo" — a fixed substitution. This session found the bug a third place: a TOOLING SKILL's own plugin instruction. The `/hephaestus:learn` skill (`skills/learn/SKILL.md`, shipped via the ProjectHephaestus marketplace; stale plugin cache at `~/.claude/plugins/cache/.../skills/learn/SKILL.md` line 420) hardcodes `gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectMnemosyne`. ProjectMnemosyne is squash-only (`{"rebase":false,"squash":true,"merge":true}`), so that instruction fails for EVERY Mnemosyne PR with `GraphQL: Merge method rebase merging is not allowed on this repository`. During a real `/learn` run, three sub-agents each hit this and independently fell back to `--auto --squash`. The durable fix is not another hardcode but settings-aware selection: query `gh api repos/<repo>` and pick the first allowed method in rebase->squash->merge order. This naturally yields `--squash` on a squash-mandated repo like ProjectHephaestus (rebase disabled) without special-casing. Shipped as ProjectHephaestus tracking issue #911, which supersedes #721 (narrower static swap) and #867 (the static `--squash` swap in the learn skill).
+
+### Previous version (v1.1.0) snapshot
+---
+name: squash-only-repo-merge-method-docs
+description: "Repo allows squash-only merges (allow_rebase_merge=false); using --rebase silently fails to arm auto-merge (CLI) or fails at runtime (code/API). The wrong merge method hides in BOTH docs and code. Use when: (1) gh pr merge --auto --rebase returns no error but auto-merge is not armed, (2) project docs or CLAUDE.md instruct --rebase for a repo that has disabled rebase merges, (3) a PyGithub pr.merge(merge_method='rebase') callsite on a squash-only repo fails with 'Rebase merges are not allowed on this repository', (4) verifying which merge method a repo supports before arming auto-merge, (5) updating stale documentation that references the wrong merge flag, (6) auditing a squash-only repo — grep for BOTH the gh pr merge --rebase CLI form and the merge_method=\"rebase\" code/API form."
+category: ci-cd
+date: 2026-06-03
+version: "1.1.0"
+user-invocable: false
+verification: verified-ci
+history: squash-only-repo-merge-method-docs.history
+tags:
+  - auto-merge
+  - squash
+  - rebase
+  - github
+  - docs
+---
+
 ## v1.1.0 (2026-06-03)
 
 **Changed by:** ProjectHephaestus PR #904 (Closes #718)

--- a/skills/squash-only-repo-merge-method-docs.md
+++ b/skills/squash-only-repo-merge-method-docs.md
@@ -1,9 +1,9 @@
 ---
 name: squash-only-repo-merge-method-docs
-description: "Repo allows squash-only merges (allow_rebase_merge=false); using --rebase silently fails to arm auto-merge (CLI) or fails at runtime (code/API). The wrong merge method hides in BOTH docs and code. Use when: (1) gh pr merge --auto --rebase returns no error but auto-merge is not armed, (2) project docs or CLAUDE.md instruct --rebase for a repo that has disabled rebase merges, (3) a PyGithub pr.merge(merge_method='rebase') callsite on a squash-only repo fails with 'Rebase merges are not allowed on this repository', (4) verifying which merge method a repo supports before arming auto-merge, (5) updating stale documentation that references the wrong merge flag, (6) auditing a squash-only repo — grep for BOTH the gh pr merge --rebase CLI form and the merge_method=\"rebase\" code/API form."
+description: "Repo allows squash-only merges (allow_rebase_merge=false); using --rebase silently fails to arm auto-merge (CLI) or fails at runtime (code/API). The wrong merge method hides in docs, code, AND skill/plugin instruction files. The robust fix is settings-aware merge-method selection (query gh api repos/<repo>, pick rebase->squash->merge), not hardcoding a different fixed method. Use when: (1) gh pr merge --auto --rebase returns no error but auto-merge is not armed, (2) project docs or CLAUDE.md instruct --rebase for a repo that has disabled rebase merges, (3) a PyGithub pr.merge(merge_method='rebase') callsite on a squash-only repo fails with 'Rebase merges are not allowed on this repository', (4) verifying which merge method a repo supports before arming auto-merge, (5) updating stale documentation that references the wrong merge flag, (6) auditing a squash-only repo — grep for BOTH the gh pr merge --rebase CLI form and the merge_method=\"rebase\" code/API form, (7) a skill/plugin instruction file (e.g. /learn, /finish-branch SKILL.md) hardcodes gh pr merge --auto --rebase against a squash-only target repo, (8) deciding the merge method for a cross-repo gh pr merge — detect allowed methods instead of hardcoding."
 category: ci-cd
 date: 2026-06-03
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
 history: squash-only-repo-merge-method-docs.history
@@ -50,6 +50,11 @@ auditing a squash-only repo, grep for BOTH the `gh pr merge --rebase` CLI form A
 - Verifying which merge method a repo supports before writing automation or instructions
 - Updating stale documentation that references the wrong merge flag for a repo
 - CI gate (`pr-policy`) reports auto-merge not enabled even though `--auto` was issued
+- A skill/plugin instruction file (e.g. `/learn`, `/finish-branch` `SKILL.md`) hardcodes
+  `gh pr merge --auto --rebase` against a squash-only target repo — a tooling skill's OWN
+  instructions are a place the wrong-merge-method bug hides, not just repo docs or code
+- Deciding the merge method for a cross-repo `gh pr merge` — **detect** the target repo's
+  allowed methods instead of hardcoding any fixed flag (the robust, settings-aware fix)
 
 ## Verified Workflow
 
@@ -70,6 +75,38 @@ gh pr view <PR_NUMBER> --json autoMergeRequest --jq '.autoMergeRequest.mergeMeth
 # Step 4 (audit): find EVERY wrong-method occurrence — BOTH the CLI form and the code/API form
 grep -rn 'merge_method="rebase"\|--auto --rebase\|gh pr merge.*--rebase' .
 # Catches: PyGithub pr.merge(merge_method="rebase"), gh pr merge --auto --rebase in docs/scripts
+```
+
+### Settings-aware merge-method selection (the robust fix)
+
+The reactive fix of swapping a hardcoded `--rebase` to a hardcoded `--squash` just trades one
+fixed assumption for another — it breaks on a rebase-only or merge-only target. Instead, **detect**
+the target repo's allowed methods and pick dynamically. Default preference order is
+`rebase` (linear history) -> `squash` -> `merge` commit; it is configurable, but rebase->squash->merge
+is the documented default. If the repo policy mandates squash (e.g. ProjectHephaestus, enforced by
+its `pr-policy` gate), detection naturally yields `--squash` because rebase is disabled there — no
+special-casing needed.
+
+```bash
+# Pick the auto-merge flag the TARGET repo actually allows.
+# Preference order: rebase (linear history) -> squash -> merge commit.
+choose_merge_flag() {
+  local repo="$1"
+  local flag
+  flag=$(gh api "repos/${repo}" --jq '[
+    (if .allow_rebase_merge then "--rebase" else empty end),
+    (if .allow_squash_merge then "--squash" else empty end),
+    (if .allow_merge_commit then "--merge"  else empty end)
+  ] | .[0] // ""')
+  if [ -z "$flag" ]; then
+    echo "ERROR: target repo ${repo} allows no merge methods" >&2
+    return 1
+  fi
+  printf '%s\n' "$flag"
+}
+
+MERGE_FLAG=$(choose_merge_flag "HomericIntelligence/ProjectMnemosyne")   # -> --squash here
+gh pr merge "$PR_NUMBER" --auto "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
 ```
 
 ### Detailed Steps
@@ -112,6 +149,8 @@ grep -rn 'merge_method="rebase"\|--auto --rebase\|gh pr merge.*--rebase' .
 | `gh pr merge --auto --rebase` on squash-only repo | Issued auto-merge with `--rebase` flag as instructed by stale CLAUDE.md | Repo has `allow_rebase_merge: false`; the command appeared to succeed but auto-merge was not armed | Always verify allowed merge methods with `gh api repos/OWNER/REPO` before using `--rebase` |
 | Relying on stale docs | CLAUDE.md documented `--rebase` because it was originally correct | Repo settings changed (or were always squash-only) without corresponding doc update | Docs about merge flags rot silently; audit CLAUDE.md against `gh api` before issuing PRs |
 | Hardcoded `pr.merge(merge_method="rebase")` in PyGithub code | `hephaestus/github/pr_merge.py` hardcoded `merge_method="rebase"` while a sibling path (`github_api.py:gh_pr_create`) already used `--auto --squash` | Failed at runtime (not silently) with `GraphQL: Rebase merges are not allowed on this repository. (mergePullRequest)` / `...(enablePullRequestAutoMerge)` — ~27 such errors in one automation run | The wrong method hides in CODE too, not just docs; grep for `merge_method="rebase"` as well as the CLI `--rebase` form, and watch for inconsistency between sibling callsites. Durable guard: a unit test that uses `inspect.getsource` on the module and asserts the source contains no `merge_method="rebase"` and does contain `merge_method="squash"` |
+| Swapped a hardcoded `--rebase` to a hardcoded `--squash` (e.g. learn skill #867) | Reactive fix: replaced the fixed `--rebase` flag with a fixed `--squash` flag | Still wrong for a rebase-only or merge-only target repo; just trades one fixed assumption for another | Detect the target repo's allowed methods via `gh api repos/<repo>` and pick dynamically (rebase->squash->merge) — see `choose_merge_flag` |
+| `/learn` skill plugin instruction ran `gh pr merge --auto --rebase` against ProjectMnemosyne (squash-only) | The shipped `/learn` `SKILL.md` (stale plugin cache line 420) hardcoded `--auto --rebase --repo HomericIntelligence/ProjectMnemosyne` | Rejected: `Merge method rebase merging is not allowed on this repository`; three sub-agents each hit it and independently fell back to `--squash` | A tooling skill's OWN instructions are a place the wrong-merge-method bug hides; fixed via settings-aware detection (ProjectHephaestus #911) |
 
 ## Results & Parameters
 
@@ -130,6 +169,39 @@ gh api repos/OWNER/REPO --jq '
 ```
 
 Always use `gh pr merge --auto --squash` in ProjectHephaestus (and any repo with the same settings).
+
+### Settings-aware merge-flag selection (preferred over any hardcode)
+
+Rather than hardcoding `--squash` (or `--rebase`), query the target repo and pick the first
+allowed method in preference order `rebase` -> `squash` -> `merge`, erroring if none are allowed.
+This yields `--squash` on a squash-mandated repo without special-casing, and stays correct if a
+repo enables/disables a method later.
+
+```bash
+# Pick the auto-merge flag the TARGET repo actually allows.
+# Preference order: rebase (linear history) -> squash -> merge commit.
+choose_merge_flag() {
+  local repo="$1"
+  local flag
+  flag=$(gh api "repos/${repo}" --jq '[
+    (if .allow_rebase_merge then "--rebase" else empty end),
+    (if .allow_squash_merge then "--squash" else empty end),
+    (if .allow_merge_commit then "--merge"  else empty end)
+  ] | .[0] // ""')
+  if [ -z "$flag" ]; then
+    echo "ERROR: target repo ${repo} allows no merge methods" >&2
+    return 1
+  fi
+  printf '%s\n' "$flag"
+}
+
+MERGE_FLAG=$(choose_merge_flag "HomericIntelligence/ProjectMnemosyne")   # -> --squash here
+gh pr merge "$PR_NUMBER" --auto "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
+```
+
+The preference order is configurable, but rebase->squash->merge is the documented default. A repo
+whose policy mandates squash (e.g. ProjectHephaestus, enforced by its `pr-policy` gate) has rebase
+disabled, so detection lands on `--squash` automatically.
 
 ### Verification that auto-merge is armed
 
@@ -171,3 +243,4 @@ This was shipped in ProjectHephaestus PR #904 (Closes #718, merged 2026-06-03, v
 |---------|---------|---------|
 | ProjectHephaestus | 2026-05-28: CLAUDE.md had stale `--rebase` instruction; PR #668 corrected it | `gh pr view 668 --json autoMergeRequest` confirmed `mergeMethod=SQUASH`; issue #666 |
 | ProjectHephaestus | 2026-06-03: `hephaestus/github/pr_merge.py` hardcoded `pr.merge(merge_method="rebase")` — code form of the same bug, ~27 runtime GraphQL errors in one automation run; PR #904 changed it to `merge_method="squash"` | Closes #718; durable guard = `inspect.getsource` unit test asserting no `merge_method="rebase"`; verified-ci |
+| ProjectHephaestus | 2026-06-03: `/learn` plugin instruction (`skills/learn/SKILL.md`, stale plugin cache line 420) hardcoded `--auto --rebase` vs squash-only ProjectMnemosyne; three sub-agents each hit `Merge method rebase merging is not allowed on this repository`; filed issue #911 for settings-aware selection (supersedes #721, #867) | `choose_merge_flag` pattern documented; verified-ci |


### PR DESCRIPTION
Amends the existing skill `squash-only-repo-merge-method-docs` from v1.1.0 to v1.2.0.

## Second-order lesson added
Swapping a hardcoded `--rebase` to a hardcoded `--squash` is itself fragile — it merely assumes a different fixed method. The robust fix is **settings-aware merge-method selection**: query the target repo via `gh api repos/<repo>` and choose the first allowed method in preference order rebase -> squash -> merge (erroring if none allowed).

## What changed
- Extended `description` and `## When to Use` with triggers for (a) a skill/plugin instruction file hardcoding `--auto --rebase` against a squash-only target, and (b) deciding a cross-repo merge method via detection.
- Added the reusable `choose_merge_flag` Bash snippet to the Verified Workflow Quick Reference and to Results & Parameters.
- Added two Failed Attempts rows (static `--squash` swap #867; `/learn` plugin `--rebase` vs squash-only ProjectMnemosyne, three sub-agents each hit it).
- Added a Verified On row; prepended a v1.2.0 history entry with a v1.1.0 snapshot.
- Bumped version 1.1.0 -> 1.2.0, date 2026-06-03.

## Verification
verified-ci — issue filed and observed end-to-end this session (2026-06-03). `python3 scripts/validate_plugins.py` passes 473/473.

Refs HomericIntelligence/ProjectHephaestus#911 (settings-aware merge-method selection; supersedes #721 and #867).