### PR TITLE
feat(skills): amend python-path-resolution-cwd-resolve-contract v1.2.0

### DIFF
--- a/skills/python-path-resolution-cwd-resolve-contract.history
+++ b/skills/python-path-resolution-cwd-resolve-contract.history
@@ -1,5 +1,20 @@
 # python-path-resolution-cwd-resolve-contract — History
 
+## v1.2.0 (2026-06-13)
+
+**Changed by:** Issue #1309 / PR #1316 implementation — post-implementation verification
+**Verification:** verified-local
+
+### What changed
+- Updated `Verified On` table: confirmed all 8 `TestGetRepoRoot` tests pass; full unit suite green (exit code 0) on PR #1316
+- Added line 157 (`test_uses_cwd_when_none` assertion) to the verified file locations
+- Bumped version to 1.2.0 to record post-implementation verification completion
+
+### Why
+The v1.1.0 skill was recorded as "unverified" because it was written during the plan-review phase before implementation. PR #1316 implemented the fix and confirmed verified-local: all 8 tests in `TestGetRepoRoot` pass, full unit suite exits 0. The skill is now confirmed correct and the verification field reflects this.
+
+---
+
 ## v1.1.0 (2026-06-13)
 
 **Changed by:** Issue #1309 plan review — P3/TDD gap finding

--- a/skills/python-path-resolution-cwd-resolve-contract.md
+++ b/skills/python-path-resolution-cwd-resolve-contract.md
@@ -3,7 +3,7 @@ name: python-path-resolution-cwd-resolve-contract
 description: "Path resolution contract for get_repo_root and similar helpers: Path.cwd() must always be followed by .resolve(), and test assertions comparing resolved paths must call .resolve() on expected values. Use when: (1) implementing path-returning helpers, (2) writing tests for functions that return resolved paths, (3) diagnosing symlink-fragile test failures."
 category: testing
 date: 2026-06-13
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: verified-local
 history: python-path-resolution-cwd-resolve-contract.history
@@ -109,4 +109,4 @@ grep -n "assert result ==" tests/unit/utils/test_general_utils.py
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | Issue #1309 follow-up to #1267 | `hephaestus/utils/helpers.py:117`, `tests/unit/utils/test_general_utils.py:140,152` |
+| ProjectHephaestus | Issue #1309 / PR #1316 | `hephaestus/utils/helpers.py:117`, `tests/unit/utils/test_general_utils.py:140,152,157`; all 8 `TestGetRepoRoot` tests pass; full unit suite green (exit code 0) |


### PR DESCRIPTION
## Summary

Amends skill `python-path-resolution-cwd-resolve-contract` from unverified v1.1.0 to verified-local v1.2.0.

- All 8 `TestGetRepoRoot` tests confirmed passing locally on ProjectHephaestus PR #1316 (issue #1309)
- Full unit suite exits 0; CI running on PR #1316
- Updated `Verified On` table with PR #1316 reference and line 157 for `test_uses_cwd_when_none`
- Added v1.2.0 history entry noting the post-implementation verification

## Key Learnings Confirmed

- Both arms of a fallback ternary must call `.resolve()` when the return is a resolved path
- Test assertions comparing resolved output against `tmp_path`/mock fixtures need `.resolve()` on the expected side
- `assert result.is_absolute()` is the correct regression guard (prescribed by issue body)
- On Linux `Path.cwd()` is already absolute; defect surfaces on macOS/WSL with symlinked `$TMPDIR`

## Validation

- [x] `python3 scripts/validate_plugins.py` — 331/331 valid
- [x] Commit signed (GPG: DA75400C08639CDDAEE6FD4C7FD616C4744A8A7C)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>