### PR TITLE
feat: amend stale-documentation-audit skill (v1.1.0) — verify the new command actually runs

### DIFF
--- a/skills/stale-documentation-audit-and-broken-reference-repair.history
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.history
@@ -2,6 +2,61 @@
 
 # stale-documentation-audit-and-broken-reference-repair — History
 
+## v1.1.0 (2026-06-12)
+
+**Changed by:** ProjectHephaestus #1216 doc-consolidation planning + R0-NOGO/R1-fix review cycle
+**Verification:** unverified (planning artifacts; plans written, not executed end-to-end, no CI confirmation)
+
+MINOR bump from v1.0.0 (the v1.0.0 file on `main` had no planning subsections — the earlier
+session's planning PR was still open when this bump was authored, so BOTH that session's
+consolidation-planning learnings AND this session's command-validity learning are folded into one
+v1.1.0 bump here).
+
+### What changed
+
+- Added §10 "Doc-drift consolidation PLANNING (proposed)" — distrust issue line numbers,
+  directory-wide grep for ALL copies, classify each hit by context, source the canonical command
+  from the `justfile`, reduce-to-redirect, verify the redirect anchor resolves. (unverified)
+- Added §11 "Verify the NEW command actually RUNS before shipping a doc fix (proposed)" — a doc fix
+  that replaces/"improves" a command must verify the replacement runs on THIS repo (not that it
+  looks canonical or appears in a sibling doc); a feature name is not an environment name; an
+  un-sourced command is a STOP signal; reduce-to-redirect can mean dropping a line; includes a
+  command-validity check and a "count-must-not-increase" guard. (unverified)
+- Added 2 "When to Use" bullets (consolidation planning; command-replacement verification).
+- Added 9 Failed Attempts rows (5 consolidation-planning, 4 command-validity).
+- Added 2 ProjectHephaestus #1216 rows to Verified On (consolidation planning; R0-NOGO/R1-fix
+  command-validity), both marked **unverified**.
+- Added `consolidation-planning` and `command-validity` tags; bumped `date` to 2026-06-12.
+
+### Why
+
+ProjectHephaestus #1216 R0 plan got a NOGO because it "upgraded" a working README activation line
+(`pixi shell`, which activates the `default` env) to `pixi shell -e dev`, which ERRORS
+`unknown environment 'dev'` — `dev` is a *feature* composed into `default` (per `pixi.toml
+[environments]`), not an environment. The plan copied `-e dev` from CONTRIBUTING.md because it
+looked canonical, but that sibling line was itself pre-existing drift. The whole mandate of the
+change was to remove "subtly wrong" docs, yet it nearly shipped a NON-RUNNING command — a P7/POLA
+regression. R1 fixed it by DROPPING the activation line (the canonical-doc redirect already covers
+it). Durable lesson: verify the NEW command actually runs before shipping it; verification must
+include a command-validity check (`pixi run -e dev true 2>&1 | grep -q "unknown environment"`) and
+a count-must-not-increase guard, not just grep-for-text.
+
+The skill-level `verification: verified-ci` is unchanged — it reflects the previously-verified
+audit/repair workflows. Both new subsections are explicitly titled "(proposed)" and carry the
+end-to-end warning.
+
+### Previous version (v1.0.0) frontmatter snapshot
+
+```yaml
+name: stale-documentation-audit-and-broken-reference-repair
+category: documentation
+date: 2026-06-07
+version: "1.0.0"
+user-invocable: false
+history: stale-documentation-audit-and-broken-reference-repair.history
+tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
+```
+
 ## v1.0.0 (2026-06-07)
 
 Consolidated 10 documentation skills into one canonical covering stale-doc drift audits and broken-reference repair. Absorbed skills:

