### PR TITLE
skill(pre-commit-hooks-and-linting-config): v1.9.0 — markdownlint CI job dedup pattern

### DIFF
--- a/skills/pre-commit-hooks-and-linting-config.history
+++ b/skills/pre-commit-hooks-and-linting-config.history
@@ -1,6 +1,35 @@
 <!-- markdownlint-disable MD024 -->
 # pre-commit-hooks-and-linting-config -- History
 
+## v1.9.0 (2026-06-13) -- Add markdownlint CI job dedup pattern (issue #1199 planning learnings)
+
+**Source:** ProjectHephaestus issue #1199 implementation plan (unverified — plan not yet implemented)
+
+**What changed:**
+
+- Added new trigger (13) to `description` and `When to Use`: removing a duplicate standalone
+  markdownlint CI job when `lint` already runs `pre-commit --all-files`.
+- Added new `Detailed Steps` section: "Removing a duplicate standalone markdownlint CI job
+  (dedup to pre-commit)" with two mandatory preconditions: (1) verify the job is NOT a
+  required-check context via `gh api repos/{owner}/{repo}/rulesets` BEFORE deleting, (2)
+  pre-scan newly-in-scope files with `--fix` then re-check for residual violations.
+- Added 2 new `Failed Attempts` rows covering the two most dangerous assumptions:
+  - Deleting a CI job without checking branch-protection required contexts
+  - Widening hook scope assuming `--fix` handles all violations
+
+**Key risks captured:**
+
+- Removing a required-check CI job causes ci-driver-blocked-required-context-drift.
+- `markdownlint-cli2 --fix` is a no-op for MD060 and MD013 long-line rules.
+- Fragile grep-count verification criterion: a step-name change elsewhere in the file
+  invalidates a count-based assertion.
+- `.claude/` hook exclusion is harmless (pre-commit only scans tracked files) but should not
+  be removed without confirming `.claude/` is gitignored.
+
+**Verification level:** `unverified` — learnings from planning, not from a completed implementation.
+
+---
+
 ## v1.8.0 (2026-06-07) -- Absorb 4 lint/quality skills (ruff-format trap, PR-diff scope, editorconfig, toolchain-churn review exemption)
 
 Consolidated 4 overlapping skills into this canonical (LQ05 cluster):

--- a/skills/pre-commit-hooks-and-linting-config.md
+++ b/skills/pre-commit-hooks-and-linting-config.md
@@ -1,9 +1,9 @@
 ---
 name: pre-commit-hooks-and-linting-config
-description: "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes — system-installed package in ~/.local/bin shadows the local dev version, (7) ruff I001/RUF059 fires on inline imports or unused tuple unpacking inside test functions after adding new tests, (8) mypy pre-commit hook fails because an UNTRACKED test file references methods not yet committed — the hook checks ALL .py files on disk including untracked ones, (9) CI ruff-format hook fails even though local `ruff check` passed — `ruff check` (lint) and `ruff format --check` (formatter) are SEPARATE tools sharing one binary and running only `check` never exercises the formatter, (10) running pre-commit against the full PR diff (every file changed since merge-base) with `--from-ref/--to-ref` not just `--files <current edit>` — a sub-agent's earlier commit can carry stale-formatter content that fails only in CI, (11) adding .editorconfig for cross-editor formatting consistency on non-Python files (YAML, JSON, Markdown, shell, Makefile), (12) an automated PR-reviewer flags lint/formatter/pre-commit-forced incidental churn as scope creep — toolchain-forced churn is exempt from YAGNI/scope review while author-chosen opportunistic work is still flagged."
+description: "Canonical guide to pre-commit hook configuration, single-source-of-truth versioning, CI/local parity, and integration of ruff/mypy/clang-format/yamllint/actionlint/golangci-lint/bandit/hadolint/shellcheck/markdownlint. Use when: (1) writing or amending .pre-commit-config.yaml, (2) diagnosing why a hook passes locally but fails in CI (version drift), (3) deciding fix-vs-suppress for lint findings, (4) adding a new linter to an existing pre-commit pipeline, (5) reconciling ruff/mypy/markdownlint config across multiple repos, (6) a pre-commit hook using a pixi console script false-fails locally even though CI passes — system-installed package in ~/.local/bin shadows the local dev version, (7) ruff I001/RUF059 fires on inline imports or unused tuple unpacking inside test functions after adding new tests, (8) mypy pre-commit hook fails because an UNTRACKED test file references methods not yet committed — the hook checks ALL .py files on disk including untracked ones, (9) CI ruff-format hook fails even though local `ruff check` passed — `ruff check` (lint) and `ruff format --check` (formatter) are SEPARATE tools sharing one binary and running only `check` never exercises the formatter, (10) running pre-commit against the full PR diff (every file changed since merge-base) with `--from-ref/--to-ref` not just `--files <current edit>` — a sub-agent's earlier commit can carry stale-formatter content that fails only in CI, (11) adding .editorconfig for cross-editor formatting consistency on non-Python files (YAML, JSON, Markdown, shell, Makefile), (12) an automated PR-reviewer flags lint/formatter/pre-commit-forced incidental churn as scope creep — toolchain-forced churn is exempt from YAGNI/scope review while author-chosen opportunistic work is still flagged, (13) removing a duplicate standalone markdownlint CI job when the lint job already runs pre-commit --all-files — MUST verify the job is NOT a required-check context in branch protection before deleting it, and MUST pre-scan the newly-in-scope files for violations that --fix cannot auto-fix."
 category: tooling
