### PR TITLE
feat(ci-cd): amend pr-rebase-conflict-resolution-patterns v1.4.0 — SHA-pin-blocked stale PRs

### DIFF
--- a/skills/pr-rebase-conflict-resolution-patterns.history
+++ b/skills/pr-rebase-conflict-resolution-patterns.history
@@ -1,6 +1,36 @@
 <!-- markdownlint-disable MD024 -->
 # pr-rebase-conflict-resolution-patterns — History
 
+## v1.4.0 (2026-06-13)
+
+**Changed by:** ProjectMnemosyne skill/learn-sha-pin-blocks-stale-prs (2026-06-13)
+
+**Verification:** verified-ci — 107 PRs unblocked and merged via Myrmidon Haiku swarm rebase, ProjectMnemosyne 2026-06-13
+
+**What changed:**
+
+- Added **trigger (13)** to frontmatter `description`: PR BLOCKED with `mergeable=MERGEABLE` but a required check shows `SKIPPED` due to org-wide SHA-pin policy causing a `needs:` dependency chain collapse.
+- Added **When to Use** bullet for the SHA-pin-blocked SKIPPED-required-check scenario (distinct from DIRTY/CONFLICTING cases — git sees no conflict, CI collapses a `needs:` chain).
+- Added **Section J** ("SHA-pin-blocked stale PRs — required check SKIPPED via dependency chain") covering: root-cause chain, diagnosis commands (`gh pr view --json statusCheckRollup`, `gh run view --log-failed | grep 'not allowed'`, `git show origin/<branch>:.github/workflows/*.yml | grep '@v[0-9]'`), single-PR rebase fix, explanation of why empty re-trigger commits do NOT work, companion "combined-status pending with count=0" caching fix via empty signed commit, and Myrmidon swarm pattern for 100+ affected PRs.
+- Added **4 Failed Attempts** rows: (1) empty re-trigger commit on SHA-pin-blocked PR, (2) arming auto-merge before rebase while BLOCKED, (3) `git checkout --ours/--theirs` blocked by Safety Net, (4) diagnosing SHA-pin-blocked PRs as a code/CI failure rather than a workflow-file staleness issue.
+- Added **SHA-pin diagnosis and fix commands** to the Results & Parameters bash block.
+- Added **Verified On** row: ProjectMnemosyne 2026-06-13, 107 PRs rebased in parallel Haiku swarm.
+- Added tags: `sha-pin`, `unpinned-actions`, `skipped-required-check`, `markdownlint`, `lint-blocked`, `org-policy`, `myrmidon-swarm`.
+
+**Why:** The skill previously covered DIRTY/CONFLICTING PRs (git conflict) but not the distinct class of BLOCKED PRs where the git state is MERGEABLE but a required CI check is SKIPPED because an upstream `needs:` job fails due to an org policy enforcement. This manifests identically to a stuck PR — `mergeStateStatus=BLOCKED` — but has a different root cause (workflow file staleness, not content conflict) and a different fix (rebase to inherit workflow changes, not conflict resolution). The empty-commit re-trigger is the most common wrong first instinct and is now explicitly documented as a failed attempt.
+
+## v1.3.0 (2026-06-11)
+
+**Changed by:** ProjectHephaestus PR #1014/#720 DIRTY-with-all-green + modify/delete resolution
+
+**What changed:**
+
+- Added trigger (11): PR DIRTY with all CI checks green — the merge conflict IS the sole blocker.
+- Added trigger (12): modify/delete conflict on a file the PR intentionally deletes.
+- Added C2 post-rebase verification checklist.
+- Added Failed Attempts rows for DIRTY-all-green diagnosis and modify/delete conflict.
+- Added Verified On rows for ProjectHephaestus PR #1014/#720.
+
 ## v1.2.0 (2026-06-11)
 
 **Changed by:** ProjectHephaestus PR #967 (issue #768) add/add already-merged rebase

