### PR TITLE
feat: amend bash-script-and-jq-failure-modes skill (2>&1 + mock-gh pattern)

### DIFF
--- a/skills/bash-script-and-jq-failure-modes.history
+++ b/skills/bash-script-and-jq-failure-modes.history
@@ -1,5 +1,17 @@
 ## Version History
 
+### v1.2.0 (2026-06-13)
+- Added Failure Mode 8: `2>&1` in command substitution corrupts jq input — gh stderr (deprecation banners, update notices, GH_DEBUG traces) merged into captured variable via `2>&1` causes jq to receive non-JSON input, producing empty output and downstream false errors. Fix: capture stdout only; do not reference `$raw` in the error path (it is empty on failure).
+- Added Failure Mode 9: mock-gh bash function pattern for Python subprocess integration tests — `export -f gh` exports a bash function override into the sourced script's environment without needing a fake binary on PATH; `stderr_noise` flag lets tests verify the 2>&1 fix holds under realistic advisory output.
+- Added Failure Mode 10: ruff D401 applies to private helper docstrings — "Helper to", "Wrapper for", "Utility that" openers fail D401 even on `_private` functions; use imperative verb openers.
+- Added Quick Reference entry for `2>&1` corruption pattern.
+- Added Results & Parameters sections: "gh api stdout-only capture pattern", "mock-gh bash function pattern", "ruff D401 imperative-mood docstring openers".
+- Added two new Failed Attempts rows: `gh api … 2>&1` corruption and "Helper to" D401 rejection.
+- Updated When to Use with three new triggers.
+- Updated description frontmatter with trigger (9) for `2>&1` gh api corruption.
+- Bumped verification: verified-local → verified-ci (PR #1273, issue #1122, all CI green).
+- Verified on: HomericIntelligence/ProjectHephaestus issue #1122, PR #1273.
+
 ### v1.1.0 (2026-05-26)
 - Added Failure Mode 7: `set -m` (job control) + single-command `(...)` subshell exec-optimization causing silent abort with no error trace.
 - Added "Diagnostic recipe: silent abort after single-command subshell" subsection with ERR/EXIT/RETURN trap recipe.

--- a/skills/bash-script-and-jq-failure-modes.md
+++ b/skills/bash-script-and-jq-failure-modes.md
@@ -1,10 +1,10 @@
 ---
 name: bash-script-and-jq-failure-modes
-description: "Diagnose and fix silent failures in bash scripting and jq under strict error-checking modes. Use when: (1) a bash script with set -euo pipefail exits unexpectedly mid-loop or mid-function, (2) grep finds no matches and kills the script via pipefail, (3) bash arrays crash with 'unbound variable' despite being declared, (4) exit 127 appears and all binaries are installed, (5) jq // operator silently drops boolean false values, (6) jq fails with syntax errors on array concatenation with conditionals, (7) Claude Code Bash cwd drifts from Read/Edit absolute paths in multi-worktree sessions, (8) a bash function with set -m + set +e silently aborts mid-execution after a single-command (...) subshell finishes with no error log and no continuation past the subshell."
+description: "Diagnose and fix silent failures in bash scripting and jq under strict error-checking modes. Use when: (1) a bash script with set -euo pipefail exits unexpectedly mid-loop or mid-function, (2) grep finds no matches and kills the script via pipefail, (3) bash arrays crash with 'unbound variable' despite being declared, (4) exit 127 appears and all binaries are installed, (5) jq // operator silently drops boolean false values, (6) jq fails with syntax errors on array concatenation with conditionals, (7) Claude Code Bash cwd drifts from Read/Edit absolute paths in multi-worktree sessions, (8) a bash function with set -m + set +e silently aborts mid-execution after a single-command (...) subshell finishes with no error log and no continuation past the subshell, (9) gh api output captured with 2>&1 corrupts jq input via non-JSON stderr lines (deprecation banners, rate-limit notices, GH_DEBUG traces)."
 category: debugging
-date: 2026-05-26
-version: "1.1.0"
-verification: verified-local
+date: 2026-06-13
+version: "1.2.0"
+verification: verified-ci
 user-invocable: false
 history: bash-script-and-jq-failure-modes.history
 tags:
@@ -28,6 +28,14 @@ tags:
   - exec-optimization
   - silent-abort
   - orchestrator-rewrite
+  - stderr
+  - 2>&1
+  - command-substitution
+  - gh-cli
+  - mock-gh
+  - integration-test
+  - ruff
+  - D401
 ---
 
 # Bash Script and jq Failure Modes Under Strict Error-Checking
@@ -51,6 +59,9 @@ tags:
 - jq fails with `syntax error, unexpected '+', expecting '}'` on array concatenation with conditionals
 - `Read` shows content that `grep` in Bash cannot find — or a commit lands on the wrong branch — in a multi-worktree session
 - A bash function with `set -m` + `set +e` silently aborts mid-execution after a single-command `(...)` subshell finishes, with no error log and no continuation past the subshell — bash trace shows execution jumping to the parent loop. The defang-with-`set +e` pattern is NOT sufficient against this trigger.
+- `gh api` output is captured with `2>&1` into a variable, then piped to `jq`, and `jq` returns empty or the script exits with "allows no merge methods" / "no valid value" — even though the API endpoint is valid.
+- A Python subprocess integration test needs to stub `gh` without creating a fake binary on `PATH`.
+- A docstring on a private helper function (`_foo`) fails ruff D401 despite starting with a capital letter.
 
 Do NOT use when:
 
@@ -103,6 +114,17 @@ jq -n --argjson files "$files_json" '{ files: $files }'
 cd /abs/path/to/main/worktree && pwd
 git rev-parse --show-toplevel
 git worktree list
+
+# --- GH API 2>&1 CORRUPTION: capture stdout only ---
+# WRONG — merges stderr into $raw; any non-JSON line breaks jq:
+raw=$(gh api "repos/${repo}" 2>&1)
+flag=$(printf '%s' "$raw" | jq -r '...')
+# CORRECT — capture stdout only; gh writes its error to stderr on failure:
+if ! raw=$(gh api "repos/${repo}"); then
+    echo "gh api repos/${repo} failed" >&2
+    return 1
+fi
+flag=$(printf '%s' "$raw" | jq -r '...')
 ```
 
 ### Failure Mode 1: Exit 127 — Orphaned Shell Function
@@ -306,6 +328,111 @@ Concrete symptom signature (from ProjectHephaestus `scripts/run_automation_loop.
 
 2. **Rewrite the orchestrator in Python.** When 3+ interacting safety mechanisms (`set -euo pipefail` + `set -m` + `set +e` defang + ERR/EXIT traps + RETURN traps + single-command subshells) accumulate, the rewrite-to-Python option becomes lower-risk than another patch. The Python equivalent uses `subprocess.run` inside a plain `for phase in ALL_PHASES` loop — phase isolation is then **structural**, not behavioral, and no shell-option landmine can silently skip iterations. See ProjectHephaestus `hephaestus/automation/loop_runner.py` for the verified replacement pattern.
 
+### Failure Mode 8: `2>&1` in Command Substitution Corrupts jq Input
+
+When `gh api` (or any CLI that emits non-JSON to stderr) is captured with `2>&1` inside `$()`, deprecation banners, update notices, and `GH_DEBUG=1` traces are merged into the captured variable. Any non-JSON line appearing before the JSON body causes `jq` to fail or return empty — silently under `-r`, producing downstream "no valid value" / "allows no merge methods" false errors even when the API response is correct.
+
+**Trigger conditions:**
+- `gh` CLI writes to stderr: deprecation notices, "A new release of gh is available", rate-limit hints, or `GH_DEBUG` traces.
+- The variable is later piped to `jq`.
+- `jq` receives a mixed blob (e.g., `"warning: new gh version available\n{...json...}"`) and either errors or returns empty.
+- Downstream code interprets empty as "no valid value" and falls through to a failure path.
+
+**Bug pattern:**
+
+```bash
+# WRONG — merges gh stderr into $raw; any non-JSON line breaks jq
+if ! raw=$(gh api "repos/${repo}/merge-methods" 2>&1); then
+    echo "failed: ${raw}" >&2
+    return 1
+fi
+flag=$(printf '%s' "$raw" | jq -r '.allow_squash_merge // false')
+```
+
+The `2>&1` was added to capture gh's error message into `$raw` for the error path — but it also captures all advisory stderr on the success path.
+
+**Correct pattern — capture stdout only:**
+
+```bash
+# CORRECT — capture stdout only; gh writes its own error to stderr on failure
+if ! raw=$(gh api "repos/${repo}/merge-methods"); then
+    echo "gh api repos/${repo}/merge-methods failed" >&2
+    echo "  (check: gh auth status; token needs 'repo' scope; repo exists)" >&2
+    return 1
+fi
+flag=$(printf '%s' "$raw" | jq -r '.allow_squash_merge // false')
+```
+
+On failure, `$raw` is empty (gh already wrote its error message to stderr). The error path message should not reference `$raw`.
+
+**Diagnostic: verify corruption is the cause:**
+
+```bash
+# Run with GH_DEBUG=1 and capture both separately:
+raw_out=$(gh api "repos/owner/repo" 2>/tmp/gh_stderr.txt)
+cat /tmp/gh_stderr.txt   # should contain only diagnostic lines, not JSON
+echo "$raw_out" | jq .   # should parse cleanly
+```
+
+### Failure Mode 9: Stubbing `gh` in Python Subprocess Integration Tests
+
+When integration-testing shell scripts that call `gh`, creating a fake `gh` binary on PATH is fragile (requires temp dir, PATH manipulation, cleanup). The simpler pattern uses an inline bash function with `export -f`:
+
+```python
+import subprocess
+from pathlib import Path
+
+SNIPPET = Path(__file__).resolve().parents[2] / "scripts" / "choose_merge_flag.sh"
+
+def _run_choose(json_body: str, *, stderr_noise: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
+    if stderr_noise:
+        gh_impl = (
+            f"gh() {{\n"
+            f"    case \"$1\" in\n"
+            f"        api)\n"
+            f"            echo \"warning: new gh version available\" >&2\n"
+            f"            printf '%s\\n' '{json_body}'\n"
+            f"            ;;\n"
+            f"    esac\n"
+            f"}}"
+        )
+    else:
+        gh_impl = f"gh() {{ case \"$1\" in api) printf '%s\\n' '{json_body}';; esac; }}"
+
+    script = f"""
+{gh_impl}
+export -f gh
+. {SNIPPET}
+choose_merge_flag owner/repo
+"""
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+```
+
+Key points:
+- `export -f gh` makes the bash function visible to the sourced script — no fake binary needed.
+- `stderr_noise: bool` flag lets tests verify the fix holds even when gh emits non-JSON to stderr.
+- The sourced script (`. SNIPPET`) runs in the same shell process, so the exported function is inherited.
+- Docstring must use imperative mood ("Run …") — not "Helper to run …" — to satisfy ruff D401.
+
+### Failure Mode 10: ruff D401 Applies to Private Helper Docstrings
+
+ruff enforces D401 ("First line of docstring should be in imperative mood") on **all** public and private functions, including those named `_foo`. The rule checks whether the first word of the docstring is an imperative verb.
+
+**Fails D401:**
+```python
+def _run_choose(json_body: str) -> subprocess.CompletedProcess[str]:
+    """Helper to run choose_merge_flag with a mocked gh."""  # "Helper" is not imperative
+```
+
+**Passes D401:**
+```python
+def _run_choose(json_body: str) -> subprocess.CompletedProcess[str]:
+    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
+```
+
+Common failing openers: "Helper to", "Wrapper for", "Utility that", "Used to". Use "Run", "Execute", "Return", "Build", "Validate" instead.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -327,6 +454,8 @@ Concrete symptom signature (from ProjectHephaestus `scripts/run_automation_loop.
 | Grep with relative path | Used `grep PATTERN .github/workflows/file.yml` to confirm change | Relative path resolved against stale cwd; returned no match | Always use absolute paths in Bash when cross-checking Edit results |
 | Blame the Edit tool | Suspected Edit was silently no-oping or operating on a cached buffer | Edit had worked correctly — divergence was in the verifier, not the editor | When two tools disagree, suspect cwd before suspecting tool bugs |
 | `set -m` + single-command `(...)` subshell exec-optimization | Defang errexit inside the function via `set +e` + `trap 'set -e' RETURN`; expected `rc=$?` to capture exit and `phase_done` to fire | bash trace shows no commands execute after the subshell completes — control returns directly to the outer parent loop. `set -m` puts the subshell in its own process group, and bash optimises single-command subshells via exec-replace, so the subshell PID dies with the command's rc and the parent's continuation context is lost. `set +e` does not help because nothing runs after the subshell to be defanged. | Diagnose with `bash -x` + ERR/EXIT traps inside the function: if `phase_start` banners appear but `phase_done` banners NEVER appear (even with stderr captured), the function body is not running past the subshell. Don't add more `set +e` — restructure to avoid the single-command subshell (e.g., extract into a real function), or replace the bash orchestrator entirely. |
+| `gh api … 2>&1` in command substitution | Added `2>&1` to capture gh's error message into `$raw` for the error path in `choose_merge_flag.sh` | gh also writes deprecation banners, update notices, and GH_DEBUG traces to stderr on SUCCESS paths; merging these into `$raw` before piping to jq produced non-JSON input, causing jq to return empty; downstream "allows no merge methods" false error on valid repos | Never redirect `2>&1` in a `$(…)` capturing API output for jq; capture stdout only; on failure `$raw` is empty and gh already printed the error to stderr |
+| Using "Helper to" opener for private function docstring | Wrote `"""Helper to run choose_merge_flag with a mocked gh."""` on `_run_choose` | ruff D401 rejected it: "Helper" is not imperative mood | ruff D401 applies to private functions too; use imperative verb openers ("Run", "Execute", "Build", "Return") regardless of whether the function name starts with `_` |
 
 ## Results & Parameters
 
@@ -403,6 +532,64 @@ git worktree list
 git rev-parse --show-toplevel
 ```
 
+### gh api stdout-only capture pattern
+
+```bash
+# Capture stdout only — do NOT use 2>&1 when the output is piped to jq
+if ! raw=$(gh api "repos/${owner}/${repo}"); then
+    echo "gh api failed" >&2
+    return 1
+fi
+result=$(printf '%s' "$raw" | jq -r '.some_field // empty')
+```
+
+On failure, `$raw` is empty; gh has already written its error message to stderr. Do not reference `$raw` in the error message.
+
+### mock-gh bash function pattern for Python integration tests
+
+```python
+import subprocess
+from pathlib import Path
+
+SNIPPET = Path(__file__).resolve().parents[2] / "scripts" / "choose_merge_flag.sh"
+
+def _run_choose(json_body: str, *, stderr_noise: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
+    if stderr_noise:
+        gh_impl = (
+            f"gh() {{\n"
+            f"    case \"$1\" in\n"
+            f"        api)\n"
+            f"            echo \"warning: new gh version available\" >&2\n"
+            f"            printf '%s\\n' '{json_body}'\n"
+            f"            ;;\n"
+            f"    esac\n"
+            f"}}"
+        )
+    else:
+        gh_impl = f"gh() {{ case \"$1\" in api) printf '%s\\n' '{json_body}';; esac; }}"
+
+    script = f"""
+{gh_impl}
+export -f gh
+. {SNIPPET}
+choose_merge_flag owner/repo
+"""
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+```
+
+Key: `export -f gh` exports the bash function into the environment so the sourced script inherits it. No fake binary on PATH needed. The `stderr_noise=True` variant verifies the fix holds under realistic gh advisory output.
+
+### ruff D401 imperative-mood docstring openers
+
+| Fails D401 | Passes D401 |
+| ---------- | ----------- |
+| "Helper to run X" | "Run X with …" |
+| "Wrapper for X" | "Wrap X and return …" |
+| "Utility that does X" | "Execute X and …" |
+| "Used to build X" | "Build X from …" |
+| "This function validates X" | "Validate X against …" |
+
 ## Verified On
 
 | Project | Context | Details |
@@ -414,3 +601,4 @@ git rev-parse --show-toplevel
 | ai-maestro (23blocks-OS) | Issue #272 — install-agent-cli.sh jq syntax error on older jq | jq array concatenation compatibility |
 | HomericIntelligence/ProjectOdyssey | Multi-worktree session — stray commit cf710fb4 on ci-pipe-handler-cores-gate branch | Bash cwd drift from Edit/Read absolute paths |
 | HomericIntelligence/ProjectHephaestus | Session 2026-05-26 — `scripts/run_automation_loop.sh` `process_repo` silently aborting after planner subshell (phases 2-6 skipped 75/75 invocations); replaced with `hephaestus/automation/loop_runner.py` | `set -m` + single-command subshell exec-optimization silent abort |
+| HomericIntelligence/ProjectHephaestus | Issue #1122, PR #1273 — `scripts/choose_merge_flag.sh` `2>&1` on `gh api` merged deprecation banners into `$raw`, causing jq to return empty; spurious "allows no merge methods" exit-1 on valid repos | `2>&1` in command substitution corrupts jq input; mock-gh bash function integration test pattern; ruff D401 on private helper docstrings |


### PR DESCRIPTION
## Summary

Amends `bash-script-and-jq-failure-modes` skill (v1.1.0 → v1.2.0) with new findings from HomericIntelligence/ProjectHephaestus PR #1273 (issue #1122).

## New Findings

**Failure Mode 8 — `2>&1` in command substitution corrupts jq input**: capturing `gh api` output with `2>&1` merges stderr into `$raw`; any non-JSON stderr line (deprecation banner, rate-limit notice, `GH_DEBUG` trace) makes jq return empty string, triggering downstream false-error paths ("allows no merge methods"). Fix: capture stdout-only; on failure `$raw` is empty and gh already printed the error to stderr.

**Failure Mode 9 — Mock-gh bash function pattern**: use an inline bash function override + `export -f gh` to stub `gh` in Python subprocess integration tests without needing a fake binary on PATH. A `stderr_noise` flag verifies the 2>&1 fix holds under realistic advisory output.

**Failure Mode 10 — ruff D401 on private helpers**: docstrings on `_private` functions must also use imperative mood openers ("Run", "Execute", "Build") — "Helper to", "Wrapper for", "Utility that" all fail D401.

## Verification Level

**verified-ci** — PR #1273 merged with all CI green (issue #1122).

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py` — 310/310 valid
- [x] Commit is signed

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>