### PR TITLE
feat(skills): promote architecture-dip-constructor-injection to verified-ci (v2.0.0)

### DIFF
--- a/skills/architecture-dip-constructor-injection-planning-risks.md
+++ b/skills/architecture-dip-constructor-injection-planning-risks.md
@@ -1,11 +1,11 @@
 ---
 name: architecture-dip-constructor-injection-planning-risks
-description: "Planning risks when replacing module-level importlib monkeypatching with constructor injection in a class hierarchy. Use when: (1) planning a DIP refactor that removes _PATCHABLE_DEPENDENCIES / importlib test-seams, (2) reviewing an implementation plan that uses **kwargs forwarding in subclass __init__, (3) assessing risk before migrating 20+ test patch sites to direct injection."
+description: "Replacing module-level importlib monkeypatching with constructor injection in a class hierarchy (DIP refactor). Use when: (1) planning or executing a DIP refactor that removes _PATCHABLE_DEPENDENCIES / importlib test-seams, (2) reviewing an implementation plan that uses **kwargs forwarding in subclass __init__, (3) assessing risk before migrating 20+ test patch sites to direct injection."
 category: architecture
 date: 2026-06-13
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
-verification: unverified
+verification: verified-ci
 tags: [DIP, dependency-injection, constructor-injection, importlib, test-seam, monkeypatch, mypy, BaseReviewer, SOLID]
 ---
 
