### PR TITLE
feat: amend python-module-decomposition-and-refactor-patterns to v1.12.0

### DIFF
--- a/skills/python-module-decomposition-and-refactor-patterns.history
+++ b/skills/python-module-decomposition-and-refactor-patterns.history
@@ -1,6 +1,57 @@
 <!-- markdownlint-disable MD024 -->
 # python-module-decomposition-and-refactor-patterns — History
 
+## v1.12.0 (2026-06-13)
+
+**Changed by:** /learn from ProjectHephaestus issue #1289 R5 planning session (continued — three additional stub-writing risks not directly source-read)
+**Verification:** unverified (planning session findings; implementation not yet executed)
+
+### What changed
+
+Added Phases 27–29 covering three additional pre-implementation verification risks identified
+during the R5 planning session for issue #1289 (ci_driver.py decomposition):
+
+**Phase 27: Source-Read Mandate for Stubs Carried Forward Without Direct Verification**
+
+Three `CIFixOrchestrator` stubs were carried forward from R4/R5 without direct source reads:
+- `_recheck_and_arm_after_fix` (ci_driver.py:1147) — plan includes `acquired_slot` parameter
+- `_resolve_dirty_pr` (ci_driver.py:1227) — plan includes `acquired_slot` parameter
+- `_attempt_ci_fixes` (ci_driver.py:1286) — plan includes `acquired_slot` parameter
+
+The `acquired_slot` parameter appeared as a fabricated parameter in R4 for
+`_retry_no_commit_once` (where source showed it did NOT exist). AST Criterion 6 verifies
+method name presence only — a wrong-but-present stub passes silently and fails at runtime
+with `TypeError: unexpected keyword argument`.
+
+Rule: Before writing any stub, run `sed -n 'Np' ci_driver.py` on the def line. Never carry
+parameters from a prior plan revision as authoritative.
+
+**Phase 28: Two-Argument Stub Arity Verification**
+
+The plan specifies `_is_bot_pr_mode(self, issue_number, pr_number)` as a two-argument method
+but the source at L596 was not directly read. Arity or keyword-only separator may differ.
+Rule: For any method with 2+ non-self args not source-read in the current session, verify
+arity and keyword-only status before writing the stub.
+
+**Phase 29: Return-Type Annotation Verification Before Stub Writing**
+
+The plan annotates `_gh_pr_state(self, pr_number: int) -> dict` without reading the return
+annotation from source. Under mypy `strict = true`, bare `dict` is rejected (missing type
+parameters). Actual type may be `dict[str, Any]` or a TypedDict. Rule: Source-read the
+return annotation; write the fully parameterized form matching source.
+
+Also added:
+- 4 new rows to Failed Attempts table (R5 acquired_slot risk, `_is_bot_pr_mode` arity,
+  `_gh_pr_state` return type, and the general carried-forward-parameter pattern)
+- 3 new use-case descriptions in frontmatter (21–23)
+- 5 new tags (source-read-before-stub, fabricated-parameter-risk, acquired-slot-verification,
+  return-type-annotation-verification, stub-arity-verification)
+- 4 new When-to-Use bullets
+- 3 new Quick Reference decision-tree entries
+- 1 new Verified On row
+
+---
+
 ## v1.11.0 (2026-06-13)
 
 **Changed by:** /learn from ProjectHephaestus issue #1289 R5 planning session (CIDriver god-class decomposition — planning-time verification rules)

--- a/skills/python-module-decomposition-and-refactor-patterns.history
+++ b/skills/python-module-decomposition-and-refactor-patterns.history
@@ -1,6 +1,98 @@
 <!-- markdownlint-disable MD024 -->
 # python-module-decomposition-and-refactor-patterns — History
 
