### PR TITLE
feat(skills): amend ci-merge-preview-script-count-drift v1.1.0

### DIFF
--- a/skills/ci-merge-preview-script-count-drift.history
+++ b/skills/ci-merge-preview-script-count-drift.history
@@ -1,9 +1,13 @@
+# ci-merge-preview-script-count-drift — Version History
+
+## v1.0.0 — 2026-06-07
+
 ---
 name: ci-merge-preview-script-count-drift
-description: "Use when: (1) CI fails with 'prose says N console scripts but pyproject.toml [project.scripts] has N+1 entries', (2) pre-commit fails with '[missing-from-docs] hephaestus-<script> is in [project.scripts] but has no row in COMPATIBILITY.md', (3) a branch cut before parallel PRs landed now has stale script counts in README/docs/COMPATIBILITY.md on the merge-preview SHA, (4) updating prose counts in README.md or docs/index.md that reference the number of console scripts, (5) a strict audit flags a stale literal count in a roadmap/planning doc (e.g. ROADMAP.md) where the number contradicts pyproject.toml [project.scripts] but CI is not currently failing."
+description: "Use when: (1) CI fails with 'prose says N console scripts but pyproject.toml [project.scripts] has N+1 entries', (2) pre-commit fails with '[missing-from-docs] hephaestus-<script> is in [project.scripts] but has no row in COMPATIBILITY.md', (3) a branch cut before parallel PRs landed now has stale script counts in README/docs/COMPATIBILITY.md on the merge-preview SHA, (4) updating prose counts in README.md or docs/index.md that reference the number of console scripts."
 category: ci-cd
 date: 2026-06-07
-version: "1.1.0"
+version: "1.0.0"
 user-invocable: false
 verification: verified-ci
 tags:
@@ -16,8 +20,6 @@ tags:
   - branch-drift
   - pre-commit
   - hephaestus
-  - roadmap
-  - audit
 ---
 
 # CI Merge-Preview Script Count Drift
@@ -27,8 +29,8 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-07 |
-| **Objective** | Diagnose and fix CI failures caused by `[project.scripts]` count drift between a feature branch and main's merge-preview SHA, and fix stale literal counts in planning/roadmap docs discovered by strict audits |
-| **Outcome** | Successfully applied to 8 PRs in one session (2026-06-07); also covers single-token doc-only fixes for roadmap/planning files where CI is not failing |
+| **Objective** | Diagnose and fix CI failures caused by `[project.scripts]` count drift between a feature branch and main's merge-preview SHA |
+| **Outcome** | Successfully applied to 8 PRs in one session — all passed CI after the fix |
 | **Verification** | verified-ci |
 
 ## When to Use
@@ -38,7 +40,6 @@ tags:
 - The failure appears on the **merge-preview SHA** (e.g., `refs/pull/<N>/merge`), not the branch's own HEAD
 - A branch was cut before parallel PRs merged new console scripts into main
 - Updating documentation that includes a prose count of console scripts
-- **A strict audit flags a stale literal count in a roadmap or planning doc (e.g., `ROADMAP.md`) where the number contradicts `pyproject.toml [project.scripts]` but CI is not currently failing** — fix is a single-token edit; verify the count from the authoritative source (pyproject.toml), not from corroborating docs
 
 ## Verified Workflow
 
@@ -49,9 +50,6 @@ tags:
 git fetch origin main
 git show origin/main:pyproject.toml | grep -c "hephaestus-"
 
-# 1b. Count-verification command (matches pyproject.toml [project.scripts] entry format)
-grep -cE '^\s*[a-z][a-z0-9-]*\s*=\s*"[^"]+:[^"]+"' pyproject.toml
-
 # 2. Find scripts missing from COMPATIBILITY.md
 diff \
   <(git show origin/main:pyproject.toml | grep "hephaestus-" | sed 's/ = .*//' | sort) \
@@ -61,9 +59,6 @@ diff \
 #    (replace the N in "N console scripts" with the count from step 1)
 
 # 4. Add missing scripts to COMPATIBILITY.md Console-Script Stability Tiers table
-
-# 5. Scope check: grep all doc files for the stale number to find every affected location
-grep -rn "<STALE_N>" docs/ README.md COMPATIBILITY.md
 ```
 
 ### Detailed Steps
@@ -114,24 +109,7 @@ diff \
 # Format: | `hephaestus-<name>` | `hephaestus.<module>:<function>` | <tier> | <since-version> |
 ```
 