--- a/skills/pr-rebase-conflict-resolution-patterns.md
+++ b/skills/pr-rebase-conflict-resolution-patterns.md
@@ -1,12 +1,12 @@
 ---
 name: pr-rebase-conflict-resolution-patterns
-description: "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted — later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed, (10) a PR's substantive change independently landed on main via a sibling PR so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual, (11) a PR is DIRTY with all CI checks green/passing — the merge conflict itself is the sole blocker (rebase, do not hunt for a failing job), (12) a rebase hits a modify/delete conflict on a file the PR intentionally deletes — confirm the base copy is still stale then git rm"
+description: "Use when: (1) a PR branch is CONFLICTING or DIRTY after main advances and needs rebasing, (2) a mass rebase of 10+ PRs is needed after a major refactor causes conflicts across the queue, (3) a stacked PR goes DIRTY when its prerequisite merges and the base must be retargeted — later CI/lint fix commits on the dependent branch are orphaned and must be cherry-picked, (4) a Safety Net hook blocks git checkout --theirs / --ours during automated rebase conflict resolution, (5) a file was completely rewritten on one branch and small targeted edits exist on the other, (6) a parallel swarm produced overlapping PRs that conflict on the same paths and one must be rebased onto the other, (7) a feature PR conflicts after a sibling refactor merges and edits must be ported to the new file structure, (8) a TypeScript or other language-level shadowing bug appears only after a rebase because two branches independently added identically-named locals to the same scope, (9) numerical or optimizer PRs conflict when main merged its own version of a shared module and API signatures changed, (10) a PR's substantive change independently landed on main via a sibling PR so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual, (11) a PR is DIRTY with all CI checks green/passing — the merge conflict itself is the sole blocker (rebase, do not hunt for a failing job), (12) a rebase hits a modify/delete conflict on a file the PR intentionally deletes — confirm the base copy is still stale then git rm, (13) a PR is BLOCKED with mergeable=MERGEABLE but a required check shows SKIPPED — the required check is gated by needs: on a job that fails because the branch carries unpinned GitHub Actions rejected by an org-wide SHA-pin policy; fix is rebase to inherit main's pinned workflow files (not an empty re-trigger commit)"
 category: ci-cd
-date: 2026-06-11
-version: "1.3.0"
+date: 2026-06-13
+version: "1.4.0"
 user-invocable: false
 history: pr-rebase-conflict-resolution-patterns.history
-tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-net, parallel-swarm, serial-merge-train, full-rewrite, shadow-variable, tdz, numeric-equivalence, clang-format, cmake, pixi-lock, force-with-lease, auto-merge, already-merged-sibling, add-add-conflict]
+tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-net, parallel-swarm, serial-merge-train, full-rewrite, shadow-variable, tdz, numeric-equivalence, clang-format, cmake, pixi-lock, force-with-lease, auto-merge, already-merged-sibling, add-add-conflict, sha-pin, unpinned-actions, skipped-required-check, markdownlint, lint-blocked, org-policy, myrmidon-swarm]
 ---
 
 # PR Rebase & Conflict Resolution Patterns
