### PR TITLE
skill(debugging): add automation-loop-post-loop-filter-omission (v1.0.0)

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Install yamllint
@@ -73,7 +73,7 @@ jobs:
           fi
       - name: Setup pixi
         if: steps.detect.outputs.skip == 'false'
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11  # v0.9.6
         with:
           pixi-version: v0.67.2
           cache: false
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Install dependencies
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Run pip-audit
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: gitleaks-report
           path: gitleaks.sarif
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Install check-jsonschema

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         run: |
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Install yamllint
@@ -130,7 +130,7 @@ jobs:
           fi
       - name: Setup pixi
         if: steps.detect.outputs.skip == 'false'
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11  # v0.9.6
         with:
           pixi-version: v0.67.2
           cache: false
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Install dependencies
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Run pip-audit
@@ -265,7 +265,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: gitleaks-report
           path: gitleaks.sarif
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Install check-jsonschema

--- a/skills/automation-loop-post-loop-filter-omission.history
+++ b/skills/automation-loop-post-loop-filter-omission.history
@@ -1,0 +1,35 @@
+<!-- markdownlint-disable MD024 -->
+# History: automation-loop-post-loop-filter-omission
+
+This file preserves previous versions of the skill before amendments.
+
+## v1.0.0 (2026-06-12)
+
+Initial version. Used `not r.post_loop_phases` as the post-loop discriminator and cited `loop_runner.py:1337` as the canonical filter reference. Both were incorrect — the correct discriminator is `not r.is_post_loop` and the correct line is 1525. See the Failed Attempts section of v1.1.0 for the full analysis.
+
+### v1.0.0 full content
+
+```markdown
+---
+name: automation-loop-post-loop-filter-omission
+description: "Use when: (1) diagnosing why loops_run reports an inflated loop count after early-exit fires, (2) a caller re-aggregates a raw result list without applying the same filter the inner function already uses, (3) auditing max()/sum() aggregations over mixed per-loop + post-loop result collections."
+category: debugging
+date: 2026-06-12
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [automation, loop-runner, post-loop, filter-omission, early-exit, aggregation, loops-run]
+---
+
+# Automation Loop: Post-Loop Filter Omission Bug
+
+The inner function `run_loop` itself already applies the correct filter at `loop_runner.py:1337`:
+
+    loop_results = [r for r in all_results if not r.post_loop_phases]
+
+Fix: Add the `if not r.post_loop_phases` predicate to mirror the filter already present inside `run_loop`.
+
+Key risk documented: If `_run_post_loop_stages` ever produces a record with `post_loop_phases=[]` (e.g., all stages skipped), the new filter misclassifies it as a per-loop record.
+
+Regression test fixture used `post_loop_phases=[...]` without `is_post_loop=True`.
+```

