### PR TITLE
feat: amend stale-documentation-audit skill (v1.1.0)

### DIFF
--- a/skills/stale-documentation-audit-and-broken-reference-repair.history
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.history
@@ -2,6 +2,62 @@
 
 # stale-documentation-audit-and-broken-reference-repair — History
 
+## v1.1.0 (2026-06-12)
+
+**Changed by:** ProjectHephaestus #1212 / PR #1244 · **Verification:** verified-precommit
+
+### What changed
+
+Refinement to the long-standing "count from code, never from another doc" rule for the case
+where a count **annotates an adjacent human-curated enumeration** (a repo-structure tree, a tier
+table, a hand-picked subset). Edits to the `.md` (all surgical, exact-string):
+
+- Frontmatter: `version` 1.0.0 → 1.1.0; `date` 2026-06-07 → 2026-06-12.
+- Added a "When to Use" trigger: "a stale count annotates an adjacent CURATED enumeration —
+  reconcile number-to-list (clarify scope/unit), not number-to-`find`".
+- Extended the **Universal rules** block with a "count annotating a curated list" refinement:
+  the list is authoritative; clarify the count's scope/unit so number == list rather than bumping
+  the number to the raw `find` count; never trust the count stated in the audit issue body.
+- Added two Failed Attempts rows: (a) bumping `19 subpackages` → `20` to match `find`
+  contradicted the 19-entry tree below it; (b) trusting the issue's stated `21 subpackages`
+  (real = 20 dirs / 19 documented).
+- Added a "Curated-list count verification" subsection to Results & Parameters with hardened
+  one-liners (assert number == enumeration count; negative-guard the bumped value) and the
+  #1212/#1244 reference.
+- Added a "Verified On" row for ProjectHephaestus #1212 / PR #1244.
+
+### Why
+
+In #1212, `CLAUDE.md:28` said "19 subpackages" while `hephaestus/` has 20 real dirs — but the
+repo-structure tree directly below enumerates exactly 19 leaf entries; the 20th dir
+(`hephaestus/scripts_lib/`) is internal repo-meta pre-commit tooling, absent from
+`hephaestus/__init__.py` re-exports and every curated list. Bumping the number to 20 to match
+`find` would have contradicted the list printed below it. The correct fix is to clarify the
+*scope* ("19 documented subpackages") so number == list. The same applied to
+`COMPATIBILITY.md:42` (7 stable + 12 provisional = 19 rows) and to `CLAUDE.md:49`'s "23 entries"
+(stated the unit: "23 SKILL.md skills"). The audit issue itself wrongly claimed "21 subpackages"
+— a reminder that issue-filed counts are also stale.
+
+### Snapshot of pre-amendment .md (frontmatter + key blocks, v1.0.0)
+
+```yaml
+name: stale-documentation-audit-and-broken-reference-repair
+category: documentation
+date: 2026-06-07
+version: "1.0.0"
+user-invocable: false
+history: stale-documentation-audit-and-broken-reference-repair.history
+```
+
+Pre-amendment **Universal rules** block (now extended):
+
+> **Universal rules**: count from code (never from other docs); use `Edit` with exact strings,
+> not whole-section rewrites; use `replace_all: true` when a stale phrase repeats; after fixing
+> the primary file, re-grep the whole corpus — stale copies survive in `docs/`,
+> `references/notes.md`, `docs/analysis-prompt.md`. Always Read a file before Editing it.
+
+The full v1.0.0 snapshot is preserved in the consolidation entry below.
+
 ## v1.0.0 (2026-06-07)
 
 Consolidated 10 documentation skills into one canonical covering stale-doc drift audits and broken-reference repair. Absorbed skills:

--- a/skills/stale-documentation-audit-and-broken-reference-repair.md
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.md
@@ -2,8 +2,8 @@
 name: stale-documentation-audit-and-broken-reference-repair
 description: "Use when: (1) running a doc-drift audit across a corpus — detecting stale counts, metric discrepancies, cross-doc contradictions, ecosystem-role drift; (2) removing phantom directory references from documentation when a path no longer exists; (3) fixing broken documentation references (dead links, stale headings); (4) auditing documentation examples for policy violations; (5) auditing and rewriting getting-started stubs by sourcing real commands from justfile and versions from pixi.toml; (6) fixing incorrect tier labels or version numbers in docs that have drifted from implementation; (7) managing the full lifecycle of placeholder and stub documentation — deletion under YAGNI, deferred-comment placeholders, rewriting with accurate codebase-grounded content; (8) resolving audit nitpicks for monolithic code by documenting verified design rationale; (9) resolving CONTRIBUTING.md case-clashes and circular cross-references in docs/; (10) validating anchor fragments in markdown deep-links to detect broken headings."
 category: documentation
