### PR TITLE
feat: amend automation-loop-post-loop-filter-omission skill to verified-ci (v1.2.0)

### DIFF
--- a/skills/automation-loop-post-loop-filter-omission.history
+++ b/skills/automation-loop-post-loop-filter-omission.history
@@ -3,6 +3,12 @@
 
 This file preserves previous versions of the skill before amendments.
 
+## v1.1.0 (2026-06-13)
+
+Corrected the discriminator from `not r.post_loop_phases` to `not r.is_post_loop` and updated line citations from `:1337`/`:1501` to `:1525`/`:1695`. Documented the fix and key risks. Still marked `unverified` — implementation plan only, not CI-confirmed.
+
+See v1.2.0 (this version) for the verified-ci outcome after PR #1278 merged.
+
 ## v1.0.0 (2026-06-12)
 
 Initial version. Used `not r.post_loop_phases` as the post-loop discriminator and cited `loop_runner.py:1337` as the canonical filter reference. Both were incorrect — the correct discriminator is `not r.is_post_loop` and the correct line is 1525. See the Failed Attempts section of v1.1.0 for the full analysis.

--- a/skills/automation-loop-post-loop-filter-omission.md
+++ b/skills/automation-loop-post-loop-filter-omission.md
@@ -3,9 +3,9 @@ name: automation-loop-post-loop-filter-omission
 description: "Use when: (1) diagnosing why loops_run reports an inflated loop count after early-exit fires, (2) a caller re-aggregates a raw result list without applying the same filter the inner function already uses, (3) auditing max()/sum() aggregations over mixed per-loop + post-loop result collections."
 category: debugging
 date: 2026-06-13
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
-verification: unverified
+verification: verified-ci
 history: automation-loop-post-loop-filter-omission.history
 tags: [automation, loop-runner, post-loop, filter-omission, early-exit, aggregation, loops-run]
 ---