@@ -17,12 +17,12 @@ tags: [DIP, dependency-injection, constructor-injection, importlib, test-seam, m
 | ------- | ------- |
 | **Date** | 2026-06-13 |
 | **Objective** | Replace `_resolve_from_subclass_module` + `_PATCHABLE_DEPENDENCIES` importlib test-seam in `BaseReviewer` with keyword-only factory parameters in `__init__` that default to the real collaborators |
-| **Outcome** | Plan only — not yet implemented (verification: unverified) |
-| **Verification** | unverified |
+| **Outcome** | Fully implemented and merged (PR #1310, issue #1194). 1572 unit tests pass in CI. |
+| **Verification** | verified-ci |
 
 ## When to Use
 
-- Planning a DIP refactor that replaces module-level monkeypatching (`unittest.mock.patch("module.ClassName")`) with constructor injection
+- Executing or planning a DIP refactor that replaces module-level monkeypatching (`unittest.mock.patch("module.ClassName")`) with constructor injection
 - The class under refactor uses `importlib.import_module(cls.__module__)` + `getattr` to pull collaborators at runtime
 - A `_PATCHABLE_DEPENDENCIES` tuple enumerates the names of injectable collaborators
 - Subclasses re-export the collaborators in their own `__all__` so `patch("subclass_module.ClassName")` resolves correctly
@@ -31,12 +31,12 @@ tags: [DIP, dependency-injection, constructor-injection, importlib, test-seam, m
 
 ## Verified Workflow
 
-> **Status**: Planning-only — the steps below are planned but not yet executed. Treat as a design reference, not a verified recipe.
+> **Status**: verified-ci — all steps below were executed for ProjectHephaestus `BaseReviewer`, PR #1310 merged, 1572 unit tests passing.
 
 ### Quick Reference
 
 ```python
-# BaseReviewer injection signature (planned)
+# BaseReviewer injection signature (verified)
 def __init__(
     self,
     options: Any,
@@ -47,7 +47,7 @@ def __init__(
     log_manager_factory: Callable[[], ThreadLogManager] = ThreadLogManager,
 ) -> None: ...
 
-# Shared test fixture (planned)
+# Shared test fixture (verified pattern)
 @pytest.fixture
 def base_deps(tmp_path):
     return dict(
@@ -57,88 +57,83 @@ def base_deps(tmp_path):
         log_manager_factory=MagicMock(return_value=MagicMock()),
     )
 
-# Subclass __init__ explicit forwarding (safer than **kwargs)
+# Subclass __init__ using **kwargs: Any (verified working with mypy --strict)
 class PRReviewer(BaseReviewer):
-    def __init__(
-        self,
-        options: Any,
-        *,
-        get_repo_root: Callable[[], Any] = _default_get_repo_root,
-        worktree_manager_factory: Callable[[], WorktreeManager] = WorktreeManager,
-        status_tracker_factory: Callable[[int], StatusTracker] = StatusTracker,
-        log_manager_factory: Callable[[], ThreadLogManager] = ThreadLogManager,
-    ) -> None:
-        super().__init__(
-            options,
-            get_repo_root=get_repo_root,
-            worktree_manager_factory=worktree_manager_factory,
-            status_tracker_factory=status_tracker_factory,
-            log_manager_factory=log_manager_factory,
-        )
+    def __init__(self, options: Any, **kwargs: Any) -> None:
+        super().__init__(options, **kwargs)
 ```
 
-### Planned Steps
+### Verified Steps
 
-1. **Verify subclass body usage before removing imports**: Read the complete body of both `pr_reviewer.py` and `address_review.py` to confirm that `WorktreeManager`, `StatusTracker`, and `ThreadLogManager` are only used at construction time (passed to `super().__init__`) and not called directly in body methods. Skipping this step risks `AttributeError` at runtime.
+1. **Verify subclass body usage before removing imports**: Read the complete body of every subclass to confirm that `WorktreeManager`, `StatusTracker`, and `ThreadLogManager` are not called directly in body methods. For `address_review.py`: `get_repo_root` was imported for the test-seam re-export but was NOT called anywhere in the module body — this must be confirmed before removing any import, not assumed.
 
-2. **Add factory parameters to `BaseReviewer.__init__`**: Use keyword-only parameters with class-as-default (e.g., `worktree_manager_factory: Callable[[], WorktreeManager] = WorktreeManager`). This preserves production call sites because the defaults behave identically to the old `importlib` resolution.
+2. **Add factory parameters to `BaseReviewer.__init__`**: Use keyword-only parameters with class-as-default (e.g., `worktree_manager_factory: Callable[[], WorktreeManager] = WorktreeManager`). `get_repo_root` gets a `_default_get_repo_root` module-level function as default (not the imported symbol directly) so tests can inject a `lambda: tmp_path` cleanly. Production call sites (`PRReviewer(options)`) need zero changes.
 
-3. **Delete `_resolve_from_subclass_module` and `_PATCHABLE_DEPENDENCIES`**: Remove the importlib machinery only after step 2 is in place and all subclasses forward the new parameters.
+3. **Delete `_resolve_from_subclass_module` and `_PATCHABLE_DEPENDENCIES`**: Remove the importlib machinery after step 2 is in place and all subclasses forward the new parameters.
 
-4. **Update subclass `__init__` signatures**: Add explicit keyword-only parameters rather than `**kwargs` — explicit forwarding is mypy-transparent. If `--strict` mypy is in use, `**kwargs` forwarding will fail type-checking without `@overload`.
+4. **Update subclass `__init__` signatures**: Use `**kwargs: Any` (NOT `**kwargs: object`). `**kwargs: object` causes mypy errors because `dict[str, object]` is incompatible with the typed keyword-only factory params. `**kwargs: Any` is opaque to mypy and passes `--strict`. If explicit forwarding is preferred for documentation value, enumerate each param explicitly — both approaches work.
 
-5. **Rewrite `test_reviewer_base_contract.py`**: The existing contract tests assert `_PATCHABLE_DEPENDENCIES` is exact and that re-exports exist on subclass modules. Both assertions become invalid after the refactor. Replace with tests that verify the injection API: that factories default to real classes, that injected mocks propagate to the constructed collaborators.
+5. **Remove `__all__` re-export blocks from subclasses**: The re-exports (`WorktreeManager`, `StatusTracker`, `ThreadLogManager`, `get_repo_root`) exist solely for the test-seam. Once tests use direct injection, they can be removed entirely. Verify no external callers do `from hephaestus.automation.pr_reviewer import WorktreeManager` before removing.
 
-6. **Migrate 20+ test patch sites**: Replace `patch("hephaestus.automation.address_review.WorktreeManager")` etc. with direct injection via the `base_deps` fixture. Read ALL test files fully before migration — some patch sites target method calls on the instance, not just construction; those are unaffected by injection alone.
+6. **Remove unused imports from subclasses**: After removing `__all__` re-exports, the module-level imports of `ThreadLogManager`, `StatusTracker`, `WorktreeManager` in the subclass files become unused. Remove them. Do NOT remove imports that are called in the module body (e.g., used in a method).
 
-7. **Decide on `__all__` re-exports**: If `WorktreeManager` etc. appear in `pr_reviewer.__all__` only to support `patch("...pr_reviewer.WorktreeManager")` and there are no external callers doing `from hephaestus.automation.pr_reviewer import WorktreeManager`, remove the re-exports. Search for external importers before removing.
+7. **Rewrite `test_reviewer_base_contract.py`**: The existing contract tests assert `_PATCHABLE_DEPENDENCIES` is exact and that re-exports exist on subclass modules. Both assertions are invalid after the refactor. Replace with tests that verify the injection API: factories default to real classes, injected mocks propagate to the constructed collaborators.
+
+8. **Migrate 20+ test patch sites**: Replace `patch("hephaestus.automation.address_review.WorktreeManager")` etc. with direct injection via the `base_deps` fixture. Add `base_deps` as a shared `@pytest.fixture` per test module; pass `**base_deps` to constructor calls. Patches targeting instance method calls (not construction) are unaffected.
+
+9. **Verify import boundary tests pass**: `test_automation_boundary.py` uses static grep to enforce the automation→library boundary. Adding module-level imports of collaborators to `_reviewer_base.py` is safe because it is in `hephaestus.automation` (product layer), not the base `hephaestus` surface.
+
+10. **Eliminate a category of code-quality-bot noise**: The old `# noqa: F401` re-export imports were flagged by the bot as "unused imports" and raised unresolvable review threads. The DI refactor eliminates this entire category.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | ---------------- | --------------- | ---------------- |
-| `**kwargs` forwarding in subclass `__init__` | Pass `**kwargs` from `PRReviewer.__init__` to `super().__init__()` instead of enumerating parameters | mypy `--strict` infers `kwargs: dict[str, Any]`, which does not satisfy the typed keyword-only signature of `BaseReviewer.__init__`; requires `@overload` stubs or explicit params | Use explicit keyword-only parameter forwarding; `**kwargs` is opaque to type checkers and adds signature debt |
-| Removing `__all__` without verifying external callers | Drop `WorktreeManager`/`StatusTracker`/`ThreadLogManager` from submodule `__all__` as part of the refactor | External code doing `from hephaestus.automation.pr_reviewer import WorktreeManager` would break silently; the import surface is part of the public API | Grep for all import sites across the codebase (and any downstream repos) before removing re-exports; keep `__all__` entries if any non-test callers exist |
-| Skipping full body read of subclasses | Assumed collaborators were only used at construction time based on reading `__init__` only | Collaborators may appear in body methods (e.g., `self._worktree_manager.do_something()`) — their removal from the module namespace would cause `NameError` at call sites | Always read the complete file before removing module-level imports or re-exports |
+| `**kwargs: object` in subclass `__init__` | Use `**kwargs: object` instead of `**kwargs: Any` when forwarding to `super().__init__()` | mypy infers `dict[str, object]` which is incompatible with the typed keyword-only factory params (`Callable[[], WorktreeManager]` etc.) | Use `**kwargs: Any` — it is opaque to mypy and satisfies `--strict` without `@overload` stubs |
+| Removing `__all__` without verifying external callers | Drop `WorktreeManager`/`StatusTracker`/`ThreadLogManager` from submodule `__all__` without checking call sites | External code doing `from hephaestus.automation.pr_reviewer import WorktreeManager` would break silently | Grep for all import sites across the codebase before removing re-exports; keep entries if any non-test callers exist |
+| Skipping full body read of subclasses | Assumed collaborators were only used at construction time based on reading `__init__` only | In `address_review.py`, `get_repo_root` was imported for the test-seam re-export but NOT called in the module body — the check must confirm actual usage, not assume | Always read the complete file before removing module-level imports or re-exports |
 | Not scanning for a third subclass | Assumed only `PRReviewer` and `AddressReviewer` exist | A third subclass that overrides `__init__` without forwarding the new parameters would silently use the old importlib path (if not deleted) or crash (if deleted) | Run `grep -r "BaseReviewer" --include="*.py"` exhaustively before assuming the subclass count is known |
+| Explicit param forwarding over `**kwargs` | Enumerate each kwarg explicitly in subclass (original plan recommendation) | More verbose, no mypy benefit over `**kwargs: Any`, more surface to keep in sync as base class evolves | `**kwargs: Any` is the simpler approach; explicit forwarding only adds value if subclasses need to set different defaults or add validation |
 
 ## Results & Parameters
 
-### Verified Code Locations (grep-confirmed)
+### Verified Code Locations
 
-| Symbol | File | Lines |
+| Symbol | File | Notes |
 | -------- | ------ | ------- |
-| `_resolve_from_subclass_module` | `hephaestus/automation/_reviewer_base.py` | 34–58 |
-| `_PATCHABLE_DEPENDENCIES` | `hephaestus/automation/_reviewer_base.py` | 90–96 |
-| `__all__` re-export block | `hephaestus/automation/pr_reviewer.py` | 49, 55, 57–58 |
-| `__all__` re-export block | `hephaestus/automation/address_review.py` | 51–55 |
-| `WorktreeManager.__init__` | `hephaestus/automation/worktree_manager.py` | 67 (no required args) |
-| `StatusTracker.__init__` | `hephaestus/automation/status_tracker.py` | 19 (`num_slots: int` required) |
-| `ThreadLogManager.__init__` | `hephaestus/automation/curses_ui.py` | 84 (no args) |
+| `BaseReviewer.__init__` injection params | `hephaestus/automation/_reviewer_base.py` | Four keyword-only factory params with production defaults |
+| `_default_get_repo_root` | `hephaestus/automation/_reviewer_base.py` | Module-level function used as default for `get_repo_root` param |
+| Deleted: `_resolve_from_subclass_module` | was `hephaestus/automation/_reviewer_base.py` | Removed entirely in PR #1310 |
+| Deleted: `_PATCHABLE_DEPENDENCIES` | was `hephaestus/automation/_reviewer_base.py` | Removed entirely in PR #1310 |
+| Deleted: `__all__` re-export block | was `hephaestus/automation/pr_reviewer.py` | Removed; re-exports existed solely for the test-seam |
+| Deleted: `__all__` re-export block | was `hephaestus/automation/address_review.py` | Removed; re-exports existed solely for the test-seam |
+| Rewritten: contract test | `tests/unit/automation/test_reviewer_base_contract.py` | Now asserts injection API instead of `_PATCHABLE_DEPENDENCIES` |
 
-### Uncertain Assumptions (Not Verified at Planning Time)
+### Factory Signatures (Verified)
 
-1. `WorktreeManager`, `StatusTracker`, `ThreadLogManager` are NOT used directly in `pr_reviewer.py` or `address_review.py` body methods beyond the re-export — plan says "keep if used" but did not scan full body of both files
-2. `**kwargs` forwarding on `PRReviewer.__init__` is compatible with mypy `--strict` — not verified against the mypy config
-3. `state_dir.mkdir(parents=True, exist_ok=True)` in `__init__` is safe to call during test construction with `tmp_path` — not verified that fixtures don't assert on unexpected directory creation
-4. Only 2 subclasses exist (`PRReviewer` and `AddressReviewer`) — not confirmed exhaustively via grep
+| Parameter | Type | Default | Notes |
+| ----------- | ------ | --------- | ------- |
+| `get_repo_root` | `Callable[[], Any]` | `_default_get_repo_root` | Module-level fn wrapping `get_repo_root()` import |
+| `worktree_manager_factory` | `Callable[[], WorktreeManager]` | `WorktreeManager` | Zero-arg; instantiates with no args |
+| `status_tracker_factory` | `Callable[[int], StatusTracker]` | `StatusTracker` | One positional arg: `num_slots: int` |
+| `log_manager_factory` | `Callable[[], ThreadLogManager]` | `ThreadLogManager` | Zero-arg; instantiates with no args |
 
-### Key Risks for Plan Reviewer
+### Key Invariants
 
-1. **mypy `--strict` + `**kwargs` incompatibility**: If `pixi run mypy` runs with `--strict` and subclasses use `**kwargs` forwarding, type checking will fail. Use explicit parameter forwarding or add `@overload` stubs.
-2. **20+ patch sites — read all tests in full**: `test_address_review.py` and `test_pr_reviewer_posting.py` have 20+ sites but were not read completely during planning. Some patches may target instance method calls, not just construction, making injection alone insufficient.
-3. **`__all__` removal breaks external API surface**: `from hephaestus.automation.pr_reviewer import WorktreeManager` is a valid import path after the current re-exports; removing `__all__` entries without verifying downstream usage is a silent breaking change.
-4. **Third subclass risk**: If any third `BaseReviewer` subclass exists and is not updated, it will silently revert to the old importlib path (if `_resolve_from_subclass_module` is kept) or crash at construction (if deleted).
-5. **`StatusTracker` requires `num_slots: int`**: The default factory `StatusTracker` (no-arg) will crash at call time because `StatusTracker.__init__` requires `num_slots`. The factory signature must be `Callable[[int], StatusTracker]` and tests must pass a mock that accepts positional args.
+1. `**kwargs: Any` (not `**kwargs: object`) required for mypy compliance when forwarding typed keyword-only params from subclass to base class.
+2. `status_tracker_factory` signature MUST be `Callable[[int], StatusTracker]` — `StatusTracker.__init__` requires `num_slots: int`; a zero-arg default crashes at call time.
+3. Production call sites need zero changes — `PRReviewer(options)` and `AddressReviewer(options)` still work unchanged because all factory params have defaults.
+4. The shared `base_deps` fixture must supply `status_tracker_factory=MagicMock(return_value=MagicMock())` — the mock must accept a positional int arg (MagicMock does by default).
 
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
-| ProjectHephaestus | Issue #1194 planning session — DIP violation fix in BaseReviewer | Plan only; implementation not started |
+| ProjectHephaestus | Issue #1194 — DIP violation fix in BaseReviewer, PR #1310 | 1572 unit tests pass in CI; verified-ci |
 
 ## References
 
 - [SOLID Dependency Inversion Principle](https://en.wikipedia.org/wiki/Dependency_inversion_principle)
 - [Python unittest.mock.patch documentation](https://docs.python.org/3/library/unittest.mock.html#patch)
 - [ProjectHephaestus Issue #1194](https://github.com/HomericIntelligence/ProjectHephaestus/issues/1194)
+- [ProjectHephaestus PR #1310](https://github.com/HomericIntelligence/ProjectHephaestus/pull/1310)


### PR DESCRIPTION
## Summary

- Amends `architecture-dip-constructor-injection-planning-risks` skill from `verification: unverified` (planning only) to `verification: verified-ci` (PR #1310 merged, 1572 unit tests passing)
- Promotes version from 1.0.0 to 2.0.0 to signal verified status
- Adds key verified findings not known at planning time: `**kwargs: Any` (not `object`) for mypy compliance, `**kwargs` idiom confirmed simpler than explicit forwarding, `get_repo_root` re-exported but not called in `address_review.py` body, confirmed elimination of code-quality-bot `# noqa: F401` noise

## Key New Knowledge (verified, not in v1.0.0)

1. `**kwargs: Any` (not `**kwargs: object`) is required when forwarding typed keyword-only params — `dict[str, object]` is mypy-incompatible
2. `**kwargs: Any` is simpler than explicit forwarding and preferred when no subclass needs different defaults
3. `get_repo_root` in `address_review.py` was re-exported for the seam but never called in the module body — must be confirmed per-file, not assumed
4. The refactor eliminates an entire category of code-quality-bot `# noqa: F401` unresolvable review threads

## References

- ProjectHephaestus issue #1194 / PR #1310
- 1572 unit tests passing in CI (verified-ci)

🤖 Generated with [Claude Code](https://claude.com/claude-code)