### PR TITLE
feat: amend license-scan-static-fallback-marker-excluded-deps skill (v1.1.0)

### DIFF
--- a/skills/license-scan-static-fallback-marker-excluded-deps.history
+++ b/skills/license-scan-static-fallback-marker-excluded-deps.history
@@ -1,13 +1,14 @@
+## v1.0.0 — 2026-06-13
+
 ---
 name: license-scan-static-fallback-marker-excluded-deps
 description: "Static fallback license map for deps excluded by platform/version markers in CI. Use when: (1) a license-scan gate skips marker-gated deps silently, (2) adding a new Windows-only or old-Python-only dep to a project with a single-leg CI license job, (3) extending check_license_compatibility.py to classify unreachable deps."
 category: ci-cd
 date: 2026-06-13
-version: "1.1.0"
+version: "1.0.0"
 user-invocable: false
 verification: unverified
 tags: []
-history: license-scan-static-fallback-marker-excluded-deps.history
 ---
 
 # License Scan Static Fallback for Marker-Excluded Deps
@@ -18,9 +19,9 @@ history: license-scan-static-fallback-marker-excluded-deps.history
 |-------|-------|
 | **Date** | 2026-06-13 |
 | **Objective** | Classify distributed deps whose platform/version markers exclude them from the single CI leg (Python 3.13 / Linux), preventing silent license-coverage holes |
-| **Outcome** | Static `STATIC_FALLBACK_LICENSES` dict added to scan script; unknown marker-excluded deps now exit(2) instead of silently skipping; staleness-mitigation tests added |
+| **Outcome** | Static `STATIC_FALLBACK_LICENSES` dict added to scan script; unknown marker-excluded deps now exit(2) instead of silently skipping |
 | **Verification** | unverified — plan only, not yet executed in CI |
-| **History** | v1.0.0 archived in `license-scan-static-fallback-marker-excluded-deps.history` |
+| **History** | N/A (initial version) |
 
 ## When to Use
 
@@ -39,7 +40,7 @@ history: license-scan-static-fallback-marker-excluded-deps.history
 
 STATIC_FALLBACK_LICENSES: dict[str, list[str]] = {
     "tomli": ["MIT"],        # python_version < '3.11'
-    "tzdata": ["Apache-2.0"],  # platform_system == 'Windows'; see NOTICE:28
+    "tzdata": ["Apache-2.0"],  # platform_system == 'Windows'; see NOTICE
 }
 
 # In scan(), replace the silent-skip branch:
