### PR TITLE
feat: amend dependency-floor-near-tested-version skill (v1.2.0)

### DIFF
--- a/skills/dependency-floor-near-tested-version.history
+++ b/skills/dependency-floor-near-tested-version.history
@@ -1,5 +1,47 @@
 # dependency-floor-near-tested-version — History
 
+## v1.2.0 (2026-06-14)
+
+**Changed by:** Issue #1202 / PR #1295 — first green CI run of this pattern
+**Verification:** verified-ci
+
+### What changed
+
+- Bumped verification from `unverified` to `verified-ci` — PR #1295 passed all CI gates (lint, unit-tests, integration-tests, markdownlint)
+- Updated Outcome in Overview table from "pending" to "verified-ci"
+- Removed the "Warning: not validated" blockquote from Verified Workflow (now confirmed)
+- Added pip-specific two-sided bound pattern to When to Use, Quick Reference, Detailed Steps, and Results & Parameters
+- Added `TestPipPinning` test class template (uses `_floor(spec)` and `_upper_cap(spec)` directly — does NOT use `TestPytestConsistency._find_dep()`)
+- Added "Choosing Between Test Patterns" table distinguishing dev-tools (cross-manifest) from load-bearing packages (absolute bounds)
+- Added Failed Attempts row: "Rebasing onto main after sibling issue landed" — rebase conflict in test file when `TestRuffConsistency` (from #1201) had already merged
+- Added pip to Verified On table: Issue #1202 / PR #1295, pip pinned `>=23.0,<27`, lock at 26.1.2
+- Updated pixi.toml lookup key notes for pip (`pixi["dependencies"]["pip"]` — top-level section)
+- Bumped version to 1.2.0, updated date to 2026-06-14
+
+### Why
+
+PR #1295 (issue #1202) pinned pip in `pixi.toml` from `"*"` to `">=23.0,<27"` and added `TestPipPinning`
+to `tests/unit/scripts/test_dependency_floor_consistency.py`. All CI gates passed, making this the
+first end-to-end validated run of the dependency-floor pattern. Key learnings:
+
+1. **pip requires two-sided bound** (unlike ruff which only needed a floor raise). pip floor=23.0
+   because that is the first stable PEP 660 editable-install release; cap = `installed_major + 1`
+   (pip 26.x installed → cap `<27`).
+2. **Test pattern differs**: `TestPipPinning` uses `_floor(spec)` and `_upper_cap(spec)` directly
+   and does NOT use `TestPytestConsistency._find_dep()`. The ruff tests check cross-manifest
+   consistency; pip tests check absolute bounds enforcement.
+3. **Lock re-solve not needed**: `pixi.lock` already satisfied `>=23.0,<27` (pip 26.1.2 in lock).
+4. **CI failure was a rebase conflict**: The branch was based on an older main that did not have
+   `TestRuffConsistency` (from issue #1201, which landed on main first). Fix: rebase onto
+   origin/main, keep both test classes, apply ruff auto-fixes surfaced by the rebase.
+
+### Previous version (v1.1.0) snapshot
+
+The v1.1.0 entry remains immediately below this entry (unchanged). The v1.1.0-rendered .md file
+content prior to v1.2.0 edits is preserved in git history at the parent commit of this amendment.
+
+---
+
 ## v1.1.0 (2026-06-13)
 
 **Changed by:** Issue #1201 plan review (NOGO → GO after DRY fix)

--- a/skills/dependency-floor-near-tested-version.md
+++ b/skills/dependency-floor-near-tested-version.md
@@ -1,11 +1,11 @@
 ---
 name: dependency-floor-near-tested-version
-description: "Pattern for raising a tool's version floor to match the tested minor version. Use when: (1) a dependency floor is much lower than the CI-resolved version, (2) adding a cross-manifest consistency regression guard for a dev tool."
+description: "Pattern for raising a tool's version floor to match the tested minor version. Use when: (1) a dependency floor is much lower than the CI-resolved version, (2) adding a cross-manifest consistency regression guard for a dev tool, (3) a load-bearing package (pip, setuptools) needs a two-sided bound, not just a floor raise."
 category: ci-cd
-date: 2026-06-13
-version: "1.1.0"
+date: 2026-06-14
+version: "1.2.0"
 user-invocable: false
-verification: unverified
+verification: verified-ci
 history: dependency-floor-near-tested-version.history
 tags: []
 ---
@@ -16,10 +16,10 @@ tags: []
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-13 |
-| **Objective** | Raise a dev tool's floor (e.g., `ruff>=0.1.0`) to match the tested minor (`>=0.15`) and add a cross-manifest regression guard |
-| **Outcome** | Plan approved (NOGO→GO after DRY fix); implementation pending |
-| **Verification** | unverified |
+| **Date** | 2026-06-14 |
+| **Objective** | Raise a dev tool's floor (e.g., `ruff>=0.1.0`) to match the tested minor (`>=0.15`) and add a cross-manifest regression guard; or add two-sided bounds for load-bearing packages (e.g., pip `>=23.0,<27`) |
+| **Outcome** | verified-ci |
+| **Verification** | verified-ci |
 | **History** | [changelog](./dependency-floor-near-tested-version.history) |
 
 ## When to Use
@@ -27,10 +27,9 @@ tags: []
 - A dependency floor in `pyproject.toml` or `pixi.toml` is much lower than what the lock resolves (e.g., `>=0.1.0` but lock resolves `0.15.12`)
 - A dev tool (ruff, mypy, pytest) has no cross-manifest consistency test in `tests/unit/scripts/test_dependency_floor_consistency.py`
 - A pip-install `.[dev]` consumer could land on a version with a different default behavior than CI enforces
+- A load-bearing package (pip, setuptools) needs a two-sided bound, not just a floor raise
 
 ## Verified Workflow
-
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
 
 ### Quick Reference
 
@@ -42,10 +41,16 @@ grep "name: ruff" pixi.lock   # or grep the conda URL
 # pyproject.toml: "ruff>=0.1.0,<1" → "ruff>=0.15,<1"
 # pixi.toml [feature.shared.dependencies]: ruff = ">=0.1.0,<1" → ruff = ">=0.15,<1"
 
+# For two-sided bounds (pip, setuptools):
+# pixi.toml: pip = "*" → pip = ">=23.0,<27"
+# where cap = installed_major + 1 (pip 26.x → <27)
+
 # 3. No lock re-solve needed if lock already satisfies the new floor
 # (0.15.12 satisfies >=0.15 — pixi install not required)
+# (pip 26.1.2 satisfies >=23.0,<27 — pixi install not required)
 
-# 4. Add TestRuffConsistency to tests/unit/scripts/test_dependency_floor_consistency.py
+# 4a. Add TestRuffConsistency (cross-manifest pattern) to tests/unit/scripts/test_dependency_floor_consistency.py
+# 4b. Add TestPipPinning (absolute bounds pattern) for load-bearing packages
 
 # 5. Run verification
 pixi run pytest tests/unit/scripts/test_dependency_floor_consistency.py -v
@@ -57,12 +62,18 @@ pixi run ruff check hephaestus scripts tests
 1. Grep the lock to confirm the resolved version: `grep "ruff-" pixi.lock | grep conda`
 2. Check all pixi.toml locations: `grep -n "ruff" pixi.toml` — confirm only one entry exists
 3. Raise the floor in both `pyproject.toml` and `pixi.toml` to `>=<tested_minor>`
-4. Add a `TestXxxConsistency` class to `test_dependency_floor_consistency.py` mirroring `TestPytestConsistency` (lines 231–331):
-   - **Reuse `TestPytestConsistency._find_dep(dev_deps, "ruff")`** — do NOT copy/duplicate the helper; it already accepts a `name` parameter for exactly this purpose
-   - Add `test_xxx_floor_matches_across_manifests` and `test_xxx_upper_cap_matches_across_manifests`
-   - Do NOT add a hardcoded sentinel test (`assert floor >= Version("0.15")`) — it goes stale
-   - Add a docstring note if the test only checks one pixi feature section (e.g., `[feature.shared]`)
+   - For load-bearing packages: set two-sided bound — floor = first stable release with the required feature, cap = `installed_major + 1`
+4. Choose the correct test pattern:
+   - **Cross-manifest consistency** (dev tools like ruff, mypy): `TestXxxConsistency` reusing `TestPytestConsistency._find_dep(dev_deps, name)` — do NOT copy/duplicate the helper
+   - **Absolute bounds enforcement** (load-bearing packages like pip): `TestPipPinning` using `_floor(spec)` and `_upper_cap(spec)` directly — does NOT use `TestPytestConsistency._find_dep()`
 5. Verify the lock is still valid (`pixi run pytest` — if the lock satisfies the new floor, no re-solve needed)
+
+### Choosing Between Test Patterns
+
+| Package type | Test class pattern | Helpers used |
+|---|---|---|
+| Dev tools (ruff, mypy, pytest) | `TestRuffConsistency` — cross-manifest | `TestPytestConsistency._find_dep(dev_deps, name)` |
+| Load-bearing (pip, setuptools) | `TestPipPinning` — absolute bounds | `_floor(spec)`, `_upper_cap(spec)` directly |
 
 ## Failed Attempts
 
@@ -72,14 +83,18 @@ pixi run ruff check hephaestus scripts tests
 | `dep.startswith("ruff")` | Simple prefix check to find ruff in dev_deps list | Would match `ruff-lsp` or other ruff-prefixed packages | Use PEP 508 specifier splitting via the existing `_find_dep(dev_deps, name)` helper |
 | Copying `_find_dep` as new per-class helper | Defined `_find_ruff_dep` as verbatim copy of `TestPytestConsistency._find_dep` with `"ruff"` hardcoded | DRY violation; reviewer NOGO'd; `_find_dep` already takes `name` parameter | Call `TestPytestConsistency._find_dep(dev_deps, "ruff")` directly |
 | Separate pre-commit script | `scripts/check_ruff_floor_consistency.py` + pre-commit hook | Disproportionate for a single constraint; unit tests already run in CI | The existing `test_dependency_floor_consistency.py` gate is sufficient |
+| Rebasing onto main after sibling issue landed | Branch based on older main without `TestRuffConsistency` (from #1201, which landed first) | Rebase conflict in `test_dependency_floor_consistency.py` — add/add conflict on the test class | Rebase onto origin/main, keep both test classes (`TestRuffConsistency` from #1201 and `TestPipPinning` from #1202), then apply ruff auto-fixes surfaced by the rebase |
 
 ## Results & Parameters
 
 **Floor target**: `>=<tested_minor>` where tested_minor is the first two version components of the lock-resolved version (e.g., `0.15.12` → `>=0.15`).
 
-**Upper cap**: Keep unchanged (`<1` for ruff, `<3` for mypy) — consistent with existing patterns.
+**Upper cap (dev tools)**: Keep unchanged (`<1` for ruff, `<3` for mypy) — consistent with existing patterns.
 
-**Test class pattern** (approved template — reuses existing helper, no duplication):
+**Upper cap (load-bearing packages)**: `installed_major + 1` (e.g., pip 26.x installed → cap `<27`). Floor = first stable release with the required feature (pip `>=23.0` = first stable PEP 660 editable-install release).
+
+**Test class pattern — ruff/dev-tools** (cross-manifest, reuses existing helper):
+
 ```python
 class TestRuffConsistency:
     """Tests for ruff floor/cap consistency across pyproject.toml and pixi.toml.
@@ -109,10 +124,42 @@ class TestRuffConsistency:
         ...
 ```
 
-**pixi.toml lookup key**: `pixi["feature"]["shared"]["dependencies"]["ruff"]` (not `feature.lint` — ruff is in `feature.shared`)
+**Test class pattern — pip/load-bearing** (absolute bounds, uses `_floor` and `_upper_cap` directly):
+
+```python
+class TestPipPinning:
+    """Tests that pip is pinned with a floor and an upper cap in pixi.toml.
+
+    pip>=23.0 is required for reliable PEP 660 editable-install support.
+    The upper cap (<installed_major+1) prevents silent breakage on major bumps.
+    """
+
+    def _get_pip_spec(self, repo_root: Path) -> str:
+        with open(repo_root / "pixi.toml", "rb") as f:
+            pixi = tomllib.load(f)
+        return pixi["dependencies"]["pip"]
+
+    def test_pip_has_floor(self, repo_root: Path) -> None:
+        spec = self._get_pip_spec(repo_root)
+        floor = _floor(spec)
+        assert floor is not None, "pip must have a lower bound in pixi.toml"
+        assert Version(floor) >= Version("23.0"), (
+            f"pip floor {floor!r} is below 23.0 — PEP 660 editable-install requires pip>=23.0"
+        )
+
+    def test_pip_has_upper_cap(self, repo_root: Path) -> None:
+        spec = self._get_pip_spec(repo_root)
+        cap = _upper_cap(spec)
+        assert cap is not None, (
+            "pip must have an upper cap in pixi.toml to prevent silent breakage on major bumps"
+        )
+```
+
+**pixi.toml lookup key**: `pixi["feature"]["shared"]["dependencies"]["ruff"]` (not `feature.lint` — ruff is in `feature.shared`); `pixi["dependencies"]["pip"]` for pip (top-level dependencies section).
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectHephaestus | Issue #1201 planning (plan approved after v1.1.0 DRY fix) | ruff floor >=0.1.0 → >=0.15; lock at 0.15.12 |
+| ProjectHephaestus | Issue #1202 / PR #1295 (green CI) | pip pinned `>=23.0,<27`; lock at 26.1.2; `TestPipPinning` added to test_dependency_floor_consistency.py |


### PR DESCRIPTION
## Summary

- Promotes `dependency-floor-near-tested-version` from `unverified` to `verified-ci` — PR #1295 in ProjectHephaestus (issue #1202) passed all CI gates (lint, unit-tests, integration-tests, markdownlint)
- Adds pip-specific two-sided bound pattern: floor=`>=23.0` (first stable PEP 660 editable-install release), cap=`installed_major+1` (pip 26.x → `<27`)
- Adds `TestPipPinning` test class template using `_floor(spec)` and `_upper_cap(spec)` directly (does NOT use `TestPytestConsistency._find_dep()` — different concern from dev-tool cross-manifest checks)
- Adds "Choosing Between Test Patterns" decision table (dev-tools cross-manifest vs load-bearing absolute bounds)
- Adds Failed Attempts row: rebase conflict when sibling issue #1201 (`TestRuffConsistency`) landed on main first — fix is rebase + keep both test classes + apply ruff auto-fixes
- Adds ProjectHephaestus Issue #1202 / PR #1295 to Verified On table
- Removes the "Warning: not validated" blockquote (now verified)
- History file uses reference-style v1.1.0 snapshot to avoid markdownlint MD024 duplicate-heading false positives from nested code blocks

## Test plan

- [x] `npx markdownlint-cli2` passes on both files (0 errors)
- [x] `python3 scripts/validate_plugins.py` passes (389/389 valid)
- [x] Signed commit verified (`gpg: Good signature`)
- [x] CI will run validate-plugins, markdownlint, unit-tests, integration-tests