--- a/skills/automation-loop-post-loop-filter-omission.md
+++ b/skills/automation-loop-post-loop-filter-omission.md
@@ -1,0 +1,167 @@
+---
+name: automation-loop-post-loop-filter-omission
+description: "Use when: (1) diagnosing why loops_run reports an inflated loop count after early-exit fires, (2) a caller re-aggregates a raw result list without applying the same filter the inner function already uses, (3) auditing max()/sum() aggregations over mixed per-loop + post-loop result collections."
+category: debugging
+date: 2026-06-12
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [automation, loop-runner, post-loop, filter-omission, early-exit, aggregation, loops-run]
+---
+
+# Automation Loop: Post-Loop Filter Omission Bug
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-12 |
+| **Objective** | Fix `loops_run` reporting an inflated count when early-exit fires during a multi-loop run that includes post-loop stages |
+| **Outcome** | Plan produced, not yet implemented or CI-confirmed |
+| **Verification** | unverified |
+| **Source** | ProjectHephaestus issue #1153 |
+| **History** | N/A (initial version) |
+
+## When to Use
+
+- `loops_run` (or equivalent) reports a count equal to the configured maximum instead of the actual number of loops executed
+- Early-exit fired on loop N < max, yet the loop count metric shows max
+- A caller aggregates a flat result list that mixes per-loop `RepoResult` records with post-loop `RepoResult` records
+- Reviewing any `max(r.field for r in results)` expression over a result list produced by a loop runner that also runs post-loop stages
+
+## Bug Description
+
+In `hephaestus/automation/loop_runner.py:1695`:
+
+```python
+loops_run = max((r.loop_idx for r in results), default=0)
+```
+
+`_run_post_loop_stages` appends `RepoResult` records to the same `results` list and **unconditionally sets `loop_idx=cfg.loops`** on each record. When early-exit fires on loop 1 of 5 and the drive-green post-loop stage runs, `loops_run` aggregates over all records including the post-loop ones and reports `5` instead of `1`.
+
+The inner function `run_loop` itself already applies the correct filter at `loop_runner.py:1337`:
+
+```python
+loop_results = [r for r in all_results if not r.post_loop_phases]
+```
+
+The caller (`main`) re-aggregates the same raw `results` list without applying that filter.
+
+## Root Cause Pattern
+
+An internal function correctly filters its result set before aggregating; the caller re-aggregates the same raw list without applying the same filter. The discriminator field `post_loop_phases` was explicitly designed for this purpose — the comment at lines 230–232 calls out this exact use case.
+
+**General pattern to watch for**: When you see `max(x.field for x in collection)` in a caller function, check whether the inner function that produced `collection` applied a filter before its own equivalent aggregation. If so, the caller must apply the same filter.
+
+## Fix
+
+Add the `if not r.post_loop_phases` predicate to mirror the filter already present inside `run_loop`:
+
+```python
+# Before (line 1695):
+loops_run = max((r.loop_idx for r in results), default=0)
+
+# After:
+loops_run = max(
+    (r.loop_idx for r in results if not r.post_loop_phases),
+    default=0,
+)
+```
+
+This mirrors the identical filter at `loop_runner.py:1337`.
+
+## Key Risks
+
+1. **Empty `post_loop_phases` list** — If `_run_post_loop_stages` ever produces a record with `post_loop_phases=[]` (e.g., all stages skipped), the new filter misclassifies it as a per-loop record. The discriminator relies on list **non-emptiness**, not a dedicated boolean flag. Verify that `_run_post_loop_stages` always appends at least one entry to `post_loop_phases` before returning.
+
+2. **`failures` aggregation is unaffected** — `failures = [r for r in results if r.any_failure]` at line 1697 iterates over ALL records including post-loop. This is **correct behavior** — post-loop stage failures must be counted. The fix only touches `loops_run`.
+
+## Existing Test Blind Spot
+
+`test_main_loops_run_early_exit` stubs `run_loop` with a clean per-loop-only result list, so it never exercises the mixed case where post-loop records are present. A new test covering the mixed case is required.
+
+### Minimal Test
+
+```python
+def test_loops_run_excludes_post_loop_records(tmp_path, monkeypatch):
+    """loops_run must not count post-loop RepoResult records."""
+    from hephaestus.automation.loop_runner import LoopConfig, RepoResult
+
+    cfg = LoopConfig(loops=5, projects_dir=tmp_path)
+
+    # Simulate: early-exit fired after loop 1, then post-loop ran
+    per_loop_record = RepoResult(repo="r1", loop_idx=1)
+    post_loop_record = RepoResult(repo="r1", loop_idx=cfg.loops)
+    post_loop_record.post_loop_phases.append("drive-green")
+
+    results = [per_loop_record, post_loop_record]
+
+    loops_run = max(
+        (r.loop_idx for r in results if not r.post_loop_phases),
+        default=0,
+    )
+    assert loops_run == 1, f"Expected 1, got {loops_run}"
+```
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Confirm the unfiltered aggregation exists:
+grep -n "loops_run" hephaestus/automation/loop_runner.py
+
+# Confirm the inner filter for comparison:
+grep -n "post_loop_phases" hephaestus/automation/loop_runner.py | head -20
+```
+
+### Detailed Steps
+
+1. **Locate the aggregation** — Find `loops_run = max(...)` at `loop_runner.py:1695` in the `main()` function.
+
+2. **Compare to inner filter** — The `run_loop` function at `loop_runner.py:1337` already filters: `loop_results = [r for r in all_results if not r.post_loop_phases]`. The caller must mirror this.
+
+3. **Apply the fix** — Add `if not r.post_loop_phases` to the generator expression inside `max(...)`.
+
+4. **Verify `_run_post_loop_stages`** — Confirm it always appends at least one entry to `post_loop_phases`. If it can produce records with `post_loop_phases=[]`, introduce a dedicated boolean flag instead.
+
+5. **Add the mixed-case test** — `test_main_loops_run_early_exit` must cover the scenario where post-loop records are present alongside per-loop records.
+
+6. **Run checks**:
+   ```bash
+   pixi run pytest tests/unit/automation/ -q --no-cov
+   pixi run ruff check hephaestus/automation/loop_runner.py
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| (None yet — plan only) | This skill documents a planned fix; the section will be populated once implementation is attempted | N/A | N/A |
+
+## Results & Parameters
+
+### Key Behavioral Invariants
+
+| Scenario | `loops_run` before fix | `loops_run` after fix |
+|----------|----------------------|-----------------------|
+| Early-exit on loop 1/5, post-loop ran | `5` (incorrect) | `1` (correct) |
+| No early-exit, all 5 loops ran, post-loop ran | `5` (correct) | `5` (correct) |
+| No post-loop stages | `N` (correct) | `N` (correct) |
+
+### Discriminator Field
+
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `post_loop_phases` | `list[str]` | Non-empty → record is a post-loop record; empty → per-loop record |
+
+### Net Change (Planned)
+
+- `hephaestus/automation/loop_runner.py`: ~3 LOC (add `if not r.post_loop_phases` predicate to `loops_run` generator)
+- `tests/unit/automation/test_loop_runner_early_exit.py` (or equivalent): +1 new test method for mixed per-loop + post-loop results
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #1153 — loops_run inflated after early-exit + post-loop stages | Plan only; not yet implemented or CI-confirmed |

--- a/skills/automation-loop-post-loop-filter-omission.md
+++ b/skills/automation-loop-post-loop-filter-omission.md
@@ -2,10 +2,11 @@
 name: automation-loop-post-loop-filter-omission
 description: "Use when: (1) diagnosing why loops_run reports an inflated loop count after early-exit fires, (2) a caller re-aggregates a raw result list without applying the same filter the inner function already uses, (3) auditing max()/sum() aggregations over mixed per-loop + post-loop result collections."
 category: debugging
-date: 2026-06-12
-version: "1.0.0"
+date: 2026-06-13
+version: "1.1.0"
 user-invocable: false
 verification: unverified
+history: automation-loop-post-loop-filter-omission.history
 tags: [automation, loop-runner, post-loop, filter-omission, early-exit, aggregation, loops-run]
 ---
 
