### PR TITLE
feat: amend python-path-resolution-cwd-resolve-contract skill (v1.1.0)

### DIFF
--- a/skills/python-path-resolution-cwd-resolve-contract.history
+++ b/skills/python-path-resolution-cwd-resolve-contract.history
@@ -1,0 +1,29 @@
+# python-path-resolution-cwd-resolve-contract — History
+
+## v1.1.0 (2026-06-13)
+
+**Changed by:** Issue #1309 plan review — P3/TDD gap finding
+**Verification:** unverified
+
+### What changed
+- Added new Failed Attempts row: isinstance-only check as regression guard
+- Added new When to Use trigger: TDD regression guard planning for path helpers
+- Added Results & Parameters example: insufficient vs required assertion
+- Added history frontmatter field
+
+### Why
+The initial v1.0.0 skill captured the Path.cwd().resolve() fix but omitted the critical
+TDD lesson: isinstance(result, Path) alone does not prove the resolved-path contract and
+passes both before and after the fix on Linux. The plan reviewer identified this as a
+major P3/TDD gap (NOGO grade C). The corrected plan adds assert result.is_absolute()
+as the required regression guard.
+
+### Previous version (v1.0.0) snapshot
+
+[See initial commit in PR #2489 — skills/python-path-resolution-cwd-resolve-contract.md]
+
+---
+
+## v1.0.0 (2026-06-13)
+
+**Initial version.**

--- a/skills/python-path-resolution-cwd-resolve-contract.md
+++ b/skills/python-path-resolution-cwd-resolve-contract.md
@@ -3,9 +3,10 @@ name: python-path-resolution-cwd-resolve-contract
 description: "Path resolution contract for get_repo_root and similar helpers: Path.cwd() must always be followed by .resolve(), and test assertions comparing resolved paths must call .resolve() on expected values. Use when: (1) implementing path-returning helpers, (2) writing tests for functions that return resolved paths, (3) diagnosing symlink-fragile test failures."
 category: testing
 date: 2026-06-13
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: python-path-resolution-cwd-resolve-contract.history
 tags: []
 ---
 
@@ -26,6 +27,7 @@ tags: []
 - Writing tests that compare `result == some_path` where the function under test calls `.resolve()`
 - Diagnosing intermittent test failures on macOS where `$TMPDIR` is a symlink through `/private/`
 - Planning code reviews for path-returning utilities
+- When writing a TDD regression guard for a path-returning helper — the test must assert `is_absolute()`, not just `isinstance(Path)`
 
 ## Verified Workflow
 
@@ -57,6 +59,7 @@ assert result == mock_git_repo
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
+| isinstance-only regression guard | Used `assert isinstance(result, Path)` as the sole test for the `Path.cwd().resolve()` fix | Passes before AND after the fix on Linux — `Path.cwd()` is already absolute, so zero coverage | Fallback tests for resolved-path helpers MUST assert `is_absolute()` — isinstance proves type only |
 | Relying on `isinstance(result, Path)` in fallback test | `test_uses_cwd_when_none` only checks `isinstance` | Does not verify the path is resolved/absolute — a symlink path is still a `Path` | Fallback tests must also assert `is_absolute()` to prove the resolve contract |
 | Skipping `.resolve()` on `Path.cwd()` | `Path.cwd() if ... else Path(start_path).resolve()` | Returns unresolved path on fallback code path — inconsistent return type | Both branches of a ternary path assignment must call `.resolve()` |
 | Comparing `result == tmp_path` in test | `assert result == mock_git_repo` | Fails on macOS where `tmp_path` is under `/var/folders/...` which is a symlink to `/private/var/...`; `get_repo_root` resolves through the symlink but `tmp_path` does not | Always call `.resolve()` on expected path values in test equality checks |
@@ -85,6 +88,15 @@ def test_uses_cwd_when_none():
     result = get_repo_root(None)
     assert isinstance(result, Path)
     assert result.is_absolute()  # proves the resolve contract
+```
+
+**TDD regression guard — insufficient vs required:**
+```python
+# INSUFFICIENT — passes before and after fix on Linux:
+assert isinstance(result, Path)
+
+# REQUIRED regression guard — fails before fix on symlinked $TMPDIR, passes after:
+assert result.is_absolute()
 ```
 
 **Audit command to find fragile assertions:**


### PR DESCRIPTION
## Summary

Amends `python-path-resolution-cwd-resolve-contract` from v1.0.0 to v1.1.0.

Adds a documented failure mode: using `isinstance(result, Path)` as the sole regression guard for a `Path.cwd().resolve()` fix. This assertion passes both before and after the fix on Linux, providing zero TDD coverage of the contract.

- `assert result.is_absolute()` is the required guard — fails before fix on symlinked paths, passes after
- Discovered via plan reviewer NOGO on ProjectHephaestus issue #1309 (P3/TDD gap)
- Applies whenever planning a regression test for any path-returning helper

## Verification Level

**unverified**

Learnings from plan review; full CI validation pending implementation of issue #1309.

## Key Findings

**What Worked**:
- Adding `assert result.is_absolute()` after isinstance check closes the TDD gap
- The assertion is the exact test that fails-before / passes-after on macOS/symlinked envs

**What Failed**:
- `isinstance(result, Path)` alone → silent pass before AND after fix; useless as regression guard

## Test Plan

- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skill appears in marketplace with updated version

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>