--- a/skills/stale-documentation-audit-and-broken-reference-repair.md
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.md
@@ -2,11 +2,11 @@
 name: stale-documentation-audit-and-broken-reference-repair
 description: "Use when: (1) running a doc-drift audit across a corpus — detecting stale counts, metric discrepancies, cross-doc contradictions, ecosystem-role drift; (2) removing phantom directory references from documentation when a path no longer exists; (3) fixing broken documentation references (dead links, stale headings); (4) auditing documentation examples for policy violations; (5) auditing and rewriting getting-started stubs by sourcing real commands from justfile and versions from pixi.toml; (6) fixing incorrect tier labels or version numbers in docs that have drifted from implementation; (7) managing the full lifecycle of placeholder and stub documentation — deletion under YAGNI, deferred-comment placeholders, rewriting with accurate codebase-grounded content; (8) resolving audit nitpicks for monolithic code by documenting verified design rationale; (9) resolving CONTRIBUTING.md case-clashes and circular cross-references in docs/; (10) validating anchor fragments in markdown deep-links to detect broken headings."
 category: documentation
-date: 2026-06-07
-version: "1.0.0"
+date: 2026-06-12
+version: "1.1.0"
 user-invocable: false
 history: stale-documentation-audit-and-broken-reference-repair.history
-tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
+tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, consolidation-planning, command-validity, merged]
 ---
 
 # Stale Documentation Audit and Broken Reference Repair
@@ -34,6 +34,8 @@ tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, 
 - An audit nitpick questions a monolithic file's organization and needs a documented rationale
 - Both `CONTRIBUTING.md` and `docs/contributing.md` exist with a circular cross-reference
 - README/docs deep-link to specific installation headings and you need CI to catch broken anchors
+- **PLANNING** a doc-drift consolidation: two+ onboarding/setup blocks have drifted from a canonical recipe and you must write an implementation plan before touching files
+- **PLANNING** a doc fix that REPLACES or "improves" a command — you must verify the new command actually runs on this repo before shipping it (not just that it looks canonical)
 
 ## Verified Workflow
 
@@ -235,6 +237,118 @@ Scan only fenced shell code blocks (never prose, to avoid matching prohibition t
 `build/`). Anchor command rules to line starts and exclude `#`-commented lines (intentional
 "BLOCKED" demonstrations are not violations). Add a regression test per new pattern.
 