@@ -18,8 +18,8 @@ tags: [automation, loop-runner, post-loop, filter-omission, early-exit, aggregat
 |-------|-------|
 | **Date** | 2026-06-13 |
 | **Objective** | Fix `loops_run` reporting an inflated count when early-exit fires during a multi-loop run that includes post-loop stages |
-| **Outcome** | Plan produced, not yet implemented or CI-confirmed |
-| **Verification** | unverified |
+| **Outcome** | Successful — one-word inline fix + regression test; PR #1278 merged green |
+| **Verification** | verified-ci — ProjectHephaestus PR #1278, all CI gates passed |
 | **Source** | ProjectHephaestus issue #1153 |
 | **History** | automation-loop-post-loop-filter-omission.history |
 
@@ -69,7 +69,7 @@ loops_run = max(
 )
 ```
 
-This mirrors the canonical filter at `loop_runner.py:1525`.
+This mirrors the canonical filter at `loop_runner.py:1525`. The fix is a **one-word inline change** — adding `if not r.is_post_loop` to the existing generator expression.
 
 ## Key Risks
 
@@ -77,11 +77,38 @@ This mirrors the canonical filter at `loop_runner.py:1525`.
 
 2. **`failures` aggregation is unaffected** — `failures = [r for r in results if r.any_failure]` at line 1697 iterates over ALL records including post-loop. This is **correct behavior** — post-loop stage failures must be counted. The fix only touches `loops_run`.
 
-## Existing Test Blind Spot
+## Verified Workflow
 
-`test_main_loops_run_early_exit` stubs `run_loop` with a clean per-loop-only result list, so it never exercises the mixed case where post-loop records are present. A new test covering the mixed case is required.
+### Quick Reference
 
-### Minimal Test
+```bash
+# Confirm the unfiltered aggregation exists:
+grep -n "loops_run" hephaestus/automation/loop_runner.py
+
+# Confirm is_post_loop definition and set site:
+grep -n "is_post_loop" hephaestus/automation/loop_runner.py | head -20
+# Expect: :234 definition, :1395 set site, :1525 canonical filter
+```
+
+### Detailed Steps
+
+1. **Locate the aggregation** — Find `loops_run = max(...)` at `loop_runner.py:1695` in the `main()` function.
+
+2. **Compare to inner filter** — The `run_loop` function at `loop_runner.py:1525` already filters: `per_loop_results = [r for r in all_results if not r.is_post_loop]`. The caller must mirror this using the same boolean flag.
+
+3. **Verify all cited line numbers on disk** — Issue bodies and planning docs are written against a snapshot that may be many commits stale. Always `grep -n` before trusting any `:N` citation. In issue #1153, the body cited `:1337` (a rate-budget sleep, unrelated) and `:1501` as the fix target; the correct post-#818 lines are `:1525` (canonical filter) and `:1695` (fix target).
+
+4. **Apply the fix** — Add `if not r.is_post_loop` to the generator expression inside `max(...)`. Do NOT use `if not r.post_loop_phases` — see Failed Attempts.
+
+5. **Add the mixed-case regression test** — Use `TestMainLoopsRunReporting._run_main_with_results` (`:666`) as the helper pattern for `main()`-layer behavior tests. This helper stubs `run_loop` directly (not `process_repo`) and patches `emit_json_status` to capture kwargs. The post-loop fixture must include BOTH `is_post_loop=True` AND `post_loop_phases=[...]` — setting only one is insufficient.
+
+6. **Run checks**:
+   ```bash
+   pixi run pytest tests/unit/automation/ -q --no-cov
+   pixi run ruff check hephaestus/automation/loop_runner.py
+   ```
+
+### Regression Test Pattern
 
 ```python
 def test_loops_run_excludes_post_loop_records(tmp_path, monkeypatch):
@@ -93,12 +120,13 @@ def test_loops_run_excludes_post_loop_records(tmp_path, monkeypatch):
     # Simulate: early-exit fired after loop 1, then post-loop ran.
     # is_post_loop=True is REQUIRED — post_loop_phases alone is ambiguous
     # for crashed/all-skipped repos where post_loop_phases=[] too.
+    # BOTH fields must be set on the fixture for correct classification.
     per_loop_record = RepoResult(repo="r1", loop_idx=1)
     post_loop_record = RepoResult(
         repo="r1",
         loop_idx=cfg.loops,
-        is_post_loop=True,
-        post_loop_phases=[PhaseResult(phase="drive-green")],
+        is_post_loop=True,                                    # required boolean
+        post_loop_phases=[PhaseResult(phase="drive-green")],  # also required
     )
 
     results = [per_loop_record, post_loop_record]
@@ -110,41 +138,16 @@ def test_loops_run_excludes_post_loop_records(tmp_path, monkeypatch):
     assert loops_run == 1, f"Expected 1, got {loops_run}"
 ```
 
-## Verified Workflow
-
-> **Note**: This workflow is proposed and unverified — it has not been run against CI.
-
-### Quick Reference
-
-```bash
-# Confirm the unfiltered aggregation exists:
-grep -n "loops_run" hephaestus/automation/loop_runner.py
-
-# Confirm is_post_loop definition:
-grep -n "is_post_loop" hephaestus/automation/loop_runner.py | head -20
-```
-
-### Detailed Steps
-
-1. **Locate the aggregation** — Find `loops_run = max(...)` at `loop_runner.py:1695` in the `main()` function.
-
-2. **Compare to inner filter** — The `run_loop` function at `loop_runner.py:1525` already filters: `per_loop_results = [r for r in all_results if not r.is_post_loop]`. The caller must mirror this using the same boolean flag.
-
-3. **Apply the fix** — Add `if not r.is_post_loop` to the generator expression inside `max(...)`. Do NOT use `if not r.post_loop_phases` — see Failed Attempts.
-
-4. **Add the mixed-case test** — `test_main_loops_run_early_exit` must cover the scenario where post-loop records (with `is_post_loop=True`) are present alongside per-loop records.
-
-5. **Run checks**:
-   ```bash
-   pixi run pytest tests/unit/automation/ -q --no-cov
-   pixi run ruff check hephaestus/automation/loop_runner.py
-   ```
+**Note**: For `main()`-layer behavior tests that exercise the full reporting path, use `TestMainLoopsRunReporting._run_main_with_results` (`:666`) which stubs `run_loop` directly and patches `emit_json_status`. This is distinct from `run_loop` behavior tests which patch `process_repo`.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | v1.0.0 planning pass | Used `not r.post_loop_phases` as the discriminator, claiming it "mirrored `loop_runner.py:1337`" (a rate-budget sleep — unrelated line). Fix was `if not r.post_loop_phases` in the generator. | (1) `post_loop_phases=[]` is ambiguous — crashed and all-skipped repos produce per-loop records with empty `post_loop_phases`, so the filter would misclassify them as post-loop. (2) The cited line 1337 was wrong; the real filter is at 1525. (3) The regression test fixture only set `post_loop_phases=[...]` without `is_post_loop=True`, so it would not guard the real bug under the correct fix. The reviewer caught all three issues. | Always use the dedicated `is_post_loop` boolean. Never rely on list-emptiness when a boolean flag exists for the same purpose. Verify cited line numbers before documenting. |
+| `post_loop_phases` emptiness as discriminator | Used `not r.post_loop_phases` to detect post-loop records in `main()` | A crashed/uncloned repo leaves BOTH phase lists empty — emptiness cannot distinguish post-loop from per-loop records | Use `is_post_loop=True` (the dedicated boolean flag defined at `:234`, set at `:1395`) |
+| Stale issue-body line citations | Trusted `:1337` (filter) and `:1501` (fix target) from the issue description | Issue body was written against pre-#818 code; post-#818 correct lines are `:1525` (canonical filter in `run_loop`) and `:1695` (fix target in `main()`) | Verify all `file:line` citations on disk with `grep -n` before acting |
+| Regression fixture with only `post_loop_phases` set | Constructed post-loop fixture with `post_loop_phases=[...]` but without `is_post_loop=True` | The fixture was not classified as post-loop under the correct predicate (`not r.is_post_loop`), so the test did not guard the actual bug | Post-loop regression fixture needs BOTH `is_post_loop=True` AND `post_loop_phases=[...]` |
 
 ## Results & Parameters
 
@@ -163,13 +166,23 @@ grep -n "is_post_loop" hephaestus/automation/loop_runner.py | head -20
 | `is_post_loop` | `bool` | **Correct discriminator.** `True` iff this record was produced by `_run_post_loop_stages`. Defined at `loop_runner.py:234`, set at `loop_runner.py:1395`. |
 | `post_loop_phases` | `list` | **Wrong discriminator.** Non-empty only when stages ran — ambiguous for crashed/all-skipped records that also have `post_loop_phases=[]`. |
 
-### Net Change (Planned)
+### Key Line References (post-#818)
 
-- `hephaestus/automation/loop_runner.py`: ~3 LOC (change `if not r.post_loop_phases` → `if not r.is_post_loop` in `loops_run` generator)
-- `tests/unit/automation/test_loop_runner_early_exit.py` (or equivalent): +1 new test method for mixed per-loop + post-loop results (fixture must include `is_post_loop=True`)
+| Line | Symbol | Role |
+|------|--------|------|
+| `:234` | `is_post_loop: bool = False` | Dataclass field definition |
+| `:1395` | `result.is_post_loop = True` | Set site in `_run_post_loop_stages` |
+| `:1525` | `per_loop_results = [r for r in all_results if not r.is_post_loop]` | Canonical filter inside `run_loop` |
+| `:1695` | `loops_run = max(...)` | Fix target in `main()` |
+| `:666` | `TestMainLoopsRunReporting._run_main_with_results` | Helper for `main()`-layer behavior tests |
+
+### Net Change
+
+- `hephaestus/automation/loop_runner.py`: 3 LOC (add `if not r.is_post_loop` to `loops_run` generator in `main()`)
+- `tests/unit/automation/test_loop_runner_early_exit.py` (or equivalent): +1 new test method for mixed per-loop + post-loop results (fixture must include BOTH `is_post_loop=True` AND `post_loop_phases=[...]`)
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | Issue #1153 — loops_run inflated after early-exit + post-loop stages | Plan only; not yet implemented or CI-confirmed |
+| ProjectHephaestus | Issue #1153 — loops_run inflated after early-exit + post-loop stages | PR #1278 merged; all CI gates passed (verified-ci) |


### PR DESCRIPTION
## Summary

Promotes `automation-loop-post-loop-filter-omission` from `unverified` plan (v1.1.0) to `verified-ci` (v1.2.0) after ProjectHephaestus issue #1153 / PR #1278 merged green.

## Key Findings

**What Worked**:
- `is_post_loop=True` is the correct discriminator for excluding post-loop records from `loops_run` in `main()`
- Mirroring the canonical filter at `loop_runner.py:1525` with one inline predicate: `if not r.is_post_loop`
- `TestMainLoopsRunReporting._run_main_with_results` (`:666`) stubs `run_loop` directly for `main()`-layer behavior tests (distinct from `run_loop` tests which patch `process_repo`)

**What Failed** (new entries added to Failed Attempts table):
- `not r.post_loop_phases` (emptiness) as discriminator — crashed/uncloned repos leave both phase lists empty, making emptiness ambiguous
- Trusting stale issue-body line citations — verify all `file:line` on disk before acting (`:1337`/`:1501` in issue body vs actual post-#818 lines `:1525`/`:1695`)
- Regression fixture with only `post_loop_phases` set (without `is_post_loop=True`) — fixture misclassified under the correct predicate

**New Additions**:
- Key line reference table (`:234` definition, `:1395` set site, `:1525` canonical filter, `:1695` fix target, `:666` test helper)
- Removed the "Note: workflow is proposed and unverified" caveat from Verified Workflow section
- Updated Outcome and Verified On to reflect merged PR

## Verification Level

**verified-ci** — PR #1278 merged green in ProjectHephaestus

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (310/310 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>