-date: 2026-06-07
-version: "1.8.0"
+date: 2026-06-13
+version: "1.9.0"
 user-invocable: false
 verification: verified-ci
 history: pre-commit-hooks-and-linting-config.history
@@ -51,6 +51,7 @@ tags: [merged, pre-commit, linting, ruff, mypy, clang-format, yamllint, actionli
 - Diagnosing CI formatter failures (mojo-format / ruff-format) on files you did not personally edit this session — a sub-agent's `--files`-scoped pre-commit missed them
 - Repository lacks `.editorconfig` and contributors use different editors with inconsistent indentation/whitespace on non-Python files (YAML, JSON, Markdown, shell, Makefile)
 - An automated PR-review agent (or human reviewer) flags lint/formatter/pre-commit-forced incidental churn (whitespace, import-sort, trailing-newline, mypy annotations) as scope creep or YAGNI, or you are designing a review rubric's scope/YAGNI dimension
+- Removing a duplicate standalone markdownlint CI job that runs the same check the `lint` job already runs via `pre-commit run --all-files` — the dedup is correct but two preconditions must hold before deletion: (a) the job name is NOT listed as a required-check context in branch protection, (b) all files that will newly fall under the pre-commit hook's `files:` pattern are pre-scanned for violations that `--fix` cannot auto-fix
 
 ## Verified Workflow
 
@@ -256,6 +257,62 @@ python3 scripts/fix_md_tables.py --all
 # Then lint the script itself:
 ruff check --fix scripts/fix_md_tables.py
 ```
+
+#### Removing a duplicate standalone markdownlint CI job (dedup to pre-commit)
+
+When a repo has both a standalone `markdownlint` CI job (e.g. in `_required.yml`) AND a `lint`
+job that already runs `pre-commit run --all-files` (which includes a markdownlint hook), the
+standalone job is pure duplication. Consolidating to pre-commit as the single source of truth is
+correct — but two preconditions MUST be verified before deleting the job:
+
+**Precondition 1 — Confirm the job is NOT a required-check context.**
+
+```bash
+# Check branch protection rulesets for the exact job name:
+gh api repos/{owner}/{repo}/rulesets --jq '.[].conditions'
+gh api repos/{owner}/{repo}/branches/main/protection/required_status_checks \
+  --jq '.checks[].context' 2>/dev/null
+# OR check the GitHub repository Settings → Branches → Protection rules UI.
+# If "markdownlint" (or the exact job name) appears in the required contexts list,
+# removing the job will BLOCK every PR indefinitely (ci-driver-blocked-required-context-drift).
+# Fix: remove the context from the ruleset BEFORE or simultaneously with deleting the job.
+```
+
+**Precondition 2 — Pre-scan newly-in-scope files for violations `--fix` cannot auto-fix.**
+
+When the pre-commit hook's `files:` pattern is widened to cover new directories (e.g. `docs/*.md`
+that the old standalone job covered but the hook did not), run `--fix` first and check for
+residual violations:
+
+```bash
+# Dry-run fix on newly-in-scope files:
+pixi run npx markdownlint-cli2 --fix "docs/**/*.md"
+# Then check whether any violations remain:
+pixi run npx markdownlint-cli2 "docs/**/*.md"
+# If violations remain after --fix, CI will immediately fail after the scope change.
+# Fix them manually before merging (see MD060 bulk table fix section for tables).
+```
+
+**Safe deletion checklist:**
+
+1. `grep -n 'needs:' .github/workflows/_required.yml` — confirm zero jobs depend on the standalone job (safe DAG deletion).
+2. Verify the job name is absent from all required-check contexts (Step 1 above).
+3. Pre-scan newly-in-scope files (Step 2 above); fix all residual violations.
+4. Widen the hook's `exclude:` pattern in `.pre-commit-config.yaml` to NOT exclude the files the old job covered (or verify it already doesn't exclude them).
+5. Delete the job block from the workflow file.
+6. Run `pixi run pre-commit run --from-ref origin/main --to-ref HEAD` locally before push.
+
+**Note on `.claude/` exclusion in pre-commit hooks:** pre-commit only runs against git-tracked
+files. Excluding `.claude/` from the hook's `exclude:` pattern is defensive but harmless if
+`.claude/` files are already untracked (in `.gitignore`). Do not remove such an exclusion
+without confirming `.claude/` is fully covered by `.gitignore`.
+
+**Verification (fragile grep criterion):** a post-change grep like
+`grep -c 'markdownlint' .github/workflows/_required.yml` to assert a specific count is fragile
+if the edit also changes a step name that contains "markdownlint" elsewhere in the file. Verify
+the expected count matches actual state after ALL edits are applied.
+
+Unverified — plan produced for ProjectHephaestus issue #1199 (not yet implemented as of 2026-06-13).
 
 #### Bandit SAST severity-level tuning (silence LOW noise without disabling checks)
 
@@ -588,6 +645,8 @@ feasible (e.g., constrained CI environments, conda-forge only providing old Go v
 | pygrep commented-out prints as negative test cases | Added `# print("NOTE: ...")` to NEGATIVE_CASES | pygrep matches raw line -- comment still contains `print.*NOTE` | Move commented-out prints to POSITIVE_CASES; pygrep does not understand comments |
 | Blanket `--skip B404,B603,B607` to silence bandit noise | Passed all three LOW-severity subprocess IDs to `--skip` | Skips injection-check IDs entirely, removing real signal for any future subprocess misuse | Use `--severity-level medium` instead -- filters by severity, not by check ID |
 | Fix MD033 by editing stray `.claude-prompt-NNN.md` to remove HTML tags | Tried to strip `<NONCE>` / `<LABEL>` tags from the file | File is an agent artifact with no source value; editing it is wasted effort and the file can recur | Always `git rm` accidental artifact files; add `.gitignore` pattern to prevent recurrence |
+| Delete a standalone `markdownlint` CI job assuming it is not a required check | Removed the job from `_required.yml` without checking branch-protection rulesets | If the job name is listed as a required status check, every subsequent PR is permanently BLOCKED (no context posted, never satisfies the rule) — `ci-driver-blocked-required-context-drift` pattern | ALWAYS run `gh api repos/{owner}/{repo}/rulesets` and the branch-protection required-checks endpoint BEFORE deleting any CI job; update the ruleset atomically with the deletion |
+| Widen markdownlint hook scope without pre-scanning new files | Extended `files:` pattern to include `docs/` assuming `--fix` would handle all violations | `markdownlint-cli2 --fix` is a silent no-op for several rules (MD060, MD013 long lines); unfixable violations break CI on the first push after the scope change | Pre-scan with `--fix` then re-run without `--fix` to confirm zero residual violations before merging |
 | `bandit --exit-zero` to pass CI while investigating | Added `--exit-zero` flag during bandit hook integration | All real findings invisible to CI; defeating the purpose of SAST | Never suppress exit codes; fix each MEDIUM+ finding properly |
 | Security hook blocking workflow file `Edit` | Used `Edit` tool on `.github/workflows/pre-commit.yml` | Project security hook fires on all Actions workflow edits | Use `python3 -c "..."` via Bash to write the file instead |
 | mypy fails on untracked test file referencing not-yet-committed methods | Created both test file and implementation file but only staged the implementation for commit 1 | mypy pre-commit hook runs on ALL `.py` files on disk, including untracked ones; sees `attr-defined` / `module-attribute` errors in the untracked test | Temporarily move the untracked test file to `/tmp` before commit 1; restore and stage it for commit 2. Only needed for strict multi-commit atomic ordering. |


### PR DESCRIPTION
## Summary

- Amends `pre-commit-hooks-and-linting-config` from v1.8.0 to v1.9.0 with planning learnings from ProjectHephaestus issue #1199 (markdownlint deduplication)
- Adds new trigger (13), a detailed safe-deletion checklist section, and two new Failed Attempts rows
- Core lesson: removing a standalone CI markdownlint job requires verifying it is NOT a required-check context in branch protection (else permanent PR blockage via ci-driver-blocked-required-context-drift), and pre-scanning newly-in-scope files since --fix is a no-op for MD060 and MD013

## Files changed

- `skills/pre-commit-hooks-and-linting-config.md` — v1.9.0, +65 lines
- `skills/pre-commit-hooks-and-linting-config.history` — v1.9.0 entry prepended

## Verification level

unverified — learnings from a planning session; ProjectHephaestus issue #1199 not yet implemented as of 2026-06-13.