### PR TITLE
feat: amend bash-stderr skills to verified-ci (PR #1273)

### DIFF
--- a/skills/bash-stderr-jq-separation.md
+++ b/skills/bash-stderr-jq-separation.md
@@ -2,10 +2,10 @@
 name: bash-stderr-jq-separation
 description: "Pattern for separating stderr from stdout in bash functions that pipe command output into jq. Use when: (1) a bash function captures CLI output (gh api, curl, etc.) for JSON parsing, (2) the command may emit stderr warnings/banners alongside valid JSON stdout, (3) 2>&1 is used to combine channels before piping into jq — this corrupts JSON parsing."
 category: debugging
-date: 2026-06-12
-version: "1.0.0"
+date: 2026-06-14
+version: "1.1.0"
 user-invocable: false
-verification: unverified
+verification: verified-ci
 tags:
   - bash
   - stderr
@@ -28,7 +28,7 @@ tags:
 | **Date** | 2026-06-12 |
 | **Objective** | Prevent gh/curl stderr noise (warnings, banners, debug traces) from corrupting jq JSON input |
 | **Outcome** | mktemp + trap RETURN pattern cleanly separates channels; dedicated regression test guards against re-introduction |
-| **Verification** | unverified — plan not yet implemented in CI |
+| **Verification** | verified-ci — PR #1273 (issue #1122) confirmed all CI checks green |
 
 ## When to Use
 
@@ -39,8 +39,6 @@ tags:
 - Adding a regression guard test: the stderr-noise test is the correct guard, not the happy-path test alone
 
 ## Verified Workflow
-
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
 
 ### Quick Reference
 
@@ -152,9 +150,15 @@ choose_merge_flag owner/repo
 # With mktemp fix: --rebase (exit 0)
 ```
 
-**Count of tests the plan adds:**
+**Regression tests added in PR #1273 (5 tests):**
 
-The issue body specifies 3 required tests. The plan adds a 4th (stderr-noise regression guard). The reviewer should confirm whether 4 tests are welcome or the plan should be trimmed to 3 (dropping the dedicated regression test and relying on the general stderr-noise assertion).
+| Test | What It Guards |
+|------|----------------|
+| `test_shell_helper_handles_gh_stderr_noise` | Direct regression: fails against old `2>&1` version, passes with fix |
+| `test_shell_helper_selects_rebase_when_all_allowed` | Preference order: rebase wins when all methods allowed |
+| `test_shell_helper_selects_squash_when_rebase_disallowed` | Fallback to squash when rebase disabled |
+| `test_shell_helper_exits_1_when_no_methods_allowed` | Error path: exit 1 when no merge methods enabled |
+| `test_shell_helper_selects_merge_when_rebase_and_squash_disallowed` | Merge commit fallback |
 
 **jq boolean fields and `//` operator:**
 
@@ -164,4 +168,4 @@ If the script uses `jq -r '... | .[0] // ""'`, ensure the `// ""` is applied to 
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | Issue #1125 planning (unverified) | `scripts/choose_merge_flag.sh:21` fix + `tests/integration/test_choose_merge_flag_sh.py` |
+| ProjectHephaestus | Issue #1122 / PR #1273 — `scripts/choose_merge_flag.sh:21` fix + 5 regression tests | All CI checks green: lint, shell-tests, integration-tests, shell-check |

--- a/skills/bash-stderr-mktemp-trap-return.md
+++ b/skills/bash-stderr-mktemp-trap-return.md
@@ -2,11 +2,19 @@
 name: bash-stderr-mktemp-trap-return
 description: "Pattern for separating stderr from stdout in bash functions using mktemp + trap RETURN. Use when: (1) a bash function calls a tool that mixes stderr into stdout (e.g., 2>&1 corrupts jq input), (2) you need clean stdout for piping while still capturing error details, (3) function uses local temp files that need guaranteed cleanup."
 category: debugging
-date: 2026-06-12
-version: "1.0.0"
+date: 2026-06-14
+version: "1.1.0"
 user-invocable: false
-verification: unverified
-tags: []
+verification: verified-ci
+tags:
+  - bash
+  - stderr
+  - mktemp
+  - trap
+  - RETURN
+  - jq
+  - gh
+  - json
 ---
 
 # Bash stderr/stdout Separation: mktemp + trap RETURN
@@ -17,8 +25,8 @@ tags: []
 |-------|-------|
 | **Date** | 2026-06-12 |
 | **Objective** | Separate stderr from stdout in bash functions so tools like `jq` receive clean JSON input |
-| **Outcome** | Proposed pattern — not yet validated in CI |
-| **Verification** | unverified |
+| **Outcome** | mktemp + trap RETURN confirmed; all CI checks green in PR #1273 |
+| **Verification** | verified-ci — PR #1273 (issue #1122) |
 
 ## When to Use
 
@@ -28,8 +36,6 @@ tags: []
 - The script uses `#!/usr/bin/env bash` — the pattern relies on bash-specific `trap RETURN`
 
 ## Verified Workflow
-
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
 
 ### Quick Reference
 
@@ -100,12 +106,10 @@ result=$(external_tool --json-output 2>"$_err_file") || {
 # result is now clean, pipe-safe stdout
 ```
 
-**Verification status**: The pattern is theoretically sound per bash manual (trap RETURN described in bash 4.x+). Not yet confirmed in the CI environment for ProjectHephaestus. Bash version >=4.2 required for reliable `trap RETURN` behavior in sourced functions.
-
-**Source**: Planning notes for ProjectHephaestus issue #1125 (`choose_merge_flag.sh` stderr/jq fix).
+**Verification status**: Confirmed in CI — PR #1273 (issue #1122). Bash version >=4.2 required for reliable `trap RETURN` behavior in sourced functions.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | Issue #1125 planning — proposed fix for `scripts/choose_merge_flag.sh:21` | Pattern designed, not yet CI-validated |
+| ProjectHephaestus | Issue #1122 / PR #1273 — `scripts/choose_merge_flag.sh:21` + 5 regression tests | All CI checks green: lint, shell-tests, integration-tests, shell-check |


### PR DESCRIPTION
## Summary

- Bumps `bash-stderr-jq-separation` v1.0.0 `unverified` → v1.1.0 `verified-ci`
- Bumps `bash-stderr-mktemp-trap-return` v1.0.0 `unverified` → v1.1.0 `verified-ci`
- Removes the "Warning: not yet validated" caveat blocks from both skills
- Adds regression test inventory (5 tests added in PR #1273) to `bash-stderr-jq-separation`
- Updates Verified On tables to cite ProjectHephaestus issue #1122 / PR #1273 with CI evidence

## Verification Level

**verified-ci** — ProjectHephaestus PR #1273 (issue #1122) fixed `scripts/choose_merge_flag.sh:21`
by replacing `raw=$(gh api "repos/${repo}" 2>&1)` with `raw=$(gh api "repos/${repo}" 2>"$_err_file")`.
All CI checks passed: lint, shell-tests, integration-tests, shell-check.

## Key Findings

**Root cause**: `raw=$(gh api ... 2>&1)` mixed stdout JSON and stderr warnings into a single variable.
When piped to `jq`, any leading non-JSON stderr noise (deprecation banners, rate-limit notices,
`GH_DEBUG` traces) caused `jq` to fail with a parse error, producing spurious exit 1.

**Fix**: Redirect stderr to a temp file (`2>"$_err_file"`), keeping `$raw` as clean JSON only.
Error messages now read from the temp file rather than from `$raw`.

**5 regression tests added**:
- `test_shell_helper_handles_gh_stderr_noise` — direct regression guard (fails against old `2>&1`)
- `test_shell_helper_selects_rebase_when_all_allowed`
- `test_shell_helper_selects_squash_when_rebase_disallowed`
- `test_shell_helper_exits_1_when_no_methods_allowed`
- `test_shell_helper_selects_merge_when_rebase_and_squash_disallowed`

## Test Plan

- [x] `markdownlint-cli2` — 0 errors on both amended files
- [x] `python3 scripts/validate_plugins.py` — 389/389 valid
- [x] Signed commit verified (`gpg: Good signature`)
- [ ] CI gate passes (pending)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>