### PR TITLE
feat: amend pixi-cache-true-unreliable skill (v2.1.0)

### DIFF
--- a/skills/pixi-cache-true-unreliable.history
+++ b/skills/pixi-cache-true-unreliable.history
@@ -1,0 +1,108 @@
+# pixi-cache-true-unreliable — History
+
+## v2.1.0 (2026-06-06)
+
+**Changed by:** ProjectHephaestus — pixi `.pixi` cache poisoning incident; PRs #1021 (setup-pixi-env composite + release.yml + pre-commit.yml) and #1026 (security.yml)
+**Verification:** verified-ci (dependency-scan went green after the fix — e.g. PR #1011 dependency-scan passed)
+
+### What changed
+
+- Added a major safety caveat: when `prefix-dev/setup-pixi` runs with `locked: true`,
+  a SECOND `actions/cache@v5` step over the `.pixi` path POISONS the freshly-installed
+  locked environment by restoring a stale `.pixi` over it (downgrading packages, e.g.
+  urllib3 2.7.0 -> 2.6.3), which then fails `pip-audit` / `dependency-scan`.
+- Documented the root-cause fix: with `locked: true`, rely on setup-pixi's built-in
+  exact-keyed `.pixi` cache and do NOT add a second `actions/cache` over `.pixi`.
+- Clarified that the v2.0.0 "add explicit actions/cache over .pixi" recommendation
+  applies to the NON-locked case; under `locked: true` it is harmful.
+- Added 3 new Failed Attempts rows, including the critical lesson that an exact-key-only
+  `.pixi` cache (no restore-keys) is STILL unsafe — it exact-hits a previously-poisoned
+  cache saved under the same lock hash.
+- Added a "When NOT to add a second cache" decision section and a diagnosis signature
+  for reading CI logs (install version vs pip-audit audited version).
+- Updated description triggers and bumped version 2.0.0 -> 2.1.0.
+
+### Why
+
+v2.0.0 universally recommended replacing `cache: true` with an explicit
+`actions/cache@v5` over `.pixi` (+ `~/.cache/rattler/cache`). That is correct for the
+unreliable internal-cache problem when NOT using `locked: true`. But with
+`prefix-dev/setup-pixi@v0.9.6` and `locked: true`, setup-pixi already installs the exact
+locked env AND maintains its own `.pixi` cache keyed on `pixi.lock`. Layering a second
+`actions/cache` over the same `.pixi` path causes the second restore (whichever runs
+last) to extract a stale archive over the fresh locked install, silently downgrading
+packages and breaking security scans on every PR even though `pixi.lock` is already
+patched. An initial fix only addressed workflows with loose `restore-keys:`; security.yml
+with an exact-key-only `.pixi` cache STILL failed because its exact key hit a
+previously-poisoned cache. The amendment records that ANY second cache over `.pixi` after
+a `--locked` setup-pixi is unsafe, regardless of restore-keys.
+
+### Previous version (v2.0.0) snapshot
+
+```markdown
+---
+name: pixi-cache-true-unreliable
+description: 'Fixes unreliable Pixi caching caused by setup-pixi''s built-in cache:
+  true option. Replace with explicit actions/cache@v5 caching both .pixi and ~/.cache/rattler/cache
+  keyed on pixi.lock. Use when: (1) CI logs show ''Saved cache with ID -1'', (2) cache
+  hits are inconsistent despite cache: true, (3) consolidating Pixi setup into a shared
+  composite action.'
+category: ci-cd
+date: 2026-03-08
+version: 2.0.0
+user-invocable: false
+---
+# Pixi cache: true Is Unreliable — Use Explicit actions/cache
+
+## Overview
+
+| Item | Details |
+| ------ | --------- |
+| Date | 2026-03-08 |
+| Project | ProjectOdyssey |
+| Objective | Consolidate 14+ independent Pixi setup blocks into a single shared composite action with reliable caching |
+| Outcome | ✅ Success — 1 composite action, 0 inline `prefix-dev/setup-pixi` calls in workflows |
+| Impact | High — eliminates `Saved cache with ID -1` failures; single source of truth for caching |
+
+## When to Use
+
+- CI logs show `Saved cache with ID -1` after a `prefix-dev/setup-pixi` step with `cache: true`
+- CI logs show HTTP 400 errors during the `prefix-dev/setup-pixi` step with `cache: true`
+- Cache hits are inconsistent or never occur despite `cache: true` being set
+- Multiple workflows each independently set up Pixi (violating DRY)
+- Consolidating Pixi setup into a shared composite action (`.github/actions/setup-pixi/action.yml`)
+- Migrating from inline setup-pixi blocks to a composite action
+
+## Root Cause
+
+`prefix-dev/setup-pixi@v0.9.x` with `cache: true` uses an internal caching mechanism that
+can silently fail, logging `Saved cache with ID -1`. This means **the cache is never actually
+saved** and every CI run downloads the full Pixi environment from scratch.
+
+The reliable fix is to **disable `cache: true`** and add an explicit `actions/cache@v5` step
+that caches both paths that Pixi uses:
+
+- `.pixi` — the environment directory (packages installed for this project)
+- `~/.cache/rattler/cache` — the package download cache (avoids re-downloading)
+
+## Verified Workflow
+
+### 1. Audit workflows for inline Pixi setup
+
+(commands omitted in snapshot — see git history for full body)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Keep `cache: true` | Used `prefix-dev/setup-pixi@v0.9.4` with `cache: true` enabled | Internally fails silently; logs "Saved cache with ID -1"; no cache ever saved | Never use `cache: true` — always use explicit `actions/cache` |
+| Cache only `.pixi` | Cached `.pixi` path only, skipped `~/.cache/rattler/cache` | Pixi re-downloads packages on every run even when `.pixi` hits | Must cache both paths or cache is incomplete |
+| Hash `pixi.toml` | Used `hashFiles('pixi.toml')` as cache key | `pixi.toml` doesn't encode exact resolved versions; false positives on cache hits | Use `pixi.lock` for precise cache invalidation |
+| Keeping unused `inputs:` block | Preserved `pixi-version` and `cache` inputs when no callers use `with:` blocks | Dead code; caused confusion and allowed accidental re-introduction of `cache: true` | Remove inputs when no callers pass `with:` blocks |
+```
+
+---
+
+## v2.0.0 (2026-03-08)
+
+**Initial version** (as recorded; consolidated from ProjectOdyssey work).

--- a/skills/pixi-cache-true-unreliable.md
+++ b/skills/pixi-cache-true-unreliable.md
@@ -1,14 +1,19 @@
 ---
 name: pixi-cache-true-unreliable
-description: 'Fixes unreliable Pixi caching caused by setup-pixi''s built-in cache:
-  true option. Replace with explicit actions/cache@v5 caching both .pixi and ~/.cache/rattler/cache
-  keyed on pixi.lock. Use when: (1) CI logs show ''Saved cache with ID -1'', (2) cache
-  hits are inconsistent despite cache: true, (3) consolidating Pixi setup into a shared
-  composite action.'
+description: 'Fixes unreliable Pixi caching from setup-pixi''s built-in cache: true,
+  AND warns that under locked: true a SECOND actions/cache over .pixi poisons the locked
+  env (downgrades packages, fails pip-audit/dependency-scan). Replace cache: true with
+  explicit actions/cache (non-locked); with locked: true rely ONLY on setup-pixi''s
+  built-in cache. Use when: (1) CI logs show ''Saved cache with ID -1'', (2) cache hits
+  inconsistent despite cache: true, (3) consolidating Pixi setup into a composite action,
+  (4) dependency-scan/pip-audit fails on an already-patched pixi.lock, (5) setup-pixi
+  installs a newer version than pip-audit then audits.'
 category: ci-cd
-date: 2026-03-08
-version: 2.0.0
+date: 2026-06-06
+version: 2.1.0
 user-invocable: false
+verification: verified-ci
+history: pixi-cache-true-unreliable.history
 ---
 # Pixi cache: true Is Unreliable — Use Explicit actions/cache
 
@@ -21,6 +26,14 @@ user-invocable: false
 | Objective | Consolidate 14+ independent Pixi setup blocks into a single shared composite action with reliable caching |
 | Outcome | ✅ Success — 1 composite action, 0 inline `prefix-dev/setup-pixi` calls in workflows |
 | Impact | High — eliminates `Saved cache with ID -1` failures; single source of truth for caching |
+| Verification | verified-ci |
+| History | [changelog](./pixi-cache-true-unreliable.history) |
+
+> **CRITICAL caveat (v2.1.0):** The "add an explicit `actions/cache` over `.pixi`"
+> recommendation below is for the **non-`locked`** case. If `prefix-dev/setup-pixi` runs
+> with `locked: true`, do **NOT** add a second `actions/cache` over `.pixi` — it poisons
+> the freshly-installed locked environment. See
+> [Locked Mode: Do Not Add a Second .pixi Cache](#locked-mode-do-not-add-a-second-pixi-cache).
 
 ## When to Use
 
@@ -30,6 +43,10 @@ user-invocable: false
 - Multiple workflows each independently set up Pixi (violating DRY)
 - Consolidating Pixi setup into a shared composite action (`.github/actions/setup-pixi/action.yml`)
 - Migrating from inline setup-pixi blocks to a composite action
+- `security`/`dependency-scan` (pip-audit) fails on EVERY PR even though `pixi.lock` is
+  already patched to the fixed version
+- CI logs show setup-pixi installing a fixed version (e.g. urllib3 2.7.0) but pip-audit
+  then reports a vulnerability against an OLDER version (e.g. 2.6.3)
 
 ## Root Cause
 
@@ -42,6 +59,83 @@ that caches both paths that Pixi uses:
 
 - `.pixi` — the environment directory (packages installed for this project)
 - `~/.cache/rattler/cache` — the package download cache (avoids re-downloading)
+
+## Locked Mode: Do NOT Add a Second .pixi Cache
+
+> **This is the most important caveat in this skill. It contradicts the
+> general recommendation above for the `locked: true` case.**
+
+When a workflow uses `prefix-dev/setup-pixi@v0.9.x` with `locked: true` (e.g.
+`pixi install -e <env> --locked`), setup-pixi **already** caches `.pixi` keyed exactly on
+the `pixi.lock` hash AND installs the correct locked environment. Adding a **second**
+`actions/cache@v5` step that caches/restores the same `.pixi` directory **POISONS** the
+environment:
+
+1. setup-pixi runs `pixi install -e <env> --locked` → installs the CORRECT locked
+   versions (e.g. urllib3 `2.7.0`).
+2. A later `actions/cache` restore step extracts a STALE `.pixi` archive **over** that
+   fresh install — `actions/cache` restore extracts on top of existing paths, and
+   **whichever cache restores LAST wins** — silently downgrading packages
+   (urllib3 `2.7.0` → `2.6.3`).
+3. `pip-audit` then audits the **downgraded** env and reports vulnerabilities
+   (e.g. `PYSEC-2026-141` / `PYSEC-2026-142`), **failing `security` / `dependency-scan`
+   on every PR — even though `pixi.lock` is already patched.**
+
+### Two poisoning variants — BOTH are dangerous
+
+| Variant | Cache key config | How it poisons |
+| ------- | ---------------- | -------------- |
+| Loose `restore-keys:` | e.g. `pixi-lint-${{ runner.os }}-` | On an exact-key miss, falls back to ANY prior lock's cache (stale) |
+| Exact-key only (NO `restore-keys`) | `pixi-...-${{ hashFiles('pixi.lock') }}` only | A cache a PREVIOUS poisoned run saved under that exact key gets an exact hit and is restored — the same lock hash keeps restoring the poison |
+
+**Key lesson:** "No `restore-keys` = safe" is **WRONG**. An exact-key-only `.pixi` cache
+still poisons because it exact-hits a previously-poisoned cache stored under the same
+`pixi.lock` hash. **ANY** second `actions/cache` over `.pixi` after a `--locked`
+setup-pixi is unsafe, regardless of `restore-keys`.
+
+### Diagnosis signature (read `gh run view --log`)
+
+```text
+# setup-pixi step
+... pixi install -e lint --locked ... urllib3-2.7.0   <- CORRECT version installed
+# later
+Cache restored from key: pixi-lint-...                 <- stale .pixi restored over it
+# pip-audit step
+Found vulnerability in urllib3 2.6.3 (PYSEC-2026-141)   <- OLD version audited
+```
+
+If the version setup-pixi installs differs from the version pip-audit audits, you have
+cache poisoning. Confirm with:
+
+```bash
+gh run view <run-id> --log | grep -iE "pixi install .*--locked|Cache restored from key|vulnerab|urllib3"
+```
+
+### Root-cause fix
+
+**Remove the redundant second `actions/cache` step over `.pixi`** and rely on
+`prefix-dev/setup-pixi`'s built-in caching (exact-keyed on `pixi.lock`, never clobbers
+the install). Do this across **ALL** workflows that have the pattern — composite actions,
+`release.yml`, `pre-commit.yml`, `security.yml`. A workflow whose `.pixi` cache has NO
+`restore-keys` must be fixed too, not just the ones with loose `restore-keys`.
+
+```bash
+# Find every actions/cache that touches .pixi after a setup-pixi/--locked step
+grep -rn -B2 -A8 "actions/cache" .github/workflows/ .github/actions/ | grep -E "\.pixi|actions/cache|locked"
+
+# After removing the redundant cache steps, confirm none remain over .pixi
+grep -rn -A8 "actions/cache" .github/workflows/ .github/actions/ | grep -n "\.pixi"
+```
+
+### Decision: should you add an explicit `actions/cache` over `.pixi`?
+
+```text
+Does the workflow use prefix-dev/setup-pixi with locked: true (or pixi install --locked)?
+├─ YES → DO NOT add a second actions/cache over .pixi.
+│        Rely on setup-pixi's built-in lock-keyed cache. Remove any existing one.
+└─ NO  → cache: true is unreliable → use ONE explicit actions/cache over
+         .pixi + ~/.cache/rattler/cache keyed on pixi.lock (see Verified Workflow below).
+```
 
 ## Verified Workflow
 
@@ -164,8 +258,10 @@ gh pr merge --auto --rebase
 | Cache path 1 | `.pixi` | Project environment directory |
 | Cache path 2 | `~/.cache/rattler/cache` | Package download cache — must include both |
 | Cache key hash source | `pixi.lock` | More precise than `pixi.toml` |
-| Restore key prefix | `pixi-${{ runner.os }}-` | Falls back to any OS-matching cache |
+| Restore key prefix | `pixi-${{ runner.os }}-` | Falls back to any OS-matching cache (**only when NOT using `locked: true`**) |
 | `cache: true` | **omit** | Unreliable — causes "Saved cache with ID -1" |
+| Second `actions/cache` over `.pixi` under `locked: true` | **remove** | Poisons the locked install; downgrades packages; fails pip-audit |
+| Locked-mode caching | rely on built-in setup-pixi cache | setup-pixi exact-keys `.pixi` on `pixi.lock` and never clobbers the install |
 
 ## Failed Attempts
 
@@ -175,3 +271,13 @@ gh pr merge --auto --rebase
 | Cache only `.pixi` | Cached `.pixi` path only, skipped `~/.cache/rattler/cache` | Pixi re-downloads packages on every run even when `.pixi` hits | Must cache both paths or cache is incomplete |
 | Hash `pixi.toml` | Used `hashFiles('pixi.toml')` as cache key | `pixi.toml` doesn't encode exact resolved versions; false positives on cache hits | Use `pixi.lock` for precise cache invalidation |
 | Keeping unused `inputs:` block | Preserved `pixi-version` and `cache` inputs when no callers use `with:` blocks | Dead code; caused confusion and allowed accidental re-introduction of `cache: true` via the `${{ inputs.cache }}` passthrough | Remove inputs when no callers pass `with:` blocks; verify first with `grep -rn -A3 "uses: ./.github/actions/setup-pixi" .github/workflows/` |
+| Second `actions/cache` over `.pixi` with `locked: true` | Kept setup-pixi's built-in `.pixi` cache AND added an explicit `actions/cache@v5` over the same `.pixi` path | The second restore extracts a STALE `.pixi` over the fresh `--locked` install (last restore wins), downgrading urllib3 2.7.0 → 2.6.3; pip-audit then audits the downgraded env and fails `dependency-scan` on every PR | With `locked: true`, never layer a second cache over `.pixi` — rely solely on setup-pixi's built-in lock-keyed cache |
+| "No `restore-keys` = safe" assumption | Fixed only the workflows with loose `restore-keys:` (setup-pixi-env, release.yml, pre-commit.yml); left security.yml's exact-key-only `.pixi` cache in place | security.yml STILL failed `dependency-scan`: its exact key (`hashFiles('pixi.lock')`) hit a `.pixi` cache that a PREVIOUS poisoned run had saved under the same hash — exact-key hit restored the poison | An exact-key-only `.pixi` cache is NOT safe; ANY second `actions/cache` over `.pixi` after a `--locked` setup-pixi is unsafe, regardless of `restore-keys` |
+| Bumping `pixi.lock` to patched version alone | Updated `pixi.lock` so the locked env had urllib3 2.7.0 | dependency-scan still failed because the poisoning cache restored 2.6.3 over the patched install; the lock fix was correct but invisible to pip-audit | Patching the lock is necessary but not sufficient when a second `.pixi` cache poisons the env — you must also remove the redundant cache |
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| ProjectOdyssey | Consolidate 14+ Pixi setup blocks into a composite action (v2.0.0) | Eliminated `Saved cache with ID -1` |
+| ProjectHephaestus | `.pixi` cache poisoning under `locked: true` — PR #1021 fixed setup-pixi-env composite + release.yml + pre-commit.yml; PR #1026 fixed security.yml (exact-key-only cache) | verified-ci: dependency-scan green on rebased PRs after the fix (e.g. PR #1011 passed) |


### PR DESCRIPTION
## Summary

Amends the existing `pixi-cache-true-unreliable` skill from **v2.0.0 → v2.1.0**.

v2.0.0 universally recommended replacing setup-pixi `cache: true` with an explicit `actions/cache` over `.pixi`. That is correct only when NOT using `locked: true`. This amendment adds the critical caveat that under `prefix-dev/setup-pixi` with `locked: true`, a SECOND `actions/cache` over `.pixi` POISONS the freshly-installed locked environment.

- setup-pixi `--locked` installs the correct versions (e.g. urllib3 2.7.0), then a later `actions/cache` restore extracts a stale `.pixi` over it (last restore wins), downgrading packages (urllib3 2.7.0 → 2.6.3).
- pip-audit then audits the downgraded env and fails `security`/`dependency-scan` on every PR even though `pixi.lock` is already patched.
- Both poisoning variants documented: loose `restore-keys:` AND exact-key-only (which still exact-hits a previously-poisoned cache).
- Root-cause fix: remove the redundant second `actions/cache` over `.pixi`; rely on setup-pixi's built-in lock-keyed cache. Apply across ALL workflows (composite actions, release.yml, pre-commit.yml, security.yml).

## Verification Level

**verified-ci** — the fix was merged to main and `dependency-scan` went green on rebased PRs (e.g. PR #1011 dependency-scan passed after the fix).

## Key Findings

**What Worked**:
- Removing the redundant `actions/cache` over `.pixi` and relying solely on setup-pixi's built-in exact-keyed cache.
- Applying the fix to every workflow with the pattern, not just the ones with loose restore-keys.

**What Failed**:
- Assuming "no restore-keys = safe" → an exact-key-only `.pixi` cache (security.yml) still exact-hit a previously-poisoned cache under the same `pixi.lock` hash and kept failing.
- Bumping `pixi.lock` alone → invisible to pip-audit while the cache restored the old version over the patched install.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (489/489 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: pixi, .pixi, cache, locked, pip-audit, dependency-scan, urllib3

Verified on: ProjectHephaestus, PRs #1021 and #1026, 2026-06-06.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>