### PR TITLE
docs(skill): amend stale-documentation-audit skill (v1.1.0) — count-annotates-curated-list

### DIFF
--- a/skills/stale-documentation-audit-and-broken-reference-repair.history
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.history
@@ -2,6 +2,81 @@
 
 # stale-documentation-audit-and-broken-reference-repair — History
 
+## v1.1.0 (2026-06-12)
+
+**Changed by:** issue #1212 plan-reviewer NOGO (count-vs-curated-list)
+**Verification:** unverified (planning-stage refinement; the plan was written and passed
+re-review but the implementation PR is not yet merged/CI-green)
+
+**What changed:** Added the "count-annotates-curated-list" rule as a new subsection under
+Detailed Steps §1 (drift audit), three Failed-Attempts rows, a property-based count-verification
+idiom in Results & Parameters, and a Key-parameters bullet. Bumped version 1.0.0 → 1.1.0 and added
+`verification: unverified` to frontmatter.
+
+**Why:** A doc count usually annotates an adjacent human-curated enumeration (tree / tier table /
+list). Its contract is "this number = the count of the list beside it," NOT
+"this number = `find … | wc -l`." Bumping the number to the raw filesystem count while the curated
+list is unchanged yields an internally-contradictory doc (a number promising N over a list of N-1)
+— worse than the original staleness and a POLA NOGO. Concrete case: ProjectHephaestus #1212,
+`CLAUDE.md:28` "(19 subpackages)" annotates a 19-leaf tree while `find` returns 20 (the 20th dir,
+`hephaestus/scripts_lib/`, is internal pre-commit tooling absent from the tree and from public
+re-exports). A first plan bumped 19→20; the reviewer NOGO'd it. Correct fix: keep 19 and clarify
+scope — "19 documented subpackages" — and verify the property (number == enumeration count) plus a
+negative guard, never grep the string just written.
+
+### Full snapshot of the PREVIOUS version (v1.0.0) content
+
+````markdown
+---
+name: stale-documentation-audit-and-broken-reference-repair
+description: "Use when: (1) running a doc-drift audit across a corpus — detecting stale counts, metric discrepancies, cross-doc contradictions, ecosystem-role drift; (2) removing phantom directory references from documentation when a path no longer exists; (3) fixing broken documentation references (dead links, stale headings); (4) auditing documentation examples for policy violations; (5) auditing and rewriting getting-started stubs by sourcing real commands from justfile and versions from pixi.toml; (6) fixing incorrect tier labels or version numbers in docs that have drifted from implementation; (7) managing the full lifecycle of placeholder and stub documentation — deletion under YAGNI, deferred-comment placeholders, rewriting with accurate codebase-grounded content; (8) resolving audit nitpicks for monolithic code by documenting verified design rationale; (9) resolving CONTRIBUTING.md case-clashes and circular cross-references in docs/; (10) validating anchor fragments in markdown deep-links to detect broken headings."
+category: documentation
+date: 2026-06-07
+version: "1.0.0"
+user-invocable: false
+history: stale-documentation-audit-and-broken-reference-repair.history
+tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
+---
+
+# Stale Documentation Audit and Broken Reference Repair
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-07 |
+| **Objective** | Canonical workflow for auditing stale documentation and repairing broken references: drift audits, phantom-dir/dead-link removal, placeholder lifecycle, getting-started rewrites, tier-label fixes, anchor validation |
+| **Outcome** | Consolidated from 10 skills covering doc-drift audits, broken-reference repair, policy-violation audits, placeholder/stub lifecycle, monolith-rationale docs, CONTRIBUTING case-clash, and anchor validation |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- A "Future Improvements" / "Future Work" section lists a feature that already shipped
+- Docs state a metric (test count, coverage %, file/agent count) that disagrees with the codebase
+- `CLAUDE.md` contradicts `pyproject.toml`/`CONTRIBUTING.md` on thresholds or policy
+- External architecture docs describe a project's ecosystem role inaccurately
+- A directory/file was removed but docs still reference the path (phantom dir / dead link)
+- Documentation examples contain commands that violate repo policy (e.g. `--label`, `--no-verify`)
+- Getting-started stubs contain fabricated APIs, placeholder prose, or malformed code fences
+- Tier labels / version numbers in docs have drifted from the authoritative table
+- Stub files contain only boilerplate and should be deleted, deferred, or rewritten
+- An audit nitpick questions a monolithic file's organization and needs a documented rationale
+- Both `CONTRIBUTING.md` and `docs/contributing.md` exist with a circular cross-reference
+- README/docs deep-link to specific installation headings and you need CI to catch broken anchors
+
+## Verified Workflow
+
+(The full v1.0.0 Verified Workflow — Quick Reference plus the nine Detailed Steps: drift audit,
+phantom-directory references, broken links and anchors, placeholder/stub lifecycle, getting-started
+rewrite, tier-label/version fixes, monolith-rationale, CONTRIBUTING case-clash redirect, and
+policy-violation audit — together with the Failed Attempts table, Results & Parameters section, and
+Verified On table, are preserved verbatim in git history at the commit immediately prior to this
+amendment. The v1.1.0 amendment is purely additive: it inserts the count-annotates-curated-list
+subsection under Detailed Step §1, three new Failed-Attempts rows, the property-based
+count-verification idiom in Results & Parameters, and two frontmatter/key-parameter lines. No
+v1.0.0 content was removed or rewritten.)
+````
+
 ## v1.0.0 (2026-06-07)
 
 Consolidated 10 documentation skills into one canonical covering stale-doc drift audits and broken-reference repair. Absorbed skills:

