### PR TITLE
feat: amend github-auto-merge-ci-gating-merge-method skill (v1.3.0)

### DIFF
--- a/skills/github-auto-merge-ci-gating-merge-method.history
+++ b/skills/github-auto-merge-ci-gating-merge-method.history
@@ -2,6 +2,47 @@
 
 # History: github-auto-merge-ci-gating-merge-method
 
+## v1.3.0 (2026-06-14)
+
+Expanded unresolved review thread diagnostic to **verified-ci** status and added full
+GraphQL copy-paste workflow (PR #1282 ProjectHephaestus, merged 2026-06-15T03:05:38Z):
+
+- **What changed:**
+  - Updated `description` field to add item (12): `mergeStateStatus=BLOCKED` with all CI
+    green and auto-merge armed — unresolved review threads are the PRIMARY blocker to check
+    FIRST before assuming CI failure.
+  - Updated `version` 1.2.0 → 1.3.0.
+  - Added tags: `review-threads`, `resolveReviewThread`.
+  - Added a new Overview row documenting the verified-ci PR #1282 finding.
+  - Added a new "When to Use" bullet: PR BLOCKED with all CI green and auto-merge armed →
+    unresolved review threads first.
+  - Added new `#### Unresolved review threads as primary BLOCKED diagnostic (verified-ci)`
+    detailed step with: stale-UI-trap warning, full diagnostic order (3 steps), copy-paste
+    GraphQL for thread query + `addPullRequestReviewThreadReply` + `resolveReviewThread`,
+    rules for resolving (only when concern genuinely addressed, cite commit SHA, CodeQL
+    classify first), and the `BLOCKED → UNKNOWN → MERGED` transition description.
+  - Updated the decision tree "all required checks green but BLOCKED" branch to call out
+    CHECK REVIEW THREADS FIRST with step numbers.
+  - Added two Failed Attempts rows: (a) assumed CI failure from stale UI; (b) waited for
+    auto-merge to self-trigger when BLOCKED with CI green.
+  - Added a new Verified On row: ProjectHephaestus PR #1282 merged at
+    2026-06-15T03:05:38Z by app/github-actions (verified-ci).
+- **Why:** The v1.2.0 skill mentioned review threads briefly (1 line in quick reference,
+  1 line in decision tree) but had no verified-ci case, no copy-paste GraphQL mutations
+  for the reply+resolve workflow, and no explicit call to check threads FIRST before
+  reinvestigating CI. PR #1282 was BLOCKED for an extended period because the stated
+  "lint failure" was stale; two unresolved threads were the actual blockers. Promoting
+  this from advisory to a primary diagnostic step with verified-ci evidence is the key
+  update.
+- **Verification:** verified-ci — PR #1282 ProjectHephaestus (`1315-harden-ci-required-gate`)
+  merged at 2026-06-15T03:05:38Z by `app/github-actions` auto-merge within seconds of
+  resolving 2 unresolved review threads via `resolveReviewThread` GraphQL mutation.
+- Bump version 1.2.0 → 1.3.0.
+
+### Snapshot of v1.2.0 (archived before the v1.3.0 edit)
+
+---
+
 ## v1.2.0 (2026-06-14)
 
 Add three new merge-blocking failure modes observed live while driving 13 open

--- a/skills/github-auto-merge-ci-gating-merge-method.md
+++ b/skills/github-auto-merge-ci-gating-merge-method.md
@@ -1,9 +1,9 @@
 ---
 name: github-auto-merge-ci-gating-merge-method
-description: "Use when: (1) a PR has mergeStateStatus CLEAN or MERGEABLE but auto-merge never fires despite all checks passing, (2) gh pr merge --auto --rebase or --squash returns an error or silently fails on a squash-only repo, (3) a PR is BLOCKED because required CI status contexts never post (workflow never triggered, paths filter excluded PR, required check name mismatch), (4) GPG-signing failures or mismatched committer emails cause commits to be unsigned and block the pr-policy gate, (5) branch protection rulesets and classic branch protection disagree and their union blocks merge, (6) a CI ruleset chicken-and-egg deadlock blocks a PR that introduces a new workflow, (7) an advisory check should not block merge but currently does because it lives in the required gate, (8) deciding which merge method a repo supports before arming auto-merge, (9) auditing required-check names after adding or removing CI jobs, (10) state:implementation-go label or pr-policy gates auto-merge arming, (11) per-issue arming-state machine is triggered on the wrong event (optimistic point vs detected merge)"
+description: "Use when: (1) a PR has mergeStateStatus CLEAN or MERGEABLE but auto-merge never fires despite all checks passing, (2) gh pr merge --auto --rebase or --squash returns an error or silently fails on a squash-only repo, (3) a PR is BLOCKED because required CI status contexts never post (workflow never triggered, paths filter excluded PR, required check name mismatch), (4) GPG-signing failures or mismatched committer emails cause commits to be unsigned and block the pr-policy gate, (5) branch protection rulesets and classic branch protection disagree and their union blocks merge, (6) a CI ruleset chicken-and-egg deadlock blocks a PR that introduces a new workflow, (7) an advisory check should not block merge but currently does because it lives in the required gate, (8) deciding which merge method a repo supports before arming auto-merge, (9) auditing required-check names after adding or removing CI jobs, (10) state:implementation-go label or pr-policy gates auto-merge arming, (11) per-issue arming-state machine is triggered on the wrong event (optimistic point vs detected merge), (12) mergeStateStatus=BLOCKED with all CI green and auto-merge armed — unresolved review threads are the PRIMARY blocker to check FIRST before assuming CI failure"
 category: ci-cd
 date: 2026-06-14
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
 history: github-auto-merge-ci-gating-merge-method.history
 tags:
@@ -19,6 +19,8 @@ tags:
   - implementation-go
   - gpg-signing
   - arming-state-machine
+  - review-threads
+  - resolveReviewThread
 ---
 
 # GitHub Auto-Merge: CI Gating, Branch Protection, and Merge Method
@@ -29,6 +31,7 @@ tags:
 | ------ | ----------- | --------- |
 | 2026-06-07 | Consolidated canonical for why GitHub auto-merge does not fire and how to arm it correctly: wrong merge method, missing/required CI status contexts, two-layer branch protection, GPG-signing blockers, ruleset bootstrap deadlock, the `state:implementation-go` arming-state machine, and advisory-vs-required gate split | Each failure mode has a verified diagnosis + fix; verified across many HomericIntelligence repos in live CI |
 | 2026-06-14 | Add the classic-vs-ruleset review-count UNION hard gate (a required human approval automation cannot provide), the keystone-PR self-introduced-required-context merge-train deadlock (merge keystone first, then re-rebase the queue), and duplicate check-run resolution after a re-run | Diagnosed live across 13 open ProjectHephaestus PRs during a `/myrmidon-swarm` drive (verified-local; the PRs had not yet merged at capture, the review-union gate was confirmed by API inspection) |
+| 2026-06-14 | Expanded unresolved review thread diagnostic to verified-ci status: PR #1282 was BLOCKED despite all CI green and auto-merge armed; the stated "lint failure" was stale; the real blockers were 2 unresolved review threads. Resolving via `resolveReviewThread` GraphQL mutation immediately triggered auto-merge (merged 2026-06-15T03:05:38Z by app/github-actions). Added full GraphQL copy-paste workflow for thread query + reply + resolve. | verified-ci — PR #1282 ProjectHephaestus merged within seconds of thread resolution |
 
 GitHub auto-merge is **stricter than branch protection** and fires only when EVERY check (required and non-required) reaches a clean terminal state, the chosen merge method is allowed, every required status context has actually posted, all commits are verified-signed, and BOTH protection layers (ruleset + classic) are satisfied. A PR that looks ready (`mergeStateStatus: CLEAN`/`MERGEABLE`) can sit forever when any one of those is silently unmet. This skill covers the merge-blocking mechanics; it does NOT cover general CI failure diagnosis, rebase-conflict resolution, review-loop orchestration, or PR enumeration.
 
@@ -46,6 +49,7 @@ GitHub auto-merge is **stricter than branch protection** and fires only when EVE
 - Deciding which merge method a repo supports before arming auto-merge; auditing required-check names after adding/removing CI jobs.
 - `pr-policy` fails on premature auto-merge: `Auto-merge is enabled before implementation review GO` (or the inverse, label present but auto-merge off).
 - A post-CI `/learn` (or any capture step) fires on the optimistic point (auto-merge armed) instead of the truth (detected merge), polluting downstream state.
+- **A PR is `BLOCKED` with all CI checks green and auto-merge already armed** — unresolved review threads are the PRIMARY blocker to check FIRST (verified-ci: PR #1282 merged immediately after thread resolution).
 
 ## Verified Workflow
 
@@ -247,6 +251,85 @@ cancelled duplicate run, re-run the FAILED run (`gh run rerun <id> --failed`) so
 a single success. Beware: a rerun re-evaluates `changes-gate` and may flip most NON-required jobs to
 `SKIPPED` (fine — only the named required contexts matter). Do NOT chase `SKIPPED` non-required jobs.
 
+#### Unresolved review threads as primary BLOCKED diagnostic (verified-ci)
+
+**FIRST check when `mergeStateStatus=BLOCKED` with all CI green and auto-merge armed.** A PR can be
+stuck in BLOCKED even though every status check shows SUCCESS, `reviewDecision` is not CHANGES_REQUESTED,
+and auto-merge is armed. The hidden cause: the repo has `required_review_thread_resolution: true` in
+classic branch protection, and one or more review threads (from bots, CodeQL, or human reviewers)
+are unresolved. GitHub silently blocks the merge engine.
+
+**Critical diagnostic order:**
+1. `gh pr checks <PR>` — verify all checks are genuinely green NOW (not reading stale UI)
+2. `gh pr view <PR> --json mergeStateStatus,autoMergeRequest,reviewDecision` — confirm BLOCKED+armed
+3. Query threads (see below) — look for `isResolved: false` entries
+
+**Stale UI trap**: GitHub's PR page can display an error message (e.g. "lint failure") from a prior
+run that has since been fixed. Always verify the CURRENT CI state via `gh pr checks` or
+`gh api .../commits/SHA/check-runs` before investigating CI jobs.
+
+```bash
+# Step 1 — Verify current CI state (not the UI which may show stale errors)
+gh pr checks <PR_NUMBER>
+
+# Step 2 — Check merge state
+gh pr view <PR_NUMBER> --json mergeStateStatus,autoMergeRequest,reviewDecision
+
+# Step 3 — List all review threads and find unresolved ones
+gh api graphql -f query='
+query($owner:String!,$name:String!,$num:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$num){
+      reviewThreads(first:50){
+        nodes{
+          isResolved
+          id
+          comments(first:10){
+            nodes{
+              author{login}
+              body
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}' -F owner=HomericIntelligence -F name=ProjectHephaestus -F num=<PR_NUMBER>
+
+# Step 4 — Reply to thread citing fixing commit (do this before resolving)
+gh api graphql -f query='
+mutation($threadId:ID!,$body:String!){
+  addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body}){
+    comment{id}
+  }
+}' -F threadId="PRRT_<id>" -F body="Addressed in commit <SHA>: <brief explanation>"
+
+# Step 5 — Resolve the thread
+gh api graphql -f query='
+mutation($id:ID!){
+  resolveReviewThread(input:{threadId:$id}){
+    thread{isResolved}
+  }
+}' -F id="PRRT_<id>"
+
+# Step 6 — Verify (mergeStateStatus briefly goes UNKNOWN, then auto-merge fires)
+gh pr view <PR_NUMBER> --json mergeStateStatus,state
+```
+
+**After resolving all unresolved threads**: `mergeStateStatus` transitions `BLOCKED` → `UNKNOWN` →
+auto-merge fires within seconds. The UNKNOWN state is transient and expected — do NOT re-arm
+auto-merge during this window.
+
+**Rules for resolving threads:**
+- Only resolve a thread where the concern is GENUINELY addressed by committed code. Cite the fixing commit SHA in your reply.
+- Do NOT resolve threads that represent open issues or open questions as a workaround.
+- If a thread is from `@github-advanced-security` (CodeQL), classify as false-positive vs genuine before resolving. Note: `dismissed_comment` max length is 280 chars (HTTP 422 otherwise).
+- A force-push amend re-runs CodeQL and can post NEW threads — re-check thread count after any amend.
+
+**Verification:** PR #1282 ProjectHephaestus (branch `1315-harden-ci-required-gate`): 2 unresolved threads, all CI green, auto-merge armed. Resolved both threads via `resolveReviewThread`; PR merged at 2026-06-15T03:05:38Z by `app/github-actions` within seconds. **verified-ci.**
+
 #### GPG-signing as a blocker
 
 The ruleset's `required_signatures` silently blocks unsigned commits, and a `pr-policy` gate often re-checks signatures via GraphQL `verified: true`. Mismatched committer emails or a missing `-S` produce unsigned commits that block merge with no obvious failing test. `git log --show-signature` showing `U` (good signature, untrusted local key) is FINE — GitHub verifies against the REGISTERED key. Always sign with `-S`; an empty re-trigger commit must also be signed or it is rejected by the same gate it is trying to unblock.
@@ -314,6 +397,8 @@ Two distinct state machines gate arming:
 | Assumed auto-merge waits for the LATEST commit's CI under `strict: false` | Trusted that a fired auto-merge meant the merged tip's CI had passed | `strict_required_status_checks_policy: false` accepts passing checks from a PRIOR commit SHA, so the newest commit's CI can still be QUEUED when auto-merge fires and merges | Check `gh api .../branches/main/protection/required_status_checks --jq .strict`; under `false`, stale-CI merges are expected behavior, not a fault |
 | Assumed all-green + auto-merge armed ⇒ will merge | Left ~13 MERGEABLE+armed PRs expecting them to fire | A CLASSIC protection `required_approving_review_count: 1` (UNION with a ruleset's `0`) requires 1 human APPROVING review the automation cannot provide; `viewerCanEnableAutoMerge=false` | Check BOTH protection layers' review-count and take the UNION; a required human approval is a hard gate — only an `APPROVED` (not `COMMENTED`) human review clears it |
 | Treated a never-posting required context as a CI flake | Re-ran CI / waited for `required-checks-gate` to post on every queued PR | The context was introduced by an unmerged keystone PR and is not on `main`; `git grep -c <ctx> origin/main -- .github/` returns 0 | Merge the keystone PR FIRST, then RE-REBASE the queue onto new `main` so each PR inherits the producer workflow and the context posts |
+| Assumed CI failure based on stale UI message when BLOCKED with green checks | Took "lint failure" message at face value; investigated lint jobs; re-ran CI | Lint had already been fixed in prior commits; CI was already green; the UI message was stale from an older run | Always run `gh pr checks <PR>` and `gh pr view --json mergeStateStatus` to get current state; do not trust the web UI error text |
+| Waited for auto-merge to self-trigger after CI passed (BLOCKED) | Expected auto-merge to fire on its own once CI was green | Two unresolved review threads were silently blocking the merge engine (`required_review_thread_resolution: true`) | `mergeStateStatus=BLOCKED` + all CI green + auto-merge armed = QUERY REVIEW THREADS FIRST via GraphQL `reviewThreads`; `resolveReviewThread` immediately unblocks |
 
 ## Results & Parameters
 
@@ -325,10 +410,12 @@ auto-merge armed but not merged
 │      → zero CI events; auto-merge will NEVER fire → manual merge or broaden paths:
 ├── mergeStateStatus == BLOCKED, failing_count == 0, workflow absent from main
 │      → ruleset bootstrap deadlock → admin-bypass / remove-rule-merge-restore / transitional PR
-├── all required checks green but BLOCKED
-│      → unresolved review threads (required_review_thread_resolution) → GraphQL reviewThreads, assess, resolve
-│      → OR a NON-required check still red/pending (auto-merge is stricter than branch protection) → fix it
-│      → OR required context name mismatch / never posted → align name + integration_id 15368
+├── all required checks green but BLOCKED  ← CHECK REVIEW THREADS FIRST (verified-ci: PR #1282)
+│      → STEP 1: query unresolved review threads via GraphQL reviewThreads (isResolved==false)
+│                reply with addPullRequestReviewThreadReply citing fixing commit
+│                then resolveReviewThread — auto-merge fires within seconds
+│      → STEP 2 (if threads all resolved): NON-required check still red/pending → fix it
+│      → STEP 3: required context name mismatch / never posted → align name + integration_id 15368
 ├── pr-policy red: "Auto-merge is enabled before implementation review GO"
 │      → label/auto-merge mismatch → add state:implementation-go OR --disable-auto
 ├── autoMergeRequest.mergeMethod absent after --rebase
@@ -382,3 +469,4 @@ auto-merge armed but not merged
 | ProjectHephaestus | `pr-policy` label-gate (#899/#901/#903/#904/#906/#908/#910), `pull_request_target` arming workflow (#915/#917), squash-only docs/code fix (#668/#904/#911), per-issue arming-state machine (#844, builds on #835), pre-armed auto-merge trap (#1073/#1075/#1077), advisory split (#1081 closes #1080) | Label alignment re-ran `pr-policy` green; settings-aware merge selection shipped; `/learn` capture keyed on detected-merge; advisory split verified-local (107 `tests/unit/ci` pass) |
 | HomericIntelligence (all 15 repos) | Two-layer protection audited + applied live; `homeric-main-baseline` ruleset rollout | Union confirmed; Keystone 404-body fake-context trap corrected; Nestor classic count:1 patched to 0 |
 | ProjectHephaestus | 2026-06-14: drove 13 open PRs toward mergeable during a `/myrmidon-swarm` run — hit the classic-vs-ruleset review-count UNION hard gate (`viewerCanEnableAutoMerge=false`), a `required-checks-gate` keystone PR (`_required.yml` `if: always()` aggregator) blocking the whole queue, and duplicate check-runs after a re-run | verified-local: the union gate was confirmed by API inspection (classic count=1 UNION ruleset count=0); keystone-first + re-rebase identified as the queue unblock; PRs had not yet merged at capture |
+| ProjectHephaestus | 2026-06-14: PR #1282 (`1315-harden-ci-required-gate`) BLOCKED with all CI green and auto-merge armed; stated "lint failure" was stale; root cause was 2 unresolved review threads; resolved via `resolveReviewThread` GraphQL mutation | **verified-ci**: PR merged at 2026-06-15T03:05:38Z by `app/github-actions` auto-merge within seconds of thread resolution; `mergeStateStatus` transitioned BLOCKED → UNKNOWN → MERGED |


### PR DESCRIPTION
## Summary

Amends the existing `github-auto-merge-ci-gating-merge-method` skill (v1.2.0 → v1.3.0) to promote unresolved review thread diagnosis to **verified-ci** status with a full GraphQL copy-paste workflow.

- PR #1282 (ProjectHephaestus, branch `1315-harden-ci-required-gate`) was BLOCKED despite all CI green and auto-merge armed
- The stated "lint failure" was stale; 2 unresolved review threads were the actual blockers
- Resolving via `resolveReviewThread` GraphQL mutation fired auto-merge within seconds (merged 2026-06-15T03:05:38Z by `app/github-actions`)

Key additions:
- New `#### Unresolved review threads as primary BLOCKED diagnostic (verified-ci)` section with `addPullRequestReviewThreadReply` + `resolveReviewThread` copy-paste GraphQL mutations
- Decision tree: CHECK REVIEW THREADS FIRST when `mergeStateStatus=BLOCKED` + all CI green
- New "When to Use" bullet and description item (12) for this pattern
- Two new Failed Attempts rows (stale UI trap; waiting for auto-merge to self-trigger)
- Tags: `review-threads`, `resolveReviewThread`

## Verification Level

**verified-ci** — PR #1282 ProjectHephaestus merged at 2026-06-15T03:05:38Z by `app/github-actions` auto-merge within seconds of resolving 2 unresolved review threads.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` — 391/391 valid
- [x] Signed commit verified (`gpg: Good signature`)
- [ ] Verify skill appears in marketplace with updated description and tags

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>