### PR TITLE
feat: amend python-module-decomposition-and-refactor-patterns skill (v1.4.0)

### DIFF
--- a/skills/python-module-decomposition-and-refactor-patterns.history
+++ b/skills/python-module-decomposition-and-refactor-patterns.history
@@ -1,6 +1,47 @@
 <!-- markdownlint-disable MD024 -->
 # python-module-decomposition-and-refactor-patterns — History
 
+## v1.4.0 (2026-06-12)
+
+**Changed by:** ProjectHephaestus #1178 first-slice scoping session (planning only)
+**Verification:** unverified (planning learning — plan produced, NO code extracted, NO tests
+run, NO CI; the verified phases 1–18 are unchanged and retain their prior verification levels)
+
+### What changed
+
+Added **Phase 19: Scope the FIRST Slice of a 3000+ Line God Class (Planning — UNVERIFIED)** to
+the workflow, with a prominent warning banner. New content:
+
+- Description trigger (13); 4 new tags (`first-slice-scoping`, `god-class`, `thin-delegation`,
+  `planning`); Overview date → 2026-06-12, outcome/trigger note the unverified Phase 19.
+- A "When to Use" bullet for 3000+ line God Classes with an explicit unverified caveat.
+- A Quick Reference decision-tree line for the first-slice case (marked UNVERIFIED).
+- 5 new Failed Attempts rows (pick-by-size, unverified omit-allowlist assertion, snapshot line
+  numbers, paraphrased lifted bodies, module-level-patch-follows-moved-symbol).
+- A Verified On row for #1178 marked UNVERIFIED (planning only).
+
+### Why
+
+Durable planning learnings about scoping the lowest-risk FIRST slice when decomposing a huge
+single-class file (ci_driver.py, 3363 lines, one CIDriver, 51 methods, 5 `# noqa: C901`):
+(1) pick by cohesion + minimal coupling (single shared `self.` attr), not by size or the
+scariest method; (2) deliberately DEFER the C901 carriers; (3) retain thin delegation wrappers
+so tests stay untouched (precedent: implementer_state.py #597); (4) one slice per PR under an
+umbrella issue. The most fragile claim (coverage-omit allowlist / "12 automation modules" count)
+and snapshot line numbers are captured as cautions: verify by running, not by reading.
+
+**Verification note:** the skill is NOT relabeled `verification: unverified` overall, because
+phases 1–18 remain verified-ci/verified-local. The new learning is unverified and is flagged
+inline (warning banner on Phase 19, UNVERIFIED markers in Overview / When to Use / Quick
+Reference / Verified On). Minor bump 1.3.0 → 1.4.0 (additive findings).
+
+### Previous version (v1.3.0) snapshot
+
+See the `## v1.3.0 (2026-06-07)` entry below and prior git history for the full pre-amendment
+content; the v1.3.0 body is preserved unchanged in this file's earlier entries.
+
+---
+
 ## v1.3.0 (2026-06-07)
 
 **Changed by:** Skill-consolidation pass (cluster PYR02)

--- a/skills/python-module-decomposition-and-refactor-patterns.md
+++ b/skills/python-module-decomposition-and-refactor-patterns.md
@@ -19,10 +19,14 @@ description: >-
   marked as fallback/reference-only after verifying zero real callers,
   (11) reading the existing substrate code before estimating a large refactor
   to avoid 3-5x LOC over-estimation, (12) finalizing code after parallel phases
-  complete by addressing technical debt accumulated during rapid development.
+  complete by addressing technical debt accumulated during rapid development,
+  (13) scoping the lowest-risk FIRST slice when decomposing a huge single-class
+  file (3000+ lines, one God Class) — pick a cohesive method cluster sharing
+  exactly one `self.` attribute, deliberately DEFER the `# noqa: C901` carriers,
+  and retain thin delegation wrappers so existing tests stay untouched.
 category: architecture
-date: 2026-06-05
-version: "1.3.0"
+date: 2026-06-12
+version: "1.4.0"
 user-invocable: false
 history: python-module-decomposition-and-refactor-patterns.history
 tags:
@@ -45,6 +49,10 @@ tags:
   - dead-code
   - estimation
   - phase-cleanup
+  - first-slice-scoping
+  - god-class
+  - thin-delegation
+  - planning
 ---
 
 # Python Module Decomposition and Refactor Patterns
@@ -53,10 +61,10 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-06-05 |
+| **Date** | 2026-06-12 |
 | **Objective** | Decompose oversized Python modules/classes into focused, independently testable units using SRP, TDD, and DRY principles |
-| **Outcome** | Synthesized from 13 verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, and post-parallel phase cleanup |
-| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases |
+| **Outcome** | Synthesized from 13 verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, post-parallel phase cleanup, and (Phase 19, **unverified**) first-slice scoping for 3000+ line God Classes |
+| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases, scoping the first slice of a huge single-class decomposition |
 
 ## When to Use
 
@@ -77,6 +85,7 @@ Apply this skill when any of the following is true:
 - A code file declares itself **"kept for reference / fallback only"** but has zero real callers and leaves stale back-references in production code
 - A `TODO.md`/roadmap/audit estimates **"thousands of LOC" or weeks** for a substrate rewrite — read the substrate first to avoid a 3-5x pessimistic estimate
 - You are in the **cleanup phase** after parallel Test/Implementation/Package phases and need to address accumulated technical debt before merge
+- You face a **single-class file of 3000+ lines** (a God Class with 40+ methods and several `# noqa: C901` suppressions) and must scope the **lowest-risk first slice** for the first PR — see Phase 19 (planning-only, unverified). Caveat: Phase 19 is a *planning* pattern produced but **not yet implemented**; do NOT trust its coverage-omit-allowlist or line-number assertions without running the tests first
 
 ## Verified Workflow
 
@@ -100,6 +109,7 @@ Decision tree:
   Dead "fallback only" file, 0 callers  → Safe Legacy Deletion (Phase 16)
   Estimating a big rewrite              → Read substrate FIRST (Phase 17)
   Cleanup after parallel phases         → Finalization checklist (Phase 18)
+  3000+ line God Class, FIRST slice?    → Cohesion+min-coupling scoping (Phase 19, UNVERIFIED)
 
 Universal rule for mock patches after any move:
   Patch where the name is LOOKED UP at call time — not where it was defined.
@@ -797,6 +807,99 @@ complex functions simplified, naming consistent, docs updated, all tests passing
 formatted, zero compiler warnings, coverage at/above floor, ready for review. Cleanup is the
 final polishing gate before PR approval and merge.
 
+### Phase 19: Scope the FIRST Slice of a 3000+ Line God Class (Planning — UNVERIFIED)
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until
+> CI confirms. It is a *planning* pattern — the plan was produced for ProjectHephaestus #1178
+> (`ci_driver.py`, 3363 lines, one `CIDriver` class, 51 methods, 5 `# noqa: C901`
+> suppressions) but **no code was extracted, no tests ran, no CI executed.** Several of its
+> assertions (coverage-omit allowlist behavior, exact line numbers) are explicitly the most
+> fragile claims — verify by running, not by reading.
+
+Use *before writing any code* when you must decompose a single huge class file and need to
+choose which extraction lands in the **first** PR. The goal is the lowest-risk slice that
+establishes a repeatable collaborator-extraction pattern — not the biggest or scariest method.
+
+**1. Pick the first slice by cohesion + minimal coupling, NOT by size or by the scariest
+method.** The best first slice is a method cluster whose bodies touch a **single shared
+`self.` attribute**, because the new collaborator can receive just that one dependency and
+never the host `self`. Verify the coupling empirically before committing:
+
+```bash
+# For each candidate method body, list the self. attributes it touches.
+# A cluster that converges on ONE attribute (e.g. self.state_dir) is the ideal first slice.
+python3 -c "
+import ast
+src = open('ci_driver.py').read()
+tree = ast.parse(src)
+candidates = {'_load_arming_state', '_save_arming_state', '_clear_arming_state', '_arming_path'}
+for node in ast.walk(tree):
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in candidates:
+        attrs = sorted({n.attr for n in ast.walk(node)
+                        if isinstance(n, ast.Attribute)
+                        and isinstance(n.value, ast.Name) and n.value.id == 'self'})
+        print(node.name, '->', attrs)
+"
+# Ideal output: every candidate prints exactly the same single attribute, e.g. ['state_dir'].
+```
+
+In #1178 the chosen cluster was the 4-method arming-state persistence group sharing exactly
+one self-attribute (`state_dir`).
+
+**2. Deliberately DEFER the `# noqa: C901` carriers to later slices.** The audit's headline
+metric (remove the C901 suppressions) is tempting to attack first, but the C901 methods are
+the **most coupled/complex** — the worst place to learn the pattern. Removing a suppression is
+a *later* slice once the cohesive low-risk extractions have established the collaborator
+pattern. The first PR removes **ZERO** C901 markers and says so explicitly in its body.
+
+**3. Collaborator extraction with RETAINED thin delegation wrappers — never delete the methods
+the tests call.** Tests call the private methods on the instance
+(`driver._load_arming_state(123)`) and patch some by name
+(`patch.object(driver, "_list_unresolved_threads_safe", ...)`). Deleting or renaming breaks
+them. Keep 1-line delegating wrappers on the host class so test call sites and internal callers
+are untouched. In-repo precedent: `implementer_state.py` (#597 `ImplementationStateManager`).
+
+```python
+# New collaborator: receives only the one dependency it needs — never `self`.
+class ArmingStateStore:
+    def __init__(self, state_dir: Path) -> None:
+        self._state_dir = state_dir
+    def load(self, pr_number: int) -> ArmingRecord | None: ...   # body lifted VERBATIM
+    def save(self, record: ArmingRecord) -> None: ...
+    def clear(self, pr_number: int) -> None: ...
+
+# Host class keeps thin delegating wrappers so tests/callers are untouched:
+def _load_arming_state(self, pr_number: int) -> ArmingRecord | None:
+    return self._arming_store.load(pr_number)
+```
+
+**4. One slice per PR under an umbrella issue.** pr-policy needs a literal `Closes #<sub-issue>`
+on its own line; file a narrow sub-issue for the slice and keep the umbrella open with
+`Refs #<umbrella>` (same gotcha as Phase 11). **YAGNI stop criterion**: re-check `wc -l` after
+each extraction; stop when the target line count is met.
+
+**Most fragile assumptions — scrutinize these before trusting the plan:**
+
+- **Coverage-omit / allowlist is the most fragile claim.** A new `hephaestus.automation.*`
+  module commonly forces same-PR edits to BOTH the `pyproject.toml` omit list AND the guard
+  tests (`test_omit_allowlist.py`'s "12 automation modules" count, `test_orchestration_smoke.py`).
+  The plan *asserts* a pure-library module stays OFF the omit list without an edit — this was
+  **not verified by running**; it could be an off-by-one or the resolver may auto-discover
+  `automation/*.py` and demand an entry. **Verify by running the test, don't assert from reading.**
+- **Line numbers are snapshot-fragile.** Any cited line (e.g. `__init__` at `:120`, a cluster at
+  `1507–1548`) drifts the moment any edit lands. Cite by **symbol name**, and re-grep
+  immediately before editing.
+- **"Bodies lifted verbatim" must stay truly verbatim** — including exact log-message strings.
+  Tests assert on substrings like `"Could not read arming record"`; any wording drift silently
+  breaks a `caplog` assertion.
+- **Patch-target rule (Phase-4 corollary).** Instance-level `patch.object(driver, "_method")`
+  **survives** delegation (the method is still on the host class). But module-level
+  `patch("...ci_driver.symbol")` does **NOT** follow a symbol moved to the new module. Grep ALL
+  test files for **both** patch styles before moving anything.
+- **mypy gotchas to pre-empt:** `dict` → `dict[str, Any]`; a collaborator type hint under a
+  circular import → `TYPE_CHECKING` guard, never `object` (Phase 3); re-exports need the
+  explicit `as` alias (Phase 5/11).
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -827,6 +930,11 @@ final polishing gate before PR approval and merge.
 | **Forgetting fixture migration after scoping a scanner** | Scoped the scanner to `scylla/` but left existing tests writing fixtures at `tmp_path/"bad.py"` | Root-level fixtures are now out of scope — tests returned zero findings and failed | After narrowing scanner scope, move every test fixture into the scoped dir and update hard-coded path assertions (`"bad.py"` → `"scylla/bad.py"`) |
 | **Trusting a TODO/audit LOC estimate without reading the substrate** | Took `TODO.md` "Phase 2: ~5000 LOC" and an audit's "CRITICAL: autograd missing" as authoritative effort | Existing tape/registry/SavedTensors infra already covered ~70%; estimate was 3-5x too high and conflated "documented" with "missing" | Read every substrate file in full with line-cited evidence BEFORE estimating (Phase 17); re-classify "missing" as "incomplete, N% gap" |
 | **Deleting legacy code before verifying zero callers** | Assumed a "fallback only" file was dead and considered deleting it on the strength of its header alone | "Fallback only" claims are not self-enforcing — the codebase may still depend on it in non-obvious ways; dead code passes all CI | Systematically grep all callers across `*.py/*.sh/*.md/.github/` first, rewrite stale back-references as self-contained comments, then delete and run full suites (Phase 16) |
+| **Picking the first slice of a God Class by size / scariest method** (Phase 19, planning) | Planned to attack the biggest `# noqa: C901` method first to maximize the headline "suppressions removed" metric | C901 methods are the most coupled/complex — worst place to establish a new collaborator pattern; high blast radius on the very first PR | Pick the cohesive cluster sharing exactly ONE `self.` attribute (verify with an AST `self.`-attr grep); DEFER all C901 carriers to later slices; first PR removes ZERO suppressions and says so |
+| **Asserting a new automation module stays off the coverage-omit allowlist without running** (Phase 19) | Plan claimed a new pure-library `hephaestus.automation.*` module needs no edit to the omit list or the "12 automation modules" count in `test_omit_allowlist.py` | NOT verified by running — a new `automation/*.py` module commonly forces same-PR edits to BOTH `pyproject.toml` omit list AND the guard tests (count + module list); could be an off-by-one or auto-discovery | Verify coverage-gate assumptions by RUNNING `test_omit_allowlist.py` / `test_orchestration_smoke.py`, never by reading — treat the "no edit needed" claim as a hypothesis |
+| **Citing snapshot line numbers in a decomposition plan** (Phase 19) | Plan referenced concrete lines (`__init__` at `:120`, cluster `1507–1548`) as edit anchors | Line numbers drift the instant any edit lands; the plan's anchors go stale mid-execution | Cite by symbol name and re-grep immediately before editing; never trust a line number carried across an edit |
+| **Paraphrasing lifted method bodies during extraction** (Phase 19) | Reworded a log message while moving a method body into the new collaborator | Tests assert on substrings like `"Could not read arming record"`; the wording drift silently broke a `caplog` assertion | "Bodies lifted verbatim" must be truly verbatim including exact log strings; diff the moved body against the original before committing |
+| **Assuming module-level patches follow a moved symbol** (Phase 19) | Expected `patch("...ci_driver.symbol")` to keep intercepting after the symbol moved to the new collaborator module | Module-level patches bind to the lookup site that no longer holds the symbol (Phase 4 rule); only instance-level `patch.object(driver, "_method")` survives delegation | Grep ALL test files for BOTH patch styles (`patch.object(driver, ...)` and `patch("...ci_driver....")`) before moving anything; retarget module-level patches to the new module |
 
 ## Results & Parameters
 
@@ -896,3 +1004,4 @@ Revised LOC estimate: ~X (vs TODO "~Y"); justification: ~Z% already in substrate
 | ProjectHephaestus | PR #745 — deleted 587-line legacy `run_automation_loop.sh` + helper + 480 lines of tests; scrubbed 8 stale back-references across 4 files; 1093 tests + 26 shell tests pass | Superseded `legacy-code-deletion-safe-removal-pattern` (Phase 16) |
 | ProjectOdyssey | PR #5457 — Phase 0 substrate read revised a TODO "~5000 LOC" estimate to ~1400; actual landed +937 LOC (CI green) | Superseded `architecture-estimate-rewrite-read-substrate-first` (Phase 17) |
 | HomericIntelligence ecosystem | Cleanup-phase coordination after parallel Test/Implementation/Package phases (KISS/DRY/SOLID finalization before merge) | Superseded `phase-cleanup` (Phase 18) |
+| ProjectHephaestus | Issue #1178 (planning only, **UNVERIFIED**) — first-slice scoping for `ci_driver.py` (3363 lines, one `CIDriver`, 51 methods, 5 `# noqa: C901`): chose the 4-method arming-state cluster sharing only `self.state_dir`, deferred all C901 carriers, retained thin delegation wrappers. NO code extracted, NO tests run, NO CI. | First-slice scoping for a 3000+ line God Class (Phase 19); coverage-omit-allowlist + line-number assertions UNVERIFIED |


### PR DESCRIPTION
## Summary

Amends the existing `python-module-decomposition-and-refactor-patterns` skill from **v1.3.0 → v1.4.0** (Minor — additive findings).

Adds **Phase 19: Scope the FIRST Slice of a 3000+ Line God Class (Planning — UNVERIFIED)**, capturing durable planning learnings from ProjectHephaestus #1178 (`ci_driver.py`, 3363 lines, one `CIDriver` class, 51 methods, 5 `# noqa: C901` suppressions).

- Pick the first slice by **cohesion + minimal coupling** (a method cluster sharing exactly ONE `self.` attribute), not by size or the scariest method.
- Deliberately **DEFER the `# noqa: C901` carriers** to later slices; the first PR removes zero suppressions and says so.
- **Retain thin delegation wrappers** so existing tests/callers stay untouched (in-repo precedent: `implementer_state.py`, #597).
- **One slice per PR** under an umbrella issue (`Closes #<sub>` + `Refs #<umbrella>`); YAGNI stop criterion via repeated `wc -l`.

## Verification Level

**unverified** — this is a *planning* learning. The plan was produced but **NOT implemented**: no code was extracted, no tests ran, no CI executed. Phase 19 carries a prominent warning banner ("This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.") and UNVERIFIED markers in the Overview, When-to-Use, Quick Reference, and Verified On entries. The pre-existing verified phases 1–18 are unchanged and retain their prior verification levels, so the skill is not relabeled `verification: unverified` overall.

## Key Findings

**What the plan got right (durable patterns)**:
- Cohesion + minimal-coupling beats size when choosing a first slice; verify coupling with an AST `self.`-attribute grep.
- Thin delegation wrappers preserve `patch.object(driver, "_method")` test call sites through extraction.

**Most fragile claims (captured as cautions, NOT verified)**:
- The coverage-omit-allowlist / "12 automation modules" count assertion in `test_omit_allowlist.py` — a new `hephaestus.automation.*` module commonly forces same-PR edits to BOTH the `pyproject.toml` omit list AND the guard tests. Verify by **running**, not by reading.
- Snapshot line numbers drift on any edit — cite by symbol name and re-grep.
- "Bodies lifted verbatim" must stay truly verbatim (tests assert on exact log strings).
- Module-level `patch("...ci_driver.symbol")` does NOT follow a symbol moved to a new module; only instance-level `patch.object` survives delegation.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (296/296 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: god class, first slice, thin delegation, decomposition

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>