### PR TITLE
docs(skills): add v1.2.0 history entry for stale-doc-audit skill

### DIFF
--- a/skills/stale-documentation-audit-and-broken-reference-repair.history
+++ b/skills/stale-documentation-audit-and-broken-reference-repair.history
@@ -2,6 +2,26 @@
 
 # stale-documentation-audit-and-broken-reference-repair — History
 
+## v1.2.0 (2026-06-13)
+
+Added stale line-number citation audit and issue-body claim verification patterns
+from ProjectHephaestus issue #1222 (PR #1299):
+
+- New "When to Use" bullet: a follow-up issue cites a specific incorrect claim that was
+  already fixed on main — verify current file state before acting; only stale cross-references
+  may remain
+- New "When to Use" bullet: a doc or test file references another file by line number — the
+  cited line numbers may have shifted independently across files that reference the same construct
+- New row in pattern classification table: "Line-number citation drift" and "Issue-body
+  fabricated claim"
+- Extended Quick Reference bash block for stale line-number citation workflow (3-step grep pattern)
+- Two new Failed Attempts rows:
+  1. "Trusting issue body claim of specific incorrect string" — planned to edit text the issue
+     said was wrong but that text no longer existed in main (prior PR had already fixed it)
+  2. "Searching only the issue-reported stale line-number value" — only grepped for `137-141`
+     but the test file carried a different stale value (`127-129`) from independent update history
+- New Verified On row: ProjectHephaestus #1222 / PR #1299
+
 ## v1.1.0 (2026-06-13)
 
 Added ADR LoC drift pattern from ProjectHephaestus issue #1177 (PR #1281):


### PR DESCRIPTION
Add the missing v1.2.0 changelog entry to the history file for the
`stale-documentation-audit-and-broken-reference-repair` skill.

The v1.2.0 amendment was merged in PR #2456 but its `.history` file was
not updated at that time. This PR adds the missing entry documenting the
learnings from ProjectHephaestus issue #1222 / PR #1299.

## Summary

- Add `## v1.2.0 (2026-06-13)` entry to `.history` file
- Documents the two key new learnings:
  1. Always grep for the exact claimed-incorrect string before trusting an issue body
  2. Search for ALL stale line-number variants across all referencing files (docs and test files updated independently carry different stale values)