### PR TITLE
feat: amend stale-documentation-audit-and-broken-reference-repair skill (v1.1.0)

### DIFF
--- a/skills/stale-documentation-audit-and-broken-reference-repair.history
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.history
@@ -2,6 +2,52 @@
 
 # stale-documentation-audit-and-broken-reference-repair — History
 
+## v1.1.0 (2026-06-12)
+
+**Changed by:** ProjectHephaestus #1208 R1 (post-NOGO replan)
+
+**Verification:** unverified (planning artifact — no edits applied, no `pixi run pytest`, no CI run).
+The CI-checkout root cause was verified-by-inspection (`test.yml` showed a bare `actions/checkout`
+with no `with:` block); the end-to-end fix is NOT verified.
+
+Additive (MINOR). Added a new §10 to the Verified Workflow — "Drift-detection test fragility —
+anti-patterns and CI-effective resolutions (Proposed)" — documenting BOTH the fragility
+anti-patterns of a drift-detection test AND their concrete, CI-effective resolutions:
+
+- **Silent-skip → hard-fail + fetch-tags (headline fix):** a drift test that `pytest.skip()`s on a
+  missing git tag is a silent no-op in CI. Root cause: a bare `actions/checkout` does a shallow,
+  tag-less fetch so `git describe --tags` returns None. Resolution = both halves: add
+  `fetch-depth: 0` + `fetch-tags: true` to the checkout step (mirror an existing release/auto-tag
+  workflow) AND replace `pytest.skip` with `pytest.fail` (belt-and-suspenders).
+- **`==`-to-latest-tag race → `>=`/"does not trail":** assert `documented_tuple >= canonical_tuple`
+  (reuse the repo's parser) so a freshly-pushed newer tag doesn't instantly red `main`, but a
+  genuinely-stale doc still fails.
+- **TDD RED must assert NON-SKIP:** run `pytest -rs`, require `1 failed` (not `1 skipped`/`1
+  passed`); GREEN steps require `0 skipped`; prove load-bearing by flipping the doc back to stale
+  and asserting non-zero exit.
+- **Verified helper detail:** `_version_from_git_tag` strips the leading `v` (returns `"0.9.5"`);
+  verify return form before assuming like-for-like comparison.
+- **Reviewer-confirmed non-issue:** a new `tests/unit/docs/` dir with no source package does NOT
+  trip a one-directional test-structure mirror check (`src − test` flags only source dirs missing a
+  test dir); a no-loose-files check is satisfied because the test lives in a subpackage.
+
+Also: bumped frontmatter `version` 1.0.0 → 1.1.0, set `date` 2026-06-12, added
+`verification: unverified`, extended tags (drift-detection-test, ci-effective, version-currency),
+added 4 Failed Attempts rows, a CI-effective version-currency test snippet in Results & Parameters,
+and a "Verified On" row for ProjectHephaestus #1208 R1.
+
+### Snapshot superseded — v1.0.0 frontmatter
+
+```yaml
+name: stale-documentation-audit-and-broken-reference-repair
+category: documentation
+date: 2026-06-07
+version: "1.0.0"
+user-invocable: false
+history: stale-documentation-audit-and-broken-reference-repair.history
+tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
+```
+
 ## v1.0.0 (2026-06-07)
 
 Consolidated 10 documentation skills into one canonical covering stale-doc drift audits and broken-reference repair. Absorbed skills:

--- a/skills/stale-documentation-audit-and-broken-reference-repair.history
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.history
@@ -2,6 +2,43 @@
 
 # stale-documentation-audit-and-broken-reference-repair — History
 
+## v1.2.0 (2026-06-12)
+
+**Changed by:** ProjectHephaestus issue #1188 implementation plan (README directory tree omits the
+`scripts_lib/` subpackage — doc-vs-reality drift). Planning artifact only. Stacked on top of the
+v1.1.0 #1208 amendment (same skill, independent learning).
+**Verification:** unverified (the new content); core workflow remains verified-ci.
+
+### What changed
+
+- New workflow subsection **1b. Counting subpackages for a directory-tree drift fix (planning)**
+  with a `> Warning:` honesty banner (unverified).
+- New "When to Use" trigger for directory-tree subpackage omission / miscount.
+- 5 new Failed Attempts rows: `ls -d */ | wc -l` overcounts via `__pycache__`; trusting the issue's
+  count; editing the first bare-number grep hit (LoC false-positive); assuming the whole tree is
+  alphabetical; treating greps (not the regression test) as the acceptance gate.
+- New Results & Parameters block: subpackage-tree drift regression test (proposed, unverified —
+  `parents[2]` depth unverified).
+- New Verified On row for ProjectHephaestus #1188 (planning only).
+- Added `subpackage-count`, `directory-tree` tags; bumped `version` 1.1.0 → 1.2.0.
+
+### Why
+
+Planning #1188 surfaced a transferable doc-drift lesson: when a directory tree quotes a package
+count, the count must be re-derived from the filesystem (dirs with `__init__.py` / `git ls-files`),
+because `ls | wc -l` includes `__pycache__` and both the README *and* the audit issue can carry the
+same off-by-one. Grepping the bare number surfaces real duplicates (a second stale copy in
+CLAUDE.md) plus noise (an unrelated "19.7k LoC" metric) that must be disambiguated before editing.
+Captured as `unverified` because the plan was never executed (no pre-commit, no test run); the
+proposed regression test and edit-placement assumptions are hypotheses.
+
+### Previous version (v1.1.0) snapshot
+
+See the v1.1.0 entry below for the prior #1208 amendment content. The remainder of the skill is
+preserved verbatim in the live file's unchanged sections.
+
+---
+
 ## v1.1.0 (2026-06-12)
 
 **Changed by:** ProjectHephaestus #1208 R1 (post-NOGO replan)
