### PR TITLE
feat: add license-scan-static-fallback-marker-excluded-deps skill

### DIFF
--- a/skills/license-scan-static-fallback-marker-excluded-deps.md
+++ b/skills/license-scan-static-fallback-marker-excluded-deps.md
@@ -1,0 +1,118 @@
+---
+name: license-scan-static-fallback-marker-excluded-deps
+description: "Static fallback license map for deps excluded by platform/version markers in CI. Use when: (1) a license-scan gate skips marker-gated deps silently, (2) adding a new Windows-only or old-Python-only dep to a project with a single-leg CI license job, (3) extending check_license_compatibility.py to classify unreachable deps."
+category: ci-cd
+date: 2026-06-13
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: []
+---
+
+# License Scan Static Fallback for Marker-Excluded Deps
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-13 |
+| **Objective** | Classify distributed deps whose platform/version markers exclude them from the single CI leg (Python 3.13 / Linux), preventing silent license-coverage holes |
+| **Outcome** | Static `STATIC_FALLBACK_LICENSES` dict added to scan script; unknown marker-excluded deps now exit(2) instead of silently skipping |
+| **Verification** | unverified — plan only, not yet executed in CI |
+| **History** | N/A (initial version) |
+
+## When to Use
+
+- A license-scan CI job runs on a single Python version x single OS and silently skips `installable_now=False` deps with a "classified on another matrix row" note — but no such row exists
+- Adding a new dep gated by `python_version < 'X'` (e.g. `tomli`) or `platform_system == 'Windows'` (e.g. `tzdata`) to a project with single-leg license CI
+- Extending `scripts/check_license_compatibility.py` pattern to ensure all distributed deps are always classified, never silently dropped
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```python
+# In scripts/check_license_compatibility.py, after ALLOWED_EXTRA_COPYLEFT:
+
+STATIC_FALLBACK_LICENSES: dict[str, list[str]] = {
+    "tomli": ["MIT"],        # python_version < '3.11'
+    "tzdata": ["Apache-2.0"],  # platform_system == 'Windows'; see NOTICE
+}
+
+# In scan(), replace the silent-skip branch:
+# OLD (silent skip -- coverage hole):
+#   print(f"note: skipping {pkg!r} -- classified on another CI row")
+#   continue
+#
+# NEW (classify or loud-fail):
+fallback = STATIC_FALLBACK_LICENSES.get(pkg)
+if fallback is not None:
+    ids = fallback  # classify using static map
+else:
+    print(f"FATAL: {pkg!r} has no static fallback -- add to STATIC_FALLBACK_LICENSES", file=sys.stderr)
+    sys.exit(2)
+```
+
+### Detailed Steps
+
+1. Identify which deps get `installable_now=False` on the CI leg by running `distributed_requirements(None)` under the CI Python version.
+2. For each such dep, look up its SPDX license in `NOTICE` (for NOTICE-documented deps) or PyPI metadata.
+3. Add `STATIC_FALLBACK_LICENSES` dict after `ALLOWED_EXTRA_COPYLEFT` in `check_license_compatibility.py`.
+4. Replace the silent-skip `continue` in `scan()` with: use fallback if present, else `sys.exit(2)`.
+5. Update module docstring's `FAILS LOUDLY` section to document the new exit path.
+6. Add `TestStaticFallback` test class with:
+   - `test_tomli_fallback_classifies_correctly` -- patches `distributed_requirements` to return `[("tomli", False)]`, patches `md.metadata` to raise `PackageNotFoundError`, asserts `scan(None) == []`
+   - `test_tzdata_fallback_classifies_correctly` -- same pattern for tzdata/Apache-2.0
+   - `test_unknown_markered_dep_exits_nonzero` -- unknown dep with no fallback -> `SystemExit(2)`
+   - `test_static_fallback_covers_all_markered_out_distributed_deps` -- live coverage assertion: every `installable_now=False` dep in `distributed_requirements(None)` is in `STATIC_FALLBACK_LICENSES`
+7. Rename existing `test_uninstalled_other_python_dep_skipped_not_failed` -> `test_uninstalled_other_python_dep_with_fallback_classifies_not_fails` (behavior changed: no longer silently skips).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Option A: second CI matrix leg | Add python-version: "3.10" leg to license-scan job | Adds ~3 min CI wall-clock; still leaves tzdata/Windows gap (no Windows runner) | A second Python leg handles `tomli` but cannot classify Windows-only deps on Linux CI -- static map is necessary for platform markers |
+| Silent skip with note | Print "classified on another CI matrix row" and `continue` | No such row exists; silent skip is a permanent coverage hole for future license changes | Never skip a distributed dep without classifying it; if not installable, classify via static map or exit(2) |
+
+## Results & Parameters
+
+**Deps with `installable_now=False` on Python 3.13 / Linux CI:**
+
+| Package | Marker | License (SPDX) | Source |
+|---------|--------|----------------|--------|
+| `tomli` | `python_version < '3.11'` | `MIT` | PyPI metadata |
+| `tzdata` | `platform_system == 'Windows'` | `Apache-2.0` | NOTICE:27 |
+
+**Key invariant enforced by coverage test:**
+
+```
+∀ pkg: installable_now=False ⟹ pkg ∈ STATIC_FALLBACK_LICENSES
+```
+
+This prevents any future marker-gated dep from silently escaping license classification.
+
+**Files changed:**
+
+- `scripts/check_license_compatibility.py`: +`STATIC_FALLBACK_LICENSES` dict, modified `scan()` silent-skip branch, updated docstring
+- `tests/unit/scripts/test_check_license_compatibility.py`: +`TestStaticFallback` (4 tests), renamed existing test
+
+## Verified Workflow
+
+> **Note:** This workflow has not been executed end-to-end. Steps are based on a planning session for issue #1258. Mark as verified once CI confirms the implementation.
+
+1. **Identify marker-excluded deps**: Run `distributed_requirements(None)` and filter entries where `installable_now=False`. Collect package names.
+2. **Cross-check NOTICE file**: For each excluded dep, look up the license in the repo's `NOTICE` file. Do NOT run `pip show` -- the package is not installed in the current env.
+3. **Add `STATIC_FALLBACK_LICENSES` dict**: Add a module-level `STATIC_FALLBACK_LICENSES: dict[str, list[str]]` constant to `scripts/check_license_compatibility.py`, keyed by lowercased package name, with SPDX identifiers as values.
+4. **Patch `scan()` silent-skip branch**: Replace the `continue` that skips `installable_now=False` deps with: use fallback if present, else `sys.exit(2)`.
+5. **Update module docstring**: Add the new exit path to the `FAILS LOUDLY` section.
+6. **Add regression test**: Write `test_static_fallback_covers_all_markered_out_distributed_deps` to assert that all marker-excluded deps are covered by `STATIC_FALLBACK_LICENSES`. This catches any future gated dep that lacks a fallback entry before it reaches CI.
+7. **Add unit tests for fallback path**: Patch `md.metadata` to raise `PackageNotFoundError` and assert the fallback licenses are returned; separately test that an unknown dep causes `SystemExit(2)`.
+8. **Run CI**: Confirm the license-scan job passes on Python 3.13 / Ubuntu 24.04 and that previously-skipped deps now appear in the scan output.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #1258 planning | Plan only -- implementation pending |


### PR DESCRIPTION
## Summary

New skill documenting the static fallback license map pattern for marker-excluded deps in single-leg CI license gates.

- Silent skip of `installable_now=False` deps is a permanent coverage hole
- `STATIC_FALLBACK_LICENSES` dict classifies unreachable deps without a second CI leg
- Unknown marker-excluded deps must `exit(2)`, not silently pass
- Coverage assertion test enforces the invariant for future deps

## Verification Level

**unverified** — plan only, CI validation pending (issue #1258 implementation)

## Key Findings

**What Worked**:
- Static map approach covers both Python-version gaps (tomli) and platform gaps (tzdata) with a single mechanism
- Loud exit(2) for unknown marker-excluded deps prevents future silent holes

**What Failed**:
- Option A (second CI matrix leg): still leaves Windows-only deps unclassified on Linux
- Silent skip with note: coverage hole — the claimed 'other CI row' doesn't exist

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (319/319 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: license, marker, fallback, tzdata, tomli

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>