@@ -50,31 +51,25 @@ STATIC_FALLBACK_LICENSES: dict[str, list[str]] = {
 # NEW (classify or loud-fail):
 fallback = STATIC_FALLBACK_LICENSES.get(pkg)
 if fallback is not None:
-    ids = fallback  # sets ids, falls through to existing is_compatible() check
+    ids = fallback  # classify using static map
 else:
     print(f"FATAL: {pkg!r} has no static fallback -- add to STATIC_FALLBACK_LICENSES", file=sys.stderr)
     sys.exit(2)
-# NOTE: do NOT duplicate the is_compatible() call here -- set ids=fallback and
-# let control fall through to the existing check below. Duplicating the call
-# creates a divergence risk when is_compatible() is later extended.
 ```
 
 ### Detailed Steps
 
 1. Identify which deps get `installable_now=False` on the CI leg by running `distributed_requirements(None)` under the CI Python version.
-2. For each such dep, look up its SPDX license in `NOTICE` (the authoritative source per the script's own docstring). Confirm line numbers: `tomli` at NOTICE:58 (MIT), `tzdata` at NOTICE:28 (Apache-2.0).
+2. For each such dep, look up its SPDX license in `NOTICE` (for NOTICE-documented deps) or PyPI metadata.
 3. Add `STATIC_FALLBACK_LICENSES` dict after `ALLOWED_EXTRA_COPYLEFT` in `check_license_compatibility.py`.
-4. Replace the silent-skip `continue` in `scan()` with: set `ids = fallback` and fall through to existing `is_compatible()` call (do not duplicate it).
+4. Replace the silent-skip `continue` in `scan()` with: use fallback if present, else `sys.exit(2)`.
 5. Update module docstring's `FAILS LOUDLY` section to document the new exit path.
 6. Add `TestStaticFallback` test class with:
    - `test_tomli_fallback_classifies_correctly` -- patches `distributed_requirements` to return `[("tomli", False)]`, patches `md.metadata` to raise `PackageNotFoundError`, asserts `scan(None) == []`
    - `test_tzdata_fallback_classifies_correctly` -- same pattern for tzdata/Apache-2.0
    - `test_unknown_markered_dep_exits_nonzero` -- unknown dep with no fallback -> `SystemExit(2)`
    - `test_static_fallback_covers_all_markered_out_distributed_deps` -- live coverage assertion: every `installable_now=False` dep in `distributed_requirements(None)` is in `STATIC_FALLBACK_LICENSES`
-7. Add **staleness-mitigation tests** (new in v1.1.0):
-   - `test_static_values_match_installed_metadata` — parametrized over `STATIC_FALLBACK_LICENSES` keys; decorated with `@pytest.mark.skipif(not importlib.util.find_spec(pkg), ...)` so it skips when dep not installed (marker excludes it on the CI leg); when installed (e.g. Python 3.10 / Windows), asserts `set(STATIC_FALLBACK_LICENSES[pkg]) & set(resolve_license(md.metadata(pkg)))` is non-empty. Catches license drift when the dep IS available.
-   - `test_static_values_match_notice` — runs unconditionally on every Python/platform; reads the `NOTICE` file from the repo root, asserts each key in `STATIC_FALLBACK_LICENSES` appears in `notice_text.lower()` AND each SPDX value appears in `notice_text`. Enforces NOTICE as authoritative source without needing the dep installed.
-8. Rename existing `test_uninstalled_other_python_dep_skipped_not_failed` -> `test_uninstalled_other_python_dep_with_fallback_classifies_not_fails` (behavior changed: no longer silently skips).
+7. Rename existing `test_uninstalled_other_python_dep_skipped_not_failed` -> `test_uninstalled_other_python_dep_with_fallback_classifies_not_fails` (behavior changed: no longer silently skips).
 
 ## Failed Attempts
 
@@ -82,8 +77,6 @@ else:
 |---------|----------------|---------------|----------------|
 | Option A: second CI matrix leg | Add python-version: "3.10" leg to license-scan job | Adds ~3 min CI wall-clock; still leaves tzdata/Windows gap (no Windows runner) | A second Python leg handles `tomli` but cannot classify Windows-only deps on Linux CI -- static map is necessary for platform markers |
 | Silent skip with note | Print "classified on another CI matrix row" and `continue` | No such row exists; silent skip is a permanent coverage hole for future license changes | Never skip a distributed dep without classifying it; if not installable, classify via static map or exit(2) |
-| Validated only keys not values | Coverage test asserted `pkg in STATIC_FALLBACK_LICENSES` but did not cross-check SPDX values | Wrong SPDX values (e.g. `"BSD-3-Clause"` instead of `"MIT"`) would pass the membership test silently | Also validate values: `test_static_values_match_installed_metadata` (when dep available) and `test_static_values_match_notice` (always) |
-| NOTICE not checked as authoritative source | v1.0.0 results table listed `tomli` source as "PyPI metadata" implying NOTICE was not checked | tomli IS documented in NOTICE:58 (MIT); the script's own docstring names NOTICE as the authoritative source | Always cross-reference NOTICE first; PyPI is a fallback when a dep is not in NOTICE |
 
 ## Results & Parameters
 
@@ -91,8 +84,8 @@ else:
 
 | Package | Marker | License (SPDX) | Source |
 |---------|--------|----------------|--------|
-| `tomli` | `python_version < '3.11'` | `MIT` | NOTICE:58 |
-| `tzdata` | `platform_system == 'Windows'` | `Apache-2.0` | NOTICE:28 |
+| `tomli` | `python_version < '3.11'` | `MIT` | PyPI metadata |
+| `tzdata` | `platform_system == 'Windows'` | `Apache-2.0` | NOTICE:27 |
 
 **Key invariant enforced by coverage test:**
 
@@ -102,37 +95,23 @@ else:
 
 This prevents any future marker-gated dep from silently escaping license classification.
 
-**Staleness-mitigation invariants (new in v1.1.0):**
-
-```
-# Values correct when dep is installed (Python 3.10 / Windows):
-set(STATIC_FALLBACK_LICENSES[pkg]) & set(resolve_license(md.metadata(pkg))) ≠ ∅
-
-# NOTICE is authoritative; must match unconditionally:
-∀ pkg ∈ STATIC_FALLBACK_LICENSES: pkg.lower() ∈ notice_text.lower()
-∀ spdx ∈ STATIC_FALLBACK_LICENSES[pkg]: spdx ∈ notice_text
-```
-
 **Files changed:**
 
-- `scripts/check_license_compatibility.py`: +`STATIC_FALLBACK_LICENSES` dict, modified `scan()` silent-skip branch (set `ids=fallback`, fall through), updated docstring
-- `tests/unit/scripts/test_check_license_compatibility.py`: +`TestStaticFallback` (6 tests total: 4 original + 2 staleness-mitigation), renamed existing test
+- `scripts/check_license_compatibility.py`: +`STATIC_FALLBACK_LICENSES` dict, modified `scan()` silent-skip branch, updated docstring
+- `tests/unit/scripts/test_check_license_compatibility.py`: +`TestStaticFallback` (4 tests), renamed existing test
 
 ## Verified Workflow
 
 > **Note:** This workflow has not been executed end-to-end. Steps are based on a planning session for issue #1258. Mark as verified once CI confirms the implementation.
 
 1. **Identify marker-excluded deps**: Run `distributed_requirements(None)` and filter entries where `installable_now=False`. Collect package names.
-2. **Cross-check NOTICE file**: For each excluded dep, look up the license in the repo's `NOTICE` file. `tomli` is at NOTICE:58 (MIT); `tzdata` is at NOTICE:28 (Apache-2.0). Do NOT rely on PyPI alone — the script's docstring names NOTICE as authoritative.
+2. **Cross-check NOTICE file**: For each excluded dep, look up the license in the repo's `NOTICE` file. Do NOT run `pip show` -- the package is not installed in the current env.
 3. **Add `STATIC_FALLBACK_LICENSES` dict**: Add a module-level `STATIC_FALLBACK_LICENSES: dict[str, list[str]]` constant to `scripts/check_license_compatibility.py`, keyed by lowercased package name, with SPDX identifiers as values.
-4. **Patch `scan()` silent-skip branch**: Replace the `continue` that skips `installable_now=False` deps with: set `ids = fallback` and fall through to the existing `is_compatible()` call. Do NOT duplicate the `is_compatible()` call inside the fallback branch — falling through reuses the same code path.
+4. **Patch `scan()` silent-skip branch**: Replace the `continue` that skips `installable_now=False` deps with: use fallback if present, else `sys.exit(2)`.
 5. **Update module docstring**: Add the new exit path to the `FAILS LOUDLY` section.
 6. **Add regression test**: Write `test_static_fallback_covers_all_markered_out_distributed_deps` to assert that all marker-excluded deps are covered by `STATIC_FALLBACK_LICENSES`. This catches any future gated dep that lacks a fallback entry before it reaches CI.
 7. **Add unit tests for fallback path**: Patch `md.metadata` to raise `PackageNotFoundError` and assert the fallback licenses are returned; separately test that an unknown dep causes `SystemExit(2)`.
-8. **Add staleness-mitigation tests**:
-   - `test_static_values_match_installed_metadata`: parametrized over `STATIC_FALLBACK_LICENSES` keys; skips when dep not installed; asserts value intersection non-empty when installed.
-   - `test_static_values_match_notice`: unconditional; reads `NOTICE`; asserts each key (lowercased) and each SPDX value is present in NOTICE text.
-9. **Run CI**: Confirm the license-scan job passes on Python 3.13 / Ubuntu 24.04 and that previously-skipped deps now appear in the scan output.
+8. **Run CI**: Confirm the license-scan job passes on Python 3.13 / Ubuntu 24.04 and that previously-skipped deps now appear in the scan output.
 
 ## Verified On
 


### PR DESCRIPTION
## Summary

- Adds two staleness-mitigation tests missing from v1.0.0: `test_static_values_match_installed_metadata` (cross-checks static values against real `importlib.metadata` when dep IS installable) and `test_static_values_match_notice` (runs unconditionally, validates SPDX values exist in NOTICE)
- Corrects false claim: `tomli` IS in NOTICE:58 (v1.0.0 incorrectly listed source as "PyPI metadata")
- Refines `scan()` fallback control flow: sets `ids=fallback`, falls through to existing `is_compatible()` call rather than duplicating it
- Archives v1.0.0 snapshot in `.history` file; adds `history` frontmatter key

## Test plan

- [ ] Skill file parses as valid Markdown with correct frontmatter fields (version: 1.1.0, history key present)
- [ ] History file contains complete v1.0.0 snapshot
- [ ] Failed Attempts table has 4 rows (2 original + 2 new)
- [ ] Detailed Steps section includes both staleness-mitigation test descriptions
- [ ] Results table shows corrected NOTICE line numbers (tomli:58, tzdata:28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)