--- a/skills/stale-documentation-audit-and-broken-reference-repair.md
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.md
@@ -2,9 +2,10 @@
 name: stale-documentation-audit-and-broken-reference-repair
 description: "Use when: (1) running a doc-drift audit across a corpus — detecting stale counts, metric discrepancies, cross-doc contradictions, ecosystem-role drift; (2) removing phantom directory references from documentation when a path no longer exists; (3) fixing broken documentation references (dead links, stale headings); (4) auditing documentation examples for policy violations; (5) auditing and rewriting getting-started stubs by sourcing real commands from justfile and versions from pixi.toml; (6) fixing incorrect tier labels or version numbers in docs that have drifted from implementation; (7) managing the full lifecycle of placeholder and stub documentation — deletion under YAGNI, deferred-comment placeholders, rewriting with accurate codebase-grounded content; (8) resolving audit nitpicks for monolithic code by documenting verified design rationale; (9) resolving CONTRIBUTING.md case-clashes and circular cross-references in docs/; (10) validating anchor fragments in markdown deep-links to detect broken headings."
 category: documentation
-date: 2026-06-07
-version: "1.0.0"
+date: 2026-06-12
+version: "1.1.0"
 user-invocable: false
+verification: unverified
 history: stale-documentation-audit-and-broken-reference-repair.history
 tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
 ---
@@ -108,6 +109,40 @@ Add a self-verifying command to the doc so future readers can re-check:
 bullet (`- N agents` → `- M agents`) and the Agent Hierarchy line (`All N agents` → `All M agents`).
 
 Optionally add a drift-detection regression test (see Results & Parameters) and an ADR.