@@ -47,6 +84,8 @@ user-invocable: false
 history: stale-documentation-audit-and-broken-reference-repair.history
 tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
 ```
+
+---
 
 ## v1.0.0 (2026-06-07)
 

--- a/skills/stale-documentation-audit-and-broken-reference-repair.md
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.md
@@ -2,11 +2,12 @@
 name: stale-documentation-audit-and-broken-reference-repair
 description: "Use when: (1) running a doc-drift audit across a corpus — detecting stale counts, metric discrepancies, cross-doc contradictions, ecosystem-role drift; (2) removing phantom directory references from documentation when a path no longer exists; (3) fixing broken documentation references (dead links, stale headings); (4) auditing documentation examples for policy violations; (5) auditing and rewriting getting-started stubs by sourcing real commands from justfile and versions from pixi.toml; (6) fixing incorrect tier labels or version numbers in docs that have drifted from implementation; (7) managing the full lifecycle of placeholder and stub documentation — deletion under YAGNI, deferred-comment placeholders, rewriting with accurate codebase-grounded content; (8) resolving audit nitpicks for monolithic code by documenting verified design rationale; (9) resolving CONTRIBUTING.md case-clashes and circular cross-references in docs/; (10) validating anchor fragments in markdown deep-links to detect broken headings."
 category: documentation
-date: 2026-06-07
-version: "1.0.0"
+date: 2026-06-12
+version: "1.1.0"
 user-invocable: false
+verification: unverified
 history: stale-documentation-audit-and-broken-reference-repair.history
-tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
+tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, drift-detection-test, ci-effective, version-currency, merged]
 ---
 
 # Stale Documentation Audit and Broken Reference Repair
@@ -235,6 +236,70 @@ Scan only fenced shell code blocks (never prose, to avoid matching prohibition t
 `build/`). Anchor command rules to line starts and exclude `#`-commented lines (intentional
 "BLOCKED" demonstrations are not violations). Add a regression test per new pattern.
 
