### PR TITLE
feat: amend github-api-secondary-rate-limit-backoff skill (v1.1.0)

### DIFF
--- a/skills/github-api-secondary-rate-limit-backoff.history
+++ b/skills/github-api-secondary-rate-limit-backoff.history
@@ -1,29 +1,70 @@
+<!-- markdownlint-disable MD024 MD026 -->
+
+# History: github-api-secondary-rate-limit-backoff
+
+This file preserves the full verbatim content of prior versions of
+`github-api-secondary-rate-limit-backoff.md`, along with the version history of
+the canonical skill (append-only, newest first).
+
+## v1.1.0 (2026-06-13)
+
+**Changed by:** ProjectHephaestus output.log root-cause analysis (RC4, PR #1326 / issue #1321)
+**Verification:** verified-local
+
+### What changed
+
+- Extended the skill from "GitHub secondary rate limit" only to the broader
+  class of "rate-limit MESSAGE PHRASING that no regex matches falls through to
+  the wrong retry path", adding the Claude CLI session-limit 429 case.
+- Added a new root-cause section for the Claude session-limit phrasing
+  (`You've hit your session limit · resets 4:20am`) which has NO parenthesized
+  timezone, so `RATE_LIMIT_RE` and `CLAUDE_USAGE_CAP_RE` (mandatory `(tz)`) both
+  miss it — the quota-reset resolver returned `None`, `wait_until` was skipped,
+  and the implement phase hard-failed instead of waiting for reset.
+- Added the fix: `CLAUDE_SESSION_LIMIT_RE` + `detect_session_limit(text)` with
+  an OPTIONAL `(tz)`, the `0` "rate-limited, reset unknown" sentinel semantics,
+  and the single common `resolve_quota_reset_epoch(*texts)` resolver that all
+  agent-invocation call sites delegate to (consolidation lesson).
+- Added the scoping exception: `client.py`'s narrow `detect_claude_usage_cap`
+  is intentionally left as-is because it raises the typed
+  `ClaudeUsageCapError` and must not also catch GitHub/session limits.
+- Added 2 Failed Attempts rows (mandatory-tz regex; patch-only-in-_implement_phase).
+- Extended "When to Use" / description triggers to include the session-limit 429 case.
+- Added ProjectHephaestus PR #1326 / issue #1321 to the Verified On table.
+- Added frontmatter `history:` field, bumped version 1.0.0 → 1.1.0, date → 2026-06-13.
+
+### Why
+
+The session-limit phrasing is the SAME root-cause shape as the original
+secondary-rate-limit gap (a message no regex matches falling through to the
+wrong path), so it belongs in the same skill. The broader lesson — cross-cutting
+"is this output a rate limit?" detection MUST live in ONE resolver every call
+site routes through — was learned because FOUR separate copies of quota
+detection existed (`_claude_quota_reset_epoch`, `scan_quota_reset`, and inline
+pairs in `client.py` / `follow_up.py`); fixing one phrasing gap left the others
+broken.
+
+## v1.0.0 (2026-06-07) Initial version.
+
+Full verbatim snapshot of the v1.0.0 canonical content:
+
+```markdown
 ---
 name: github-api-secondary-rate-limit-backoff
-description: 'Fix rate-limit message phrasings that no regex matches falling through
-  to the wrong retry path in rate_limit.py. Use when GitHub secondary rate limit
-  messages fall through to the generic 1s/2s/4s transient retry path with no useful
-  log output, OR when a Claude CLI session-limit 429 (e.g. "You''ve hit your session
-  limit · resets 4:20am" with NO parenthesized timezone) is not matched by
-  RATE_LIMIT_RE or CLAUDE_USAGE_CAP_RE so the quota-reset resolver returns None and
-  the implement phase hard-fails instead of waiting for the reset — instead of being
-  identified and routed through the proper rate-limit backoff path.
+description: 'Fix GitHub secondary rate limit errors being silently mishandled by
+  detect_rate_limit() in rate_limit.py. Use when GitHub secondary rate limit messages
+  fall through to the generic 1s/2s/4s transient retry path with no useful log output
+  instead of being identified and routed through the proper rate-limit backoff path.
 
   '
 category: debugging
-date: 2026-06-13
-version: 1.1.0
-history: github-api-secondary-rate-limit-backoff.history
+date: 2026-06-07
+version: 1.0.0
 user-invocable: false
 tags:
 - github-api
 - rate-limit
 - secondary-rate-limit
-- session-limit
-- claude-cli
-- quota-reset
-- regex-phrasing-gap
-- detection-consolidation
 - backoff
 - retry
 - hephaestus
@@ -46,8 +87,6 @@ tags:
 Use this skill when:
 - GitHub API calls fail with `"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."` but the retry log shows generic `"gh call failed (attempt N), retrying in Ns"` with 1s/2s/4s waits
 - `detect_rate_limit()` returns `False` for secondary rate limit messages
-- A Claude CLI session-limit 429 (`result: "You've hit your session limit · resets 4:20am"` with **NO** parenthesized timezone) is not matched by `RATE_LIMIT_RE` or `CLAUDE_USAGE_CAP_RE`, the quota-reset resolver returns `None`, the `wait_until(reset_epoch)` branch is skipped, and the implement phase **hard-fails** the issue instead of waiting for the reset
-- A rate-limit detector exists in more than one place (e.g. `_claude_quota_reset_epoch`, `scan_quota_reset`, inline detect pairs) and a new phrasing has to be patched in N places — a sign detection must be consolidated into one resolver
 - You need to add a new rate-limit signal type that has no reset epoch (unlike primary REST or GraphQL limits)
 - Writing tests that mock `time` and need to distinguish rate-limit sleeps from per-thread throttle sleeps
 
@@ -79,70 +118,6 @@ You have exceeded a secondary rate limit. Please wait a few minutes before you t
 Neither regex matches this text. Therefore `detect_rate_limit()` returns `False`, `_extract_reset_epoch()` returns `None`, and `_gh_call_impl` falls through to the generic transient error branch which uses `wait_seconds = 2**attempt` (1s, 2s, 4s...).
 
 The secondary rate limit also has **no reset epoch** in the error message — the primary rate-limit path's `_extract_reset_epoch()` has nothing to parse. This means secondary limits must be handled as a separate detection path, not by augmenting `detect_rate_limit()`.
-
-## Root Cause (same shape): Claude session-limit 429 with no timezone
-
-The Claude CLI emits a session-limit 429 as a `result` field with **NO** parenthesized timezone:
-
-```text
-result: "You've hit your session limit · resets 4:20am"
-```
-
-In `hephaestus/github/rate_limit.py`:
-- `RATE_LIMIT_RE` requires `Limit reached` **plus** a `(tz)` group.
-- `CLAUDE_USAGE_CAP_RE` requires a **mandatory** `\((?P<tz>...)\)`.
-
-Neither matches the tz-less session-limit phrasing. So the quota-reset resolver
-returned `None`, the `wait_until(reset_epoch)` branch was skipped, and the
-implement phase **hard-failed** the issue instead of waiting for the 4:20am
-reset.
-
-Detection note: `api_error_status` / the literal `429` are never inspected —
-detection is purely text/regex on the `result` field. The subtype can be
-`"success"` while `is_error: true`; the error must still be treated as an error
-via `is_error` (the code already does this). This is the **same root-cause
-shape** as the secondary-rate-limit gap above: a phrasing that no regex matches
-falls through to the wrong path.
-
-### The fix
-
-Add `CLAUDE_SESSION_LIMIT_RE` + `detect_session_limit(text)` to `rate_limit.py`.
-The regex makes the `(tz)` **OPTIONAL**: it matches `(hit|reached) your session
-limit` with an optional `resets <time>` and an optional `(tz)`.
-
-- When a reset time is present, parse via the existing
-  `parse_reset_epoch(time, tz_or_empty)` — it defaults tz to
-  `America/Los_Angeles` and rolls to tomorrow if the time is already past.
-- When the message matches but has **no parseable reset time**, return the `0`
-  "rate-limited, reset unknown" **sentinel**. Callers must back off, not treat
-  `0` as "no limit" — preserve the `is not None` chaining everywhere (a `0`
-  reset is still a real limit; only `None` means "no limit detected").
-
-### Consolidation: one resolver, all call sites
-
-The broader lesson. There were **four** separate copies of quota detection:
-
-- `_claude_quota_reset_epoch` in `_implement_phase.py`
-- `scan_quota_reset` in `claude_invoke.py`
-- inline detect pairs in `client.py` and `follow_up.py`
-
-Fixing a phrasing gap in one place left the others broken. The fix added a
-**single common resolver** `resolve_quota_reset_epoch(*texts)` in
-`rate_limit.py` that runs all three detectors (`detect_rate_limit`,
-`detect_claude_usage_cap`, `detect_session_limit`) and is exported. Every
-agent-invocation call site now delegates to it (`_claude_quota_reset_epoch`,
-`scan_quota_reset`, the `follow_up` `is_error` guard).
-
-**Lesson**: cross-cutting "is this output a rate limit?" detection MUST live in
-ONE resolver that all call sites route through — otherwise a new phrasing must
-be patched in N places and some get missed.
-
-**Deliberate exception**: `client.py`'s narrow `detect_claude_usage_cap` was
-intentionally left as-is. It raises the typed `ClaudeUsageCapError` for
-gh-surfaced caps and must **NOT** also catch GitHub rate limits / session limits
-routed through the gh subprocess wrapper. So "route everything through the
-resolver" has one deliberate exception where a typed-exception path needs the
-narrow detector.
 
 ## Verified Workflow
 
@@ -260,8 +235,6 @@ def test_secondary_rate_limit_retries_with_15s_base_backoff(self, mock_run, mock
 | --------- | ---------------- | --------------- | ---------------- |
 | Standalone sleep+continue | Call `time.sleep(15 * 2**attempt)` then `continue` directly in the except branch | Bypasses `retry_on_rate_limit=False` check; raises generic `RuntimeError` on exhaustion instead of `GitHubRateLimitError` | Always route through `_handle_rate_limit_attempt` to preserve error semantics |
 | Augment detect_rate_limit() | Return True for secondary messages from existing `detect_rate_limit()` | Secondary limits have no reset epoch; `_extract_reset_epoch()` returns None causing same fallback | Handle secondary limits as a separate detection path, not via primary rate-limit detector |
-| Mandatory-timezone regex | Add a session-limit regex with a required `\((?P<tz>...)\)` group like `CLAUDE_USAGE_CAP_RE` | The session-limit phrasing has NO `(tz)`, so the mandatory group never matched and the message still fell through | Make the `(tz)` OPTIONAL and default it (to `America/Los_Angeles`) when absent |
-| Patch detection only in _implement_phase | Add `detect_session_limit` only to `_claude_quota_reset_epoch` in `_implement_phase.py` | Planner / plan-reviewer / follow-up call sites (`scan_quota_reset`, `follow_up` is_error guard) still hard-failed on the same phrasing | Consolidate all detectors into one `resolve_quota_reset_epoch(*texts)` resolver that every call site routes through |
 
 ## Results & Parameters
 
@@ -283,29 +256,9 @@ from hephaestus.github.rate_limit import (
 )
 ```
 
-### Session-limit detector + resolver (v1.1.0)
-
-| Parameter | Value | Rationale |
-| ----------- | ------- | ----------- |
-| `CLAUDE_SESSION_LIMIT_RE` shape | `(hit\|reached) your session limit`, optional `resets <time>`, optional `(tz)` | The session-limit phrasing has no `(tz)`; making it optional lets the same regex match both tz-bearing and tz-less variants |
-| Reset-time parse | `parse_reset_epoch(time, tz_or_empty)` | Defaults tz to `America/Los_Angeles`; rolls to tomorrow if the time is already past |
-| No-reset-time return | `0` sentinel ("rate-limited, reset unknown") | Callers must back off; `0` is a real limit. Only `None` means "no limit" — preserve `is not None` chaining everywhere |
-| Common resolver | `resolve_quota_reset_epoch(*texts)` | Runs `detect_rate_limit`, `detect_claude_usage_cap`, `detect_session_limit`; exported and used by every agent-invocation call site |
-
-**Call sites consolidated onto `resolve_quota_reset_epoch`:**
-
-- `_claude_quota_reset_epoch` (`_implement_phase.py`)
-- `scan_quota_reset` (`claude_invoke.py`)
-- the `follow_up` `is_error` guard (`follow_up.py`)
-
-**Deliberate exception (NOT consolidated):** `client.py`'s narrow
-`detect_claude_usage_cap` stays as-is — it raises the typed
-`ClaudeUsageCapError` for gh-surfaced caps and must not catch GitHub/session
-limits routed through the gh subprocess wrapper.
-
 ## Verified On
 
 | Project | Context | Details |
 | --------- | --------- | --------- |
 | ProjectHephaestus | PR #1092 — secondary rate limit detection and backoff | 10 new unit tests pass locally; CI pending at capture time |
-| ProjectHephaestus | PR #1326 / issue #1321 — Claude session-limit 429 (tz-less) detection + resolver consolidation | verified-local: `detect_session_limit` + `resolve_quota_reset_epoch` verified at runtime against the literal message; 103 rate-limit + follow-up unit tests pass locally; CI pending at capture |
+```


### PR DESCRIPTION
## Summary

Amends the `github-api-secondary-rate-limit-backoff` skill (minor bump
v1.0.0 → v1.1.0) to cover the **same root-cause shape** for a different
message: a Claude CLI session-limit 429 phrasing that no regex matches
falling through to the wrong path.

## What changed

- **New root-cause section**: the Claude CLI emits a session-limit 429 as
  `result: "You've hit your session limit · resets 4:20am"` with **NO**
  parenthesized timezone. `RATE_LIMIT_RE` and `CLAUDE_USAGE_CAP_RE` both
  require `(tz)`, so neither matched — the quota-reset resolver returned
  `None`, `wait_until` was skipped, and the implement phase hard-failed
  instead of waiting for the reset.
- **The fix**: `CLAUDE_SESSION_LIMIT_RE` + `detect_session_limit(text)` with
  an **optional** `(tz)`; the `0` "reset unknown" sentinel semantics
  (callers back off; only `None` means "no limit"); and a single common
  `resolve_quota_reset_epoch(*texts)` resolver that all agent-invocation
  call sites delegate to (`_claude_quota_reset_epoch`, `scan_quota_reset`,
  the follow-up `is_error` guard).
- **Consolidation lesson** plus the deliberate `client.py` exception (its
  narrow `detect_claude_usage_cap` stays as-is to raise the typed
  `ClaudeUsageCapError`).
- 2 new Failed Attempts rows; session-limit Results subsection; new
  Verified On row for ProjectHephaestus PR #1326 / issue #1321.
- Adds `history:` frontmatter field; full v1.0.0 snapshot archived in
  `github-api-secondary-rate-limit-backoff.history`.

## Verification

- `python3 scripts/validate_plugins.py` → 381/381 valid.
- `markdownlint-cli2` on both files → 0 errors.
- Underlying learning verified-local (ProjectHephaestus PR #1326): 103
  rate-limit + follow-up unit tests pass locally.

Previous version archived in `github-api-secondary-rate-limit-backoff.history`.