@@ -38,7 +38,8 @@ tags: [git, rebase, merge-conflict, pr, batch, stacked-pr, cherry-pick, safety-n
 - A PR's substantive change independently landed on main via a sibling PR, so a rebase produces an add/add conflict on a duplicated new file and the PR becomes a near-no-op residual (only a trivial delta remains vs main).
 - A PR is `DIRTY`/`CONFLICTING` with **all CI checks green/passing** — the merge conflict itself is the sole blocker; rebase, do not hunt for a failing job (`gh pr view N --json mergeStateStatus,mergeable,statusCheckRollup`).
 - A rebase hits a **modify/delete conflict on a file the PR intentionally deletes** (`CONFLICT (modify/delete): <path> deleted in <commit> and modified in HEAD`) — confirm the base copy is still the stale content the PR removes, then `git rm`.
-- Common trigger phrases: "fix these failing PRs", "rebase all branches onto main", "mass rebase after merge wave", "stacked PR went dirty", "Safety Net blocked git checkout".
+- A PR is **BLOCKED with `mergeable=MERGEABLE`** (no git conflict) but a **required check shows `SKIPPED`** — the required check (e.g. `markdownlint`) is declared `needs: lint` and the `lint` job fails because the branch carries **unpinned GitHub Actions** (`actions/setup-python@v6`) rejected by an org-wide SHA-pin policy. The fix is a **rebase onto current main** so the branch inherits main's pinned workflow files; pushing an empty re-trigger commit does NOT fix this.
+- Common trigger phrases: "fix these failing PRs", "rebase all branches onto main", "mass rebase after merge wave", "stacked PR went dirty", "Safety Net blocked git checkout", "markdownlint SKIPPED BLOCKED", "action not allowed must be pinned".
 
 ## Verified Workflow
 
@@ -163,6 +164,90 @@ git checkout --ours marketplace.json                    # main has the union; PR
 
 `git checkout --ours/--theirs/--`, `git restore`, `git reset --hard`, `git branch -D`, `git worktree remove --force`, `rm -rf <fixed-path>`, and even commit-message text containing `git restore --theirs` are blocked. Safety Net custom rules can only ADD restrictions, not bypass built-ins. Workarounds: `git show :2:/:3:` writes (conflict take); `git reset --keep` (not `--hard`); `git branch -d` (not `-D`); `git worktree remove` (not `--force`); `git stash`/`stash drop` to discard artifact edits (NOT mid-rebase with unmerged paths — git refuses); `mktemp -d` (not pre-cleaning a fixed path); write commit messages via `git commit -F /tmp/msg.txt`; escalate `git checkout --ours` to the main conversation (sub-agents share the hook environment).
 
+#### J. SHA-pin-blocked stale PRs — required check SKIPPED via dependency chain
+
+**Symptom:** A PR shows `mergeable=MERGEABLE` (no git conflict) but `mergeStateStatus=BLOCKED`. Inspecting check-runs reveals a required context (e.g. `markdownlint`) has status `SKIPPED`, not `failed`. The PR's `validate` check passed.
+
+**Root cause chain:**
+
+1. An org-wide policy PR pinned all GitHub Actions to full commit SHAs and forbade unpinned action references (e.g. `actions/setup-python@v6` → must be `actions/setup-python@<sha>`).
+2. PR branches created **before** that policy PR still carry unpinned actions in their local copy of the workflow files.
+3. Those branches' `lint` job fails with: `The action X is not allowed. Actions in this workflow must be pinned to a full-length commit SHA.`
+4. The required `markdownlint` job is declared `needs: lint` — when `lint` fails (not `skipped`, but `failure`), `markdownlint` is **SKIPPED** by GitHub Actions dependency semantics.
+5. GitHub branch protection treats `SKIPPED` as **not satisfied** for a required check context — identical to the check never running. The PR stays BLOCKED even though `validate` passed and there is no git conflict.
+
+**Diagnosis commands:**
+
+```bash
+# 1. Confirm the required contexts
+gh api repos/OWNER/REPO/branches/main/protection/required_status_checks --jq '.contexts'
+# or for rulesets:
+gh api repos/OWNER/REPO/rulesets --jq '.[].rules[].parameters.required_status_checks'
+
+# 2. List check-runs on the PR's head SHA — find any required context that is SKIPPED
+gh pr view <N> --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.conclusion == "SKIPPED" or .conclusion == null) | {name, conclusion, status}'
+
+# 3. Inspect the failing lint log for the pin-policy error
+gh run list --json databaseId,name,conclusion --jq '.[] | select(.conclusion == "failure") | .databaseId' | head -3
+gh run view <id> --log-failed | grep -iE 'not allowed|must be pinned|pin'
+# Expected: "The action 'actions/setup-python@v6' is not allowed ... must be pinned to a full-length commit SHA"
+
+# 4. Confirm the PR branch still carries the unpinned action
+git show origin/<branch>:.github/workflows/<workflow>.yml | grep -E 'uses:.*@v[0-9]'
+```
+
+**Fix:**
+
+```bash
+# Rebase the branch onto current main — inherits main's pinned workflow files
+git worktree add /tmp/pr-<N> origin/<branch>
+git -C /tmp/pr-<N> rebase origin/main
+# Skill PRs touching only skills/*.md rebase CLEANLY (0 conflicts typical)
+git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
+gh pr merge <N> --auto --squash   # re-arm after every force-push
+git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/pr-<N>
+```
+
+**Why an empty re-trigger commit does NOT work:** an empty commit replays on the same branch tip, which still carries the unpinned workflow file. CI runs `lint` against those same unpinned actions, fails identically, and `markdownlint` is SKIPPED again. The branch MUST inherit main's pinned workflow files via rebase.
+
+**Companion: combined-status "pending" with count=0 (separate stuck state)**
+
+After rebasing and arming auto-merge, you may observe a second stuck state: **both required check-runs pass** (`validate=success`, `markdownlint=success`) but GitHub's legacy combined-status still reads `pending` and blocks auto-merge. This is a GitHub caching artifact — the combined-status engine has not recomputed after the force-push. Pushing an **empty signed commit** forces GitHub to recompute:
+
+```bash
+git -C /tmp/pr-<N> commit --allow-empty -S -m "chore: re-trigger combined-status recompute"
+git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
+gh pr merge <N> --auto --squash
+```
+
+Once GitHub recomputes (typically seconds to minutes), all passing PRs merge. This is a pure caching fix, not a workflow fix — it only applies AFTER the rebase has already made the check-runs green.
+
+**Swarm execution for 100+ affected PRs:**
+
+Partition PRs across parallel Haiku sub-agents, one isolated worktree per PR:
+
+```bash
+# Per sub-agent: sequential rebase over assigned PR list
+for N in <assigned-prs>; do
+  branch=$(gh pr view $N --repo OWNER/REPO --json headRefName --jq .headRefName)
+  git worktree add /tmp/rebase-$N origin/$branch
+  if git -C /tmp/rebase-$N rebase origin/main 2>&1 | grep -q CONFLICT; then
+    echo "CONFLICT PR#$N — flag, do not stall"
+    git -C /tmp/rebase-$N rebase --abort
+    git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/rebase-$N
+    continue
+  fi
+  git -C /tmp/rebase-$N push --force-with-lease origin HEAD:$branch
+  gh pr merge $N --auto --squash --repo OWNER/REPO
+  git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/rebase-$N
+done
+```
+
+- Flag genuine conflicts (stale skills/*.md rarely conflict; workflow conflicts mean the branch predates even main's structure).
+- Use `--squash` — squash-only repos reject `--rebase`.
+- Re-arm auto-merge AFTER the push, not before.
+
 #### C2. Post-rebase verification checklist (run before claiming clean)
 
 - **No conflict markers survive** in any rewritten file: `grep -nE '^(<<<<<<<|=======|>>>>>>>)' <file>` returns nothing.
@@ -208,6 +293,10 @@ git checkout --ours marketplace.json                    # main has the union; PR
 | Suppressing a transitive-dep CVE with `--ignore-vuln` | Silenced a pip-audit red across all PRs | Hides the advisory; must repeat per CVE | Pin the fixed version in `pixi.toml`, regen lock, ship as a separate small PR that unblocks the repo |
 | Punting a mechanical lint failure to the author | Deferred a Mojo Syntax Validation failure | It was mechanical (variadic `List[T](args)` → typed literal `var x: List[Int]=[...]`) | Read the actual error; reserve "needs author" for real domain decisions |
 | Rebasing onto a broken main / starting without checking for open PRs | Rebased a queue while main CI was red / `git branch -vv` "ahead 1" misled | Can't unblock PRs via a broken main; "ahead 1" is a squash artifact | `gh pr list --state open` + `gh run list --branch main` first; `git cherry` to confirm unmerged work |
+| Empty re-trigger commit to fix SHA-pin-blocked SKIPPED required check | Pushed an empty commit to force CI re-run on a branch where `markdownlint` showed SKIPPED and PR was BLOCKED with `mergeable=MERGEABLE` | The empty commit replays against the same branch tip, which still carries the unpinned action in its workflow file — `lint` fails identically with "action must be pinned to full-length commit SHA", `markdownlint` is SKIPPED again, and the PR stays BLOCKED | The branch must REBASE onto current main to inherit main's pinned workflow files; only then will `lint` pass and `markdownlint` run to completion (verified-ci: 107 PRs unblocked, ProjectMnemosyne 2026-06-13) |
+| Enabling auto-merge while required check still SKIPPED (before rebase) | Armed `gh pr merge --auto --squash` on a BLOCKED PR before rebasing | `mergeStateStatus=BLOCKED` means auto-merge is ignored even after arming — GitHub records the arm but cannot merge; the branch stays stuck | Rebase first → push → THEN arm auto-merge; re-arm after every force-push |
+| `git checkout --ours/--theirs` during rebase in Safety-Net-guarded repo | Attempted standard conflict resolution shortcut during the rebase phase | Safety Net hook blocks `git checkout <ref> -- <path>` as a destructive operation | Use `git show origin/main:<path> > <path>` (equivalent to `--ours` in rebase context) then `git add <path>` |
+| Diagnosing SHA-pin-blocked PRs as a CI/code failure | Investigated failing job logs in the PR's own code/tests | The real failure is in the workflow file (unpinned action reference), not the PR's code content — the PR's actual code is typically fine | Compare required contexts list against head-SHA check-runs; a required context showing SKIPPED when it should be SUCCESS points to a `needs:` chain collapse upstream, not a code bug |
 
 ## Results & Parameters
 
@@ -249,8 +338,24 @@ git push origin HEAD:<prereq-branch>                            # fast-forward, 
 git checkout -b <pr-branch>-fix origin/<pr-branch>
 git cherry-pick <fix-sha> && git push origin <pr-branch>-fix:<pr-branch>
 
-# Empty signed commit to re-trigger checks that never ran
+# Empty signed commit to re-trigger checks that never ran (NOT for SHA-pin SKIPPED — use rebase)
 git commit --allow-empty -S -m "chore: re-trigger CI"
+
+# SHA-pin BLOCKED: diagnose and fix
+# 1. Identify which required context is SKIPPED
+gh pr view <N> --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.conclusion == "SKIPPED") | {name, conclusion}'
+# 2. Inspect lint failure for pin-policy error
+gh run view <failing-run-id> --log-failed | grep -iE 'not allowed|must be pinned'
+# 3. Fix: rebase to inherit main's pinned workflow files
+git worktree add /tmp/pr-<N> origin/<branch>
+git -C /tmp/pr-<N> rebase origin/main
+git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
+gh pr merge <N> --auto --squash --repo OWNER/REPO
+git -C "$HOME/.agent-brain/<repo>" worktree remove /tmp/pr-<N>
+# 4. If combined-status still "pending" after checks turn green: empty-commit recompute
+git -C /tmp/pr-<N> commit --allow-empty -S -m "chore: re-trigger combined-status recompute"
+git -C /tmp/pr-<N> push --force-with-lease origin HEAD:<branch>
 ```
 
 ## Verified On
@@ -270,3 +375,4 @@ git commit --allow-empty -S -m "chore: re-trigger CI"
 | Myrmidons | 13 stacked-PR EOF-fixer cascade (~39 trivial conflicts, sed loop); shellcheck swarm in `.claude/worktrees/agent-*` (git -C + detached-HEAD branch -f); 0-open-PR squash-artifact detection | verified-ci / verified-local |
 | Agamemnon / Odysseus | Extraction destination PRs #419/#420/#421; Odysseus #43 NATS reconciliation vs merged #32; Agamemnon #422 empty-commit re-trigger of 6 required checks | verified-ci / verified-local |
 | HomericIntelligence/Odysseus | PR #64 full-file-rewrite conflict on docs/architecture.md (234-line rewrite vs 3-line delta) | verified-local |
+| ProjectMnemosyne | 2026-06-13: org-wide SHA-pin policy PR landed on main; ~107 skill PRs created before the pin carried `actions/setup-python@v6` (unpinned). `lint` failed with "action not allowed — must be pinned", cascading to `markdownlint=SKIPPED` (declared `needs: lint`). All 107 PRs showed `mergeable=MERGEABLE` + `mergeStateStatus=BLOCKED`. Parallel Myrmidon Haiku swarm rebased each PR onto main (~9 PRs/agent in isolated worktrees, `--force-with-lease`). Skill PRs touching only `skills/*.md` rebased cleanly (0 conflicts). After push, CI re-ran with pinned actions, `lint` passed, `markdownlint` ran to success, auto-merge-armed PRs merged. Secondary: 107 PRs exhibited combined-status `pending` (count=0) caching; empty signed commit forced recompute and cleared the block. **verified-ci** | verified-ci |


### PR DESCRIPTION
## Summary

Amends `skills/pr-rebase-conflict-resolution-patterns.md` from v1.3.0 → v1.4.0 to capture a new, distinct class of stale PR: branches carrying unpinned GitHub Actions that are blocked by an org-wide SHA-pin policy.

**Root cause chain (verified-ci: 107 PRs, ProjectMnemosyne 2026-06-13):**

1. Org-wide policy PR pinned all GHA to full commit SHAs; unpinned refs now forbidden
2. Stale skill PR branches carry `actions/setup-python@v6` in workflow files
3. `lint` job fails: _"The action X is not allowed — must be pinned to full-length commit SHA"_
4. Required `markdownlint` job is declared `needs: lint` → GitHub marks it `SKIPPED`
5. Branch protection: `SKIPPED ≠ satisfied` → PR stays `mergeStateStatus=BLOCKED` even though `mergeable=MERGEABLE`

**Fix:** rebase onto current main (inherits pinned workflow files). **Empty re-trigger commit does NOT fix it** — it runs the same unpinned workflow again.

## Changes

- **Trigger (13)** added to frontmatter description: BLOCKED+MERGEABLE with a required check SKIPPED via `needs:` chain collapse from unpinned-action lint failure
- **When to Use** bullet for the SHA-pin SKIPPED-required-check scenario
- **Section J** — full diagnostic playbook: root-cause chain, `gh pr view --json statusCheckRollup` / `gh run view --log-failed | grep 'not allowed'` diagnosis commands, single-PR rebase fix, combined-status `pending` (count=0) caching companion fix (empty signed commit), Myrmidon Haiku swarm pattern for 100+ PRs
- **4 Failed Attempts rows:**
  - Empty re-trigger commit (runs same unpinned workflow — fails identically)
  - Auto-merge armed before rebase while BLOCKED (ignored by GitHub)
  - `git checkout --ours/--theirs` during rebase (blocked by Safety Net)
  - Diagnosing as code failure rather than workflow-file staleness
- **SHA-pin diagnosis + fix commands** appended to Results & Parameters
- **Verified On** row: ProjectMnemosyne 2026-06-13, 107 PRs rebased via parallel Haiku swarm, verified-ci
- **History** entry for v1.4.0; back-filled v1.3.0 entry

## Test plan

- [x] `python3 scripts/validate_plugins.py` → 387/387 valid
- [x] Pre-commit hooks pass (trim whitespace, end-of-file, large-files, GPG sign)
- [x] Branch history is clean (1 commit, signed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)