### PR TITLE
feat: amend git-worktree-sys-path-precedence-issue skill (v1.1.0)

### DIFF
--- a/skills/git-worktree-sys-path-precedence-issue.history
+++ b/skills/git-worktree-sys-path-precedence-issue.history
@@ -1,0 +1,62 @@
+<!-- markdownlint-disable MD024 -->
+# git-worktree-sys-path-precedence-issue — History
+
+## v1.1.0 (2026-06-12)
+
+**Changed by:** ProjectHephaestus Issue #1217 — wiring an inert `--json` flag into `hephaestus-check-repo-analyze-skills` via `emit_json_status()`
+**Verification:** verified-local
+
+### What changed
+
+- Added a "console-script verification trap" trigger (5) to the frontmatter `description` and a
+  new "When to Use" bullet: verifying a console-script fix from inside a worktree where the
+  installed entry point emits EMPTY/unpatched output and tempts the wrong conclusion
+  "the fix does not work."
+- Added a `### Console-Script Verification Probe (which tree resolved?)` subsection to the
+  Verified Workflow with the reusable `module.__file__` + `inspect.getsource(main)` diagnostic
+  snippet, and the guidance that the authoritative LOCAL verification is `python -m <module>` or
+  a direct `from <module> import main; main([...])` — NOT the installed entry-point script — and
+  that `pixi run dev-install` re-points `which <console-script>` but does NOT fix the
+  script-execution `sys.path[0]` shadowing.
+- Added two Failed Attempts rows: (a) trusting an empty console-script run as proof the fix is
+  broken (Issue #1217); (b) running `pixi run dev-install` to fix the shadowing.
+- Added a Verified On row for ProjectHephaestus Issue #1217 (2026-06-12, verified-local; CI for
+  PR #1253 pending).
+- Bumped version 1.0.0 → 1.1.0 (minor — new findings + two new failed-attempt rows + new
+  workflow subsection; no breaking changes). Skill-level `verification` stays `verified-local`.
+
+### Why
+
+The original skill framed the issue purely as "subprocess-spawned console scripts load stale code
+from the main repo." Issue #1217 surfaced the same root cause in a distinct, high-cost context:
+the VERIFICATION step. Running the installed entry point inside the worktree produced empty,
+unpatched output and nearly led to a false "the fix doesn't work" conclusion. Root-causing live
+via `module.__file__` (resolved to the OUTER repo tree) and `inspect.getsource(m.main)`
+(`"args.json" in src` was False) proved the editable install was shadowing the worktree code on
+the script-execution path, while `python -m` and direct import loaded the patched module. This
+amendment captures the reusable diagnostic probe and the rule: never trust an empty console-script
+run inside a worktree as evidence a fix failed; re-verify via `python -m` and check
+`module.__file__`.
+
+### Previous version (v1.0.0) snapshot of the changed regions
+
+#### Frontmatter (description / date / version)
+
+````markdown
+description: "Document the sys.path ordering issue in workspace-based git worktrees where the main project directory comes before the worktree in Python's module search path, causing subprocess-spawned entry points (console scripts) to import modules from the main repo instead of the worktree, even though the editable install (.pth file) correctly points to the worktree. Code changes work in direct Python imports but fail in subprocess invocations. Use when: (1) running console scripts via subprocess that load stale code from the main repo, (2) debugging entry points that work in direct Python imports but fail via pixi run or subprocess.run(), (3) code changes in a git worktree work when imported directly but fail when invoked as a console script, (4) sys.path shows main project directory before worktree path."
+category: tooling
+date: 2026-06-06
+version: "1.0.0"
+````
+
+#### When to Use (final bullet, pre-amendment)
+
+````markdown
+- Building automation tools or test suites that spawn console scripts as subprocess commands from within a git worktree
+````
+
+#### Failed Attempts (pre-amendment — last row only; two rows appended after it)
+
+````markdown
+| Checking only the main .pth file | Examined `.pth` file in main repo's site-packages | Missed that the worktree was using the SAME `.pixi/envs/default` and the .pth file there was also pointing to the worktree (correctly) | Both the main repo and worktree share `.pixi/envs/default`; the .pth file is correct in both cases. The issue is NOT the .pth target but the sys.path ordering. |
+````

--- a/skills/git-worktree-sys-path-precedence-issue.md
+++ b/skills/git-worktree-sys-path-precedence-issue.md
@@ -1,9 +1,9 @@
 ---
 name: git-worktree-sys-path-precedence-issue
-description: "Document the sys.path ordering issue in workspace-based git worktrees where the main project directory comes before the worktree in Python's module search path, causing subprocess-spawned entry points (console scripts) to import modules from the main repo instead of the worktree, even though the editable install (.pth file) correctly points to the worktree. Code changes work in direct Python imports but fail in subprocess invocations. Use when: (1) running console scripts via subprocess that load stale code from the main repo, (2) debugging entry points that work in direct Python imports but fail via pixi run or subprocess.run(), (3) code changes in a git worktree work when imported directly but fail when invoked as a console script, (4) sys.path shows main project directory before worktree path."
+description: "Document the sys.path ordering issue in workspace-based git worktrees where the main project directory comes before the worktree in Python's module search path, causing subprocess-spawned entry points (console scripts) to import modules from the main repo instead of the worktree, even though the editable install (.pth file) correctly points to the worktree. Code changes work in direct Python imports but fail in subprocess invocations. Use when: (1) running console scripts via subprocess that load stale code from the main repo, (2) debugging entry points that work in direct Python imports but fail via pixi run or subprocess.run(), (3) code changes in a git worktree work when imported directly but fail when invoked as a console script, (4) sys.path shows main project directory before worktree path, (5) VERIFYING a console-script fix from inside a worktree where the installed entry point emits empty/unpatched output and you might wrongly conclude 'the fix does not work' — re-verify via python -m <module> and probe module.__file__ / inspect.getsource(main)."
 category: tooling
-date: 2026-06-06
-version: "1.0.0"
+date: 2026-06-12
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
 tags:
@@ -38,6 +38,7 @@ tags:
 - Workspace-based git monorepos using pixi and editable installs (`pip install -e .`) where worktrees share `.pixi/envs/default` with the parent checkout
 - Debugging why console scripts report old function behavior, old version strings, or missing recent code additions despite the worktree containing the updated files
 - Building automation tools or test suites that spawn console scripts as subprocess commands from within a git worktree
+- **Verifying a console-script fix locally from inside a worktree** — when running the installed entry point (e.g. `hephaestus-check-repo-analyze-skills --json`) emits EMPTY or UNPATCHED output and tempts you to conclude "the fix does not work." The script-execution path resolves `hephaestus` from the OUTER repo source tree (which lacks your fix); `python -m <module>` and direct `from <module> import main` both load the patched worktree code. Re-verify there before believing the fix failed.
 
 Do NOT use this skill when:
 
@@ -75,6 +76,30 @@ pixi run hephaestus-agent-stage --version
 export PYTHONPATH="/path/to/worktree:$PYTHONPATH"
 pixi run hephaestus-agent-stage --version
 ```
+
+### Console-Script Verification Probe (which tree resolved?)
+
+When verifying a fix from a worktree, the DEFINITIVE check is which file actually
+loaded — not the console-script's output. Probe `module.__file__` and the source:
+
+```python
+# Run from inside the worktree
+from hephaestus.validation import repo_analyze_skills as m
+import inspect
+print("MODFILE:", m.__file__)                       # reveals which tree resolved
+print("HAS_FIX:", "args.json" in inspect.getsource(m.main))
+# If MODFILE points OUTSIDE the worktree (e.g. /home/.../ProjectHephaestus/hephaestus/...
+# instead of /home/.../build/.worktrees/issue-NNNN/hephaestus/...), the editable
+# install is shadowing your code and HAS_FIX will be False.
+```
+
+Authoritative LOCAL verification of a console-script fix inside a worktree is
+`python -m <module>` OR `python -c "from <module> import main; main([...])"` — NOT
+the installed entry-point script. Note: `pixi run dev-install` re-points
+`which <console-script>` to the worktree's bin but does NOT fix the
+script-execution `sys.path[0]` shadowing, because the shared pixi env's `.pth`
+still references the outer source tree. CI checks the branch out into a clean
+standalone tree, so the entry point resolves correctly there.
 
 ### Detailed Steps
 
@@ -195,6 +220,8 @@ pixi run hephaestus-agent-stage --version
 | Running console script directly without pixi | Executed `/path/to/.pixi/envs/default/bin/hephaestus-agent-stage` as a raw subprocess | Still loaded from main repo; the issue is that the Python interpreter inside that executable was started with a sys.path that included the main repo before the worktree | The problem is not the shell invocation; it's the Python process's environment and sys.path ordering. Pixi run context preserves the environment better. |
 | Setting PYTHONPATH in shell before invoking subprocess | Exported `PYTHONPATH=/path/to/worktree:$PYTHONPATH` in bash, then called subprocess | subprocess.run() did NOT inherit the shell's exported PYTHONPATH; only env passed explicitly to subprocess gets it | When using subprocess.run() in Python, env vars are NOT inherited from the parent shell unless explicitly passed via the `env=` parameter; `os.environ.copy()` is required. |
 | Checking only the main .pth file | Examined `.pth` file in main repo's site-packages | Missed that the worktree was using the SAME `.pixi/envs/default` and the .pth file there was also pointing to the worktree (correctly) | Both the main repo and worktree share `.pixi/envs/default`; the .pth file is correct in both cases. The issue is NOT the .pth target but the sys.path ordering. |
+| Trusting an empty console-script run as proof the fix is broken | Verified an `--json` console-script fix by running the installed entry point `hephaestus-check-repo-analyze-skills --json` from inside the worktree (Issue #1217); it emitted EMPTY/unpatched output (exit 0, no JSON envelope), suggesting the fix did not work | The script-execution `sys.path[0]` became the wrapper's bin dir and the editable `.pth` resolved `hephaestus` from the OUTER repo tree (which lacks the fix). `python -m hephaestus.validation.repo_analyze_skills --json` and a direct `from ... import main; main([...])` both emitted the correct envelope | Never conclude "the fix doesn't work" from an empty/unpatched console-script run inside a worktree. Re-verify with `python -m <module>` and probe `module.__file__`; if it points outside the worktree, the editable install is shadowing your code. CI resolves correctly because it checks out a clean standalone tree. |
+| Running `pixi run dev-install` to fix the console-script shadowing | Ran `pixi run dev-install` (≈ `pip install -e .`) in the worktree expecting the installed entry point to then load the worktree code | `which <console-script>` re-pointed to the worktree's bin, but the script-execution `sys.path[0]` shadowing persisted because the shared pixi env's `.pth` still references the OUTER source tree | `dev-install` updates the bin shim, not the `.pth` precedence for script execution. For LOCAL verification use `python -m <module>` / direct import; the entry point itself is only reliable in CI's clean checkout. |
 
 ## Results & Parameters
 
@@ -307,6 +334,7 @@ Does your code run subprocess commands from a git worktree?
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectHephaestus | Issue #724: Add -V/--version flag to 44 console scripts | 2026-06-06 — Discovered during implementation that `pixi run hephaestus-agent-stage --version` loaded stale code from main repo in a git worktree. Direct imports worked correctly. Root cause: sys.path ordering with main repo before worktree. Solution: Use `pixi run` for all subprocess invocations of console scripts. Verified locally (pixi run works, direct subprocess fails). CI not examined in detail. |
+| ProjectHephaestus | Issue #1217: Wire inert `--json` into `hephaestus-check-repo-analyze-skills` via `emit_json_status()` | 2026-06-12 — During VERIFICATION the installed console script emitted EMPTY/unpatched output from the worktree, falsely suggesting the fix failed. Probing `module.__file__` showed `hephaestus` resolving to the OUTER repo tree; `inspect.getsource(m.main)` showed `"args.json" in src` was False. `python -m hephaestus.validation.repo_analyze_skills --json` and direct `main([...])` import both emitted the correct JSON envelope. `pixi run dev-install` re-pointed `which` but did NOT fix script-execution shadowing. Lesson: authoritative local console-script verification inside a worktree is `python -m` / direct import, not the entry point. verified-local; CI for PR #1253 pending. |
 
 ## References
 


### PR DESCRIPTION
## Summary

Amends the existing `git-worktree-sys-path-precedence-issue` skill (v1.0.0 → **v1.1.0**, minor bump) to capture a high-cost VERIFICATION trap surfaced during ProjectHephaestus Issue #1217 (wiring an inert `--json` flag into the `hephaestus-check-repo-analyze-skills` console script via `emit_json_status()`).

When verifying a console-script fix from inside a git worktree, running the **installed entry point** emitted EMPTY/unpatched output (exit 0, no JSON envelope) — falsely suggesting the fix did not work. Root cause (proven live): the script-execution `sys.path[0]` becomes the wrapper's bin dir and the editable `.pth` resolves `hephaestus` to the OUTER repo source tree, which lacks the fix. `python -m <module>` and direct `from <module> import main; main([...])` both load the patched worktree code.

## Verification Level

**verified-local** (unchanged). The fix's unit tests pass; the `sys.path` shadowing was directly observed and root-caused live via `module.__file__` / `inspect.getsource(main)` probing. CI for ProjectHephaestus PR #1253 pending.

## Key Findings

### What Worked
- `python -m hephaestus.validation.repo_analyze_skills --json` → correct JSON envelope.
- Direct `from <module> import main; main([...])` → correct JSON envelope.
- Diagnostic probe `module.__file__` + `inspect.getsource(m.main)` pinpointed the shadowing (MODFILE pointed at the outer repo; `"args.json" in src` was False).

### What Failed
- Running the installed console script `hephaestus-check-repo-analyze-skills --json` from the worktree → empty/unpatched output (false negative).
- `pixi run dev-install` re-pointed `which <console-script>` to the worktree bin but did NOT fix the script-execution `sys.path[0]` shadowing (shared pixi env `.pth` still references the outer tree).

## Changes
- Frontmatter: new trigger (5) in `description`; `date` → 2026-06-12; `version` → 1.1.0.
- New "When to Use" bullet for console-script verification.
- New `### Console-Script Verification Probe` subsection with the reusable `module.__file__` / `inspect.getsource` snippet.
- Two new Failed Attempts rows (empty-run false negative; `dev-install` does not fix it).
- New Verified On row (Issue #1217).
- New `.history` file with a v1.0.0 snapshot of the changed regions.

## Test Plan
- `python3 scripts/validate_plugins.py` → **296/296 valid** (target file `git-worktree-sys-path-precedence-issue.md` passes).
- Commit is GPG-signed.