### PR TITLE
feat: add tooling-hephaestus-implementer-no-changes-state-skip skill

### DIFF
--- a/skills/tooling-hephaestus-implementer-no-changes-state-skip.md
+++ b/skills/tooling-hephaestus-implementer-no-changes-state-skip.md
@@ -1,0 +1,131 @@
+---
+name: tooling-hephaestus-implementer-no-changes-state-skip
+description: "When hephaestus implementer_phase_runner raises RuntimeError('No changes produced...') from pr_manager because a branch has 0 commits vs main (work already merged), detect this specific case and apply state:skip + return WorkerResult(success=True) instead of failing. Use when: (1) an automation loop inflates rc=1 for issues whose work already landed via a prior merged PR, (2) diagnosing why drive-green stays suppressed after implementation loops 1-4 even though the actual code change is already merged, (3) implementing or reviewing error handling in _implement_issue in implementer_phase_runner.py."
+category: tooling
+date: 2026-06-07
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - implementer
+  - implementer-phase-runner
+  - no-changes-produced
+  - state-skip
+  - workerresult
+  - pr-manager
+  - no-commits-vs-main
+  - automation-loop
+  - rc-inflation
+  - drive-green
+---
+
+# Implementer "No Changes Produced" → state:skip
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-07 |
+| **Objective** | Fix `_implement_issue` in `implementer_phase_runner.py` so that a `RuntimeError("No changes produced...")` from `pr_manager` (branch has 0 commits vs main — work already merged) is treated as success + state:skip, not failure. |
+| **Outcome** | Successful — PR #1090 filed; pre-commit hooks + mypy (320 files) + ruff + 3402 unit tests all pass. |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- An automation loop reports `rc=1` for an issue whose implementation was already merged via a prior PR (work IS done, branch is clean, but the implementer calls `create_or_update_pr` and gets "no commits vs main").
+- Drive-green stays suppressed on loops 1–4 (pre-existing Bug #818 suppresses it on `rc != 0`); the root cause can be rc inflation here.
+- Implementing or reviewing error handling inside `_implement_issue` in `hephaestus/automation/implementer_phase_runner.py`.
+- Distinguishing "agent ran but produced no new work" (genuine failure) from "branch has no new commits because the work already merged" (already done — not a failure).
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# In hephaestus/automation/implementer_phase_runner.py
+# Inside _implement_issue, in the `except RuntimeError as e:` block:
+
+msg = str(e)
+if "no commits vs" in msg.lower() or "no changes produced" in msg.lower():
+    impl._log("info",
+              f"Issue #{issue_number}: no new commits vs main — work already merged; applying state:skip",
+              thread_id)
+    self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: already implemented — state:skip")
+    with contextlib.suppress(Exception):
+        gh_issue_add_labels(issue_number, [STATE_SKIP])
+    return WorkerResult(issue_number=issue_number, success=True)
+# fall through to other RuntimeError handling below
+```
+
+Detection: the error message from `pr_manager.create_or_update_pr` when `_branch_has_commits_vs_base`
+returns False is:
+`"No changes produced for issue ...#<N>: branch '<N>-auto-impl' has no commits vs 'main'. Skipping PR creation..."`
+
+Match both substrings in case the message wording changes slightly:
+```python
+"no commits vs" in msg.lower() or "no changes produced" in msg.lower()
+```
+
+### Detailed Steps
+
+1. **Understand the root cause.** `pr_manager.create_or_update_pr` raises `RuntimeError("No changes produced...")` when `_branch_has_commits_vs_base(branch, base)` returns False. This means the implementation branch has 0 commits beyond `main`. This happens legitimately when the code change already landed via a prior merged PR.
+
+2. **Add the early-return check at the TOP of the `except RuntimeError as e:` block** in `_implement_issue`. The check must be added before any other RuntimeError handling so the success path fires before the failure path.
+
+3. **Call `gh_issue_add_labels` directly — no `dry_run` guard.** The handler is only reachable when `dry_run=False` because `_implement_issue` already returns early at ~line 241 when `dry_run=True`. The RuntimeError from `_finalize_pr` (where this handler lives, ~line 380) is unreachable in dry-run mode. Adding `if not self.options.dry_run:` would be dead code and misleading.
+
+4. **Apply `state:skip` (not `state:done` or close).** `state:skip` is the existing mechanism the implementer checks at the top of `_implement_issue` to skip re-processing. It reuses the existing pattern without making a judgment about full resolution — a human can verify the closed state and close the issue.
+
+5. **Return `WorkerResult(success=True)`.** This prevents rc inflation that would suppress drive-green on subsequent loops.
+
+6. **Write a unit test** in `tests/unit/automation/test_implementer.py` under class `TestNoChangesProducedAppliesStateSkip`:
+   - Mock `_finalize_pr` to raise `RuntimeError("No changes produced for issue #736 ...")`
+   - Assert `gh_issue_add_labels(736, ["state:skip"])` was called
+   - Assert `result.success is True`
+   - Do NOT write a dry_run variant — the handler is unreachable in dry-run mode (the test would be vacuous).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Add `if not self.options.dry_run:` guard inside the handler | Wrapped `gh_issue_add_labels` call in a dry-run check | Dead code — `_implement_issue` returns early on `dry_run=True` at ~line 241; the handler (`_finalize_pr` region ~line 380) is unreachable in dry-run mode | Do NOT add the guard; call `gh_issue_add_labels` directly. Adding it is misleading and will confuse future readers. |
+| Apply the fix in `pr_manager.py` (not raise, return instead) | Changed `create_or_update_pr` to return None instead of raising | Changes the throw/no-throw contract of `create_or_update_pr` — callers relying on the exception for error flow break | Fix at the orchestration layer (`implementer_phase_runner.py`), not in the data-access layer. The semantic distinction (already-done vs genuine failure) belongs at the orchestration level. |
+| Write a vacuous dry_run test | Added a test that mocked `_implement_issue` to return before the handler | Tests nothing — the handler is unreachable in dry-run mode by design | Only write reachable tests; explicitly document that a dry_run test is vacuous and was removed. |
+
+## Results & Parameters
+
+### Error message to detect
+
+Source: `pr_manager.create_or_update_pr` → `_branch_has_commits_vs_base` returns False.
+
+```text
+"No changes produced for issue ...#<N>: branch '<N>-auto-impl' has no commits vs 'main'. Skipping PR creation..."
+```
+
+Detection idiom:
+```python
+"no commits vs" in msg.lower() or "no changes produced" in msg.lower()
+```
+
+### Why the rc inflation mattered
+
+With `rc=1` returned for "already merged" issues, Bug #818 (drive-green structurally suppressed on loops 1–4 via the not-final-loop gate) was triggered on EVERY loop, not just the last. The combined effect: the loop ran 5 times, flagged already-done issues as failures, and never reached a clean-pass to run drive-green. This fix stops the rc inflation; Bug #818 is separately tracked.
+
+### Related skills
+
+- `multi-repo-pr-automation-loop-orchestration` — see "Hephaestus loop deadlocks (drive-green discovery)" and the existing-PR labeling deadlock fix (PRs #1073–#1079). That skill has the opposite "no-commit guard" (pre==post HEAD ⇒ hard-fail) in the CI driver; the semantics here are DIFFERENT (0 commits vs main in the implementer = work already landed = success, not failure).
+
+### Verification metrics
+
+- 3402 unit tests passed
+- mypy clean (320 files)
+- ruff clean
+- pre-commit hooks pass
+- PR: #1090 (HomericIntelligence/ProjectHephaestus)
+- Issues: #1088 (BLOCKED poll), #1089 (no-changes skip)
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #1090, Issues #1088/#1089 — "no changes produced" RuntimeError should apply state:skip | verified-ci; 3402 tests passed; mypy/ruff/pre-commit clean; 2026-06-07 |


### PR DESCRIPTION
## Summary

New skill documenting the fix for `implementer_phase_runner.py` where `RuntimeError("No changes produced...")` from `pr_manager` was treated as failure when the branch has 0 commits vs main (work already merged via a prior PR).

- Detects `"no commits vs" in msg.lower() or "no changes produced" in msg.lower()`
- Applies `state:skip` label and returns `WorkerResult(success=True)` instead of failing
- Documents why `dry_run` guard must NOT be added (dead code — handler is unreachable in dry-run)
- Documents why fix belongs in `implementer_phase_runner.py` not `pr_manager.py`

## Verification Level

**verified-ci**

PR #1090 filed with all pre-commit hooks passing, mypy clean (320 files), ruff clean, 3402 unit tests passed.

## Key Findings

**What Worked**:
- Detecting the specific error message at the orchestration layer (`_implement_issue` except block)
- Applying `state:skip` (not `state:done`) to reuse the existing skip mechanism idempotently
- `WorkerResult(success=True)` prevents rc inflation that suppressed drive-green (interacted with Bug #818)

**What Failed**:
- `if not self.options.dry_run:` guard → dead code, handler is unreachable in dry-run mode by design
- Fixing in `pr_manager.py` → changes throw/no-throw contract; fix belongs at the orchestration layer

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` — 363/363 valid
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: no-changes-produced, state-skip, implementer, no-commits-vs

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>