+#### 10. Drift-detection test fragility — anti-patterns and CI-effective resolutions (Proposed)
+
+> **⚠️ Proposed (unverified).** The resolutions below come from ProjectHephaestus #1208
+> planning round R1 (a re-plan after R0 got NOGO for shipping a no-op drift guard). The
+> CI-checkout root cause was **verified by inspection** (reading `test.yml` showed a bare
+> `actions/checkout` step). The end-to-end fix (test actually runs+passes in CI with the new
+> checkout config) is **NOT** verified — no edits were applied, no `pixi run pytest`, no CI run.
+> Treat as a design blueprint, not a CI-green claim.
+
+A drift-detection regression test (§1, Results & Parameters) is only worth shipping if it can
+actually **go red in CI**. Three fragility anti-patterns make a drift guard a silent no-op; each
+has a concrete resolution.
+
+##### Making the drift guard CI-effective (resolutions)
+
+**(a) Silent-skip → hard-fail + fetch-tags (THE headline fix).** A test that calls
+`pytest.skip()` when it cannot resolve the git tag is a silent no-op gate: it shows green in CI
+while guarding nothing. **Root cause (verified-by-inspection):** GitHub Actions `actions/checkout`
+with a **bare** `uses:` (no `with:` block) does a shallow, single-commit, **tag-less** fetch, so a
+helper that shells `git describe --tags` returns `None`. **Resolution — take BOTH halves
+(belt-and-suspenders):**
+
+1. Add `fetch-depth: 0` and `fetch-tags: true` to the test job's checkout step. Mirror an existing
+   workflow in the repo that already does this (e.g. an auto-tag / release workflow) rather than
+   inventing config.
+2. Replace `pytest.skip(...)` with `pytest.fail(...)` carrying remediation text. If the checkout
+   config ever regresses, the test goes **RED loudly** instead of green-but-skipped.
+
+> **Lesson: a guard that silently skips is not a guard.** Never use `pytest.skip` for the absence
+> of the very authority (here, the git tag) that the test exists to check.
+
+**(b) `==`-to-latest-tag race → `>=` / "does not trail" comparison.** Asserting
+`documented == latest_tag` reds `main` the instant a *new* tag is pushed — before anyone edits the
+doc — reintroducing the manual chore the drift test was meant to kill. **Resolution:** assert the
+documented version is **not strictly older** than the latest tag
+(`documented_tuple >= canonical_tuple`). A freshly-pushed newer tag does **not** instantly fail,
+but a genuinely-stale doc (e.g. `0.9.2` vs `0.9.5`) still fails. Reuse the repo's existing
+version-tuple parser; do not hand-roll the comparison.
+
+**(c) Verified helper detail (worked):** the repo's `_version_from_git_tag(repo_root)` **strips the
+leading `v`** (returns `"0.9.5"`, not `"v0.9.5"`), matching the doc's printed form. Verify the
+return form before assuming the comparison is like-for-like — a `v`-prefixed tuple parse vs a
+bare-version doc string would mis-compare.
+
+**(d) TDD RED step must assert NON-SKIP, not just "fails".** Because of the skip trap, a developer
+can see a green run that is actually a SKIP and conclude the test passed. **Resolution:** run the
+RED step with `pytest -rs` and require the summary line read `1 failed` (NOT `1 skipped` / `1
+passed`); the GREEN / sanity steps require `0 skipped`. To prove the guard is load-bearing, add a
+verification snippet that temporarily flips the doc back to the stale version and asserts a
+**non-zero** exit.
+
+```bash
+# RED must be a genuine FAIL, not a SKIP (the skip trap masquerades as green)
+pixi run pytest -rs tests/unit/docs/test_version_currency.py | tail -3   # expect "1 failed", 0 skipped
+# Prove it is load-bearing: flip the doc back to the stale version → non-zero exit
+git stash && <revert doc to stale 0.9.2> && pixi run pytest -q tests/unit/docs/...; echo "exit=$?"  # expect non-zero
+```
+
+**(e) Reviewer-confirmed non-issue (record so future plans don't re-litigate):** placing a *new*
+test dir like `tests/unit/docs/` with **no** corresponding source package does **not** trip a
+one-directional test-structure mirror check — `src_packages − test_packages` only flags **source**
+dirs MISSING a test dir, not test-only dirs. A no-loose-files check is also satisfied because the
+test lives inside a subpackage, not at the test-root.
+
 ### Validate, Commit, and PR
 
 ```bash
@@ -267,6 +332,10 @@ gh pr merge --auto --rebase
 | Full pre-commit suite without skipping | Ran all hooks on a host with a GLIBC mismatch | `mojo-format` fails on GLIBC < 2.32 (environment, not code) | Use `SKIP=mojo-format`; only non-Mojo hooks matter for doc-only changes |
 | Deleting `docs/contributing.md` to resolve the case-clash | Removed the file entirely | Breaks inbound links from the docs index | Reduce to a redirect; keep root as canonical |
 | Per-file reviewers for citation corpus | Reviewed each entry individually | Could not see cross-document §-drift or arXiv ID-to-title swaps | Both failure modes need a cross-corpus structural audit, not per-file review |
+| `pytest.skip(...)` when the git tag can't be resolved (drift test) | Skipped the drift assertion if `git describe --tags` returned None | A bare `actions/checkout` does a shallow tag-less fetch → the test silently SKIPPED in CI, guarding nothing while showing green (R0 NOGO) | A guard that silently skips is not a guard; `pytest.fail(...)` + add `fetch-depth: 0` / `fetch-tags: true` to the checkout step (belt-and-suspenders) |
+| `assert documented == latest_tag` for version currency | Required the doc version to equal the latest git tag exactly | Reds `main` the instant a NEW tag is pushed, before anyone edits the doc — reintroduces the manual chore the test was meant to kill | Assert "does not trail": `documented_tuple >= canonical_tuple` (a newer tag passes; a genuinely-stale doc still fails); reuse the repo's version-tuple parser |
+| RED step that only checks "the run failed" | Treated any non-pass as a successful RED | A SKIP also isn't a pass, so a silent-skip masquerades as a satisfied RED step | Run `pytest -rs`; require the summary be `1 failed` (NOT `1 skipped`/`1 passed`); GREEN steps require `0 skipped` |
+| Comparing a `v`-prefixed tag tuple to a bare doc version | Assumed `git describe` form matched the doc's printed form | `_version_from_git_tag` strips the leading `v` (returns `"0.9.5"`) — a `v`-prefixed parse would mis-compare | Verify the helper's return form before assuming the comparison is like-for-like |
 
 ## Results & Parameters
 
@@ -303,6 +372,36 @@ def test_no_stale_claims(doc: Path, pattern: str) -> None:
     assert not matches, f"{doc.name} contains forbidden phrase: {matches}"
 ```
 
+### Version-currency drift test — CI-effective form (Proposed, unverified)
+
+For a *version-currency* drift guard (doc version vs latest git tag), the naive form is a no-op in
+CI. Apply the §10 resolutions: **never `pytest.skip` on a missing tag** (that is exactly the
+authority under test), assert **does-not-trail** (`>=`) not `==`, and ensure CI checkout fetches
+tags.
+
+```python
+def test_documented_version_not_stale() -> None:
+    canonical = _version_from_git_tag(REPO_ROOT)  # strips leading "v" → "0.9.5"
+    if canonical is None:
+        # HARD FAIL, never skip: a tag-less checkout (bare actions/checkout) must surface loudly.
+        pytest.fail(
+            "Could not resolve the latest git tag — the CI checkout step likely lacks "
+            "fetch-depth: 0 / fetch-tags: true. This guard is a no-op without tags."
+        )
+    documented = parse_version_tuple(read_documented_version())     # reuse repo's parser
+    assert parse_version_tuple(canonical) <= documented, (          # doc must NOT trail the tag
+        f"Documented version {documented} trails latest tag {canonical}; bump the doc."
+    )
+```
+
+```yaml
+# CI: the test job's checkout MUST fetch tags (mirror the repo's auto-tag/release workflow)
+- uses: actions/checkout@<pinned>
+  with:
+    fetch-depth: 0
+    fetch-tags: true
+```
+
 ### Reliable markdownlint invocation
 
 ```bash
@@ -331,4 +430,5 @@ pixi run npx markdownlint-cli2 <file>
 | ProjectOdyssey | Issues #3344, #3365; PR #3320; PR #4847 | Workflow README audit, agent-count fix, post-migration README sync |
 | ProjectOdyssey | Issues #3142/#3308, #3304/#3913, #3305/#3917, #3918/#4830, #3141/#3303, #3914/#4828, #3915/#4829 | Stub deletion, installation/quickstart rewrite, IDE-setup extend, getting-started audit, anchor validator |
 | ProjectHephaestus | Issue #792 (PR #984); Issue #630 (PR #667) | Monolith-rationale ADR; CONTRIBUTING case-clash redirect |
+| ProjectHephaestus | Issue #1208 R1 (post-NOGO replan) — **Proposed/unverified** | Drift-guard CI-effectiveness: silent-skip→hard-fail+fetch-tags, `==`→`>=` currency, RED-must-not-skip; CI-checkout root cause verified-by-inspection, end-to-end fix unverified |
 | mvillmow/Random | Predictive-Coding-in-Mojo Phase 0 | Cross-doc citation drift: 8 stale §-refs, 2 arXiv ID swaps caught |

--- a/skills/stale-documentation-audit-and-broken-reference-repair.md
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.md
@@ -3,11 +3,11 @@ name: stale-documentation-audit-and-broken-reference-repair
 description: "Use when: (1) running a doc-drift audit across a corpus — detecting stale counts, metric discrepancies, cross-doc contradictions, ecosystem-role drift; (2) removing phantom directory references from documentation when a path no longer exists; (3) fixing broken documentation references (dead links, stale headings); (4) auditing documentation examples for policy violations; (5) auditing and rewriting getting-started stubs by sourcing real commands from justfile and versions from pixi.toml; (6) fixing incorrect tier labels or version numbers in docs that have drifted from implementation; (7) managing the full lifecycle of placeholder and stub documentation — deletion under YAGNI, deferred-comment placeholders, rewriting with accurate codebase-grounded content; (8) resolving audit nitpicks for monolithic code by documenting verified design rationale; (9) resolving CONTRIBUTING.md case-clashes and circular cross-references in docs/; (10) validating anchor fragments in markdown deep-links to detect broken headings."
 category: documentation
 date: 2026-06-12
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: unverified
 history: stale-documentation-audit-and-broken-reference-repair.history
-tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, drift-detection-test, ci-effective, version-currency, merged]
+tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, drift-detection-test, ci-effective, version-currency, subpackage-count, directory-tree, merged]
 ---
 
 # Stale Documentation Audit and Broken Reference Repair
@@ -16,10 +16,10 @@ tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, 
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-06-07 |
+| **Date** | 2026-06-12 |
 | **Objective** | Canonical workflow for auditing stale documentation and repairing broken references: drift audits, phantom-dir/dead-link removal, placeholder lifecycle, getting-started rewrites, tier-label fixes, anchor validation |
 | **Outcome** | Consolidated from 10 skills covering doc-drift audits, broken-reference repair, policy-violation audits, placeholder/stub lifecycle, monolith-rationale docs, CONTRIBUTING case-clash, and anchor validation |
-| **Verification** | verified-ci |
+| **Verification** | verified-ci (core workflow); the v1.2.0 "Counting subpackages for a directory-tree drift fix" planning addition is `unverified` — see its inline warning |
 
 ## When to Use
 
@@ -35,6 +35,7 @@ tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, 
 - An audit nitpick questions a monolithic file's organization and needs a documented rationale
 - Both `CONTRIBUTING.md` and `docs/contributing.md` exist with a circular cross-reference
 - README/docs deep-link to specific installation headings and you need CI to catch broken anchors
+- A README/CLAUDE.md directory tree omits or miscounts a subpackage and you must re-derive the true package count from the filesystem (not trust the doc's own number or the issue's)
 
 ## Verified Workflow
 
@@ -109,6 +110,46 @@ Add a self-verifying command to the doc so future readers can re-check:
 bullet (`- N agents` → `- M agents`) and the Agent Hierarchy line (`All N agents` → `All M agents`).
 
 Optionally add a drift-detection regression test (see Results & Parameters) and an ADR.
+
+#### 1b. Counting subpackages for a directory-tree drift fix (planning)
+
+> **Warning:** This subsection is `unverified` — derived from an implementation *plan* for
+> ProjectHephaestus #1188 (README directory tree omits the `scripts_lib/` subpackage). The plan was
+> not executed end-to-end (no pre-commit run, no regression test executed). Treat the counting
+> recipe as verified, but treat the proposed regression test and edit-placement assumptions as
+> hypotheses until CI confirms.
+
+When a README/CLAUDE.md directory tree omits a subpackage and quotes a package count, **re-derive
+the count from the filesystem yourself** — trust neither the doc's claim nor the audit issue's
+number. Both can carry the same off-by-one error.
+
+```bash
+# WRONG — overcounts: includes __pycache__/ and any dot-dirs
+ls -d hephaestus/*/ | wc -l            # returned 21 (20 real + __pycache__)
+
+# RIGHT — count only real packages (those with an __init__.py)
+find hephaestus -maxdepth 2 -name __init__.py -printf '%h\n' | sort -u | wc -l
+# or, tracked files only (ignores cache entirely):
+git ls-files 'hephaestus/*/__init__.py' | wc -l   # → 20
+```
+
+Then re-grep the **bare number** across the whole corpus and disambiguate every hit before editing —
+the same stale count usually lives in more than one file, and an unrelated metric will false-positive:
+
+```bash
+grep -rn "19" README.md CLAUDE.md
+# README.md:tree caption "19 ... subpackages"  → REAL stale copy (fix)
+# CLAUDE.md:28 "19 documented subpackages"      → REAL second stale copy (fix)
+# CLAUDE.md:62 "19.7k LoC"                       → FALSE POSITIVE, unrelated metric (do NOT change)
+```
+
+For the tree insertion itself, the new entry must sort into the existing order — verify the **local
+neighborhood** is alphabetical (e.g. `scripts_lib/` sorts between `resilience/` and `system/`) by
+reading the adjacent lines; do not assume the entire tree is sorted. The inserted comment text is
+planner-authored prose, not a copied docstring — flag it for maintainer wording review. The real
+acceptance gate is a regression test that asserts every `*/__init__.py` package appears in the tree,
+not the greps (the greps are for human/CI reproduction). The CLAUDE.md "avoid raw grep" guidance
+applies to agent tool-use, not to a doc's copy-paste verification block.
 
 #### 2. Phantom-directory references
 
@@ -336,6 +377,11 @@ gh pr merge --auto --rebase
 | `assert documented == latest_tag` for version currency | Required the doc version to equal the latest git tag exactly | Reds `main` the instant a NEW tag is pushed, before anyone edits the doc — reintroduces the manual chore the test was meant to kill | Assert "does not trail": `documented_tuple >= canonical_tuple` (a newer tag passes; a genuinely-stale doc still fails); reuse the repo's version-tuple parser |
 | RED step that only checks "the run failed" | Treated any non-pass as a successful RED | A SKIP also isn't a pass, so a silent-skip masquerades as a satisfied RED step | Run `pytest -rs`; require the summary be `1 failed` (NOT `1 skipped`/`1 passed`); GREEN steps require `0 skipped` |
 | Comparing a `v`-prefixed tag tuple to a bare doc version | Assumed `git describe` form matched the doc's printed form | `_version_from_git_tag` strips the leading `v` (returns `"0.9.5"`) — a `v`-prefixed parse would mis-compare | Verify the helper's return form before assuming the comparison is like-for-like |
+| `ls -d hephaestus/*/ \| wc -l` as the package count | Counted directory entries to ground-truth the README tree | Returned 21 — includes `__pycache__/`; the real tracked count is 20 | Count only dirs with `__init__.py` (`git ls-files '*/__init__.py'`); `ls \| wc -l` is not a reliable package count |
+| Trusting the audit issue's count ("19 → 20") | Took the issue's number as ground truth | The issue can carry the same off-by-one as the README; both said "19" | Re-derive the count independently from the filesystem before fixing |
+| Editing the first `19` grep hit found | Planned to fix the count where grep matched | `CLAUDE.md:62 "19.7k LoC"` is an unrelated metric that must NOT change | Grep the bare number, then disambiguate every hit (real duplicate vs noise) before editing |
+| Assuming the whole tree is alphabetical | Inferred insertion point from "tree is sorted" | Only the local neighborhood was verified; full-tree order was never checked | Read the adjacent lines to confirm the local sort; don't assume global ordering |
+| Treating the greps as the acceptance gate | Listed grep/pytest in the plan's verification block | Greps reproduce the finding but don't prevent regression; a planner-authored comment may mis-word | The regression test (every `*/__init__.py` appears in the tree) is the real gate; flag authored prose for maintainer review |
 
 ## Results & Parameters
 
@@ -402,6 +448,25 @@ def test_documented_version_not_stale() -> None:
     fetch-tags: true
 ```
 
+### Subpackage-tree drift test pattern (Python, proposed — unverified)
+
+> Proposed in the #1188 plan but **not executed**. The `parents[2]` depth assumes a
+> `tests/unit/<file>.py` layout → repo root; verify the actual depth before relying on it.
+
+```python
+"""Fail if a hephaestus subpackage is missing from the README directory tree."""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]   # tests/unit/<file>.py -> root (VERIFY depth)
+
+def test_readme_lists_every_subpackage() -> None:
+    pkg_dir = REPO_ROOT / "hephaestus"
+    packages = {p.parent.name for p in pkg_dir.glob("*/__init__.py")}  # ignores __pycache__
+    readme = (REPO_ROOT / "README.md").read_text()
+    missing = sorted(name for name in packages if f"{name}/" not in readme)
+    assert not missing, f"README directory tree omits subpackages: {missing}"
+```
+
 ### Reliable markdownlint invocation
 
 ```bash