+#### 10. Doc-drift consolidation PLANNING (proposed)
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+Use when an issue asks you to *consolidate* two or more drifted onboarding/setup blocks onto a
+single canonical recipe and you must produce an **implementation plan** before editing. The core
+durable lesson: **the issue's cited file:line ranges are frequently STALE and the duplicated
+content frequently appears in MORE places than the issue cites — always re-grep directory-wide
+and verify every line number on disk before planning any edit.**
+
+Proposed planning steps:
+
+1. **Distrust the issue's line numbers.** Do not plan against `file.md:34-45` from the issue body.
+   `grep -n` for the actual heading or recipe and confirm where it really lives.
+
+   ```bash
+   # Issue claimed canonical block at CONTRIBUTING.md:34-45; reality:
+   grep -n "just bootstrap\|^## Development Setup" CONTRIBUTING.md   # → 53-65, NOT 34-45
+   ```
+
+2. **Directory-wide grep, never single-file, to find ALL copies.** The issue usually cites one
+   drifted block; there are often more.
+
+   ```bash
+   grep -rn "pre-commit install\|pixi install" README.md CONTRIBUTING.md docs/
+   # Cited block: README.md:54-61. Grep ALSO found README:130-138
+   # ("Setup Development Environment") with the SAME drift — patching only the
+   # cited block would have left the drift alive.
+   ```
+
+3. **Classify each grep hit by surrounding context** before deciding to edit. Incidental keyword
+   matches are not drift. (e.g. README:50/252/515 matched `pixi install` but were an extras note,
+   a dependency-add example, and a branch-protection example — correctly left untouched.)
+   ProjectHephaestus #1216 R0/R1 is a second confirming data point for all three lessons above.
+
+4. **Source ground truth for the canonical command from the authoritative file — never invent it.**
+
+   ```bash
+   sed -n '20,24p' justfile   # bootstrap recipe: pixi install / pixi run dev-install / pixi run pre-commit install
+   ```
+
+   The README was "subtly wrong" precisely because it predated `dev-install` and the
+   `pixi run pre-commit` wrapper — read the recipe, do not reconstruct it from memory.
+
+5. **Reduce-to-redirect, do not delete.** Keep the section heading + anchor and replace the command
+   block with a pointer to the canonical recipe. This preserves inbound anchors and reading flow.
+   Reducing-to-redirect can also mean **dropping a stray command line entirely** (see §11 step 4) —
+   fewer commands means less drift surface (KISS).
+
+6. **Verify the redirect target anchor resolves.** When a redirect points at
+   `CONTRIBUTING.md#development-setup`, add a plan step that confirms the GitHub-rendered slug exists.
+
+   ```bash
+   grep -n "^## Development Setup" CONTRIBUTING.md   # confirms the #development-setup anchor
+   ```
+
+7. **Gate:** docs-only change → markdownlint is the only gate (MD032 blanks-around-lists is the
+   usual offender); no unit tests.
+
+#### 11. Verify the NEW command actually RUNS before shipping a doc fix (proposed)
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+Use when a doc-consolidation/cleanup plan **replaces one command with another** or "improves" a
+command. The core durable lesson: **a replacement command must be verified to actually run on THIS
+repo — not merely that it looks canonical or appears in a sibling doc. Shipping a non-running
+command is a P7/POLA regression, even when the change's whole mandate was to remove "subtly wrong"
+docs.** The fix that removes drift must not introduce a new, worse instance of drift.
+
+Concrete evidence — ProjectHephaestus #1216 (R0 plan got NOGO; R1 fixed it):
+
+- The R0 plan "upgraded" a README activation line from bare `pixi shell` (which WORKS — it
+  activates the `default` env) to `pixi shell -e dev` (which ERRORS: `unknown environment 'dev'`).
+  It did this only because `CONTRIBUTING.md` used `-e dev`, so it *looked* canonical — but that
+  CONTRIBUTING line is ITSELF pre-existing drift.
+- **A feature name is not an environment name.** `pixi.toml` defines the environments under
+  `[environments]` (here only `default = { features = ["shared", "dev"], ... }` and `lint`).
+  `dev` is a *feature* composed into `default`, NOT an environment — so `pixi run -e dev` /
+  `pixi shell -e dev` fail. Verify against the `[environments]` table, never the `[feature.*]` tables.
+- **An "un-sourced / uncertain" command is a STOP signal.** The R0 plan half-noticed the doubt
+  ("the one command not sourced from the bootstrap recipe") and resolved it the WRONG way — it
+  kept the unverified command. When you flag a command as uncertain: verify it runs or drop it,
+  never ship it on a hunch.
+- **Don't propagate a sibling doc's error.** When consolidating doc A to point at doc B, doc B may
+  itself contain drift (here `CONTRIBUTING.md` `-e dev`). Copying B's commands verbatim imports
+  B's bugs. Verify B's commands too, or redirect by anchor reference rather than restating commands.
+- **R1 fix = DROP the activation line, don't restate a command.** The redirect to the canonical doc
+  already covers activation; fewer commands = less drift surface (KISS). Reduce-to-redirect can mean
+  dropping a line, not only replacing it.
+
+Verification must include a COMMAND-VALIDITY check, not just a grep-for-text:
+
+```bash
+# Prove the environment does NOT exist (the replacement command would fail):
+pixi run -e dev true 2>&1 | grep -q "unknown environment" && echo "DROP: 'dev' is a feature, not an env"
+
+# Confirm the recipe / anchor you redirect to actually exists:
+grep -nE "^bootstrap:" justfile                       # the recipe you point at exists
+grep -n "^## Development Setup" CONTRIBUTING.md        # the redirect anchor resolves
+
+# Count-must-not-INCREASE guard: prove you did not add a new instance of a known-broken command.
+# N = the pre-existing number of "-e dev" hits; it must not go UP after your edit.
+grep -rn "\-e dev" README.md CONTRIBUTING.md | wc -l  # must equal the pre-edit N, never N+1
+```
+
+Ground-truth check for the `[environments]` vs `[feature.*]` distinction:
+
+```bash
+sed -n '/^\[environments\]/,/^\[/p' pixi.toml   # the ONLY valid -e values live here
+grep -nE "^\[feature\." pixi.toml                # feature names are NOT environment names
+```
+
 ### Validate, Commit, and PR
 
 ```bash
@@ -267,6 +381,15 @@ gh pr merge --auto --rebase
 | Full pre-commit suite without skipping | Ran all hooks on a host with a GLIBC mismatch | `mojo-format` fails on GLIBC < 2.32 (environment, not code) | Use `SKIP=mojo-format`; only non-Mojo hooks matter for doc-only changes |
 | Deleting `docs/contributing.md` to resolve the case-clash | Removed the file entirely | Breaks inbound links from the docs index | Reduce to a redirect; keep root as canonical |
 | Per-file reviewers for citation corpus | Reviewed each entry individually | Could not see cross-document §-drift or arXiv ID-to-title swaps | Both failure modes need a cross-corpus structural audit, not per-file review |
+| Planning edits against the issue's cited line numbers | Took `CONTRIBUTING.md:34-45` from the issue body as the canonical block | Lines 34-45 were the "Code Contributions" list; the real `just bootstrap` block was at 53-65 | Never trust issue line numbers — grep for the actual heading/recipe and verify on disk before planning (ProjectHephaestus #1216) |
+| Single-file grep to find the drifted copies | Grepped only the README block the issue cited (`README.md:54-61`) | A SECOND onboarding copy at README:130-138 had the same drift; patching only the cited block leaves the drift alive | Directory-wide `grep -rn` across README/CONTRIBUTING/docs to find every copy |
+| Treating every keyword hit as drift to edit | Considered editing all `pixi install` matches | README:50/252/515 matched but were an extras note, a dependency-add example, a branch-protection example — different contexts | Classify each grep hit by surrounding context before deciding to edit |
+| Reconstructing the canonical command from memory | Was about to write the `pixi install`/`pre-commit` steps from recollection | README was subtly wrong because it predated `dev-install` and the `pixi run pre-commit` wrapper | Source the recipe from the `justfile` (`sed -n '20,24p' justfile`), never invent it |
+| Adding a cross-doc redirect without checking the target anchor | Planned to point READMEs at `CONTRIBUTING.md#development-setup` | A redirect to a non-existent anchor silently 404s on GitHub render | Add a plan step `grep -n "^## Development Setup" CONTRIBUTING.md` to confirm the slug resolves |
+| "Upgrading" a working command to a canonical-looking one without running it | R0 plan replaced bare `pixi shell` (works — activates `default`) with `pixi shell -e dev` because `CONTRIBUTING.md` used `-e dev` | `dev` is a FEATURE composed into `default`, not an environment — `pixi shell -e dev` ERRORS `unknown environment 'dev'`; the doc fix shipped a non-running command (P7/POLA regression). NOGO at R0 (ProjectHephaestus #1216) | Verify the NEW command actually runs on THIS repo (`pixi run -e dev true` → `unknown environment`); check `pixi.toml [environments]`, not `[feature.*]` — a feature name is not an env name |
+| Resolving an "un-sourced/uncertain" command by keeping it | R0 plan flagged the activation line as "the one command not sourced from the bootstrap recipe" yet shipped it unverified | An un-sourced command is a STOP signal, not a footnote; shipping it on a hunch caused the NOGO | When you flag a command as uncertain: verify it runs or DROP it — never ship on a hunch |
+| Copying a sibling doc's command verbatim during consolidation | R0 plan trusted `CONTRIBUTING.md`'s `-e dev` because it was the "canonical" doc to redirect to | The sibling doc (`CONTRIBUTING.md`) itself contained the pre-existing drift; copying it imported the bug | Doc B may have drift too — verify B's commands, or redirect by anchor reference instead of restating commands |
+| Restating an activation command in the consolidated doc | R0 plan replaced one activation command with another | R1 fix DROPPED the line entirely — the canonical-doc redirect already covers activation; fewer commands = less drift surface (KISS) | Reduce-to-redirect can mean dropping a line, not only replacing it |
 
 ## Results & Parameters
 
@@ -331,4 +454,6 @@ pixi run npx markdownlint-cli2 <file>
 | ProjectOdyssey | Issues #3344, #3365; PR #3320; PR #4847 | Workflow README audit, agent-count fix, post-migration README sync |
 | ProjectOdyssey | Issues #3142/#3308, #3304/#3913, #3305/#3917, #3918/#4830, #3141/#3303, #3914/#4828, #3915/#4829 | Stub deletion, installation/quickstart rewrite, IDE-setup extend, getting-started audit, anchor validator |
 | ProjectHephaestus | Issue #792 (PR #984); Issue #630 (PR #667) | Monolith-rationale ADR; CONTRIBUTING case-clash redirect |
+| ProjectHephaestus | Issue #1216 (planning artifact, **unverified**) | Consolidate two drifted README onboarding blocks onto canonical `just bootstrap` — PLANNING only; plan written but not executed end-to-end, no CI confirmation. Source of the §10 doc-drift consolidation planning workflow |
+| ProjectHephaestus | Issue #1216 — R0 NOGO → R1 fix (planning artifact, **unverified**) | Command-validity finding (§11): R0 plan replaced working `pixi shell` with non-running `pixi shell -e dev` (`dev` is a feature, not an env); R1 dropped the line. Came from an adversarial plan review, not CI |
 | mvillmow/Random | Predictive-Coding-in-Mojo Phase 0 | Cross-doc citation drift: 8 stale §-refs, 2 arXiv ID swaps caught |


### PR DESCRIPTION
## Summary

Amends `stale-documentation-audit-and-broken-reference-repair` from **v1.0.0 → v1.1.0**.

Folds **two** doc-drift planning learnings into a single MINOR bump:

- **§10 (proposed)** — doc-drift consolidation PLANNING discipline (from a prior session): distrust the issue's cited line numbers, directory-wide grep to find ALL drifted copies, classify each hit by context, source the canonical command from the `justfile`, reduce-to-redirect, verify the redirect anchor resolves.
- **§11 (proposed) — the headline new learning** — **a doc fix that REPLACES or "improves" a command must verify the NEW command actually runs on THIS repo — not merely that it looks canonical or appears in a sibling doc. Shipping a non-running command is a P7/POLA regression, even when the change's whole mandate was to remove "subtly wrong" docs.**

## Verification Level

**unverified** — both new subsections are planning artifacts (plans written, not executed end-to-end; no CI confirmation). Each is titled "(proposed)" and carries the warning "This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms." The command-validity finding came from an **adversarial plan review (R0 NOGO → R1 fix)**, not CI. The skill-level `verification: verified-ci` is unchanged — it reflects the previously-verified audit/repair workflows, not the new planning subsections.

## Key Findings (ProjectHephaestus #1216, R0 NOGO → R1 fix)

- R0 plan "upgraded" a working `pixi shell` (activates the `default` env) to `pixi shell -e dev`, which **ERRORS** `unknown environment 'dev'`. It copied `-e dev` from CONTRIBUTING.md because it looked canonical — but that sibling line is itself pre-existing drift.
- **A feature name is not an environment name.** `pixi.toml [environments]` defines only `default` (which composes the `dev` *feature*) and `lint`; there is no `dev` env. Verify against `[environments]`, never `[feature.*]`.
- **An un-sourced / uncertain command is a STOP signal** — verify it runs or drop it; never ship on a hunch.
- **Don't propagate a sibling doc's error** when consolidating doc A → doc B; verify B's commands or redirect by anchor.
- **R1 fix = DROP the line**, not restate a command — reduce-to-redirect can mean dropping (KISS).
- Verification must include a **command-validity check** (`pixi run -e dev true 2>&1 | grep -q "unknown environment"`) and a **count-must-not-increase** guard, not just grep-for-text.

## Reconciliation note

The prior session's planning PR (#2345, `skill/doc-onboarding-drift-planning`) was still **open/unmerged** and `main` was still at **v1.0.0** with no planning subsections. Per the /learn amendment rules, this PR bumps 1.0.0 → 1.1.0 and folds **both** the prior session's §10 learnings and this session's §11 learning into one v1.1.0 bump.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (296/296 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with `command-validity` / `consolidation-planning` keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>