+## v1.10.0 (2026-06-13)
+
+**Changed by:** /learn from ProjectHephaestus PR #1292 (issue #1179 — CIDriver god-class decomposition execution using narrow-callable DIP injection)
+**Verification:** verified-ci (PR #1292 merged, all CI gates passed, 146 existing tests + 22 new tests pass)
+
+### What changed
+
+Added Phase 23: God-Class Execution — Narrow-Callable Injection (DIP) Pattern — four
+implementation-time rules discovered during the first complete execution of a god-class
+decomposition using dependency inversion through injected callables:
+
+1. **Rule 1: Lambda wrapping mandatory for all injected callables** — bare bound-method
+   references (`self._head_advanced`) are captured at construction time; `patch.object` applied
+   after construction is bypassed. Always use `lambda *a, **k: self._method(*a, **k)` so the
+   mock is re-read at call time.
+
+2. **Rule 2: Patch each module's `run` import separately when a method chain splits** — after
+   moving the pre-agent SHA snapshot to an orchestrator, there are two distinct `run` lookup
+   sites: `ci_fix_orchestrator.run` (pre-agent) and `ci_driver.run` (post-agent). A test that
+   patches only the orchestrator's `run` hits real git on the second call.
+
+3. **Rule 3: Update attribute access in ALL sibling test files after migration** — moving
+   `_viewer_login` from `CIDriver` to `PRDiscovery` generates 6 mypy strict errors across
+   sibling test files; grep all tests for `driver.<migrated_attr>` and update to
+   `driver._collaborator.<attr>`.
+
+4. **Rule 4: Update `companions` tuple in phase-wiring tests when AGENT_* constants move** —
+   `test_phase_agent_wiring.py` scans a primary module plus any `companions` files for the
+   constant; an empty `companions=()` after a constant moves to an extracted module causes
+   the test to find no import and fail.
+
+Added 5 new Failed Attempts rows covering issues encountered during PR #1292 execution:
+- Bare bound-method reference bypassing patch.object (→ Phase 23 Rule 1)
+- Single run-patch after pre/post SHA split (→ Phase 23 Rule 2)
+- Forgotten _viewer_login attribute access in sibling test files (→ Phase 23 Rule 3)
+- companions=() not updated in phase-wiring test (→ Phase 23 Rule 4)
+- Logger patches targeting old module after extraction (→ Phase 4)
+
+Added 1 new outcome benchmark:
+- `ci_driver.py` (4 collaborators, narrow-callable DIP): 3,338 → 2,404 lines (−28%)
+
+Added 2 new "When to Use" bullets:
+- Executing a god-class decomposition with narrow-callable injection (DIP)
+- Sibling test files access internal attributes directly
+
+Added lambda wrapping subsection to Phase 2 (Choose Extraction Strategy).
+
+Added expanded Phase 4 notes: attribute access in tests + companions tuple in phase-wiring tests.
+
+Updated description (trigger 17), tags (6 new: lambda-injection, dip-narrow-callable,
+patch-object-compatibility, sibling-test-attribute-access, companions-tuple,
+cross-module-patching), Quick Reference (Phase 23), Trigger row, Verified On (new row).
+Bumped 1.9.0 → 1.10.0.
+
+### Why
+
+PR #1292 was the first complete execution of the CIDriver decomposition that had been
+planned and risk-audited across Phases 19, 22 (and their precursor Phases 20-21). Four
+execution-time traps emerged that are orthogonal to the planning risks:
+
+- The lambda vs. bare-reference trap (Rule 1) is a fundamental Python scoping issue that
+  affects any class-based extraction using DIP injection; it cannot be detected by planning.
+- The cross-module run-patch trap (Rule 2) only emerges when a pre/post SHA read is split
+  across modules — impossible to anticipate without executing.
+- The attribute-access and companions-tuple traps (Rules 3 and 4) are mechanical consistency
+  issues that a checklist can prevent but that grep-before-commit can also catch.
+
+These four rules form the execution complement to the planning rules in Phases 19 and 22.
+
+## v1.9.0 (2026-06-13)
+
+**Changed by:** /learn from ProjectHephaestus issue #1289 (CIDriver second decomposition pass planning, shared-state write-back)
+**Verification:** unverified (plan not yet executed; CI not run)
+
+### What changed
+
+Added Phase 22: God-Class Delegation — Shared-State Write-Back Rules. Six rules for
+design choices that must be made BEFORE writing any extraction code when methods being
+moved to a collaborator populate shared mutable state, are used by multiple collaborator
+groups, or where test fixtures pre-seed cache attributes:
+
+1. Identify every dict/cache written by the candidate method group
+2. Choose a write-back strategy for shared mutable dicts (Pattern A: return+assign in stub;
+   Pattern B: inject setter callable; Pattern C: mutable dict parameter)
+3. Methods called by multiple collaborator groups stay on the host
+4. Test fixture pre-seeding after cache extraction — keep cache on host or update all fixtures
+5. Read method bodies before assigning to collaborators (grep/name alone insufficient)
+6. Pre-plan __init__.py export conditionality (read it, don't leave "if/else" unresolved)
+
+Added 6 new Failed Attempts rows and updated tags, description (trigger 16), Verified On.
+Bumped 1.8.0 → 1.9.0.
+
 ## v1.6.0 (2026-06-13)
 
 **Changed by:** /learn from ProjectHephaestus issue #1196 Phase 20 reviewer NOGO (exception-contract POLA violation)

--- a/skills/python-module-decomposition-and-refactor-patterns.history
+++ b/skills/python-module-decomposition-and-refactor-patterns.history
@@ -1,6 +1,57 @@
 <!-- markdownlint-disable MD024 -->
 # python-module-decomposition-and-refactor-patterns — History
 
+## v1.11.0 (2026-06-13)
+
+**Changed by:** /learn from ProjectHephaestus issue #1289 R5 planning session (CIDriver god-class decomposition — planning-time verification rules)
+**Verification:** unverified (planning session findings; implementation not yet executed)
+
+### What changed
+
+Added Phases 24–26 covering three pre-implementation verification rules discovered during the
+R5 planning session for issue #1289:
+
+**Phase 24: Keyword-Only Method Signature Verification**
+
+A method identified for extraction (`_retry_no_commit_once`, ci_driver.py:2296) had a
+fabricated positional signature in the plan, including a non-existent `acquired_slot` param.
+The real method uses `*` (keyword-only) with 7 named params. Forwarding via positional args
+raises `TypeError` at runtime. The AST Criterion 6 (name-presence check) passes silently for
+wrong-signature stubs — it only checks the method name, not its signature.
+
+Rule: Read the actual `def` line before writing any stub. If `*` appears, the stub def must
+also use `*`, and the forwarding call must use `keyword=value` for every param.
+
+**Phase 25: `_gh_call` Multi-Module Split Attribution via Test-Class Boundaries**
+
+`_gh_call` is patched in 26 places across one test file, moving to 4+ destination modules.
+Two range-grep spot-checks only covered 2 of 26 sites. The correct approach: grep all
+patch sites with line numbers, then bucket each patch line into the test class whose
+start-line is the largest ≤ the patch line. Each class tests one method; each method goes
+to one collaborator; the bucket directly gives the destination module. Verify total across
+all buckets equals the total site count.
+
+**Phase 26: Delegation Chain Through Sub-Modules — Pre-Check Before Patch Migration**
+
+`_find_pr_for_issue` already delegates internally to `_review_utils.find_pr_for_issue`,
+which calls `_review_utils._gh_call`. The test (`TestBodySearch`, L1561) patches
+`hephaestus.automation._review_utils._gh_call` — not `ci_driver._gh_call`. Moving the
+method to a collaborator does not require migrating this patch. Rule: read the patch string
+before adding any site to the migration table; if it already targets a sub-module, it stays
+where it is.
+
+Also added:
+- 3 new rows to Failed Attempts table (keyword-only signature fabrication, range-grep
+  insufficient for multi-module split, delegation chain pre-check omitted)
+- 3 new use-case descriptions in frontmatter (18–20)
+- 5 new tags (keyword-only-signature, gh-call-patch-migration, test-class-bucket-analysis,
+  delegation-chain-pre-check, review-utils-delegation)
+- 3 new When-to-Use bullets
+- 3 new Quick Reference decision-tree entries
+- 1 new Verified On row
+
+---
+
 ## v1.10.0 (2026-06-13)
 
 **Changed by:** /learn from ProjectHephaestus PR #1292 (issue #1179 — CIDriver god-class decomposition execution using narrow-callable DIP injection)

--- a/skills/python-module-decomposition-and-refactor-patterns.md
+++ b/skills/python-module-decomposition-and-refactor-patterns.md
@@ -45,10 +45,19 @@ description: >-
   wrapping injected callables so patch.object remains effective after extraction, updating
   attribute access in sibling test files after cache migration, updating companions tuples in
   phase-wiring tests when AGENT_* constants move to extracted modules, and patching each
-  module's imported run separately when a method chain splits across module boundaries.
+  module's imported run separately when a method chain splits across module boundaries,
+  (18) verifying keyword-only method signatures (`*` separator in def line) before writing
+  delegation stubs — fabricated positional signatures for keyword-only methods raise TypeError
+  at runtime and pass AST name-presence checks silently,
+  (19) mapping `_gh_call` patch sites to destination modules via test-class bucket analysis
+  when splitting a symbol across 4+ modules — range-grep spot-checks miss sites, class-boundary
+  bucketing is the only reliable approach for multi-module splits,
+  (20) tracing delegation chains through sub-modules before adding _gh_call patches to a
+  migration table — if the existing test already patches a sub-module (e.g. _review_utils._gh_call),
+  the patch does not need to move regardless of where the method moves.
 category: architecture
 date: 2026-06-13
-version: "1.10.0"
+version: "1.11.0"
 user-invocable: false
 history: python-module-decomposition-and-refactor-patterns.history
 tags:
@@ -91,6 +100,11 @@ tags:
   - sibling-test-attribute-access
   - companions-tuple
   - cross-module-patching
+  - keyword-only-signature
+  - gh-call-patch-migration
+  - test-class-bucket-analysis
+  - delegation-chain-pre-check
+  - review-utils-delegation
 ---
 
 # Python Module Decomposition and Refactor Patterns
@@ -101,8 +115,8 @@ tags:
 | ------- | ------- |
 | **Date** | 2026-06-13 |
 | **Objective** | Decompose oversized Python modules/classes/functions into focused, independently testable units using SRP, TDD, and DRY principles |
-| **Outcome** | Synthesized from 15+ verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, post-parallel phase cleanup, god-class decomposition planning risks (state ownership, cross-call coupling, constant re-export, delegation stub type loss, coverage omit-allowlist traps, shared mutable dict write-back, methods shared across multiple collaborators, test fixture pre-seeding after cache extraction, method body read before assignment, __init__.py export conditionality verification), exception-contract verification before documenting wrapper behavior, three Phase 20 implementation-time traps (exception-boundary removal unmasks StopIteration from exhausted side_effect mocks; returncode-guard obligation at every call site of an absorbed-exception helper; agent mock type determines downstream subprocess.run consumption), god-function decomposition planning rules (arithmetic chain verification, docstring budget, for-loop body sizing, return type tracing, N-tuple completeness, captured variable audit, approach table completeness, AST-measure discipline), and god-class narrow-callable DIP execution (lambda wrapping for patch.object compatibility, cross-module import patching when method chains split, sibling test attribute path updates after cache migration, companions tuple updates in phase-wiring tests) |
-| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases, planning a multi-collaborator god-class decomposition, extracting a two-branch provider-conditional dispatch with heterogeneous return types, documenting exception contracts for wrapper methods, planning god-function decomposition (individual functions > 80L), planning delegation-stub extraction where extracted methods populate shared dicts or caches read by the host class, executing a god-class decomposition using narrow-callable injection (DIP) where bare bound-method references to injected callables break patch.object |
+| **Outcome** | Synthesized from 15+ verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, post-parallel phase cleanup, god-class decomposition planning risks (state ownership, cross-call coupling, constant re-export, delegation stub type loss, coverage omit-allowlist traps, shared mutable dict write-back, methods shared across multiple collaborators, test fixture pre-seeding after cache extraction, method body read before assignment, __init__.py export conditionality verification), exception-contract verification before documenting wrapper behavior, three Phase 20 implementation-time traps (exception-boundary removal unmasks StopIteration from exhausted side_effect mocks; returncode-guard obligation at every call site of an absorbed-exception helper; agent mock type determines downstream subprocess.run consumption), god-function decomposition planning rules (arithmetic chain verification, docstring budget, for-loop body sizing, return type tracing, N-tuple completeness, captured variable audit, approach table completeness, AST-measure discipline), god-class narrow-callable DIP execution (lambda wrapping for patch.object compatibility, cross-module import patching when method chains split, sibling test attribute path updates after cache migration, companions tuple updates in phase-wiring tests), keyword-only method signature verification before writing stubs (fabricated positional signatures pass AST checks silently but raise TypeError at runtime), _gh_call multi-module split attribution via test-class boundary bucketing (range-grep spot-checks are insufficient for 4+ destination modules; class-boundary bucket analysis is required), and delegation-chain pre-check before adding _gh_call patches to migration tables (if existing test patches a sub-module like _review_utils._gh_call, that patch does not move regardless of where the method relocates) |
+| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases, planning a multi-collaborator god-class decomposition, extracting a two-branch provider-conditional dispatch with heterogeneous return types, documenting exception contracts for wrapper methods, planning god-function decomposition (individual functions > 80L), planning delegation-stub extraction where extracted methods populate shared dicts or caches read by the host class, executing a god-class decomposition using narrow-callable injection (DIP) where bare bound-method references to injected callables break patch.object, writing delegation stubs for methods with keyword-only parameters (`*` separator), planning migration of a symbol patched in 10+ test sites across multiple test classes when the symbol will move to 4+ destination modules, or verifying whether an existing test's _gh_call patch already targets a sub-module (making migration unnecessary for that test) |
 
 ## When to Use
 
@@ -129,6 +143,9 @@ Apply this skill when any of the following is true:
 - You are **planning god-class delegation extraction** where methods being moved to a collaborator populate shared mutable state (dicts, caches) that the host class reads elsewhere, where a method is used by multiple collaborator groups (assign to host, not one group), or where test fixtures pre-seed cache attributes on the host that will no longer be in scope after extraction
 - You are **executing a god-class decomposition with narrow-callable injection (DIP)** and need to wire collaborators using injected callables — including: using lambda wrapping (not bare method references) to preserve patch.object effectiveness, updating sibling test files that directly access attributes now living on a collaborator, updating companions tuples in phase-wiring tests when AGENT_* constants move to extracted modules, and patching each module's `run` import independently when a pre/post-agent SHA read splits across module boundaries
 - A class's **sibling test files access internal attributes directly** (e.g., `driver._viewer_login`) that will move to an extracted collaborator — grep test files before and after extraction to update attribute paths
+- A method being extracted has a **`*` (keyword-only) separator** in its `def` line — the stub def must also use `*`, and the forwarding call must use `keyword=value` for every param; AST name-presence checks pass even for wrong-signature stubs
+- A shared symbol (e.g., `_gh_call`) is **patched in 10+ test sites across one file** and will move to **4+ destination modules** — use test-class boundary bucketing (grep `^class` start lines, bucket each patch line) rather than range-grep spot-checks to attribute every patch site to its destination
+- An extracted method's **existing test already patches a sub-module** (e.g., `_review_utils._gh_call`) — verify the patch string before adding the site to the migration table; if the patch already targets the sub-module, it does not need to move regardless of where the method relocates
 
 ## Verified Workflow
 
@@ -157,6 +174,9 @@ Decision tree:
   Planning god-function decomposition   → Function-size planning rules (Phase 21)
   God-class delegation w/ shared state → Shared-state write-back rules (Phase 22)
   God-class execution w/ DIP injection → Narrow-callable injection rules (Phase 23)
+  Keyword-only method stub writing      → Verify `*` in def line before any stub (Phase 24)
+  _gh_call split to 4+ modules          → Test-class bucket analysis (Phase 25)
+  _gh_call patch already sub-module?   → Delegation chain pre-check (Phase 26)
 
 Universal rule for mock patches after any move:
   Patch where the name is LOOKED UP at call time — not where it was defined.
@@ -1804,6 +1824,174 @@ for the constant; without it, the test only scans the primary module and fails.
 - [ ] ci_driver.py line count meets target (−28% or better)
 ```
 
+### Phase 24: Keyword-Only Method Signature Verification
+
+**Problem**: During R5 planning for issue #1289, `_retry_no_commit_once` was given a fabricated
+positional signature in the plan (including a fabricated `acquired_slot` parameter). The real
+method at `ci_driver.py:2296` uses `*` (keyword-only) with params:
+
+```python
+def _retry_no_commit_once(
+    self,
+    *,
+    issue_number: int,
+    pr_number: int,
+    worktree_path: Path,
+    pr_head_branch: str,
+    pre_agent_sha: str,
+    session_id: str,
+    max_retries: int = 2,
+) -> bool:
+```
+
+Forwarding a keyword-only method with positional args raises `TypeError` at runtime.
+The AST-check in Criterion 6 (method name presence) only checks whether the method name
+exists in the stub — it does **not** verify signature correctness. A wrong-but-present stub
+passes the check silently.
+
+**Rule**: For every method being extracted, read the actual `def` line and the complete
+parameter list (including whether `*` appears as the first param after `self`) before writing
+any stub. Never infer keyword-only status from call-site context alone.
+
+**Stub template for keyword-only methods**:
+
+```python
+# In host class (delegation stub):
+def _retry_no_commit_once(
+    self,
+    *,
+    issue_number: int,
+    pr_number: int,
+    worktree_path: Path,
+    pr_head_branch: str,
+    pre_agent_sha: str,
+    session_id: str,
+    max_retries: int = 2,
+) -> bool:
+    return self._collaborator._retry_no_commit_once(
+        issue_number=issue_number,
+        pr_number=pr_number,
+        worktree_path=worktree_path,
+        pr_head_branch=pr_head_branch,
+        pre_agent_sha=pre_agent_sha,
+        session_id=session_id,
+        max_retries=max_retries,
+    )
+```
+
+#### Phase 24 Checklist
+
+```markdown
+## Keyword-Only Stub Checklist (Phase 24)
+
+### Before writing any stub
+- [ ] Read the actual `def` line in the source file — not a plan summary, the real line
+- [ ] Check: does `*` appear as a standalone parameter before named params?
+- [ ] If yes: stub def MUST use `*` too; forwarding call MUST use `keyword=value` for every param
+- [ ] Verify no fabricated params (params not in the real def) appear in the stub
+- [ ] Verify no params from the real def are missing from the stub
+
+### AST check limitation
+- [ ] Criterion 6 (name-presence check) passes for wrong-signature stubs — it ONLY checks the method name
+- [ ] Signature correctness is your responsibility; the check will not catch it
+```
+
+### Phase 25: `_gh_call` Multi-Module Split Attribution via Test-Class Boundaries
+
+**Problem**: When `_gh_call` is patched in 26+ places across one test file, and the symbol
+moves to 4+ destination modules, "17-way split" estimates and range-grep spot-checks are
+both insufficient. Two range greps only cover 2 of 26 sites — the remaining 24 sites are
+unaccounted for.
+
+**Fix**: Map every patch site to its test class by:
+
+1. Get class start lines:
+
+```bash
+grep -n "^class " tests/unit/automation/test_ci_driver.py
+```
+
+2. Get all patch sites:
+
+```bash
+grep -n "ci_driver\._gh_call" tests/unit/automation/test_ci_driver.py
+```
+
+3. Bucket each patch line into the class whose start-line is the **largest ≤ the patch line**.
+   Each test class tests one method; each method goes to one collaborator module.
+   The bucket directly gives the destination module.
+
+4. Verify the total across all buckets equals the total patch count before finalizing.
+
+**Verification after migration**:
+
+```bash
+# Only the N lines that stay in ci_driver should remain; all others must be gone
+grep -n "ci_driver\._gh_call" tests/unit/automation/test_ci_driver.py | \
+  grep -v "^<line1>:\|^<line2>:..." && echo "FAIL" || echo "PASS"
+```
+
+**Rule**: Never estimate `_gh_call` migration scope from a count of methods or a range-based
+spot-grep. Always bucket every patch line by class boundary to determine its destination.
+
+#### Phase 25 Checklist
+
+```markdown
+## _gh_call Multi-Module Split Checklist (Phase 25)
+
+### Before planning migration
+- [ ] `grep -n "^class " test_file.py` — record all class name + start-line pairs
+- [ ] `grep -n "symbol_being_moved\._gh_call" test_file.py` — collect ALL patch lines with line numbers
+- [ ] For each patch line: find the class whose start-line is largest ≤ patch line number
+- [ ] Tally sites per bucket (per destination module)
+- [ ] Sum all buckets — must equal total patch count; if not, a site was missed
+
+### After migration
+- [ ] Re-run the grep — zero sites targeting old module should remain (except intentional ones)
+- [ ] Run the full test suite — every test class that had patches must still pass
+```
+
+### Phase 26: Delegation Chain Through Sub-Modules — Pre-Check Before Patch Migration
+
+**Finding**: `_find_pr_for_issue` in `ci_driver.py` already delegates internally to
+`_review_utils.find_pr_for_issue`, which in turn calls `_review_utils._gh_call` — NOT
+`ci_driver._gh_call`. The test (`TestBodySearch`, line 1561) patches
+`hephaestus.automation._review_utils._gh_call`.
+
+Moving `_find_pr_for_issue` to a collaborator does **not** require migrating any `_gh_call`
+patch for this method's tests — the symbol never lived in `ci_driver`'s namespace at the
+test level.
+
+**Rule**: Before adding a method's `_gh_call` patch sites to the migration table, read the
+patch string in the test. If the existing test already patches a sub-module (e.g.,
+`_review_utils._gh_call`), that patch does not need to move regardless of where the method
+moves.
+
+**Pre-check command**:
+
+```bash
+# For a method under consideration, find all its test class's patches:
+grep -n "ci_driver\._gh_call\|_review_utils\._gh_call\|other_submodule\._gh_call" \
+  tests/unit/automation/test_ci_driver.py | \
+  awk -F: '$1 >= CLASS_START && $1 <= CLASS_END'
+```
+
+If the output shows `_review_utils._gh_call` (not `ci_driver._gh_call`), the patch site
+belongs to the sub-module and stays put.
+
+#### Phase 26 Checklist
+
+```markdown
+## Delegation Chain Pre-Check Checklist (Phase 26)
+
+### For each method identified for migration
+- [ ] Read the method body — does it delegate to a sub-module function (e.g., `_review_utils.X`)?
+- [ ] If yes: check the test's patch string — does it patch `ci_driver._gh_call` or `_review_utils._gh_call`?
+- [ ] If the test patches the sub-module directly: this patch site does NOT belong in the migration table
+- [ ] Only add `ci_driver._gh_call` patches (not sub-module patches) to the migration count for this method
+- [ ] Document the delegation chain in the plan: `_find_pr_for_issue → _review_utils.find_pr_for_issue → _review_utils._gh_call`
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -1871,6 +2059,9 @@ for the constant; without it, the test only scans the primary module and fails.
 | **Forgetting `_viewer_login` attribute access in sibling test files** | Moved `_viewer_login` from `CIDriver` to `PRDiscovery` without updating `test_ci_driver_author_scope.py` which accessed `driver._viewer_login` directly | mypy reported `"CIDriver" has no attribute "_viewer_login"`; 6 mypy errors; tests failed | After moving any instance attribute to a collaborator, grep all test files for `driver.<attr>` and update to `driver._collaborator.<attr>` (Phase 23, Rule 3) |
 | **`companions=()` not updated in phase-wiring test** | `AGENT_CI_DRIVER` import moved to extracted collaborators (`ci_fix_orchestrator.py`, `post_merge_processor.py`) but `test_phase_agent_wiring.py` still had `("ci_driver.py", "AGENT_CI_DRIVER", ())` with empty companions tuple | Test checks the combined source of module + companions for the AGENT_* import; empty companions meant only `ci_driver.py` was scanned, which no longer has the import | When an `AGENT_*` constant moves to an extracted collaborator, add that collaborator filename to the `companions` tuple in `test_phase_agent_wiring.py` (Phase 23, Rule 4) |
 | **Logger patches targeting old module after extraction** | Left `patch("hephaestus.automation.ci_driver.logger")` for a warning that now emits from `pr_discovery.logger` | Mock showed 0 calls — warning emitted from extracted module's logger | After extracting a module, grep all test files for `ci_driver.logger` patches and update to `<new_module>.logger` (Phase 4) |
+| **Fabricated positional signature for keyword-only method** | Plan gave `_retry_no_commit_once` a positional signature including a fabricated `acquired_slot` param; the real method at ci_driver.py:2296 uses `*` (keyword-only) with 7 actual params | Forwarding via positional args raises `TypeError` at runtime; AST Criterion 6 checks name presence only — wrong-but-present stub passes silently | Before writing any stub, read the actual `def` line; if `*` appears, stub def must also use `*` and the forwarding call must use `keyword=value` for every param (Phase 24) |
+| **Range-grep spot-check insufficient for multi-module _gh_call split** | Used two range-grep checks to estimate `_gh_call` migration scope when the symbol moved to 4+ destination modules across 26 patch sites | Only 2 of 26 sites were covered; 24 sites were unaccounted for, making the migration table incomplete | Grep all patch sites with line numbers; bucket each line into its test class by finding the largest class-start ≤ patch-line; each class → one method → one destination module; verify bucket totals equal the total site count (Phase 25) |
+| **Adding _gh_call patch for delegating method without checking its sub-module chain** | Added `_find_pr_for_issue`'s test to the `ci_driver._gh_call` migration table without reading the test's patch string | The test already patched `_review_utils._gh_call` — not `ci_driver._gh_call`; the symbol never lived in `ci_driver`'s namespace at the test level, so the migration was unnecessary | Before adding any method's patch sites to a migration table, read the actual patch string in the test; if it targets a sub-module, that site does not move regardless of where the method relocates (Phase 26) |
 
 ## Results & Parameters
 
@@ -1948,3 +2139,4 @@ Revised LOC estimate: ~X (vs TODO "~Y"); justification: ~Z% already in substrate
 | ProjectHephaestus | Issue #1180 — planning decomposition of 7 god-functions across 4 files in `hephaestus/automation/` (R0→R3 planning cycle): R0 NOGO (waived 128L `_implement_issue` as "marginal"); R1 NOGO (claimed reduction with no extraction step); R2 NOGO (6-tuple dropped `reopened`, approach table missing two helpers); R3 approved; 8 planning rules identified: (1) arithmetic chain non-negotiable — no waivers; (2) docstring lines count toward function span; (3) for-loop body > 40L is a standalone extraction candidate; (4) helpers absorbing the only call to a data-fetching function must return the fetched data; (5) orchestrator N-tuple must cover ALL post-call variables; (6) every captured variable in an extracted body is a missing parameter; (7) approach table must list ALL helpers per target; (8) AST-measure before planning — never trust issue-cited line numbers (unverified — plan not yet executed) | New Phase 21: God-Function Decomposition Planning Rules (v1.8.0) |
 | ProjectHephaestus | Issue #1289 — planning second decomposition pass of `ci_driver.py` (3,358 lines) using Dependency Inversion + delegation stubs to preserve `patch.object` test targets; 4 collaborators proposed (`PRDiscovery`, `CICheckInspector`, `CIFixOrchestrator`, `ArmingOrchestrator`); 6 additional planning risks identified: (1) `shared_pr_issues` write-back not designed — `_discover_prs` moving to `PRDiscovery` populates dict that arming fan-out reads on CIDriver; (2) `_tracked_worktree_changes` used by both `CICheckInspector` and `CIFixOrchestrator` — cross-collaborator coupling if assigned to one; (3) test fixture pre-seeding of `driver._viewer_login` stops working after cache migrates to collaborator; (4) method bodies not read before assigning to collaborators (`_arm_all_unarmed_open_prs` etc. assigned by name only); (5) conditional `__init__.py` export step not resolved at plan time — `__init__.py` not read; (6) line count projection used 25-line average for method bodies without reading actual lengths — no fallback plan if target not reached after PRDiscovery (unverified — implementation not yet started) | New Phase 22: God-Class Delegation Shared-State Write-Back Rules (v1.9.0) |
 | ProjectHephaestus | PR #1292 (Issue #1179) — executed CIDriver god-class decomposition using narrow-callable injection (DIP): ci_driver.py 3,338 → 2,404 lines (−28%); 4 collaborators extracted (`pr_discovery.py` 260L, `ci_check_inspector.py` 130L, `ci_fix_orchestrator.py` 530L, `post_merge_processor.py` 230L); 4 implementation traps discovered: (1) bare bound-method references to injected callables bypass `patch.object` — all injected callables must be lambda-wrapped; (2) pre/post-SHA split after orchestrator extraction requires patching BOTH `ci_fix_orchestrator.run` and `ci_driver.run` independently; (3) `_viewer_login` attribute migration generated 6 mypy errors in sibling test files — all attribute access paths must be updated; (4) `AGENT_CI_DRIVER` move to extracted module broke `test_phase_agent_wiring.py` — companions tuple required update; 146 existing tests + 22 new tests pass; all CI gates passed (verified-ci) | New Phase 23: God-Class Narrow-Callable DIP Execution Pattern (v1.10.0) |
+| ProjectHephaestus | Issue #1289 R5 planning session — 3 new pre-implementation verification rules discovered: (1) `_retry_no_commit_once` at ci_driver.py:2296 uses keyword-only `*` separator; plan gave it a fabricated positional signature including non-existent `acquired_slot` param — AST Criterion 6 would pass silently but runtime raises `TypeError`; fix: read actual `def` line before any stub; (2) `_gh_call` patched in 26 sites across one test file moving to 4+ destination modules — two range-grep spot-checks only covered 2 of 26 sites; fix: bucket all patch lines by test-class start-line boundary; (3) `_find_pr_for_issue` tests already patch `_review_utils._gh_call` (not `ci_driver._gh_call`) because the method already delegates through `_review_utils`; these sites do not need migration regardless of where the method moves; fix: read the patch string before adding any site to the migration table (plan not yet executed) | New Phases 24–26: Keyword-Only Sig Verification, _gh_call Bucket Analysis, Delegation Chain Pre-Check (v1.11.0) |

--- a/skills/python-module-decomposition-and-refactor-patterns.md
+++ b/skills/python-module-decomposition-and-refactor-patterns.md
@@ -54,10 +54,19 @@ description: >-
   bucketing is the only reliable approach for multi-module splits,
   (20) tracing delegation chains through sub-modules before adding _gh_call patches to a
   migration table — if the existing test already patches a sub-module (e.g. _review_utils._gh_call),
-  the patch does not need to move regardless of where the method moves.
+  the patch does not need to move regardless of where the method moves,
+  (21) source-reading every stub before writing it when three or more methods carried forward from
+  a prior plan revision were never directly source-read — the AST Criterion 6 name-presence check
+  passes silently for wrong-but-present stubs; fabricated parameters (e.g. `acquired_slot`) that
+  do not exist in source cause TypeError at runtime,
+  (22) verifying two-argument method stubs against source — a method name-matches a one-argument
+  plan entry but the actual source may have a different arity or keyword-only separator,
+  (23) verifying return type annotations against source before writing stubs — a method
+  returning `dict` in the plan may actually return `dict[str, Any]` or a named TypedDict, and
+  type mismatch passes tests but fails mypy strict.
 category: architecture
 date: 2026-06-13
-version: "1.11.0"
+version: "1.12.0"
 user-invocable: false
 history: python-module-decomposition-and-refactor-patterns.history
 tags:
@@ -105,6 +114,11 @@ tags:
   - test-class-bucket-analysis
   - delegation-chain-pre-check
   - review-utils-delegation
+  - source-read-before-stub
+  - fabricated-parameter-risk
+  - acquired-slot-verification
+  - return-type-annotation-verification
+  - stub-arity-verification
 ---
 
 # Python Module Decomposition and Refactor Patterns
@@ -115,8 +129,8 @@ tags:
 | ------- | ------- |
 | **Date** | 2026-06-13 |
 | **Objective** | Decompose oversized Python modules/classes/functions into focused, independently testable units using SRP, TDD, and DRY principles |
-| **Outcome** | Synthesized from 15+ verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, post-parallel phase cleanup, god-class decomposition planning risks (state ownership, cross-call coupling, constant re-export, delegation stub type loss, coverage omit-allowlist traps, shared mutable dict write-back, methods shared across multiple collaborators, test fixture pre-seeding after cache extraction, method body read before assignment, __init__.py export conditionality verification), exception-contract verification before documenting wrapper behavior, three Phase 20 implementation-time traps (exception-boundary removal unmasks StopIteration from exhausted side_effect mocks; returncode-guard obligation at every call site of an absorbed-exception helper; agent mock type determines downstream subprocess.run consumption), god-function decomposition planning rules (arithmetic chain verification, docstring budget, for-loop body sizing, return type tracing, N-tuple completeness, captured variable audit, approach table completeness, AST-measure discipline), god-class narrow-callable DIP execution (lambda wrapping for patch.object compatibility, cross-module import patching when method chains split, sibling test attribute path updates after cache migration, companions tuple updates in phase-wiring tests), keyword-only method signature verification before writing stubs (fabricated positional signatures pass AST checks silently but raise TypeError at runtime), _gh_call multi-module split attribution via test-class boundary bucketing (range-grep spot-checks are insufficient for 4+ destination modules; class-boundary bucket analysis is required), and delegation-chain pre-check before adding _gh_call patches to migration tables (if existing test patches a sub-module like _review_utils._gh_call, that patch does not move regardless of where the method relocates) |
-| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases, planning a multi-collaborator god-class decomposition, extracting a two-branch provider-conditional dispatch with heterogeneous return types, documenting exception contracts for wrapper methods, planning god-function decomposition (individual functions > 80L), planning delegation-stub extraction where extracted methods populate shared dicts or caches read by the host class, executing a god-class decomposition using narrow-callable injection (DIP) where bare bound-method references to injected callables break patch.object, writing delegation stubs for methods with keyword-only parameters (`*` separator), planning migration of a symbol patched in 10+ test sites across multiple test classes when the symbol will move to 4+ destination modules, or verifying whether an existing test's _gh_call patch already targets a sub-module (making migration unnecessary for that test) |
+| **Outcome** | Synthesized from 15+ verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, post-parallel phase cleanup, god-class decomposition planning risks (state ownership, cross-call coupling, constant re-export, delegation stub type loss, coverage omit-allowlist traps, shared mutable dict write-back, methods shared across multiple collaborators, test fixture pre-seeding after cache extraction, method body read before assignment, __init__.py export conditionality verification), exception-contract verification before documenting wrapper behavior, three Phase 20 implementation-time traps (exception-boundary removal unmasks StopIteration from exhausted side_effect mocks; returncode-guard obligation at every call site of an absorbed-exception helper; agent mock type determines downstream subprocess.run consumption), god-function decomposition planning rules (arithmetic chain verification, docstring budget, for-loop body sizing, return type tracing, N-tuple completeness, captured variable audit, approach table completeness, AST-measure discipline), god-class narrow-callable DIP execution (lambda wrapping for patch.object compatibility, cross-module import patching when method chains split, sibling test attribute path updates after cache migration, companions tuple updates in phase-wiring tests), keyword-only method signature verification before writing stubs (fabricated positional signatures pass AST checks silently but raise TypeError at runtime), _gh_call multi-module split attribution via test-class boundary bucketing (range-grep spot-checks are insufficient for 4+ destination modules; class-boundary bucket analysis is required), delegation-chain pre-check before adding _gh_call patches to migration tables (if existing test patches a sub-module like _review_utils._gh_call, that patch does not move regardless of where the method relocates), source-read-before-stub mandate for any method carried forward from a prior plan revision without direct source verification (AST name checks pass for wrong-but-present parameters, only source-read confirms correctness), and return-type annotation verification against source before writing stubs (mypy strict rejects `dict` for `dict[str, Any]`) |
+| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases, planning a multi-collaborator god-class decomposition, extracting a two-branch provider-conditional dispatch with heterogeneous return types, documenting exception contracts for wrapper methods, planning god-function decomposition (individual functions > 80L), planning delegation-stub extraction where extracted methods populate shared dicts or caches read by the host class, executing a god-class decomposition using narrow-callable injection (DIP) where bare bound-method references to injected callables break patch.object, writing delegation stubs for methods with keyword-only parameters (`*` separator), planning migration of a symbol patched in 10+ test sites across multiple test classes when the symbol will move to 4+ destination modules, verifying whether an existing test's _gh_call patch already targets a sub-module (making migration unnecessary for that test), or writing any stub for a method that was not directly source-read in the current planning session (prior-revision plan parameters may be fabricated) |
 
 ## When to Use
 
@@ -146,6 +160,9 @@ Apply this skill when any of the following is true:
 - A method being extracted has a **`*` (keyword-only) separator** in its `def` line — the stub def must also use `*`, and the forwarding call must use `keyword=value` for every param; AST name-presence checks pass even for wrong-signature stubs
 - A shared symbol (e.g., `_gh_call`) is **patched in 10+ test sites across one file** and will move to **4+ destination modules** — use test-class boundary bucketing (grep `^class` start lines, bucket each patch line) rather than range-grep spot-checks to attribute every patch site to its destination
 - An extracted method's **existing test already patches a sub-module** (e.g., `_review_utils._gh_call`) — verify the patch string before adding the site to the migration table; if the patch already targets the sub-module, it does not need to move regardless of where the method relocates
+- You are writing any **stub for a method that was not directly source-read in the current planning session** — parameters carried forward from a prior plan revision (e.g., `acquired_slot`) may be fabricated; AST name-presence checks pass silently for wrong-but-present stubs; only a direct `sed -n 'Np'` read of the `def` line confirms signature correctness
+- A plan stub shows a **two-argument method** (e.g., `_is_bot_pr_mode(self, issue_number, pr_number)`) whose source was never read in the current session — arity may differ from the plan
+- A plan stub specifies `-> dict` for a **return type annotation** but the source was not read — actual type may be `dict[str, Any]` or a named TypedDict; type mismatch passes tests but fails mypy strict
 
 ## Verified Workflow
 
@@ -177,6 +194,9 @@ Decision tree:
   Keyword-only method stub writing      → Verify `*` in def line before any stub (Phase 24)
   _gh_call split to 4+ modules          → Test-class bucket analysis (Phase 25)
   _gh_call patch already sub-module?   → Delegation chain pre-check (Phase 26)
+  Stub for method not source-read yet   → Source-read mandate before any stub (Phase 27)
+  Two-arg stub without source-read      → Arity verification before stub (Phase 28)
+  Return type in stub without source    → Return-type annotation verification (Phase 29)
 
 Universal rule for mock patches after any move:
   Patch where the name is LOOKED UP at call time — not where it was defined.
@@ -1992,6 +2012,149 @@ belongs to the sub-module and stays put.
 - [ ] Document the delegation chain in the plan: `_find_pr_for_issue → _review_utils.find_pr_for_issue → _review_utils._gh_call`
 ```
 
+### Phase 27: Source-Read Mandate for Stubs Carried Forward Without Direct Verification
+
+Use when writing any delegation stub for a method that was NOT directly source-read in the
+current planning session. The risk applies whenever a plan revision (R2, R3, R4, R5…)
+carries forward signatures from an earlier revision without re-verifying against the current
+source.
+
+**Warning:** This pattern has not yet been validated end-to-end with CI. Treat as a strong
+pre-implementation checklist until the implementer runs and confirms.
+
+**The problem**: A prior plan revision (e.g., R4) may have fabricated a parameter for a
+method that does not have it in source. The AST Criterion 6 check verifies method name
+presence only — a wrong-but-present stub passes silently. The failure surfaces only at
+runtime as `TypeError: unexpected keyword argument`.
+
+**Three R5 methods carrying this risk** (as of 2026-06-13):
+
+| Method | Location | Unconfirmed parameter | Risk |
+|--------|----------|-----------------------|------|
+| `_recheck_and_arm_after_fix` | ci_driver.py:1147 | `acquired_slot` | May not exist in source |
+| `_resolve_dirty_pr` | ci_driver.py:1227 | `acquired_slot` | May not exist in source |
+| `_attempt_ci_fixes` | ci_driver.py:1286 | `acquired_slot` | May not exist in source |
+
+The `acquired_slot` parameter appeared as a fabricated parameter in R4 for
+`_retry_no_commit_once` (where source showed it did NOT exist). The same risk applies to any
+method not directly source-read.
+
+**Implementer action** — before coding these stubs, run:
+
+```bash
+sed -n '1147p;1227p;1286p' hephaestus/automation/ci_driver.py
+```
+
+For each `def` line, check:
+
+1. Is there a `*` keyword-only separator? (if yes, stub must also use `*`)
+2. Is `acquired_slot` actually present? (if not, do not include it in stub or forwarding call)
+3. Are there other parameters not shown in the plan?
+
+**General rule**: For ANY method not directly source-read in the current session, run:
+
+```bash
+grep -n "def <method_name>" hephaestus/automation/ci_driver.py
+sed -n '<line>p' hephaestus/automation/ci_driver.py
+```
+
+Never carry forward a parameter from a prior plan revision as authoritative. AST Criterion 6
+is a name-presence check only — it cannot detect wrong-but-present parameters.
+
+#### Phase 27 Checklist
+
+```markdown
+## Source-Read-Before-Stub Checklist (Phase 27)
+
+### Before writing any stub in the implementation
+- [ ] List all stubs being written in this session
+- [ ] For each stub: was the `def` line directly source-read in this planning session?
+- [ ] If NOT source-read: run `sed -n '<line>p' <file>.py` before writing
+- [ ] For each `def` line read: (a) note `*` separator if present, (b) list all actual params,
+      (c) confirm no plan-carried params are missing or fabricated
+- [ ] Specifically for `_recheck_and_arm_after_fix`, `_resolve_dirty_pr`, `_attempt_ci_fixes`:
+      verify whether `acquired_slot` is actually in the def line
+```
+
+### Phase 28: Two-Argument Stub Arity Verification
+
+Use when a plan stub specifies a method with two or more non-self arguments and the
+source was not directly read in the current session.
+
+**The problem**: A plan entry like `_is_bot_pr_mode(self, issue_number, pr_number)` assumes
+two arguments, but the source at line 596 may have a different arity or a keyword-only
+separator. Calling with wrong arity raises `TypeError` at runtime; passing required arguments
+as positional when source uses `*` also raises `TypeError`.
+
+**Implementer action** — before coding `_is_bot_pr_mode` stub:
+
+```bash
+grep -n "def _is_bot_pr_mode" hephaestus/automation/ci_driver.py
+sed -n '<found_line>p' hephaestus/automation/ci_driver.py
+```
+
+Check: (a) is the arity exactly `(self, issue_number, pr_number)`? (b) is there a `*`
+keyword-only separator? (c) are parameter names spelled correctly?
+
+**General rule**: Any method with 2+ non-self arguments whose source was not read in the
+current session must be source-verified before stub writing. Arity errors are among the
+most common runtime failures from plans carried across revisions.
+
+#### Phase 28 Checklist
+
+```markdown
+## Two-Arg Stub Arity Checklist (Phase 28)
+
+### Before writing stubs for multi-argument methods
+- [ ] For each method with 2+ non-self args in the plan: was the def line source-read?
+- [ ] If NOT source-read: `grep -n "def <method>" <file>.py; sed -n '<line>p' <file>.py`
+- [ ] Confirm arity matches plan (exact number and names of parameters)
+- [ ] Check for `*` separator — if present, stub must use keyword-only form
+- [ ] Specifically for `_is_bot_pr_mode`: verify actual arity before writing stub
+```
+
+### Phase 29: Return-Type Annotation Verification Before Stub Writing
+
+Use when a plan specifies a return type annotation (e.g., `-> dict`) for a stub but the
+source was not directly read in the current session.
+
+**The problem**: A plan stub showing `_gh_pr_state(self, pr_number: int) -> dict` may
+underspecify the return type. The actual source may return `dict[str, Any]`, a specific
+`TypedDict` subclass, or a narrower type. Under mypy strict mode:
+
+- `-> dict` causes a `type-arg` mypy error (bare `dict` without type parameters)
+- `-> dict[str, Any]` is correct if the source returns a general dict
+- `-> SomePrStateDict` (a TypedDict) requires importing the TypedDict
+
+Type mismatch passes tests (duck typing) but fails the mypy gate that CI enforces.
+
+**Implementer action** — before coding `_gh_pr_state` stub:
+
+```bash
+grep -n "def _gh_pr_state" hephaestus/automation/ci_driver.py
+sed -n '<found_line>p' hephaestus/automation/ci_driver.py
+```
+
+Read the full return annotation. If the source has `-> dict[str, Any]`, use that exactly.
+If it returns a TypedDict, import and use the TypedDict.
+
+**General rule**: Never write `-> dict` (bare) in a stub unless source confirms it. Under
+mypy `strict = true`, bare generic types are rejected. Always use the fully parameterized
+form matching the source.
+
+#### Phase 29 Checklist
+
+```markdown
+## Return-Type Annotation Checklist (Phase 29)
+
+### Before writing stubs with dict/list/set return types
+- [ ] For each stub with `-> dict`, `-> list`, `-> set` in the plan: source-read the def line
+- [ ] Confirm the actual return annotation is fully parameterized (e.g., `dict[str, Any]`)
+- [ ] If source returns a TypedDict: import it and use the named type in the stub
+- [ ] Run mypy after writing stubs: `pixi run mypy hephaestus/automation/ci_driver.py`
+- [ ] Specifically for `_gh_pr_state`: verify actual return type annotation before writing stub
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -2062,6 +2225,9 @@ belongs to the sub-module and stays put.
 | **Fabricated positional signature for keyword-only method** | Plan gave `_retry_no_commit_once` a positional signature including a fabricated `acquired_slot` param; the real method at ci_driver.py:2296 uses `*` (keyword-only) with 7 actual params | Forwarding via positional args raises `TypeError` at runtime; AST Criterion 6 checks name presence only — wrong-but-present stub passes silently | Before writing any stub, read the actual `def` line; if `*` appears, stub def must also use `*` and the forwarding call must use `keyword=value` for every param (Phase 24) |
 | **Range-grep spot-check insufficient for multi-module _gh_call split** | Used two range-grep checks to estimate `_gh_call` migration scope when the symbol moved to 4+ destination modules across 26 patch sites | Only 2 of 26 sites were covered; 24 sites were unaccounted for, making the migration table incomplete | Grep all patch sites with line numbers; bucket each line into its test class by finding the largest class-start ≤ patch-line; each class → one method → one destination module; verify bucket totals equal the total site count (Phase 25) |
 | **Adding _gh_call patch for delegating method without checking its sub-module chain** | Added `_find_pr_for_issue`'s test to the `ci_driver._gh_call` migration table without reading the test's patch string | The test already patched `_review_utils._gh_call` — not `ci_driver._gh_call`; the symbol never lived in `ci_driver`'s namespace at the test level, so the migration was unnecessary | Before adding any method's patch sites to a migration table, read the actual patch string in the test; if it targets a sub-module, that site does not move regardless of where the method relocates (Phase 26) |
+| **Carrying `acquired_slot` forward from R4 into R5 stubs without source verification** | R4 plan fabricated `acquired_slot` as a parameter for `_retry_no_commit_once`; R5 plan carried the same parameter into stubs for `_recheck_and_arm_after_fix` (L1147), `_resolve_dirty_pr` (L1227), `_attempt_ci_fixes` (L1286) without source-reading those def lines | AST Criterion 6 name-presence check passes silently for wrong-but-present parameters; runtime raises `TypeError: unexpected keyword argument 'acquired_slot'` if the parameter does not exist in source; R4 already showed this exact failure mode for `_retry_no_commit_once` | Before writing any stub, run `sed -n 'Np' ci_driver.py` on the def line; never carry parameters from a prior plan revision as authoritative (Phase 27) |
+| **Plan specified `_is_bot_pr_mode(self, issue_number, pr_number)` without source-read** | R5 plan delegated `_is_bot_pr_mode` as a two-argument method based on plan inference, not direct source read of L596 | Arity or keyword-only separator may differ; calling with wrong arity raises `TypeError` at runtime; a `*` separator in source requires keyword-only forwarding calls | Source-read the def line before specifying arity in any stub; two-argument methods are a common site for arity mismatch across plan revisions (Phase 28) |
+| **Stub annotated `-> dict` for `_gh_pr_state` without source-read** | R5 plan showed `_gh_pr_state(self, pr_number: int) -> dict` without reading the actual return annotation in source | mypy strict rejects bare `dict` (missing type parameters); actual source may return `dict[str, Any]` or a TypedDict; type mismatch passes tests but fails CI mypy gate | Always source-read the return annotation; under `strict = true`, write the fully parameterized form (`dict[str, Any]`) matching source exactly (Phase 29) |
 
 ## Results & Parameters
 
@@ -2140,3 +2306,4 @@ Revised LOC estimate: ~X (vs TODO "~Y"); justification: ~Z% already in substrate
 | ProjectHephaestus | Issue #1289 — planning second decomposition pass of `ci_driver.py` (3,358 lines) using Dependency Inversion + delegation stubs to preserve `patch.object` test targets; 4 collaborators proposed (`PRDiscovery`, `CICheckInspector`, `CIFixOrchestrator`, `ArmingOrchestrator`); 6 additional planning risks identified: (1) `shared_pr_issues` write-back not designed — `_discover_prs` moving to `PRDiscovery` populates dict that arming fan-out reads on CIDriver; (2) `_tracked_worktree_changes` used by both `CICheckInspector` and `CIFixOrchestrator` — cross-collaborator coupling if assigned to one; (3) test fixture pre-seeding of `driver._viewer_login` stops working after cache migrates to collaborator; (4) method bodies not read before assigning to collaborators (`_arm_all_unarmed_open_prs` etc. assigned by name only); (5) conditional `__init__.py` export step not resolved at plan time — `__init__.py` not read; (6) line count projection used 25-line average for method bodies without reading actual lengths — no fallback plan if target not reached after PRDiscovery (unverified — implementation not yet started) | New Phase 22: God-Class Delegation Shared-State Write-Back Rules (v1.9.0) |
 | ProjectHephaestus | PR #1292 (Issue #1179) — executed CIDriver god-class decomposition using narrow-callable injection (DIP): ci_driver.py 3,338 → 2,404 lines (−28%); 4 collaborators extracted (`pr_discovery.py` 260L, `ci_check_inspector.py` 130L, `ci_fix_orchestrator.py` 530L, `post_merge_processor.py` 230L); 4 implementation traps discovered: (1) bare bound-method references to injected callables bypass `patch.object` — all injected callables must be lambda-wrapped; (2) pre/post-SHA split after orchestrator extraction requires patching BOTH `ci_fix_orchestrator.run` and `ci_driver.run` independently; (3) `_viewer_login` attribute migration generated 6 mypy errors in sibling test files — all attribute access paths must be updated; (4) `AGENT_CI_DRIVER` move to extracted module broke `test_phase_agent_wiring.py` — companions tuple required update; 146 existing tests + 22 new tests pass; all CI gates passed (verified-ci) | New Phase 23: God-Class Narrow-Callable DIP Execution Pattern (v1.10.0) |
 | ProjectHephaestus | Issue #1289 R5 planning session — 3 new pre-implementation verification rules discovered: (1) `_retry_no_commit_once` at ci_driver.py:2296 uses keyword-only `*` separator; plan gave it a fabricated positional signature including non-existent `acquired_slot` param — AST Criterion 6 would pass silently but runtime raises `TypeError`; fix: read actual `def` line before any stub; (2) `_gh_call` patched in 26 sites across one test file moving to 4+ destination modules — two range-grep spot-checks only covered 2 of 26 sites; fix: bucket all patch lines by test-class start-line boundary; (3) `_find_pr_for_issue` tests already patch `_review_utils._gh_call` (not `ci_driver._gh_call`) because the method already delegates through `_review_utils`; these sites do not need migration regardless of where the method moves; fix: read the patch string before adding any site to the migration table (plan not yet executed) | New Phases 24–26: Keyword-Only Sig Verification, _gh_call Bucket Analysis, Delegation Chain Pre-Check (v1.11.0) |
+| ProjectHephaestus | Issue #1289 R5 planning session (continued) — 3 additional pre-implementation verification risks identified for `ci_driver.py` stub writing: (1) plan carried `acquired_slot` parameter for `_recheck_and_arm_after_fix` (L1147), `_resolve_dirty_pr` (L1227), `_attempt_ci_fixes` (L1286) without source-reading those def lines — same fabrication risk as R4's `_retry_no_commit_once`; AST Criterion 6 passes silently; fix: `sed -n '1147p;1227p;1286p' ci_driver.py` before writing any stub; (2) plan specified `_is_bot_pr_mode(self, issue_number, pr_number)` as two-arg without source-reading L596 — arity or keyword-only separator may differ; (3) plan annotated `_gh_pr_state(self, pr_number: int) -> dict` without reading return annotation from source — mypy strict rejects bare `dict`; actual type may be `dict[str, Any]` or TypedDict; `acquired_slot` is the #1 risk in R5 (plan not yet executed) | New Phases 27–29: Source-Read Mandate, Arity Verification, Return-Type Annotation (v1.12.0) |

--- a/skills/python-module-decomposition-and-refactor-patterns.md
+++ b/skills/python-module-decomposition-and-refactor-patterns.md
@@ -40,10 +40,15 @@ description: >-
   one collaborator), test fixture pre-seeding of cache attributes after extraction (pre-seeding
   driver._cache doesn't affect collaborator._cache), reading method bodies before assigning
   them to collaborators (name-only assignment is insufficient), and verifying __init__.py
-  export conditionality before planning conditional export steps.
+  export conditionality before planning conditional export steps,
+  (17) executing a god-class decomposition using narrow-callable injection (DIP) — lambda
+  wrapping injected callables so patch.object remains effective after extraction, updating
+  attribute access in sibling test files after cache migration, updating companions tuples in
+  phase-wiring tests when AGENT_* constants move to extracted modules, and patching each
+  module's imported run separately when a method chain splits across module boundaries.
 category: architecture
 date: 2026-06-13
-version: "1.9.0"
+version: "1.10.0"
 user-invocable: false
 history: python-module-decomposition-and-refactor-patterns.history
 tags:
@@ -80,6 +85,12 @@ tags:
   - stopiteration-exception-boundary
   - returncode-guard
   - noqa-c901-removal-verification
+  - lambda-injection
+  - dip-narrow-callable
+  - patch-object-compatibility
+  - sibling-test-attribute-access
+  - companions-tuple
+  - cross-module-patching
 ---
 
 # Python Module Decomposition and Refactor Patterns
@@ -90,8 +101,8 @@ tags:
 | ------- | ------- |
 | **Date** | 2026-06-13 |
 | **Objective** | Decompose oversized Python modules/classes/functions into focused, independently testable units using SRP, TDD, and DRY principles |
-| **Outcome** | Synthesized from 15+ verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, post-parallel phase cleanup, god-class decomposition planning risks (state ownership, cross-call coupling, constant re-export, delegation stub type loss, coverage omit-allowlist traps, shared mutable dict write-back, methods shared across multiple collaborators, test fixture pre-seeding after cache extraction, method body read before assignment, __init__.py export conditionality verification), exception-contract verification before documenting wrapper behavior, three Phase 20 implementation-time traps (exception-boundary removal unmasks StopIteration from exhausted side_effect mocks; returncode-guard obligation at every call site of an absorbed-exception helper; agent mock type determines downstream subprocess.run consumption), and god-function decomposition planning rules (arithmetic chain verification, docstring budget, for-loop body sizing, return type tracing, N-tuple completeness, captured variable audit, approach table completeness, AST-measure discipline) |
-| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases, planning a multi-collaborator god-class decomposition, extracting a two-branch provider-conditional dispatch with heterogeneous return types, documenting exception contracts for wrapper methods, planning god-function decomposition (individual functions > 80L), planning delegation-stub extraction where extracted methods populate shared dicts or caches read by the host class |
+| **Outcome** | Synthesized from 15+ verified skills; covers function-level extraction, class-based extraction, circular import fixes, immutability refactoring, extensibility-driven decomposition, CLI entry-point extraction with preserved patch routing, top-level symbol extraction to break sibling module cycles, CC>15 pipeline-step extraction, scanner-to-subdirectory scoping, context-manager double-counter fixes, safe legacy-code deletion, substrate-read-before-estimate discipline, post-parallel phase cleanup, god-class decomposition planning risks (state ownership, cross-call coupling, constant re-export, delegation stub type loss, coverage omit-allowlist traps, shared mutable dict write-back, methods shared across multiple collaborators, test fixture pre-seeding after cache extraction, method body read before assignment, __init__.py export conditionality verification), exception-contract verification before documenting wrapper behavior, three Phase 20 implementation-time traps (exception-boundary removal unmasks StopIteration from exhausted side_effect mocks; returncode-guard obligation at every call site of an absorbed-exception helper; agent mock type determines downstream subprocess.run consumption), god-function decomposition planning rules (arithmetic chain verification, docstring budget, for-loop body sizing, return type tracing, N-tuple completeness, captured variable audit, approach table completeness, AST-measure discipline), and god-class narrow-callable DIP execution (lambda wrapping for patch.object compatibility, cross-module import patching when method chains split, sibling test attribute path updates after cache migration, companions tuple updates in phase-wiring tests) |
+| **Trigger** | Files >800 lines, circular import errors, mixed-concern methods, C901/CC>15 complexity, extensibility requirements, CLI main() extraction, deferred imports inside function bodies preventing static analysis, broad scanners needing subdirectory scope, stale callers after context-manager refactors, dead fallback files, pessimistic refactor estimates, technical debt after parallel phases, planning a multi-collaborator god-class decomposition, extracting a two-branch provider-conditional dispatch with heterogeneous return types, documenting exception contracts for wrapper methods, planning god-function decomposition (individual functions > 80L), planning delegation-stub extraction where extracted methods populate shared dicts or caches read by the host class, executing a god-class decomposition using narrow-callable injection (DIP) where bare bound-method references to injected callables break patch.object |
 
 ## When to Use
 
@@ -116,6 +127,8 @@ Apply this skill when any of the following is true:
 - A function contains a **two-branch if/else over a boolean predicate** (e.g., `is_codex(agent)`) where each branch invokes a different external agent/subprocess API returning heterogeneous types, and you want to extract it into a unified private helper method without introducing a Protocol/Strategy class
 - You are **planning god-function decomposition** — individual functions exceeding the project's line-length threshold (e.g., > 80L) and need arithmetic chain verification, docstring budget accounting, for-loop body sizing, return type tracing for absorbed call sites, N-tuple completeness for orchestrator helpers, captured variable auditing, and approach-table completeness before writing any code
 - You are **planning god-class delegation extraction** where methods being moved to a collaborator populate shared mutable state (dicts, caches) that the host class reads elsewhere, where a method is used by multiple collaborator groups (assign to host, not one group), or where test fixtures pre-seed cache attributes on the host that will no longer be in scope after extraction
+- You are **executing a god-class decomposition with narrow-callable injection (DIP)** and need to wire collaborators using injected callables — including: using lambda wrapping (not bare method references) to preserve patch.object effectiveness, updating sibling test files that directly access attributes now living on a collaborator, updating companions tuples in phase-wiring tests when AGENT_* constants move to extracted modules, and patching each module's `run` import independently when a pre/post-agent SHA read splits across module boundaries
+- A class's **sibling test files access internal attributes directly** (e.g., `driver._viewer_login`) that will move to an extracted collaborator — grep test files before and after extraction to update attribute paths
 
 ## Verified Workflow
 
@@ -143,6 +156,7 @@ Decision tree:
   Two-branch bool-predicate dispatch    → Provider-dispatch extraction (Phase 20)
   Planning god-function decomposition   → Function-size planning rules (Phase 21)
   God-class delegation w/ shared state → Shared-state write-back rules (Phase 22)
+  God-class execution w/ DIP injection → Narrow-callable injection rules (Phase 23)
 
 Universal rule for mock patches after any move:
   Patch where the name is LOOKED UP at call time — not where it was defined.
@@ -220,6 +234,27 @@ def _build_tier_actions(self, tier_id, ...):
 **Design rule**: Methods should return `(config, checkpoint)` tuples rather than mutating `self` —
 makes unit tests trivial and enables explicit data flow.
 
+**Lambda wrapping for test compatibility** (critical when using class-based extraction with `patch.object`):
+
+When injecting host methods into a collaborator, ALWAYS use lambdas, never bare method references:
+
+```python
+# WRONG — stored reference captured at init time; patch.object bypassed:
+self._fix_orchestrator = CIFixOrchestrator(
+    head_advanced=self._head_advanced,  # captured at init, patch won't intercept
+)
+
+# RIGHT — lambda re-evaluates self._head_advanced at call time:
+self._fix_orchestrator = CIFixOrchestrator(
+    head_advanced=lambda *a, **k: self._head_advanced(*a, **k),  # patch works
+)
+```
+
+This applies to ALL injected callables, not just the "interesting" ones. A bare bound method
+is effectively a snapshot; a lambda is a live lookup. `patch.object(driver, "_head_advanced")`
+replaces `driver._head_advanced` on the object — the lambda re-reads it at call time while the
+bare reference does not.
+
 ### Phase 3: Create New Module (Self-Contained, No Parent Imports)
 
 The new module must be **self-contained** — it cannot import from the original module
@@ -264,6 +299,35 @@ Also update logger patches — warnings logged by an extracted class still targe
 # After extracting CheckpointFinalizer, update:
 patch("scylla.e2e.runner.logger") → patch("scylla.e2e.checkpoint_finalizer.logger")
 ```
+
+Also update attribute access in tests — when an instance attribute migrates to a collaborator,
+sibling test files that access it directly on the host will break with a mypy error or
+`AttributeError`:
+
+```python
+# After moving self._viewer_login from CIDriver to PRDiscovery:
+# WRONG: driver._viewer_login = ""
+# RIGHT: driver._pr_discovery._viewer_login = ""
+```
+
+Grep all test files for `driver.<attr>` (or `<host_instance>.<moved_attr>`) before and after
+every attribute migration. mypy strict mode surfaces these as `"CIDriver" has no attribute
+"_viewer_login"` — 6 such errors across test files are typical for a single cache attribute move.
+
+Also update `companions` tuples in phase-wiring tests — when an `AGENT_*` constant moves from
+the host module to an extracted collaborator, the test that verifies the import source must add
+the collaborator filename to the `companions` tuple:
+
+```python
+# test_phase_agent_wiring.py — BEFORE extraction:
+("ci_driver.py", "AGENT_CI_DRIVER", ())
+
+# AFTER constant moves to ci_fix_orchestrator.py:
+("ci_driver.py", "AGENT_CI_DRIVER", ("ci_fix_orchestrator.py",))
+```
+
+The `companions` tuple lists extra files the test scans in addition to the primary module;
+an empty tuple means only the primary module is checked.
 
 ### Phase 5: Module Decomposition — Re-export vs. Update Import Sites
 
@@ -1607,6 +1671,139 @@ Any method assigned without reading its body may:
       and sum actual lines rather than using average estimates
 ```
 
+### Phase 23: God-Class Execution — Narrow-Callable Injection (DIP) Pattern
+
+Use when EXECUTING a god-class decomposition using Dependency Inversion through injected callables.
+This phase covers the implementation-time traps discovered during ProjectHephaestus PR #1292
+(CIDriver decomposed into 4 collaborators using narrow-callable injection: `pr_discovery.py`,
+`ci_check_inspector.py`, `ci_fix_orchestrator.py`, `post_merge_processor.py`).
+
+**Warning:** These rules are derived from a single verified CI execution. Treat as strong
+guidance but re-verify on new codebases.
+
+#### Rule 1: Lambda wrapping is mandatory for all injected callables
+
+When the host class injects its own methods into a collaborator via `__init__`, ALWAYS wrap
+them as lambdas. Bare bound-method references are captured at construction time; a mock applied
+to `driver._method` AFTER construction has no effect on the collaborator's stored reference.
+
+```python
+# WRONG — bare bound method is a snapshot; patch.object(driver, "_head_advanced") bypassed:
+self._fix_orchestrator = CIFixOrchestrator(
+    head_advanced=self._head_advanced,
+)
+
+# RIGHT — lambda re-evaluates self._head_advanced at call time; patch works:
+self._fix_orchestrator = CIFixOrchestrator(
+    head_advanced=lambda *a, **k: self._head_advanced(*a, **k),
+)
+```
+
+Apply to ALL injected callables without exception — even ones that seem "unlikely to be mocked"
+in tests. The cost is negligible; the debugging cost of a missed one is large.
+
+#### Rule 2: Patch each module's `run` import separately when a method chain splits
+
+When a pre-agent SHA snapshot moves to an extracted collaborator but the post-agent SHA
+read stays on the host, there are now TWO different lookup sites for `run` (or any shared
+utility function):
+
+```text
+Pre-agent snapshot:  ci_fix_orchestrator.run   (imported in the collaborator)
+Post-agent read:     ci_driver.run             (imported in the host)
+```
+
+Patching only `ci_fix_orchestrator.run` leaves the host's `run` unpatched — the second
+`run` call hits real git on a tmp_path with no repo and fails with a confusing error.
+
+```python
+# WRONG — only patches the orchestrator's run:
+with patch("hephaestus.automation.ci_fix_orchestrator.run", ...):
+    driver._run_ci_fix_session(...)
+
+# RIGHT — patches both lookup sites:
+with (
+    patch("hephaestus.automation.ci_fix_orchestrator.run", return_value=pre_sha),
+    patch("hephaestus.automation.ci_driver.run", return_value=post_sha),
+):
+    driver._run_ci_fix_session(...)
+```
+
+**General rule**: When a method chain splits across modules, identify every file that has
+`from subprocess_utils import run` (or similar) and patch the `run` name in EACH file that
+is exercised by the test path.
+
+#### Rule 3: Update attribute access in ALL sibling test files after migration
+
+When an instance attribute migrates from the host to a collaborator (e.g., `_viewer_login`
+moves from `CIDriver` to `PRDiscovery`), sibling test files that access it directly on the
+host will silently stop working. mypy strict mode surfaces these as attribute errors:
+
+```python
+# After moving _viewer_login from CIDriver to PRDiscovery:
+# WRONG — driver no longer has this attribute:
+driver._viewer_login = ""
+
+# RIGHT — access through the collaborator:
+driver._pr_discovery._viewer_login = ""
+```
+
+**Grep command** (run before and after each migration):
+
+```bash
+grep -rn "driver\._viewer_login\|driver\.<migrated_attr>" tests/
+```
+
+A single cache attribute migration typically generates 6 mypy errors across sibling test files.
+Fix all of them in the same commit as the migration.
+
+#### Rule 4: Update `companions` tuple in phase-wiring tests when AGENT_* constants move
+
+If the codebase has a test that verifies where `AGENT_*` constants are imported from (a common
+pattern for validating agent-wiring), it uses a `companions` tuple to list extra files to scan:
+
+```python
+# test_phase_agent_wiring.py
+@pytest.mark.parametrize("module,agent_const,companions", [
+    ("ci_driver.py", "AGENT_CI_DRIVER", ()),      # BEFORE: constant in ci_driver.py
+])
+```
+
+When `AGENT_CI_DRIVER` moves to `ci_fix_orchestrator.py`, add the new file to `companions`:
+
+```python
+    ("ci_driver.py", "AGENT_CI_DRIVER", ("ci_fix_orchestrator.py",)),  # AFTER
+```
+
+The `companions` tuple tells the test to scan both `ci_driver.py` AND `ci_fix_orchestrator.py`
+for the constant; without it, the test only scans the primary module and fails.
+
+#### Phase 23 Execution Checklist
+
+```markdown
+## God-Class Narrow-Callable DIP Execution Checklist (Phase 23)
+
+### Before wiring collaborators in __init__
+- [ ] Every injected callable is wrapped as `lambda *a, **k: self._method(*a, **k)` — no bare `self._method`
+- [ ] Verified by: `grep -n "self\._[a-z]" __init__` and confirm none are bare (not in a lambda)
+
+### After each collaborator is extracted
+- [ ] Grep all test files for `host_instance.<migrated_attr>` — update to `host._collaborator.<attr>`
+- [ ] Run mypy — zero new attribute errors expected after migration
+- [ ] Check phase-wiring tests for `companions` tuples — update if AGENT_* moved
+
+### When a pre/post SHA split occurs
+- [ ] Identify every file that imports `run` (or the split utility)
+- [ ] In each test that exercises the split path, patch each file's `run` independently
+- [ ] Verify both mocks are called (assert_called_once on each)
+
+### Final verification
+- [ ] All 146+ pre-existing tests pass
+- [ ] New collaborator tests pass (22+ for a 4-collaborator extraction)
+- [ ] mypy clean (zero attribute errors)
+- [ ] ci_driver.py line count meets target (−28% or better)
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -1669,6 +1866,11 @@ Any method assigned without reading its body may:
 | **Assigning method bodies to collaborators based on name/grep without reading the body** | `_arm_all_unarmed_open_prs`, `_check_arming_on_drive_start`, `_arming_state_path/load/save/clear` were assigned to `ArmingOrchestrator` based on method name and grep output only | Bodies not read; may reference state or call methods that break the injection model | Read every method body before assigning it to a collaborator; grep output and names alone are insufficient — the body may reveal state dependencies or cross-group calls that change the assignment (Phase 22, Rule 5) |
 | **Writing conditional `__init__.py` export step without reading `__init__.py`** | Plan said "if `automation/__init__.py` already exports `CIDriver`; otherwise skip" — conditionality not resolved at plan time | `__init__.py` content was not read during planning; whether to add exports and where was left ambiguous | Read `__init__.py` directly before planning any export step; never leave "if/else export" conditionality unresolved in the plan (Phase 22, Phase 22 Checklist) |
 | **Estimating line count target achievability without reading method bodies** | Plan estimated 37 methods × ~25 lines avg = ~814 net savings, projecting ci_driver.py to ~2,544 lines with no fallback plan if wrong | Method body lengths were not read; if average is <25 lines, target may not be reached after PRDiscovery alone | For line count projections: read the top-N longest method bodies directly (using AST measurement) and sum actual lines rather than applying an average estimate; if projection is near the threshold, include a fallback plan (Phase 22 Checklist) |
+| **Storing direct bound-method references in collaborator init** | Passed `head_advanced=self._head_advanced` (bare bound method) to collaborator constructor | `patch.object(driver, "_head_advanced")` doesn't intercept — the collaborator captured the original reference at init time, bypassing the mock | Always wrap injected callables as `lambda *a, **k: self._method(*a, **k)`; the lambda re-evaluates `self._method` at call time so `patch.object` works (Phase 23, Rule 1) |
+| **Single `run` module patch after pre/post SHA split** | Patched only `ci_fix_orchestrator.run` for both pre-agent and post-agent SHA reads after moving pre-agent snapshot to orchestrator | Post-agent SHA read (`_head_advanced`) uses `ci_driver.run` not `ci_fix_orchestrator.run`; second call missed the mock and hit real git on non-repo tmp_path | When a method chain splits across modules, patch each module's `run` import separately; the pre-agent call uses the orchestrator's `run`, the post-agent call uses ci_driver's `run` (Phase 23, Rule 2) |
+| **Forgetting `_viewer_login` attribute access in sibling test files** | Moved `_viewer_login` from `CIDriver` to `PRDiscovery` without updating `test_ci_driver_author_scope.py` which accessed `driver._viewer_login` directly | mypy reported `"CIDriver" has no attribute "_viewer_login"`; 6 mypy errors; tests failed | After moving any instance attribute to a collaborator, grep all test files for `driver.<attr>` and update to `driver._collaborator.<attr>` (Phase 23, Rule 3) |
+| **`companions=()` not updated in phase-wiring test** | `AGENT_CI_DRIVER` import moved to extracted collaborators (`ci_fix_orchestrator.py`, `post_merge_processor.py`) but `test_phase_agent_wiring.py` still had `("ci_driver.py", "AGENT_CI_DRIVER", ())` with empty companions tuple | Test checks the combined source of module + companions for the AGENT_* import; empty companions meant only `ci_driver.py` was scanned, which no longer has the import | When an `AGENT_*` constant moves to an extracted collaborator, add that collaborator filename to the `companions` tuple in `test_phase_agent_wiring.py` (Phase 23, Rule 4) |
+| **Logger patches targeting old module after extraction** | Left `patch("hephaestus.automation.ci_driver.logger")` for a warning that now emits from `pr_discovery.logger` | Mock showed 0 calls — warning emitted from extracted module's logger | After extracting a module, grep all test files for `ci_driver.logger` patches and update to `<new_module>.logger` (Phase 4) |
 
 ## Results & Parameters
 
@@ -1683,6 +1885,7 @@ Any method assigned without reading its body may:
 | `llm_judge.py` (module decomposition) | 1,488 | 142 | −90% | `build_pipeline.py`, `judge_context.py`, `judge_execution.py`, `judge_artifacts.py` |
 | `stages.py` + `run_report.py` (re-export) | 1,534 + 1,385 | 855 + 289 | −44% / −79% | 4 new modules |
 | Extensibility refactor (6 PRs) | — | — | −415 net | `discovery/`, `subtest_provider.py`, `TestFixture` |
+| `ci_driver.py` (4 collaborators, narrow-callable DIP) | 3,338 | 2,404 | −28% | `pr_discovery.py` (260L), `ci_check_inspector.py` (130L), `ci_fix_orchestrator.py` (530L), `post_merge_processor.py` (230L) |
 
 ### New test benchmarks
 
@@ -1744,3 +1947,4 @@ Revised LOC estimate: ~X (vs TODO "~Y"); justification: ~Z% already in substrate
 | ProjectHephaestus | Issue #1196 Phase 20 implementation — extracted `_invoke_agent_session` + `_push_ci_fix` into `ci_driver.py`; removed `# noqa: C901` from `_run_ci_fix_session`; added 11 new tests (`TestInvokeAgentSession` 8 tests, `TestPushCiFix` 3 tests); 157 tests in `test_ci_driver.py` pass; ruff + mypy clean; three implementation traps discovered: (1) outer `except Exception` was masking `StopIteration` from exhausted mock `side_effect` lists — removal exposed latent miscounting in `test_codex_ci_fix_session_skips_push_when_head_did_not_advance` (needed 3rd `run` side_effect for `clean_status`); (2) caller of `_invoke_agent_session` in `_retry_no_commit_once` lacked `if retry_result.returncode != 0: return False` — no-commit marker was being written incorrectly; (3) mock for `invoke_claude_with_session` in retry test had to be changed from `return_value=...` to `raise CalledProcessError` to avoid consuming excess `run` side_effects; CI gate pending (verified-local) | Phase 20 implementation traps: exception-boundary removal unmasks StopIteration, returncode-guard obligation at call sites, agent-mock type determines downstream `run` consumption (v1.7.0) |
 | ProjectHephaestus | Issue #1180 — planning decomposition of 7 god-functions across 4 files in `hephaestus/automation/` (R0→R3 planning cycle): R0 NOGO (waived 128L `_implement_issue` as "marginal"); R1 NOGO (claimed reduction with no extraction step); R2 NOGO (6-tuple dropped `reopened`, approach table missing two helpers); R3 approved; 8 planning rules identified: (1) arithmetic chain non-negotiable — no waivers; (2) docstring lines count toward function span; (3) for-loop body > 40L is a standalone extraction candidate; (4) helpers absorbing the only call to a data-fetching function must return the fetched data; (5) orchestrator N-tuple must cover ALL post-call variables; (6) every captured variable in an extracted body is a missing parameter; (7) approach table must list ALL helpers per target; (8) AST-measure before planning — never trust issue-cited line numbers (unverified — plan not yet executed) | New Phase 21: God-Function Decomposition Planning Rules (v1.8.0) |
 | ProjectHephaestus | Issue #1289 — planning second decomposition pass of `ci_driver.py` (3,358 lines) using Dependency Inversion + delegation stubs to preserve `patch.object` test targets; 4 collaborators proposed (`PRDiscovery`, `CICheckInspector`, `CIFixOrchestrator`, `ArmingOrchestrator`); 6 additional planning risks identified: (1) `shared_pr_issues` write-back not designed — `_discover_prs` moving to `PRDiscovery` populates dict that arming fan-out reads on CIDriver; (2) `_tracked_worktree_changes` used by both `CICheckInspector` and `CIFixOrchestrator` — cross-collaborator coupling if assigned to one; (3) test fixture pre-seeding of `driver._viewer_login` stops working after cache migrates to collaborator; (4) method bodies not read before assigning to collaborators (`_arm_all_unarmed_open_prs` etc. assigned by name only); (5) conditional `__init__.py` export step not resolved at plan time — `__init__.py` not read; (6) line count projection used 25-line average for method bodies without reading actual lengths — no fallback plan if target not reached after PRDiscovery (unverified — implementation not yet started) | New Phase 22: God-Class Delegation Shared-State Write-Back Rules (v1.9.0) |
+| ProjectHephaestus | PR #1292 (Issue #1179) — executed CIDriver god-class decomposition using narrow-callable injection (DIP): ci_driver.py 3,338 → 2,404 lines (−28%); 4 collaborators extracted (`pr_discovery.py` 260L, `ci_check_inspector.py` 130L, `ci_fix_orchestrator.py` 530L, `post_merge_processor.py` 230L); 4 implementation traps discovered: (1) bare bound-method references to injected callables bypass `patch.object` — all injected callables must be lambda-wrapped; (2) pre/post-SHA split after orchestrator extraction requires patching BOTH `ci_fix_orchestrator.run` and `ci_driver.run` independently; (3) `_viewer_login` attribute migration generated 6 mypy errors in sibling test files — all attribute access paths must be updated; (4) `AGENT_CI_DRIVER` move to extracted module broke `test_phase_agent_wiring.py` — companions tuple required update; 146 existing tests + 22 new tests pass; all CI gates passed (verified-ci) | New Phase 23: God-Class Narrow-Callable DIP Execution Pattern (v1.10.0) |


### PR DESCRIPTION
Add Phases 27–29 to the `python-module-decomposition-and-refactor-patterns` skill, capturing
three pre-implementation verification risks discovered in R5 of issue #1289 (ci_driver.py
god-class decomposition into 4 collaborators).

## Summary

**Phase 27: Source-Read Mandate for Stubs Carried Forward Without Direct Verification**

Three `CIFixOrchestrator` stubs were carried into R5 without direct source reads:
- `_recheck_and_arm_after_fix` (ci_driver.py:1147) — plan includes `acquired_slot` param
- `_resolve_dirty_pr` (ci_driver.py:1227) — plan includes `acquired_slot` param
- `_attempt_ci_fixes` (ci_driver.py:1286) — plan includes `acquired_slot` param

The `acquired_slot` parameter was fabricated in R4 for `_retry_no_commit_once` (where source
showed it did NOT exist). AST Criterion 6 verifies method name only — wrong-but-present
parameters pass silently and fail at runtime with `TypeError`.

Rule: `sed -n 'Np' ci_driver.py` before writing any stub. Never carry parameters from a
prior plan revision as authoritative.

**Phase 28: Two-Argument Stub Arity Verification**

Plan specifies `_is_bot_pr_mode(self, issue_number, pr_number)` without source-reading L596.
Arity or keyword-only separator may differ. Rule: source-verify any 2+-arg method not read
in the current session.

**Phase 29: Return-Type Annotation Verification Before Stub Writing**

Plan annotates `_gh_pr_state -> dict` without reading source. Under mypy `strict = true`,
bare `dict` is rejected. Rule: source-read the return annotation; use fully parameterized
form matching source.

## Changes

- Phases 27, 28, 29 added to Verified Workflow
- 4 new Failed Attempts rows
- 3 new frontmatter use-case descriptions (21–23)
- 5 new tags
- 4 new When-to-Use bullets
- 3 new Quick Reference entries
- 1 new Verified On row
- History entry for v1.12.0

Note: PR #2498 (v1.11.0) is still open; this PR branches from that branch and extends it
with R5 learnings. Both will merge to main when ready.

Closes #2499