@@ -431,4 +496,5 @@ pixi run npx markdownlint-cli2 <file>
 | ProjectOdyssey | Issues #3142/#3308, #3304/#3913, #3305/#3917, #3918/#4830, #3141/#3303, #3914/#4828, #3915/#4829 | Stub deletion, installation/quickstart rewrite, IDE-setup extend, getting-started audit, anchor validator |
 | ProjectHephaestus | Issue #792 (PR #984); Issue #630 (PR #667) | Monolith-rationale ADR; CONTRIBUTING case-clash redirect |
 | ProjectHephaestus | Issue #1208 R1 (post-NOGO replan) — **Proposed/unverified** | Drift-guard CI-effectiveness: silent-skip→hard-fail+fetch-tags, `==`→`>=` currency, RED-must-not-skip; CI-checkout root cause verified-by-inspection, end-to-end fix unverified |
+| ProjectHephaestus | Issue #1188 (planning only — unverified) | README tree omits `scripts_lib/` subpackage; count-from-code recipe, bare-number disambiguation, subpackage-tree regression test |
 | mvillmow/Random | Predictive-Coding-in-Mojo Phase 0 | Cross-doc citation drift: 8 stale §-refs, 2 arXiv ID swaps caught |


### PR DESCRIPTION
Amends the `stale-documentation-audit-and-broken-reference-repair` skill **v1.0.0 → v1.1.0** (MINOR, additive).