@@ -15,12 +16,12 @@ tags: [automation, loop-runner, post-loop, filter-omission, early-exit, aggregat
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-12 |
+| **Date** | 2026-06-13 |
 | **Objective** | Fix `loops_run` reporting an inflated count when early-exit fires during a multi-loop run that includes post-loop stages |
 | **Outcome** | Plan produced, not yet implemented or CI-confirmed |
 | **Verification** | unverified |
 | **Source** | ProjectHephaestus issue #1153 |
-| **History** | N/A (initial version) |
+| **History** | automation-loop-post-loop-filter-omission.history |
 
 ## When to Use
 
@@ -39,23 +40,23 @@ loops_run = max((r.loop_idx for r in results), default=0)
 
 `_run_post_loop_stages` appends `RepoResult` records to the same `results` list and **unconditionally sets `loop_idx=cfg.loops`** on each record. When early-exit fires on loop 1 of 5 and the drive-green post-loop stage runs, `loops_run` aggregates over all records including the post-loop ones and reports `5` instead of `1`.
 
-The inner function `run_loop` itself already applies the correct filter at `loop_runner.py:1337`:
+The inner function `run_loop` itself already applies the correct filter at `loop_runner.py:1525`:
 
 ```python
-loop_results = [r for r in all_results if not r.post_loop_phases]
+per_loop_results = [r for r in all_results if not r.is_post_loop]
 ```
 
 The caller (`main`) re-aggregates the same raw `results` list without applying that filter.
 
 ## Root Cause Pattern
 
-An internal function correctly filters its result set before aggregating; the caller re-aggregates the same raw list without applying the same filter. The discriminator field `post_loop_phases` was explicitly designed for this purpose — the comment at lines 230–232 calls out this exact use case.
+An internal function correctly filters its result set before aggregating; the caller re-aggregates the same raw list without applying the same filter. The dedicated boolean `is_post_loop: bool = False` (defined at `loop_runner.py:234`) was introduced precisely for this purpose — the dataclass comment at lines 231–233 explains that `post_loop_phases=[]` cannot distinguish post-loop records from crashed or all-skipped per-loop records.
 
-**General pattern to watch for**: When you see `max(x.field for x in collection)` in a caller function, check whether the inner function that produced `collection` applied a filter before its own equivalent aggregation. If so, the caller must apply the same filter.
+**General pattern to watch for**: When you see `max(x.field for x in collection)` in a caller function, check whether the inner function that produced `collection` applied a filter before its own equivalent aggregation. If so, the caller must apply the same filter using the same discriminator.
 
 ## Fix
 
-Add the `if not r.post_loop_phases` predicate to mirror the filter already present inside `run_loop`:
+Add the `if not r.is_post_loop` predicate to mirror the filter already present inside `run_loop`:
 
 ```python
 # Before (line 1695):
@@ -63,16 +64,16 @@ loops_run = max((r.loop_idx for r in results), default=0)
 
 # After:
 loops_run = max(
-    (r.loop_idx for r in results if not r.post_loop_phases),
+    (r.loop_idx for r in results if not r.is_post_loop),
     default=0,
 )
 ```
 
-This mirrors the identical filter at `loop_runner.py:1337`.
+This mirrors the canonical filter at `loop_runner.py:1525`.
 
 ## Key Risks
 
-1. **Empty `post_loop_phases` list** — If `_run_post_loop_stages` ever produces a record with `post_loop_phases=[]` (e.g., all stages skipped), the new filter misclassifies it as a per-loop record. The discriminator relies on list **non-emptiness**, not a dedicated boolean flag. Verify that `_run_post_loop_stages` always appends at least one entry to `post_loop_phases` before returning.
+1. **`is_post_loop` is the correct discriminator** — `is_post_loop: bool = False` is defined at `loop_runner.py:234` and set unconditionally to `True` at `loop_runner.py:1395` when `_run_post_loop_stages` constructs a record. Do NOT use `post_loop_phases` non-emptiness as the discriminator — that field is empty for crashed or all-skipped repos, making it ambiguous (see Failed Attempts).
 
 2. **`failures` aggregation is unaffected** — `failures = [r for r in results if r.any_failure]` at line 1697 iterates over ALL records including post-loop. This is **correct behavior** — post-loop stage failures must be counted. The fix only touches `loops_run`.
 
@@ -85,19 +86,25 @@ This mirrors the identical filter at `loop_runner.py:1337`.
 ```python
 def test_loops_run_excludes_post_loop_records(tmp_path, monkeypatch):
     """loops_run must not count post-loop RepoResult records."""
-    from hephaestus.automation.loop_runner import LoopConfig, RepoResult
+    from hephaestus.automation.loop_runner import LoopConfig, PhaseResult, RepoResult
 
     cfg = LoopConfig(loops=5, projects_dir=tmp_path)
 
-    # Simulate: early-exit fired after loop 1, then post-loop ran
+    # Simulate: early-exit fired after loop 1, then post-loop ran.
+    # is_post_loop=True is REQUIRED — post_loop_phases alone is ambiguous
+    # for crashed/all-skipped repos where post_loop_phases=[] too.
     per_loop_record = RepoResult(repo="r1", loop_idx=1)
-    post_loop_record = RepoResult(repo="r1", loop_idx=cfg.loops)
-    post_loop_record.post_loop_phases.append("drive-green")
+    post_loop_record = RepoResult(
+        repo="r1",
+        loop_idx=cfg.loops,
+        is_post_loop=True,
+        post_loop_phases=[PhaseResult(phase="drive-green")],
+    )
 
     results = [per_loop_record, post_loop_record]
 
     loops_run = max(
-        (r.loop_idx for r in results if not r.post_loop_phases),
+        (r.loop_idx for r in results if not r.is_post_loop),
         default=0,
     )
     assert loops_run == 1, f"Expected 1, got {loops_run}"
@@ -105,29 +112,29 @@ def test_loops_run_excludes_post_loop_records(tmp_path, monkeypatch):
 
 ## Verified Workflow
 
+> **Note**: This workflow is proposed and unverified — it has not been run against CI.
+
 ### Quick Reference
 
 ```bash
 # Confirm the unfiltered aggregation exists:
 grep -n "loops_run" hephaestus/automation/loop_runner.py
 
-# Confirm the inner filter for comparison:
-grep -n "post_loop_phases" hephaestus/automation/loop_runner.py | head -20
+# Confirm is_post_loop definition:
+grep -n "is_post_loop" hephaestus/automation/loop_runner.py | head -20
 ```
 
 ### Detailed Steps
 
 1. **Locate the aggregation** — Find `loops_run = max(...)` at `loop_runner.py:1695` in the `main()` function.
 
-2. **Compare to inner filter** — The `run_loop` function at `loop_runner.py:1337` already filters: `loop_results = [r for r in all_results if not r.post_loop_phases]`. The caller must mirror this.
+2. **Compare to inner filter** — The `run_loop` function at `loop_runner.py:1525` already filters: `per_loop_results = [r for r in all_results if not r.is_post_loop]`. The caller must mirror this using the same boolean flag.
 
-3. **Apply the fix** — Add `if not r.post_loop_phases` to the generator expression inside `max(...)`.
+3. **Apply the fix** — Add `if not r.is_post_loop` to the generator expression inside `max(...)`. Do NOT use `if not r.post_loop_phases` — see Failed Attempts.
 
-4. **Verify `_run_post_loop_stages`** — Confirm it always appends at least one entry to `post_loop_phases`. If it can produce records with `post_loop_phases=[]`, introduce a dedicated boolean flag instead.
+4. **Add the mixed-case test** — `test_main_loops_run_early_exit` must cover the scenario where post-loop records (with `is_post_loop=True`) are present alongside per-loop records.
 
-5. **Add the mixed-case test** — `test_main_loops_run_early_exit` must cover the scenario where post-loop records are present alongside per-loop records.
-
-6. **Run checks**:
+5. **Run checks**:
    ```bash
    pixi run pytest tests/unit/automation/ -q --no-cov
    pixi run ruff check hephaestus/automation/loop_runner.py
@@ -137,7 +144,7 @@ grep -n "post_loop_phases" hephaestus/automation/loop_runner.py | head -20
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| (None yet — plan only) | This skill documents a planned fix; the section will be populated once implementation is attempted | N/A | N/A |
+| v1.0.0 planning pass | Used `not r.post_loop_phases` as the discriminator, claiming it "mirrored `loop_runner.py:1337`" (a rate-budget sleep — unrelated line). Fix was `if not r.post_loop_phases` in the generator. | (1) `post_loop_phases=[]` is ambiguous — crashed and all-skipped repos produce per-loop records with empty `post_loop_phases`, so the filter would misclassify them as post-loop. (2) The cited line 1337 was wrong; the real filter is at 1525. (3) The regression test fixture only set `post_loop_phases=[...]` without `is_post_loop=True`, so it would not guard the real bug under the correct fix. The reviewer caught all three issues. | Always use the dedicated `is_post_loop` boolean. Never rely on list-emptiness when a boolean flag exists for the same purpose. Verify cited line numbers before documenting. |
 
 ## Results & Parameters
 
@@ -149,16 +156,17 @@ grep -n "post_loop_phases" hephaestus/automation/loop_runner.py | head -20
 | No early-exit, all 5 loops ran, post-loop ran | `5` (correct) | `5` (correct) |
 | No post-loop stages | `N` (correct) | `N` (correct) |
 
-### Discriminator Field
+### Discriminator Fields
 
 | Field | Type | Semantics |
 |-------|------|-----------|
-| `post_loop_phases` | `list[str]` | Non-empty → record is a post-loop record; empty → per-loop record |
+| `is_post_loop` | `bool` | **Correct discriminator.** `True` iff this record was produced by `_run_post_loop_stages`. Defined at `loop_runner.py:234`, set at `loop_runner.py:1395`. |
+| `post_loop_phases` | `list` | **Wrong discriminator.** Non-empty only when stages ran — ambiguous for crashed/all-skipped records that also have `post_loop_phases=[]`. |
 
 ### Net Change (Planned)
 
-- `hephaestus/automation/loop_runner.py`: ~3 LOC (add `if not r.post_loop_phases` predicate to `loops_run` generator)
-- `tests/unit/automation/test_loop_runner_early_exit.py` (or equivalent): +1 new test method for mixed per-loop + post-loop results
+- `hephaestus/automation/loop_runner.py`: ~3 LOC (change `if not r.post_loop_phases` → `if not r.is_post_loop` in `loops_run` generator)
+- `tests/unit/automation/test_loop_runner_early_exit.py` (or equivalent): +1 new test method for mixed per-loop + post-loop results (fixture must include `is_post_loop=True`)
 
 ## Verified On
 

--- a/skills/automation-planner-learn-record-writing-robustness.history
+++ b/skills/automation-planner-learn-record-writing-robustness.history
@@ -1,0 +1,148 @@
+# Skill History: automation-planner-learn-record-writing-robustness
+
+## Changelog
+
+### v1.1.0 — 2026-06-12
+**Type:** Minor (new findings added, R0 correction)
+
+**Changes:**
+- Corrects R0 item (Pattern 3): prompt directive placement fix belongs in `build_learn_prompt` in `learn.py`, NOT in `capture_planner_learnings`
+- Adds Failed Attempt: R0 plan edited wrong function (POLA violation caught by reviewer)
+- Documents `start: float = 0.0` sentinel theoretical risk; recommends `float | None` alternative
+- Confirms OSError patch path: `patch("hephaestus.automation.planner_review_loop.Path.write_text", ...)`
+- Adds prompt directive ordering test assertion pattern
+- Flags `learn_succeeded_at` removal audit as non-exhaustive (grep-only, not full dependency graph)
+- Adds Pattern 4 (Sentinel Value Safety) as explicit section
+- Updates tags to include `build_learn_prompt`
+- Updates description to reference `build_learn_prompt` specifically
+
+---
+
+## v1.0.0 Snapshot — 2026-06-12
+
+```markdown
+---
+name: automation-planner-learn-record-writing-robustness
+description: "Robustness patterns for planner learn record writing in hephaestus/automation/planner_review_loop.py. Use when: (1) auditing or refactoring _write_planner_learn_record, (2) adding companion file writes (json + log), (3) changing persisted JSON schema fields, (4) designing multi-part prompt directives."
+category: architecture
+date: 2026-06-12
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: ["planner", "learn-record", "write-order", "json", "schema", "prompt-design"]
+---
+
+# Automation Planner Learn Record Writing Robustness
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-12 |
+| **Objective** | Identify and address robustness gaps in `_write_planner_learn_record` in `hephaestus/automation/planner_review_loop.py` |
+| **Outcome** | Planning session complete — three concrete patterns identified; implementation not yet executed |
+| **Verification** | unverified |
+| **Source Issue** | ProjectHephaestus #1138 |
+
+## When to Use
+
+- Auditing or refactoring `_write_planner_learn_record` in `planner_review_loop.py`
+- Adding or changing any pair of companion files (authoritative `.json` + human-readable `.log`)
+- Dropping or renaming a field in any persisted `.json` schema (e.g., `learn_succeeded_at`)
+- Designing multi-part prompt strings where output format directives might be misplaced
+- Comparing `_write_planner_learn_record` against `_write_learn_record` in `learn.py` for symmetry
+
+## Verified Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```bash
+# Audit consumers of a persisted JSON field before removing it
+grep -r "learn_succeeded_at" hephaestus/ tests/ scripts/
+
+# Verify write order in _write_planner_learn_record: json must come before log
+grep -n "_write_planner_learn_record\|\.json\|\.log" hephaestus/automation/planner_review_loop.py | head -40
+
+# Compare with learn.py reference implementation
+grep -n "_write_learn_record\|\.json\|\.log" hephaestus/automation/learn.py | head -20
+```
+
+### Detailed Steps
+
+#### Pattern 1 — Write Order Atomicity (json before log)
+
+1. Locate the two companion file writes in `_write_planner_learn_record` (around line 599–666 of `planner_review_loop.py` at planning time — line numbers may shift).
+2. Confirm the current order: if `.log` is written before `.json`, swap them.
+3. The authoritative `.json` file must always be written first so that a mid-write crash leaves the authoritative record present (even if incomplete) rather than only the human-readable log.
+4. Reference: `learn.py:_write_learn_record` writes `.json` only — mirror that discipline in the planner variant.
+
+#### Pattern 2 — Schema Field Removal Audit
+
+1. Before removing any field from a persisted `.json` schema, run a consumer audit:
+   ```bash
+   grep -r "<field_name>" hephaestus/ tests/ scripts/
+   ```
+2. For the specific case of `learn_succeeded_at → learn_duration_s`:
+   - Confirm all readers of the old field name are updated or that the field is truly unused.
+   - `learn_duration_s` is computed from `time.monotonic()` start/end; the `start: float = 0.0` sentinel is safe in practice (monotonic is always > 0 at normal process start) but document the assumption.
+3. Add a migration note in the PR body so downstream consumers of the JSON records are warned.
+
+#### Pattern 3 — Prompt Directive Placement
+
+1. In multi-part prompt strings (e.g., `capture_planner_learnings`), output format directives must appear AFTER the content block they govern.
+2. Pattern: `[context/background] → [content block] → [output format directives]`
+3. If a bullet-output directive appears mid-prompt before the plan block, restructure so `build_learn_prompt`'s imperatives trail naturally after the content.
+4. Review the full prompt string after any refactor to verify directive ordering is preserved.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Log-before-json write order | `_write_planner_learn_record` wrote `.log` then `.json` | A crash mid-sequence leaves only the human-readable log with no authoritative record | Always write authoritative file first; human-readable is secondary |
+| Dropping `learn_succeeded_at` without audit | Field removal planned without grep-checking consumers | Silent breakage in downstream readers that parse the JSON | Grep all consumers before any schema field removal |
+| Mid-prompt directive placement | Output format directive placed before the content block in `capture_planner_learnings` | Directive appeared to govern earlier content, not the plan block that follows | Directives must follow the content they govern |
+
+## Results & Parameters
+
+### Write Order Rule (copy-paste pattern)
+
+```python
+# CORRECT — authoritative first, human-readable second
+_write_json_record(path_json, record)   # authoritative
+_write_log_record(path_log, record)     # human-readable
+
+# INCORRECT — do not write log before json
+_write_log_record(path_log, record)     # human-readable (wrong order)
+_write_json_record(path_json, record)   # authoritative too late
+```
+
+### Schema Change Audit Command
+
+```bash
+# Run before removing any persisted JSON field
+FIELD="learn_succeeded_at"
+grep -rn "$FIELD" hephaestus/ tests/ scripts/ docs/
+```
+
+### Prompt Structure Template
+
+```python
+prompt = (
+    f"{context_background_block}\n\n"
+    f"{content_block}\n\n"
+    f"{output_format_directives}"  # ALWAYS last
+)
+```
+
+### Sentinel Value Note
+
+`start: float = 0.0` in `_write_planner_learn_record` is a safe sentinel because `time.monotonic()` always returns a value > 0 after normal process initialization. However, document this assumption with an inline comment to prevent future confusion.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #1138 planning session | Patterns identified via code review; implementation not yet executed |
+```

--- a/skills/automation-planner-learn-record-writing-robustness.md
+++ b/skills/automation-planner-learn-record-writing-robustness.md
@@ -1,0 +1,166 @@
+---
+name: automation-planner-learn-record-writing-robustness
+description: "Robustness patterns for planner learn record writing in hephaestus/automation/planner_review_loop.py. Use when: (1) auditing or refactoring _write_planner_learn_record, (2) adding companion file writes (json + log), (3) changing persisted JSON schema fields, (4) designing multi-part prompt directives in build_learn_prompt."
+category: architecture
+date: 2026-06-12
+version: "1.1.0"
+user-invocable: false
+verification: unverified
+tags: ["planner", "learn-record", "write-order", "json", "schema", "prompt-design", "build_learn_prompt"]
+---
+
+# Automation Planner Learn Record Writing Robustness
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-12 |
+| **Objective** | Identify and address robustness gaps in `_write_planner_learn_record` in `hephaestus/automation/planner_review_loop.py` |
+| **Outcome** | Planning session complete (R0 + R1) — four concrete patterns identified; R1 corrects R0 POLA violation on prompt directive placement |
+| **Verification** | unverified |
+| **Source Issue** | ProjectHephaestus #1138 |
+
+## When to Use
+
+- Auditing or refactoring `_write_planner_learn_record` in `planner_review_loop.py`
+- Adding or changing any pair of companion files (authoritative `.json` + human-readable `.log`)
+- Dropping or renaming a field in any persisted `.json` schema (e.g., `learn_succeeded_at`)
+- Designing multi-part prompt strings where output format directives might be misplaced in `build_learn_prompt`
+- Comparing `_write_planner_learn_record` against `_write_learn_record` in `learn.py` for symmetry
+
+## Verified Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```bash
+# Audit consumers of a persisted JSON field before removing it
+grep -r "learn_succeeded_at" hephaestus/ tests/ scripts/
+
+# Verify write order in _write_planner_learn_record: json must come before log
+grep -n "_write_planner_learn_record\|\.json\|\.log" hephaestus/automation/planner_review_loop.py | head -40
+
+# Compare with learn.py reference implementation
+grep -n "_write_learn_record\|\.json\|\.log" hephaestus/automation/learn.py | head -20
+
+# Verify OSError patch path for test coverage
+grep -n "from pathlib import Path" hephaestus/automation/planner_review_loop.py
+# Expected at line 21 — confirms patch("hephaestus.automation.planner_review_loop.Path.write_text", ...)
+
+# Verify prompt directive ordering in build_learn_prompt
+grep -n "Do NOT return a plan\|plan text\|build_learn_prompt" hephaestus/automation/learn.py | head -20
+```
+
+### Detailed Steps
+
+#### Pattern 1 — Write Order Atomicity (json before log)
+
+1. Locate the two companion file writes in `_write_planner_learn_record` (around line 599–666 of `planner_review_loop.py` at planning time — line numbers may shift).
+2. Confirm the current order: if `.log` is written before `.json`, swap them.
+3. The authoritative `.json` file must always be written first so that a mid-write crash leaves the authoritative record present (even if incomplete) rather than only the human-readable log.
+4. Reference: `learn.py:_write_learn_record` writes `.json` only — mirror that discipline in the planner variant.
+
+#### Pattern 2 — Schema Field Removal Audit
+
+1. Before removing any field from a persisted `.json` schema, run a consumer audit:
+   ```bash
+   grep -r "<field_name>" hephaestus/ tests/ scripts/
+   ```
+2. For the specific case of `learn_succeeded_at → learn_duration_s`:
+   - Confirm all readers of the old field name are updated or that the field is truly unused.
+   - `learn_duration_s` is computed from `time.monotonic()` start/end; the `start: float = 0.0` sentinel is safe in practice (monotonic is always > 0 at normal process start) but document the assumption.
+3. **Audit scope caveat (R1):** The grep-based consumer audit is NOT exhaustive — it covers the local repo but does not traverse the full dependency graph across sibling projects. Flag this as a risk in the PR body so downstream consumers of the JSON records are warned.
+4. Add a migration note in the PR body so downstream consumers of the JSON records are warned.
+
+#### Pattern 3 — Prompt Directive Placement (CORRECTED in R1)
+
+> **R1 Correction:** R0 described this pattern as editing `capture_planner_learnings`. R1 corrects: the fix belongs in `build_learn_prompt` in `learn.py`. Editing `capture_planner_learnings` violates POLA because issue #1138 explicitly named `build_learn_prompt` as the target function. When an issue spec names a specific function, edit that function — not an adjacent one with similar context.
+
+1. In `build_learn_prompt` (in `learn.py`), output format directives must appear AFTER the content block they govern.
+2. Pattern: `[context/background] → [content block] → [output format directives]`
+3. If a bullet-output directive appears mid-prompt before the plan block, restructure `build_learn_prompt` so its imperatives trail naturally after the content.
+4. Do NOT make this change in `capture_planner_learnings` — that function provides context strings, not the final prompt assembly.
+5. Review the full prompt string in `build_learn_prompt` after any refactor to verify directive ordering is preserved.
+
+**Assertion to add in tests:**
+```python
+# Verify imperatives appear AFTER content in build_learn_prompt output
+prompt = build_learn_prompt(plan_text="plan text", ...)
+assert prompt.index("Do NOT return a plan") < prompt.index("plan text") is False
+# More precisely: the directive should follow the plan block
+assert prompt.index("plan text") < prompt.index("Do NOT return a plan")
+```
+
+#### Pattern 4 — Sentinel Value Safety
+
+1. The `start: float = 0.0` sentinel in `_write_planner_learn_record` uses `if start else None` to detect "not set".
+2. This is theoretically unsafe: `0.0` is a valid `time.monotonic()` return value at process start (though extremely rare in practice).
+3. Safer alternative: `start: float | None = None` with `if start is not None else None`.
+4. A reviewer may flag the sentinel check. Document the assumption with an inline comment, or use the `None`-typed sentinel.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Log-before-json write order | `_write_planner_learn_record` wrote `.log` then `.json` | A crash mid-sequence leaves only the human-readable log with no authoritative record | Always write authoritative file first; human-readable is secondary |
+| Dropping `learn_succeeded_at` without audit | Field removal planned without grep-checking consumers | Silent breakage in downstream readers that parse the JSON | Grep all consumers before any schema field removal |
+| Mid-prompt directive placement (wrong function) | R0 plan — added `Do NOT return a plan` directive to `_capture_planner_learnings` context string | Issue #1138 explicitly named `build_learn_prompt` in `learn.py` as the target; editing the adjacent function violates POLA and doesn't fix the actual prompt structure | When the issue spec names a specific function, that is the target — read the function signature before editing neighbors |
+
+## Results & Parameters
+
+### Write Order Rule (copy-paste pattern)
+
+```python
+# CORRECT — authoritative first, human-readable second
+_write_json_record(path_json, record)   # authoritative
+_write_log_record(path_log, record)     # human-readable
+
+# INCORRECT — do not write log before json
+_write_log_record(path_log, record)     # human-readable (wrong order)
+_write_json_record(path_json, record)   # authoritative too late
+```
+
+### Schema Change Audit Command
+
+```bash
+# Run before removing any persisted JSON field
+FIELD="learn_succeeded_at"
+grep -rn "$FIELD" hephaestus/ tests/ scripts/ docs/
+# NOTE: This audits the local repo only. Cross-project consumers are NOT covered.
+```
+
+### Prompt Structure Template (build_learn_prompt)
+
+```python
+# In build_learn_prompt (learn.py) — NOT in capture_planner_learnings
+prompt = (
+    f"{context_background_block}\n\n"
+    f"{content_block}\n\n"
+    f"{output_format_directives}"  # ALWAYS last; edit THIS function, not capture_planner_learnings
+)
+```
+
+### Sentinel Value Note
+
+`start: float = 0.0` in `_write_planner_learn_record` uses `if start else None`. This is safe in practice because `time.monotonic()` always returns a value > 0 after normal process initialization. However:
+
+- **Theoretical risk:** `0.0` is a valid monotonic value at process start — the sentinel check would incorrectly treat it as "not set"
+- **Safer alternative:** `start: float | None = None` with `if start is not None`
+- Document the assumption with an inline comment to prevent future reviewer flags
+
+### OSError Test Patch Path
+
+When testing OSError handling in `_write_planner_learn_record`, the correct patch path is:
+```python
+patch("hephaestus.automation.planner_review_loop.Path.write_text", side_effect=OSError(...))
+```
+This is valid because `from pathlib import Path` is at line 21 of `planner_review_loop.py`.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #1138 planning session (R0) | Patterns identified via code review; implementation not yet executed |
+| ProjectHephaestus | Issue #1138 planning session (R1) | R0 POLA violation corrected; sentinel gotcha documented; OSError patch path confirmed |

--- a/skills/ci-cd-cpp-asan-gtest-discovery-branch-protection.md
+++ b/skills/ci-cd-cpp-asan-gtest-discovery-branch-protection.md
@@ -1,0 +1,178 @@
+---
+name: ci-cd-cpp-asan-gtest-discovery-branch-protection
+description: "C++ CI repair patterns for ASAN/UBSAN test discovery failures and GitHub branch protection drift. Use when: (1) gtest_discover_tests() aborts at CMake configure time with ASan runtime error, (2) branch ruleset required_approving_review_count resets to 0 causing daily audit CI failures, (3) upgrading peter-evans/create-pull-request from v6 to v8, (4) upgrading gitleaks/gitleaks-action from v2 to v3."
+category: ci-cd
+date: 2026-06-13
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - asan
+  - ubsan
+  - sanitizer
+  - gtest
+  - cmake
+  - gtest_discover_tests
+  - branch-protection
+  - ruleset
+  - required-reviewers
+  - peter-evans-create-pull-request
+  - gitleaks
+---
+
+# C++ CI Repair: ASAN Test Discovery + Branch Protection Drift
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-13 |
+| **Objective** | Fix recurring C++ CI failures: ASAN-linked test binaries crashing at CMake configure time, and GitHub ruleset required_approving_review_count silently resetting to 0 |
+| **Outcome** | Both fixes verified in CI via PRs to ProjectNestor (#111) and ProjectCharybdis (#263) |
+| **Verification** | verified-ci |
+
+## When to Use
+
+1. `gtest_discover_tests()` in CMake causes CI failure with `ASan runtime does not come first in initial library list` at configure time
+2. A daily ruleset-audit CI job is failing with `required_approving_review_count is 0, expected >= 1`
+3. Upgrading `peter-evans/create-pull-request` from v6 to v8 — need to know what inputs break
+4. Upgrading `gitleaks/gitleaks-action` from v2 to v3 — need to know what breaks
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Fix 1: ASAN gtest discovery — add DISCOVERY_MODE PRE_TEST
+# In CMakeLists.txt:
+gtest_discover_tests(my_test_target DISCOVERY_MODE PRE_TEST)
+
+# Fix 2: Branch protection reset — run existing script if present
+bash scripts/apply-branch-protection.sh
+
+# Fix 2 alternative — patch via API
+RULESET_ID=15556497  # find with: gh api repos/ORG/REPO/rulesets
+RULES=$(gh api repos/ORG/REPO/rulesets/$RULESET_ID | jq '.rules | map(if .type == "pull_request" then .parameters.required_approving_review_count = 1 else . end)')
+gh api --method PATCH repos/ORG/REPO/rulesets/$RULESET_ID --field enforcement=active --field "rules=$RULES"
+```
+
+### Detailed Steps
+
+#### Fix 1: ASAN/UBSAN + gtest_discover_tests
+
+**Root cause:** `gtest_discover_tests()` default mode (`POST_BUILD`) runs the test binary at CMake configure/build time to enumerate tests via `--gtest_list_tests`. When the binary is linked with `-fsanitize=address`, the ASan runtime `.so` must be the first shared library loaded. In the non-test GitHub Actions environment, LD_PRELOAD is not set, causing the immediate abort:
+```
+==XXXXX==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
+CMake Error at .../GoogleTestAddTests.cmake:132: Error running test executable.
+```
+
+**Fix:** Add `DISCOVERY_MODE PRE_TEST` to every `gtest_discover_tests()` call:
+
+```cmake
+# Before (broken with ASAN):
+gtest_discover_tests(nestor_tests)
+gtest_discover_tests(nestor_tests PROPERTIES TIMEOUT 120)
+
+# After (ASAN-safe):
+gtest_discover_tests(nestor_tests DISCOVERY_MODE PRE_TEST)
+gtest_discover_tests(nestor_tests DISCOVERY_MODE PRE_TEST PROPERTIES TIMEOUT 120)
+```
+
+`DISCOVERY_MODE PRE_TEST` defers the `--gtest_list_tests` invocation to actual test runtime when `ctest` sets up the proper sanitizer environment.
+
+Find all affected targets:
+```bash
+grep -rn "gtest_discover_tests" . --include="CMakeLists.txt"
+```
+
+#### Fix 2: Branch protection required_approving_review_count reset
+
+**Root cause:** GitHub's rulesets API can reset `required_approving_review_count` to 0 after certain operations (push events, API calls by other tools). A daily audit workflow checking this will fail until fixed.
+
+**Step 1:** Check if the repair script exists:
+```bash
+ls scripts/apply-branch-protection.sh 2>/dev/null
+```
+
+**Step 2a:** If script exists, run it:
+```bash
+bash scripts/apply-branch-protection.sh
+# Should output: OK: required_approving_review_count=1 confirmed on 'homeric-main-baseline'
+```
+
+**Step 2b:** If no script, patch directly:
+```bash
+# Find your ruleset ID
+gh api repos/ORG/REPO/rulesets | jq '.[] | {id, name}'
+
+# Patch — preserves all other rules, only sets reviewer count
+RULESET_ID=<id>
+RULES=$(gh api repos/ORG/REPO/rulesets/$RULESET_ID \
+  | jq '.rules | map(if .type == "pull_request" then .parameters.required_approving_review_count = 1 else . end)')
+gh api --method PATCH repos/ORG/REPO/rulesets/$RULESET_ID \
+  --field enforcement=active \
+  --field "rules=$RULES"
+```
+
+#### Fix 3: peter-evans/create-pull-request v6 to v8 upgrade
+
+The `author`/`committer` format changed in v7+. Safe upgrade if the workflow does NOT use `author:` or `committer:` inputs. Repos using only `commit-message`, `title`, `body`, `branch`, `delete-branch` can upgrade transparently.
+
+```yaml
+# This upgrade is safe — no author/committer inputs used:
+- uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+  with:
+    commit-message: "chore: update vendored schema"
+    title: "Update vendored JSON schema"
+    body: "Automated update"
+    branch: update-schema
+    delete-branch: true
+```
+
+#### Fix 4: gitleaks/gitleaks-action v2 to v3 upgrade
+
+No breaking input changes for standard usage. Direct SHA swap:
+```yaml
+# Before:
+uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
+
+# After:
+uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| 1 | Set `LD_PRELOAD` in gtest step env to force ASan preload | Env var on the CMake configure step doesn't propagate to child processes spawned by GoogleTestAddTests.cmake during test discovery | `DISCOVERY_MODE PRE_TEST` is the canonical CMake solution — don't fight the discovery phase |
+| 2 | Added PROPERTIES ENVIRONMENT "LD_PRELOAD=..." to gtest_discover_tests | PROPERTIES keyword applies to test properties, not the discovery invocation itself | Use DISCOVERY_MODE PRE_TEST instead; it completely skips the binary invocation at configure time |
+| 3 | Used `gh api --method PATCH` with a JSON-encoded `rules` string | The PATCH endpoint requires `rules` as a JSON array object, not a JSON-encoded string | Use `--field "rules=$RULES"` where `$RULES` is the raw jq output (array), not a quoted string |
+
+## Results & Parameters
+
+### ASAN gtest discovery fix — verified in ProjectNestor
+
+- Affected: `test/CMakeLists.txt` with 3 `gtest_discover_tests()` calls
+- PR: HomericIntelligence/ProjectNestor#111
+- Outcome: CodeQL and Required Checks now passing on PR
+
+### Branch protection fix — verified in ProjectCharybdis
+
+- Ruleset: `homeric-main-baseline` (id=15556497)
+- Script: `scripts/apply-branch-protection.sh` (existed and worked)
+- PR: HomericIntelligence/ProjectCharybdis#263
+- Outcome: Daily ruleset-audit workflow now passes
+
+### Action version SHAs (2026-06-13)
+
+| Action | Version | SHA |
+|--------|---------|-----|
+| `peter-evans/create-pull-request` | v8.1.1 | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` |
+| `gitleaks/gitleaks-action` | v3.0.0 | `e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e` |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectNestor | CodeQL ASAN failure fix 2026-06-13 | PR #111 — 3 gtest_discover_tests calls fixed |
+| ProjectCharybdis | Daily ruleset-audit failure fix 2026-06-13 | PR #263 — apply-branch-protection.sh ran successfully |


### PR DESCRIPTION
## Summary

- Adds new skill `automation-loop-post-loop-filter-omission` (v1.0.0, category: debugging, verification: unverified)
- Documents the canonical filter-omission bug where `loops_run = max(r.loop_idx for r in results)` in `loop_runner.py:1695` includes post-loop `RepoResult` records whose `loop_idx=cfg.loops` is set unconditionally, causing inflated loop counts after early-exit
- Captures the one-line fix (`if not r.post_loop_phases` predicate), key risks (empty `post_loop_phases` edge case), existing test blind spot in `test_main_loops_run_early_exit`, and the general detection pattern for this class of aggregation bug
- Source: ProjectHephaestus issue #1153

## Test plan

- [ ] `validate_plugins.py` passes (297/297 valid — verified locally before commit)
- [ ] Signed commit verified (`gpg: Good signature`)
- [ ] Skill follows the established format (frontmatter, all required sections present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)