### PR TITLE
feat: amend automation-implementer-no-changes-state-skip skill (add alias)

### DIFF
--- a/skills/tooling-hephaestus-implementer-no-changes-state-skip.md
+++ b/skills/tooling-hephaestus-implementer-no-changes-state-skip.md
@@ -1,9 +1,11 @@
 ---
 name: tooling-hephaestus-implementer-no-changes-state-skip
+aliases:
+  - automation-implementer-no-changes-state-skip
 description: "When hephaestus implementer_phase_runner raises RuntimeError('No changes produced...') from pr_manager because a branch has 0 commits vs main (work already merged), detect this specific case and apply state:skip + return WorkerResult(success=True) instead of failing. Use when: (1) an automation loop inflates rc=1 for issues whose work already landed via a prior merged PR, (2) diagnosing why drive-green stays suppressed after implementation loops 1-4 even though the actual code change is already merged, (3) implementing or reviewing error handling in _implement_issue in implementer_phase_runner.py."
 category: tooling
 date: 2026-06-07
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: verified-ci
 tags:


### PR DESCRIPTION
## Summary

- Amends `tooling-hephaestus-implementer-no-changes-state-skip` skill to add `automation-implementer-no-changes-state-skip` as an alias
- The existing skill already fully captured this session's learning at `verified-ci` level (PR #1090 filed, 3402 tests passed, mypy/ruff/pre-commit clean)
- This amendment ensures the `automation-*` prefixed name is discoverable when searching for this pattern

## Verification Level

**verified-ci** — existing skill already at CI-verified level. Alias addition validated with `python3 scripts/validate_plugins.py` (291/291 pass).

## Key Findings

**What Worked**:
- Catching RuntimeError with 'no commits vs' or 'no changes produced' substring check
- `contextlib.suppress(Exception)` around label application (graceful if GH API fails)
- Returning `WorkerResult(success=True)` to prevent rc=1 inflation suppressing drive-green

**What Failed**:
- dry_run guard on `gh_issue_add_labels` — dead code (`_implement_issue` returns early on `dry_run=True` before reaching the except block)

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (291/291 pass)
- [ ] Verify skill appears in marketplace

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>