## What this adds

This round (ProjectHephaestus #1208 R1, a re-plan after R0 got NOGO for shipping a drift-detection test that was a no-op in CI) contributes the **concrete CI-effective RESOLUTIONS** to the drift-guard fragility anti-patterns. A new §10 ("Drift-detection test fragility — anti-patterns and CI-effective resolutions") documents BOTH the anti-patterns AND how to fix each:

- **Silent-skip → hard-fail + fetch-tags (headline fix):** a drift test that `pytest.skip()`s when it can't resolve the git tag is a silent no-op gate. Root cause: a **bare** `actions/checkout` (no `with:`) does a shallow, tag-less fetch. Resolution = both halves: add `fetch-depth: 0` + `fetch-tags: true` to the checkout step AND replace `pytest.skip` with `pytest.fail` (belt-and-suspenders).
- **`==`-to-latest-tag race → `>=`/"does not trail":** assert `documented_tuple >= canonical_tuple` so a freshly-pushed newer tag doesn't instantly red `main`.
- **TDD RED must assert NON-SKIP:** `pytest -rs`, require `1 failed` (not skipped/passed); GREEN requires `0 skipped`.
- **Verified helper detail:** `_version_from_git_tag` strips leading `v` (returns `"0.9.5"`).
- **Reviewer-confirmed non-issue:** a test-only `tests/unit/docs/` dir doesn't trip a one-directional test-structure mirror check.

Also: 4 new Failed Attempts rows, a CI-effective version-currency test snippet, a Verified On row, frontmatter `verification: unverified` + tags, and a `.history` snapshot of the prior v1.0.0.

## Verification

**verification: unverified.** This is a PLANNING artifact — the R1 plan was NOT executed (no edits, no `pixi run pytest`, no CI run). The CI-checkout root cause (bare `actions/checkout` ⇒ no tags) was **verified by inspection** of `test.yml`; the end-to-end fix (test actually runs+passes in CI) is NOT verified. The new section is labeled "Proposed" with a warning banner. No CI-green is claimed.

Note: this complements the still-open #2338 (the §10 caveats); main is at v1.0.0, so this increments one MINOR from main and folds in both the caveats and their resolutions.

`python3 scripts/validate_plugins.py` → Valid: 296/296.