### PR TITLE
feat: add license-scan-marker-excluded-fallback skill

### DIFF
--- a/skills/license-scan-marker-excluded-fallback.md
+++ b/skills/license-scan-marker-excluded-fallback.md
@@ -1,0 +1,137 @@
+---
+name: license-scan-marker-excluded-fallback
+description: "Documents how to fix CI license-scan blind spots for PEP 508 marker-excluded deps. Use when: (1) CI scans licenses on a single Python/OS matrix leg and silently skips marker-gated deps, (2) a dep has platform_system or python_version markers that exclude the CI environment, (3) you need fail-closed behavior for ungated deps."
+category: ci-cd
+date: 2026-06-13
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: ["license", "pep508", "markers", "fallback", "ci-coverage", "tomli", "tzdata"]
+---
+
+# License Scan Marker-Excluded Fallback
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-13 |
+| **Objective** | Fix CI license-scan blind spot for PEP 508 marker-excluded distributed deps (`tomli`, `tzdata`) |
+| **Outcome** | Plan produced; implementation pending (issue #1256, ProjectHephaestus) |
+| **Verification** | unverified — plan-only, not yet implemented or CI-confirmed |
+
+## When to Use
+
+- A CI license-scan job runs on a single Python version/OS matrix leg (e.g., Python 3.13 / Ubuntu 24.04)
+- Some distributed deps have PEP 508 markers that exclude the CI environment (e.g., `python_version < '3.11'`, `platform_system == 'Windows'`)
+- Those deps are silently skipped with a note claiming "another CI row will classify them" — but no such row exists
+- A new gated dep is added to `pyproject.toml` and you need to ensure it gets license-classified
+- The `_installable_in_current_env` function returns `False` for a dep that is part of the distributed package
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```python
+# In scripts/check_license_compatibility.py
+
+# 1. Add static fallback map (values from NOTICE file)
+FALLBACK_LICENSES: dict[str, list[str]] = {
+    "tomli": ["MIT"],
+    "tzdata": ["Apache-2.0"],
+}
+
+# 2. In scan(), when PackageNotFoundError fires with installable_now=False:
+#    Look up in FALLBACK_LICENSES instead of skipping.
+#    Fail closed if no fallback entry exists.
+except PackageNotFoundError:
+    if not installable_now:
+        fallback = FALLBACK_LICENSES.get(pkg_name.lower())
+        if fallback is None:
+            print(f"ERROR: {pkg_name} is marker-excluded and has no FALLBACK_LICENSES entry", file=sys.stderr)
+            sys.exit(2)
+        licenses = fallback
+    else:
+        raise
+```
+
+### Detailed Steps
+
+1. **Identify marker-excluded distributed deps**: Run `distributed_requirements(None)` and collect entries where `installable_now=False`. In ProjectHephaestus, these are `tomli` (python_version < '3.11') and `tzdata` (platform_system == 'Windows') on Python 3.13 / Linux.
+
+2. **Look up licenses from NOTICE file**: Check `NOTICE` file for the license of each excluded dep. Do NOT rely on `pip show` — the dep is not installed. Cross-check with PyPI metadata if possible.
+
+3. **Add `FALLBACK_LICENSES` dict**: Add a module-level constant keyed by lowercased package name. Value is a list of SPDX identifiers matching the format used elsewhere in the script.
+
+4. **Modify `scan()` to use fallbacks**: In the `except PackageNotFoundError` block, when `installable_now=False`, look up the fallback. If the package is not in the map, `sys.exit(2)` — fail closed rather than silently skip.
+
+5. **Add regression test**: Write `test_fallback_covers_all_installed_marker_excluded_deps` (see Results & Parameters). This test catches any future gated dep that lacks a fallback entry BEFORE it reaches CI.
+
+6. **Add unit test for fallback path**: Patch `md.metadata` to raise `PackageNotFoundError` and verify the fallback licenses are used.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| CI matrix expansion for `tzdata` | Add a Python 3.10 CI leg to cover `tomli` | Covers `tomli` but still cannot classify `tzdata` (`platform_system == 'Windows'`) on Linux CI; a Windows runner would be disproportionate for one dep | A single static fallback map is simpler and more maintainable than matrix expansion for platform-specific deps |
+| Trusting the skip message | Rely on the original `scan()` code at lines 266-272 which printed "classified on the matching CI matrix row" | No such matching CI row existed — the promise was hollow; the dep was silently unclassified | Never rely on a skip message that claims "another row will handle it" without verifying the other row exists |
+
+## Results & Parameters
+
+### Regression Test (copy-paste ready)
+
+```python
+def test_fallback_covers_all_installed_marker_excluded_deps(self):
+    """Catch any future gated dep that lacks a fallback entry before it reaches CI."""
+    excluded = {
+        name
+        for name, installable_now in distributed_requirements(None)
+        if not installable_now
+    }
+    missing = excluded - set(FALLBACK_LICENSES)
+    assert not missing, f"Add to FALLBACK_LICENSES: {sorted(missing)}"
+```
+
+### Known Gated Deps (ProjectHephaestus, as of 2026-06-13)
+
+| Package | Marker | SPDX License | Source |
+|---------|--------|--------------|--------|
+| `tomli` | `python_version < '3.11'` | `MIT` | `NOTICE:58` |
+| `tzdata` | `platform_system == 'Windows'` | `Apache-2.0` | `NOTICE:28-29` |
+
+### Key Assumptions & Risks
+
+**Critical gotcha — `tomli` extra placement:**
+The `tomli` dep that matters is in the `toml` **runtime** extra (`pyproject.toml:65`), NOT the `dev` extra (`pyproject.toml:59`). The `dev` extra copy is excluded from the distributed package. Confusing these two is an easy mistake during review.
+
+**Unverified SPDX IDs:**
+`tzdata`'s SPDX identifier `Apache-2.0` was taken from `NOTICE:28-29` without running `pip install tzdata` on a Windows machine to verify the package metadata directly. The NOTICE file is human-maintained and could drift from actual package metadata. A future upgrade of `tzdata` or `tomli` that changes their license will NOT be caught automatically — it requires a human to update both `NOTICE` and `FALLBACK_LICENSES`.
+
+**`_installable_in_current_env` ambient env dependency:**
+The function at `check_license_compatibility.py:106-116` evaluates markers without `python_version` in the env dict — it relies on the current interpreter's ambient environment. This is pre-existing behavior, not introduced by this fix.
+
+### Test Patching Notes
+
+- `test_marker_excluded_dep_classified_from_fallback` patches `md.metadata` globally — verify this doesn't interfere with other tests if `scan()` internally calls `_meta_for()` which also calls `md.metadata(name)`. `_meta_for()` calls `md.metadata(name)` which IS what gets patched, so this should be correct.
+- `patch.dict("check_license_compatibility.FALLBACK_LICENSES", ...)` requires the test to import `FALLBACK_LICENSES` at the top of the test file — ensure the import is present.
+- `test_fallback_covers_all_installed_marker_excluded_deps` may use `pytest.skip` with a bare `return` after it for type narrowing — this pattern matches existing tests in the file (see line 166-168).
+
+## Verified Workflow
+
+> **Note:** This workflow has not been executed end-to-end. Steps are based on a planning session for issue #1256. Mark as verified once CI confirms the implementation.
+
+1. **Identify marker-excluded deps**: Run `distributed_requirements(None)` and filter entries where `installable_now=False`. Collect package names.
+2. **Cross-check NOTICE file**: For each excluded dep, look up the license in the repo's `NOTICE` file. Do NOT run `pip show` — the package is not installed in the current env.
+3. **Add `FALLBACK_LICENSES` dict**: Add a module-level `FALLBACK_LICENSES: dict[str, list[str]]` constant to `scripts/check_license_compatibility.py`, keyed by lowercased package name, with SPDX identifiers as values.
+4. **Patch `scan()` exception handler**: In the `except PackageNotFoundError` block, when `installable_now=False`, look up the fallback. Call `sys.exit(2)` if no fallback entry exists (fail closed).
+5. **Add regression test**: Write `test_fallback_covers_all_installed_marker_excluded_deps` to assert that all marker-excluded deps are covered by `FALLBACK_LICENSES`.
+6. **Add unit test for fallback path**: Patch `md.metadata` to raise `PackageNotFoundError` and assert the fallback licenses are returned.
+7. **Run CI**: Confirm the license-scan job passes on Python 3.13 / Ubuntu 24.04 and that previously-skipped deps now appear in the scan output.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #1256 planning session (2026-06-13) | Plan-only; implementation pending |


### PR DESCRIPTION
## Summary

New skill documenting the fix for CI license-scan blind spots caused by PEP 508 marker-excluded distributed deps.

- Documents static `FALLBACK_LICENSES` dict pattern with fail-closed `sys.exit(2)` semantics
- Captures critical gotcha: `tomli` in `toml` runtime extra vs `dev` extra confusion
- Includes regression test pattern that catches future ungated deps before CI

## Verification Level

**unverified** — Plan-only. Implementation is pending under issue #1256 in ProjectHephaestus. The pattern is theoretically sound but has not been executed end-to-end.

## Key Findings

**What the Pattern Does**:
- Adds `FALLBACK_LICENSES: dict[str, list[str]]` keyed by lowercased package name
- In `scan()`, when `PackageNotFoundError` fires with `installable_now=False`, looks up fallback instead of skipping
- If no fallback entry exists, `sys.exit(2)` — fail closed rather than silently skip

**What Failed**:
- CI matrix expansion → covers `tomli` but not `tzdata` (Windows-only dep on Linux CI)
- Trusting the skip message → original code claimed "another row will handle it" but no such row existed

## Test Plan

- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: license, fallback, marker, pep508

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>