-#### Step 5 — Fix roadmap/planning doc stale counts (audit-discovered, no CI failure)
-
-When a strict audit flags a stale literal in a planning doc (e.g., `ROADMAP.md` says "13 of **37** declared tools" but pyproject.toml has 47):
-
-```bash
-# Verify the count from the authoritative source — do NOT trust corroborating docs
-grep -cE '^\s*[a-z][a-z0-9-]*\s*=\s*"[^"]+:[^"]+"' pyproject.toml
-
-# Scope check: find every file containing the stale number
-grep -rn "37" docs/ README.md COMPATIBILITY.md
-
-# Apply a single-token fix to only the files that are in scope
-# Leave the numerator (e.g., "13 of N") untouched if the issue only covers N
-```
-
-**Key scope principle**: when prose says "M of N declared tools", only fix N if the audit issue is about the total count; leave M unless that is separately tasked.
-
-#### Step 6 — Verify locally before pushing
+#### Step 5 — Verify locally before pushing
 
 ```bash
 # Confirm the count now matches
@@ -151,13 +129,12 @@ grep "console script" README.md
 | Attempt 2 | Ran pre-commit locally on branch HEAD and saw no failures | The check compares installed package scripts (branch) vs. docs (branch) — they agree locally. The discrepancy only appears when CI installs from the merge-preview's merged `pyproject.toml` | Local pre-commit green ≠ CI green when the failure is a merge-preview artifact |
 | Attempt 3 | Updated README prose count but not `docs/index.md` | The `hephaestus-check-cli-tier-docs` hook scans BOTH files; partial fix still fails | Always grep for ALL prose count references: `grep -rn "console script" README.md docs/index.md` |
 | Attempt 4 | Updated prose counts but forgot to add the missing script to COMPATIBILITY.md | Two separate checks run: (a) prose count vs. `[project.scripts]`, (b) `[project.scripts]` entries vs. COMPATIBILITY.md rows. Both must pass | Fix both the prose count and the COMPATIBILITY.md row in the same commit |
-| Attempt 5 | Verified the stale count by checking README or COMPATIBILITY.md (which already showed the correct number) instead of counting from `pyproject.toml` directly | Cross-referencing docs can agree with each other while still being wrong if they were updated inconsistently; the roadmap file was missed | The authoritative source for the script count is always `pyproject.toml [project.scripts]`, not corroborating docs — count from the code, not from other prose |
 
 ## Results & Parameters
 
 **Root cause pattern:** Branch cut before PR N-1 and PR N-2 merged into main. Those PRs each added one new `hephaestus-*` console script. The branch's `pyproject.toml` has N-2 scripts; after merge-preview, `pyproject.toml` has N scripts from main. The branch's `README.md`, `docs/index.md`, and `COMPATIBILITY.md` still reference N-2.
 
-**Affected files (always three for merge-preview failures):**
+**Affected files (always three):**
 
 | File | What to Fix |
 |------|------------|
@@ -165,20 +142,11 @@ grep "console script" README.md
 | `docs/index.md` | Same prose count reference |
 | `COMPATIBILITY.md` | Add missing row(s) to Console-Script Stability Tiers table |
 
-**Affected files (single-token audit fix for roadmap/planning):**
-
-| File | What to Fix |
-|------|------------|
-| `docs/ROADMAP.md` (or similar) | Single literal number: `37` → `47` (or whatever pyproject.toml reports) |
-
 **Diagnostic commands:**
 
 ```bash
 # Count scripts on main
 git show origin/main:pyproject.toml | grep -c "hephaestus-"
-
-# Count using entry-format regex (most precise — matches [project.scripts] entries)
-grep -cE '^\s*[a-z][a-z0-9-]*\s*=\s*"[^"]+:[^"]+"' pyproject.toml
 
 # List script names (sorted for diff)
 git show origin/main:pyproject.toml | grep "hephaestus-" | sed 's/ = .*//' | sort
@@ -188,9 +156,6 @@ grep "^| \`hephaestus-" COMPATIBILITY.md | sed "s/^| \`//;s/\` |.*//" | sort
 
 # Find prose count references
 grep -n "console script" README.md docs/index.md
-
-# Find ALL files containing a specific stale number (for audit-discovered fixes)
-grep -rn "<STALE_N>" docs/ README.md COMPATIBILITY.md
 ```
 
 **Session results:** Applied fix to 8 PRs in one session (2026-06-07). All 8 passed CI after updating prose counts + COMPATIBILITY.md rows. The failure was caused by two parallel PRs (#1046 adding `hephaestus-check-cli-tier-docs` and #1067 adding `hephaestus-audit-prs`) merging into main after the affected branches were cut.
@@ -200,4 +165,3 @@ grep -rn "<STALE_N>" docs/ README.md COMPATIBILITY.md
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectHephaestus | 8 PRs in session 2026-06-07 | Merge-preview SHA showed N+2 scripts from main vs. N in branch docs; fixed by updating README.md, docs/index.md, COMPATIBILITY.md |
-| ProjectHephaestus | PR #1270, issue #1190, 2026-06-13 | Strict audit found `docs/ROADMAP.md:15` said "37 declared tools" but pyproject.toml had 47; single-token fix (`37`→`47`); README and COMPATIBILITY.md already correct; CI passed cleanly on first push |


### PR DESCRIPTION
## Summary

- Adds a new **When to Use** trigger: strict audit flags a stale literal count in a roadmap/planning doc (e.g. `ROADMAP.md`) where the number contradicts `pyproject.toml [project.scripts]` but CI is not currently failing
- Adds **Attempt 5** to Failed Attempts: anti-pattern of verifying count from corroborating docs (README, COMPATIBILITY.md) instead of counting from `pyproject.toml` directly — the authoritative source must be code, not cross-referencing prose
- Adds count-verification regex command to Quick Reference: `grep -cE '^\s*[a-z][a-z0-9-]*\s*=\s*"[^"]+:[^"]+"' pyproject.toml`
- Adds scope principle: when prose says "M of N declared tools", fix only N if the issue is about total count; leave M unless separately tasked
- Extends **Verified On** table with PR #1270 / issue #1190 evidence (2026-06-13, verified-ci)
- Archives v1.0.0 in `ci-merge-preview-script-count-drift.history`
- Bumps version 1.0.0 → 1.1.0

## Source

Session: ProjectHephaestus PR #1270, closing issue #1190 (strict-audit stale `37`→`47` in `docs/ROADMAP.md:15`). CI passed cleanly on first push.

## Test plan

- [x] `python3 scripts/validate_plugins.py` passes 334/334 skills
- [x] Commit is GPG-signed
- [x] History file created for first amendment