### PR TITLE
feat: amend pytest-coverage-threshold-and-enforcement skill (v1.3.0)

### DIFF
--- a/skills/pytest-coverage-threshold-and-enforcement.history
+++ b/skills/pytest-coverage-threshold-and-enforcement.history
@@ -1,6 +1,32 @@
 <!-- markdownlint-disable MD024 -->
 # pytest-coverage-threshold-and-enforcement — History
 
+## v1.3.0 (2026-06-13)
+
+**Amendment**: Promoted Issue #1198 planning content from unverified to verified-ci (PR #1293), and added test_doc_config.py fixture isolation finding.
+
+### New content added
+
+- Overview Outcome and Verification updated to mention v1.3.0
+- Verified Workflow note: promoted Steps I (planning pre-conditions) from "unverified" to "verified-ci (PR #1293)"
+- Section I warning block: replaced warning with verified-ci notice (4054 passed, 21 skipped; TOTAL 85.57% ≥ 83% gate; CI run #27458373439)
+- Section I step 7: new finding — `test_doc_config.py` fixtures (`_minimal_pyproject(fail_under=80)`) are isolated tmp_path test data, not repo assertions; no test changes needed when raising the real floor
+- New subsection "Verified behaviors from ProjectHephaestus #1198 / PR #1293 (v1.3.0)" in Results & Parameters: 5 confirmed behaviors (addopts absence acceptance, CLAUDE.md pattern requirement, fixture isolation, measure-first buffer, addopts cosmetic under `--override-ini`)
+- Failed Attempts: 2 new rows — raising floor without updating CLAUDE.md (hidden `check_claude_md_threshold()` dependency); assuming `test_doc_config.py` fixtures assert real config
+- Verified On: updated Issue #1198 row from "Unverified — planning session" to "verified-ci" with PR #1293 details
+
+### Verification level
+
+`verified-ci` — PR #1293 merged; floor raised 80% → 83%; 4054 unit tests passed, 21 skipped; TOTAL 85.57% ≥ 83% gate confirmed.
+
+### Source
+
+- Issue: ProjectHephaestus #1198
+- PR: ProjectHephaestus #1293
+- Session date: 2026-06-13
+
+---
+
 ## v1.2.0 (2026-06-13)
 
 **Amendment**: Added per-module branch-rate floor margin rule from ProjectHephaestus issue #1197, PR #1288.

--- a/skills/pytest-coverage-threshold-and-enforcement.md
+++ b/skills/pytest-coverage-threshold-and-enforcement.md
@@ -3,7 +3,7 @@ name: pytest-coverage-threshold-and-enforcement
 description: "Use when: (1) establishing [tool.coverage.report].fail_under as the single source of truth by removing redundant --cov-fail-under from CI and pyproject.toml addopts; (2) configuring multiple coverage report formats (xml, html, lcov) for CI and local use; (3) CI coverage % is lower than local because GitHub computes coverage against the merge-preview tree (PR HEAD merged with main HEAD) — adding entries to coverage.run.omit for files not on the branch IS the correct fix; (4) aggregate coverage gates hide under-tested critical modules — enforce per-file floors via parse_module_coverage() + coverage.toml + CI step; (5) some modules are intentionally omitted from measurement (live CLI/TTY) and need an integration backstop to catch import-time regressions; (6) pytest.importorskip() guards hide easy coverage wins — install optional deps and write targeted branch tests; (7) tuning coverage thresholds to match actual baselines and avoid false CI failures; (8) generate_coverage.sh fails in CI with wrong paths, cmake source dir errors, lcov gcov version mismatch on Ubuntu 24.04, or geninfo 'unable to create link .gcda'; (9) coverage is raised by adding targeted tests for uncovered branches plus unlocking skipped optional-dependency test groups; (10) planning a coverage threshold consolidation — verify actual coverage %, confirm consistency-checker accepts addopts absence, check whether CI uses --override-ini=addopts= before deciding where the real gate lives; (11) setting per-module branch-rate floor values in coverage.toml — choose margin 3-4pp below actual to avoid brittle thresholds that fail CI on unrelated PRs."
 category: testing
 date: 2026-06-13
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
 history: pytest-coverage-threshold-and-enforcement.history
 tags:
@@ -29,8 +29,8 @@ tags:
 | ------- | ------- |
 | **Date** | 2026-06-13 |
 | **Objective** | Configure, tune, and enforce pytest/coverage thresholds — single source of truth, per-module floors, merge-preview reconciliation, integration backstops for omitted modules, optional-dep unlocks, and lcov/geninfo CI fixes; planning pattern for threshold consolidation |
-| **Outcome** | Success — consolidated knowledge for establishing `fail_under` as canonical, raising real coverage, and keeping CI gates green and honest; v1.1.0 adds planning-phase pre-conditions and the --override-ini=addopts= CI pattern; v1.2.0 adds per-module floor margin rule (3-4pp below actual) |
-| **Verification** | verified-ci (existing); unverified (v1.1.0 planning additions from ProjectHephaestus issue #1198); verified-ci (v1.2.0 floor margin rule from ProjectHephaestus issue #1197, PR #1288) |
+| **Outcome** | Success — consolidated knowledge for establishing `fail_under` as canonical, raising real coverage, and keeping CI gates green and honest; v1.1.0 adds planning-phase pre-conditions and the --override-ini=addopts= CI pattern; v1.2.0 adds per-module floor margin rule (3-4pp below actual); v1.3.0 promotes Issue #1198 from unverified to verified-ci and adds test_doc_config.py fixture isolation finding |
+| **Verification** | verified-ci (existing); unverified (v1.1.0 planning additions from ProjectHephaestus issue #1198); verified-ci (v1.2.0 floor margin rule from ProjectHephaestus issue #1197, PR #1288); verified-ci (v1.3.0 — #1198 implementation confirmed via PR #1293) |
 | **History** | [changelog](./pytest-coverage-threshold-and-enforcement.history) |
 
 ## When to Use
@@ -53,7 +53,7 @@ tags:
 
 ## Verified Workflow
 
-> **Note:** Steps I–II below are planning pre-conditions added in v1.1.0 (ProjectHephaestus issue #1198, unverified). Steps A–H are verified-ci.
+> **Note:** Steps I–II below are planning pre-conditions added in v1.1.0 (ProjectHephaestus issue #1198) and promoted to **verified-ci** in v1.3.0 (PR #1293). Steps A–H are verified-ci.
 
 ### Quick Reference
 
@@ -115,7 +115,7 @@ lcov --capture --directory . --output-file "$COVERAGE_INFO" \
 
 #### I. Planning pre-conditions before changing any threshold (v1.1.0, unverified)
 
-> **Warning:** This section documents a planning session for ProjectHephaestus issue #1198. It has not been validated end-to-end in CI. Treat as a hypothesis until CI confirms.
+> **Verified-ci (v1.3.0):** This section was added as a planning session for ProjectHephaestus issue #1198 and promoted to verified-ci by PR #1293 (4054 passed, 21 skipped; TOTAL 85.57% ≥ 83% gate). All steps in this section have been validated end-to-end.
 
 Before touching `fail_under` or `--cov-fail-under` anywhere:
 
@@ -136,6 +136,8 @@ Before touching `fail_under` or `--cov-fail-under` anywhere:
    - Actual < 80% (below existing floor): **do not remove the addopts flag yet**; investigate why coverage dropped first
 
 6. **Check CLAUDE.md** — if a `check_claude_md_threshold()` validator exists, it may require a threshold mention in CLAUDE.md; grep the file before concluding no doc change is needed.
+
+7. **Verify test_doc_config.py fixtures are test data, not repo assertions** — calls like `_minimal_pyproject(fail_under=80)` inside `test_doc_config.py` create isolated tmp_path repos to exercise checker logic. They do NOT assert that the real repo's `pyproject.toml` has `fail_under=80`. No test changes are needed when raising the real floor because those fixtures are parameterized test data, not invariant checks on the live config.
 
 **Key insight for ProjectHephaestus**: The CI `--override-ini="addopts="` in `_required.yml` clears ALL addopts. CI coverage collection is driven entirely by explicit flags on the pytest line in `_required.yml`. Therefore:
 - Removing `--cov-fail-under=80` from addopts at `pyproject.toml:201`: no-op for CI
@@ -303,12 +305,24 @@ lcov --capture --directory . --output-file "$COVERAGE_INFO" \
 | Tests without installing the optional dep | Wrote tests assuming `jsonschema` was importable | `pytest.importorskip` still skipped them; coverage unchanged | Install the optional dep in CI first; guards block unguarded runs |
 | Assuming all uncovered code is reachable | Tried to hit every uncovered line | Some branches are genuinely unreachable (ImportError guards, conditional jumps) | Distinguish "unreachable" from "unexecuted"; don't chase impossible paths |
 | Per-module floor set within 0.75pp of actual | Set `automation/models.py` floor to 68% when measured branch-rate was 68.75% — only 0.75pp margin | PR reviewer rejected immediately: any new uncovered branch in models.py would fail CI for unrelated PRs | Rule: `floor = floor(actual_branch_rate - 3)` to `floor(actual_branch_rate - 4)`; never set a per-module floor within 1-2pp of the measured value |
+| Raising floor without updating CLAUDE.md | Assumed no doc update was needed when consolidating thresholds | `check_claude_md_threshold()` errors when no `<N>%+ test coverage` pattern exists in CLAUDE.md — hidden CI dependency | Always grep CLAUDE.md for a coverage pattern before concluding the doc change is optional; the doc-config checker runs as part of `hephaestus-check-doc-config` in CI |
+| Assuming test_doc_config.py fixtures assert real config | Interpreted `_minimal_pyproject(fail_under=80)` calls as repo invariants that needed updating when raising the floor | Those calls create isolated tmp_path repos to test checker logic — completely decoupled from the actual pyproject.toml | Read the test file; fixture calls with numeric values are parameterized test inputs, not snapshot tests of the live config |
 | Relative BUILD_DIR in lcov script | Used `BUILD_DIR=build/x86.coverage.debug` directly | After `cd`, all derived coverage paths were wrong | Canonicalize BUILD_DIR to absolute at script startup |
 | `cmake ... ..` after cd | Used `..` as the cmake source dir inside BUILD_DIR | `..` resolved to BUILD_DIR's parent, not PROJECT_ROOT | Pass `"$PROJECT_ROOT"` explicitly |
 | `--ignore-errors negative,mismatch` only | Added `mismatch` to suppress the gcov format error | `B33*` vs `4.8*` still fatal with lcov 2.0 | Add `version` to the ignore list |
 | `--ignore-errors negative,mismatch,version` | Fixed version error, script ran further | Shared source basenames across targets caused gcda symlink collisions | Add `gcov` to the ignore list as well |
 
 ## Results & Parameters
+
+### Verified behaviors from ProjectHephaestus #1198 / PR #1293 (v1.3.0, verified-ci)
+
+| Behavior | Details |
+| -------- | ------- |
+| `check_addopts_cov_fail_under()` accepts absence | Confirmed at `test_doc_config.py:176`: returns `[]` when flag is absent from addopts — removing it does NOT trip the consistency checker |
+| `check_claude_md_threshold()` requires pattern | `doc_config.py:149` errors when no `<N>%+ test coverage` pattern in CLAUDE.md; `83%+ test coverage enforced; target 90%` satisfies regex `r"(\d+)%\+?\s+test coverage"` |
+| `test_doc_config.py` fixtures are test data | `_minimal_pyproject(fail_under=80)` calls at lines 33, 49, 251, 261, 289, 304 create tmp_path repos for checker logic testing — NOT assertions on the real repo config; no test changes needed when raising real floor |
+| Measure-first with 2% buffer | CI baseline 85.76% (run #27458373439); `floor(85.76) - 2 = 83`; actual on PR 85.57%; buffer 2.57% |
+| addopts removal is cosmetic under `--override-ini="addopts="` | Removing `--cov-fail-under` from addopts has zero CI effect when CI uses `--override-ini="addopts="`; the load-bearing change is removing the explicit flag from `_required.yml` |
 
 ### Threshold consolidation outcomes
 
@@ -404,5 +418,5 @@ Diagnostic order (each bug masks the next): (1) BUILD_DIR absolute vs relative; 
 | ProjectHephaestus | Issue #623 | Optional-dep unlock `[dev,schema]` + targeted tests; schema.py 56% → 94.81% |
 | ProjectHephaestus | PR #603, PR #606 (2026-05-27) | Merge-preview coverage gate diagnosis; omit-list entry for main-only `loop_runner.py` unblocked CI |
 | ProjectKeystone | PR #340 (2026-04-24) | Fixed all 4 sequential lcov/geninfo CI bugs; coverage script ran to completion |
-| ProjectHephaestus | Issue #1198 planning (2026-06-13) | **Unverified** — planning session for coverage threshold consolidation (raise enforced floor from 80% to 90%); identified `--override-ini="addopts="` makes addopts removal a CI no-op; confirmed `check_addopts_cov_fail_under()` accepts addopts absence (test_doc_config.py:176); real CI gate is `_required.yml:585`; implementation not run, actual coverage % not measured |
+| ProjectHephaestus | Issue #1198, PR #1293 (2026-06-13) | **verified-ci** — raised enforced floor from 80% to 83% (measured baseline 85.76%, 2pp buffer); consolidated `--cov-fail-under` to single source of truth via `[tool.coverage.report].fail_under`; confirmed `--override-ini="addopts="` makes addopts removal a CI no-op (only the `_required.yml` flag is load-bearing); confirmed `check_addopts_cov_fail_under()` accepts absence (test_doc_config.py:176); added `83%+ test coverage enforced; target 90%` to CLAUDE.md to satisfy `check_claude_md_threshold()`; CI run #27458373439: 4054 passed, 21 skipped, TOTAL 85.57% ≥ 83% gate |
 | ProjectHephaestus | Issue #1197, PR #1288 (2026-06-13) | **verified-ci** — per-module floor margin rule: set 3-4pp below actual; `automation/models.py` floor initially 68% (0.75pp margin, reviewer rejected); lowered to 65% (3.75pp margin, merged); three new floors added: `automation/arming_state.py@98`, `automation/dependency_resolver.py@74`, `automation/models.py@65`; confirmed Cobertura XML paths have no `hephaestus/` prefix |


### PR DESCRIPTION
Promotes Issue #1198 planning content from unverified to verified-ci based on PR #1293 (floor raised 80% → 83%, CI run #27458373439: 4054 passed, 21 skipped, TOTAL 85.57% ≥ 83% gate).

## Changes

- Bumped version: 1.2.0 → 1.3.0
- Promoted Steps I (planning pre-conditions) note from "unverified" to "verified-ci (PR #1293)"
- Added step I.7: `test_doc_config.py` fixtures are isolated test data, not repo invariants
- New "Verified behaviors" table in Results & Parameters (5 confirmed behaviors)
- Two new Failed Attempts rows: CLAUDE.md hidden dependency, fixture misinterpretation
- Updated Verified On table: Issue #1198 row now "verified-ci" with full PR #1293 details
- History entry for v1.3.0

## Verification

`verified-ci` — PR #1293 merged; 322/322 skills validate.