-date: 2026-06-07
-version: "1.0.0"
+date: 2026-06-12
+version: "1.1.0"
 user-invocable: false
 history: stale-documentation-audit-and-broken-reference-repair.history
 tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, anchor-validation, tier-labels, doc-audit, doc-sync, merged]
@@ -24,6 +24,8 @@ tags: [doc-drift, stale-doc, broken-references, phantom-dir, placeholder, stub, 
 
 - A "Future Improvements" / "Future Work" section lists a feature that already shipped
 - Docs state a metric (test count, coverage %, file/agent count) that disagrees with the codebase
+- A stale count annotates an adjacent CURATED enumeration (tree listing, tier table) — reconcile
+  number-to-list (clarify scope/unit), not number-to-`find`
 - `CLAUDE.md` contradicts `pyproject.toml`/`CONTRIBUTING.md` on thresholds or policy
 - External architecture docs describe a project's ecosystem role inaccurately
 - A directory/file was removed but docs still reference the path (phantom dir / dead link)
@@ -80,6 +82,17 @@ pre-commit run --all-files            # or: SKIP=mojo-format pixi run pre-commit
 whole-section rewrites; use `replace_all: true` when a stale phrase repeats; after fixing the
 primary file, re-grep the whole corpus — stale copies survive in `docs/`, `references/notes.md`,
 `docs/analysis-prompt.md`. Always Read a file before Editing it.
+
+**Refinement — count annotating a curated list**: when the count annotates a CURATED
+enumeration (a repo-structure tree, a tier table, a hand-picked subset), the *list* is the
+authoritative source, not the raw `find`/`ls` filesystem count. Reconcile the number to the
+list by clarifying the count's scope/unit (e.g. `19 subpackages` → `19 **documented**
+subpackages`; `23 entries` → `23 **SKILL.md skills**`) so that number == list. Do NOT bump the
+number up to the raw `find` count — that creates a self-contradiction with the enumeration
+printed directly below the line. The filesystem may legitimately hold extra entries the doc
+intentionally excludes (internal repo-meta tooling, partials dirs with no marker file). Also
+never trust the count stated in the audit *issue body* — issue-filed counts are themselves often
+stale; always re-derive against the actual file.
 
 ### Detailed Steps
 
@@ -267,6 +280,8 @@ gh pr merge --auto --rebase
 | Full pre-commit suite without skipping | Ran all hooks on a host with a GLIBC mismatch | `mojo-format` fails on GLIBC < 2.32 (environment, not code) | Use `SKIP=mojo-format`; only non-Mojo hooks matter for doc-only changes |
 | Deleting `docs/contributing.md` to resolve the case-clash | Removed the file entirely | Breaks inbound links from the docs index | Reduce to a redirect; keep root as canonical |
 | Per-file reviewers for citation corpus | Reviewed each entry individually | Could not see cross-document §-drift or arXiv ID-to-title swaps | Both failure modes need a cross-corpus structural audit, not per-file review |
+| Bumped `19 subpackages` → `20` to match `find` | Raised the number to the raw filesystem dir count | Contradicted the 19-entry tree printed directly below the line (the 20th dir is internal repo-meta tooling, absent from every curated list) | Reconcile number to the curated list it annotates, not to the raw filesystem count; clarify scope instead (`19 documented subpackages`) |
+| Trusted the audit issue's stated count (`21 subpackages`) | Took the count from the issue body at face value | Issue-filed counts are themselves stale (real = 20 dirs / 19 documented) | Always re-derive against the actual file; never trust the count in the issue body |
 
 ## Results & Parameters
 
@@ -322,6 +337,26 @@ pixi run npx markdownlint-cli2 <file>
   `references/notes.md`, `docs/analysis-prompt.md`.
 - **Policy-audit exclusions**: `docs/arxiv/`, `tests/claude-code/`, `.pixi/`, `build/`, `node_modules/`.
 
+### Curated-list count verification (assert number == enumeration)
+
+Harden acceptance checks to assert the *number equals the enumeration count* (count the list,
+not the string you just wrote), and negative-guard against reintroducing the bumped value:
+
+```bash
+# Tree leaf entries (├── / └──) directly under the "documented subpackages" line == 19
+sed -n '29,47p' CLAUDE.md | grep -cE '^│   ├──|^│   └──'        # must equal 19
+# Provisional tier rows in COMPATIBILITY.md == 12
+grep -cE '^\| `hephaestus\.' COMPATIBILITY.md                   # must equal 12 (provisional)
+# Negative guard: the wrongly-bumped value must NOT appear
+! grep -rn "20 subpackages" CLAUDE.md COMPATIBILITY.md
+```
+
+For a skill/marker corpus, count the canonical marker file (`SKILL.md`), not a naive `*.md`
+glob — partials/notes/history files over-count (see `skill-corpus-count-excludes-notes-and-history-files`).
+Stating the *unit* (`23 SKILL.md skills`) resolves the ambiguity without changing the number.
+
+Reference: ProjectHephaestus #1212 / PR #1244 (signed commit `b8719488`).
+
 ## Verified On
 
 | Project | Context | Details |
@@ -331,4 +366,5 @@ pixi run npx markdownlint-cli2 <file>
 | ProjectOdyssey | Issues #3344, #3365; PR #3320; PR #4847 | Workflow README audit, agent-count fix, post-migration README sync |
 | ProjectOdyssey | Issues #3142/#3308, #3304/#3913, #3305/#3917, #3918/#4830, #3141/#3303, #3914/#4828, #3915/#4829 | Stub deletion, installation/quickstart rewrite, IDE-setup extend, getting-started audit, anchor validator |
 | ProjectHephaestus | Issue #792 (PR #984); Issue #630 (PR #667) | Monolith-rationale ADR; CONTRIBUTING case-clash redirect |
+| ProjectHephaestus | Issue #1212 (PR #1244) | Count-vs-curated-list reconciliation: clarified scope/unit (`19 documented subpackages`, `23 SKILL.md skills`) instead of bumping number to raw `find` count (verified-precommit) |
 | mvillmow/Random | Predictive-Coding-in-Mojo Phase 0 | Cross-doc citation drift: 8 stale §-refs, 2 arXiv ID swaps caught |


### PR DESCRIPTION
## Summary

Amends the existing `stale-documentation-audit-and-broken-reference-repair` skill (v1.0.0 → v1.1.0) with a refinement to the "count from code, never from another doc" rule.

**New rule:** when a count *annotates an adjacent human-curated enumeration* (a repo-structure tree, a tier table, a hand-picked subset), the *list* — not the raw `find`/`ls` filesystem count — is authoritative. Reconcile number-to-list by clarifying the count's **scope/unit** (e.g. `19 subpackages` → `19 documented subpackages`; `23 entries` → `23 SKILL.md skills`) so that number == list. Bumping the number to the raw `find` count creates a self-contradiction with the enumeration printed directly below the line. Also: never trust the count stated in the audit issue body — issue-filed counts are themselves often stale.

Captured from ProjectHephaestus #1212 / PR #1244 (signed commit `b8719488`).

### Changes
- Frontmatter `version` 1.0.0 → 1.1.0, `date` → 2026-06-12 (`history` field already present).
- New "When to Use" trigger for the curated-enumeration case.
- Extended **Universal rules** with the count-annotating-a-curated-list refinement.
- Two new **Failed Attempts** rows (bumped `19`→`20` to match `find`; trusted the issue's stated `21`).
- New **Results & Parameters** subsection with hardened verification one-liners (assert number == enumeration; negative-guard the bumped value).
- New **Verified On** row for ProjectHephaestus #1212 / PR #1244.
- Prepended a v1.1.0 `.history` entry (what/why + pre-amendment snapshot).

## Verification Level

**verified-precommit** — `python3 scripts/validate_plugins.py` passes (296/296); `markdownlint-cli2` reports 0 errors on both the `.md` and `.history`. CI on this PR is pending at time of writing (not yet verified-ci).

## Key Findings

**What worked:** clarifying the count's *scope/unit* keeps the number unchanged and makes it agree with the curated list it annotates.

**What failed:** (a) bumping `19 subpackages` → `20` to match `find` contradicted the 19-entry tree below the line — the 20th dir (`hephaestus/scripts_lib/`) is internal repo-meta tooling excluded from every curated list; (b) trusting the audit issue's stated `21 subpackages` (real = 20 dirs / 19 documented) — issue-filed counts are themselves stale.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` passes (296/296)
- [x] All 5 required sections + Failed Attempts pipe table intact
- [x] `markdownlint-cli2` clean on `.md` and `.history`
- [x] Commit signed (GPG "Good signature"), only `skills/` files touched, no `.claude-plugin/` files