+
+##### Count-annotates-curated-list rule (Added 2026-06-12 from planning; not yet CI-confirmed)
+
+A doc count usually **annotates an adjacent human-curated enumeration** (a tree, a tier table,
+a bullet list). Its contract is "this number = the count of the list beside it," NOT
+"this number = `find … | wc -l`." When an audit flags such a count as stale, **reconcile
+number-to-LIST, not number-to-filesystem.** Bumping the number to the raw `find` count while the
+curated list is unchanged produces an internally-contradictory doc (a number promising N over a
+list of N-1) — strictly worse than the original "staleness" and a POLA-review NOGO.
+
+Three sub-rules:
+
+1. **Before changing a flagged count, locate what it annotates** (the tree/table/list immediately
+   adjacent) and count THAT. If the curated count and the `find` count differ, the gap is usually
+   an intentionally-excluded item (internal tooling, private module) — investigate the gap item's
+   role (read its `__init__` docstring; check whether it is re-exported from the public
+   `__init__`) before deciding.
+2. **Prefer scope-clarifying words over number bumps** when the number is correct for its curated
+   set: `"N documented subpackages"`, `"N SKILL.md skills"`, `"N public modules"`. This resolves
+   the audit's ambiguity complaint without changing a correct number AND without scope-creeping the
+   curated list. Do NOT enroll an internal-only item into a public-facing curated list just to
+   justify a bump — that is scope creep beyond a `[MINOR]` count-clarity fix (violates KISS/YAGNI).
+3. **Verify the PROPERTY, not the string you wrote.** A check like `grep -q "ships 20 subpackages"`
+   passes while the doc self-contradicts. Instead assert *number == enumeration count* and add a
+   negative guard that the wrong value was not introduced (see Results & Parameters for the idiom).
+
+**Concrete case (ProjectHephaestus issue #1212)** — `CLAUDE.md:28` said "(19 subpackages)" above
+a tree enumerating exactly 19 leaf packages; `find hephaestus -maxdepth 1 -type d ! -name
+__pycache__ | wc -l` = 20. The 20th dir, `hephaestus/scripts_lib/`, is internal pre-commit tooling
+(docstring: "Importable library code for repo-meta consistency check scripts"), absent from the
+tree and from `hephaestus/__init__.py` re-exports. A first plan bumped 19→20 "to match find"; a
+reviewer NOGO'd it because the number annotates the 19-entry tree, and the same contradiction sat
+in `COMPATIBILITY.md:42` ("ships 19 subpackages" over Stable(7)+Provisional(12)=19 tier tables, no
+`scripts_lib` row). Correct fix: keep 19 and clarify scope — "19 documented subpackages".
 
 #### 2. Phantom-directory references
 
@@ -267,6 +302,9 @@ gh pr merge --auto --rebase
 | Full pre-commit suite without skipping | Ran all hooks on a host with a GLIBC mismatch | `mojo-format` fails on GLIBC < 2.32 (environment, not code) | Use `SKIP=mojo-format`; only non-Mojo hooks matter for doc-only changes |
 | Deleting `docs/contributing.md` to resolve the case-clash | Removed the file entirely | Breaks inbound links from the docs index | Reduce to a redirect; keep root as canonical |
 | Per-file reviewers for citation corpus | Reviewed each entry individually | Could not see cross-document §-drift or arXiv ID-to-title swaps | Both failure modes need a cross-corpus structural audit, not per-file review |
+| Bumping a flagged count to the raw `find`/`wc` value | Treated "19 subpackages" as stale and changed it to 20 to match the filesystem | The number annotates an adjacent 19-entry curated tree; 20 contradicts the list, and the same orphan appears in a sibling doc's tier tables | A count annotates the list beside it — reconcile number-to-list, not number-to-filesystem |
+| Enrolling the gap item into the curated list to justify the bump | Considered adding a `scripts_lib` row to the tree + a tier-table row | `scripts_lib` is internal pre-commit tooling, not public API — documenting it as public surface is scope creep beyond a [MINOR] count-clarity fix | Investigate the gap item's role; internal-only items stay excluded — clarify the count's SCOPE instead |
+| Verification that greps the string just written | `grep -q "ships 20 subpackages"` as the acceptance check | Passes even though the doc now self-contradicts (number 20 over a 19-row table) | Assert the PROPERTY (number == enumeration count) and add a negative guard against the wrong value |
 
 ## Results & Parameters
 
@@ -313,9 +351,28 @@ pre-commit run --all-files
 pixi run npx markdownlint-cli2 <file>
 ```
 
+### Property-based count verification (Added 2026-06-12 from planning; not yet CI-confirmed)
+
+When a count annotates a curated enumeration, verify the *property* (number == list length), not
+the string you wrote, and add a negative guard against the raw-`find` value:
+
+```bash
+# number annotates a tree → assert the tree count equals the number in prose
+test "$(sed -n '<tree-line-range>p' DOC.md | grep -cE '^│   ├──|^│   └──')" -eq 19 \
+  && grep -q "19 documented subpackages" DOC.md
+# number annotates tier tables → count the table rows, assert equality
+prov=$(sed -n '/### Provisional/,/## Next/p' DOC.md | grep -cE '^\| `pkg\.') ; test "$prov" -eq 12
+# negative guard: the wrong (raw-find) value must NOT appear
+! grep -rn "20 subpackages" DOC.md
+# identify the gap item's role before deciding to exclude it
+cat hephaestus/<gap_dir>/__init__.py   # read docstring; check it's absent from public __init__ re-exports
+```
+
 ### Key parameters
 
 - **Counts**: round + `+` for non-deterministic (`3,000+`); exact (no `+`) for deterministic sums.
+- **Curated-list counts**: reconcile number-to-list, not number-to-filesystem; prefer scope words
+  (`"N documented subpackages"`) over bumping a number that is correct for its adjacent enumeration.
 - **Mojo version in docs**: range from `pixi.toml` (`>=0.26.1,<0.27`), never a nightly string.
 - **HTML comments** pass MD033 (comments aren't elements) — safe for deferred-section placeholders.
 - **Files most likely to hold stale refs**: `docs/index.md`, `docs/README.md`, `docs/glossary.md`,


### PR DESCRIPTION
## Summary

Amends the `stale-documentation-audit-and-broken-reference-repair` skill (v1.0.0 → v1.1.0) to encode the **count-annotates-curated-list** rule surfaced by the ProjectHephaestus issue #1212 plan-reviewer NOGO.

A doc count usually annotates an adjacent human-curated enumeration (a tree, a tier table, a bullet list). Its contract is "this number = the count of the list beside it," NOT "this number = `find … | wc -l`." When an audit flags such a count as stale, reconcile number-to-LIST, not number-to-filesystem. Bumping to the raw `find` count while the curated list is unchanged produces an internally-contradictory doc (a number promising N over a list of N-1) — worse than the original staleness and a POLA NOGO.

## Verification Level

**unverified** — planning-stage refinement from the issue #1212 NOGO. The plan was written and passed re-review, but the implementation PR is not yet merged/CI-green. Marked `verification: unverified` in frontmatter and in the history entry; the new subsections carry an inline "Added 2026-06-12 from planning; not yet CI-confirmed" note. The pre-existing "Verified Workflow" content (verified-ci) was not downgraded.

## Key Findings

- `CLAUDE.md:28` "(19 subpackages)" annotates a 19-leaf tree; `find` returns 20. The 20th dir, `hephaestus/scripts_lib/`, is internal pre-commit tooling, absent from the tree and from public `__init__` re-exports.
- A first plan bumped 19→20 "to match find"; the reviewer NOGO'd it because the number annotates the curated 19-entry tree (same contradiction in `COMPATIBILITY.md:42`'s tier tables).
- Correct fix: keep 19 and clarify scope — "19 documented subpackages" — without scope-creeping an internal-only package into a public curated list.
- Verify the PROPERTY (number == enumeration count) plus a negative guard, never grep the string just written.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` → Valid 296/296
- [x] Version bumped 1.0.0 → 1.1.0; `date:` → 2026-06-12; `verification: unverified` added
- [x] Newest-first history entry prepended with prior-version snapshot
- [x] Commit signed (GPG good signature)