### PR TITLE
feat(skills): amend tooling-stage-only-your-own-files v1.0.0 → v1.1.0 (salvage cherry-pick conflict)

### DIFF
--- a/skills/tooling-stage-only-your-own-files-in-shared-worktree.history
+++ b/skills/tooling-stage-only-your-own-files-in-shared-worktree.history
@@ -1,14 +1,50 @@
+<!-- markdownlint-disable MD024 -->
+
+# History: tooling-stage-only-your-own-files-in-shared-worktree
+
+This file preserves the amendment history and superseded snapshots of the
+`tooling-stage-only-your-own-files-in-shared-worktree` skill.
+
+## v1.1.0 (2026-06-15)
+
+**Changed by:** ProjectHephaestus PR #1371 (reused-worktree salvage `git add -A` → cherry-pick conflict)
+**Verification:** verified-ci — fix merged to ProjectHephaestus main (PR #1371, closed #1369); CI green.
+
+**What changed and why:**
+
+- Added two new **Failed-Attempts** rows covering a NEW variant of the core lesson: using
+  `git add -A` inside the salvage-commit path of a REUSED worktree, then cherry-picking that
+  commit after a `reset --hard`. The blanket `add -A` swept unrelated leftover state into the
+  salvage commit; re-applying it via `cherry-pick` hit a CONFLICT that hard-failed the entire
+  issue (#1289 was the collateral victim).
+- Added a **Verified-Workflow note** in the skill: use `git add -u` (tracked modifications
+  only) instead of `git add -A` in salvage paths; wrap the `git cherry-pick` in try/except so
+  a salvage-restore conflict aborts+warns instead of raising.
+- Extended the **"Use when"** description to include the reused-worktree salvage-commit +
+  cherry-pick-conflict scenario.
+- Updated **"Verified On"** to cite ProjectHephaestus PR #1371 / issue #1369.
+
+Motivation: The automation loop's "preserve in-progress changes across a re-sync" path
+(for reused worktrees) ran `git add -A` before the salvage commit. This swept in unrelated
+untracked leftover state. When the salvage commit was then re-applied via
+`git cherry-pick -S {sha}` (after `reset --hard origin/{branch}`), it CONFLICTED and aborted
+the entire issue. The fix uses `git add -u` (tracks only modified tracked files) and wraps
+the cherry-pick in try/except so conflicts abort+warn instead of propagating as a fatal error.
+
+### Snapshot of v1.0.0 body
+
+```yaml
 ---
 name: tooling-stage-only-your-own-files-in-shared-worktree
-description: "Use when: (1) an automation/address-review loop runs in a SHARED worktree that already carries unrelated pre-existing dirty changes (modified/deleted/untracked files) from a different change; (2) you are about to commit your fix and are tempted to run `git add -A` / `git add .`; (3) a commit accidentally bundled unrelated files (scratch artifacts like .claude-address-review-*.md, deletions, sibling edits); (4) you need to un-bundle a too-broad commit without losing the other (not-yours) changes; (5) reviewing whether an agent's commit scope matches only the files it actually edited; (6) implementing a salvage-commit path for a REUSED worktree (preserve in-progress changes across re-sync) — specifically when `git add -A` in the salvage commit followed by cherry-pick after `reset --hard` produces a CONFLICT that hard-fails the entire issue."
+description: "Use when: (1) an automation/address-review loop runs in a SHARED worktree that already carries unrelated pre-existing dirty changes (modified/deleted/untracked files) from a different change; (2) you are about to commit your fix and are tempted to run `git add -A` / `git add .`; (3) a commit accidentally bundled unrelated files (scratch artifacts like .claude-address-review-*.md, deletions, sibling edits); (4) you need to un-bundle a too-broad commit without losing the other (not-yours) changes; (5) reviewing whether an agent's commit scope matches only the files it actually edited."
 category: tooling
-date: 2026-06-15
-version: "1.1.0"
-history: tooling-stage-only-your-own-files-in-shared-worktree.history
+date: 2026-06-12
+version: "1.0.0"
 user-invocable: false
-verification: verified-ci
-tags: [git, git-add, staging, git-add-all, address-review, automation-loop, shared-worktree, dirty-working-tree, commit-scope, git-reset-soft, signed-commit, pr-hygiene, clobber, salvage-commit, reused-worktree, cherry-pick, git-add-u]
+verification: verified-local
+tags: [git, git-add, staging, git-add-all, address-review, automation-loop, shared-worktree, dirty-working-tree, commit-scope, git-reset-soft, signed-commit, pr-hygiene, clobber]
 ---
+```
 
 # Stage Only Your Own Files in a Shared Worktree
 
@@ -16,10 +52,10 @@ tags: [git, git-add, staging, git-add-all, address-review, automation-loop, shar
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-06-15 |
-| **Objective** | When fixing PR review threads or implementing salvage-commit paths inside an automation loop's shared/reused worktree, commit ONLY the files you actually edited — never `git add -A` — because the loop-runner worktree commonly carries unrelated pre-existing dirty state that a blanket add silently bundles into your commit; in salvage paths, the bundled unrelated state can cause a `git cherry-pick` conflict that hard-fails the entire issue |
-| **Outcome** | Successful — bug was observed (9-file commit instead of 2-file commit; cherry-pick conflict aborting issue #1289), recovered with `git reset --soft`, re-staged explicitly, and re-committed with correct scope; salvage path fixed to use `git add -u` + non-fatal cherry-pick abort |
-| **Verification** | verified-ci |
+| **Date** | 2026-06-12 |
+| **Objective** | When fixing PR review threads inside an automation loop's shared worktree, commit ONLY the files you actually edited — never `git add -A` — because the loop-runner worktree commonly carries unrelated pre-existing dirty state that a blanket add silently bundles into your commit |
+| **Outcome** | Successful — bug was observed (9-file commit instead of 2-file commit), recovered with `git reset --soft`, re-staged explicitly, and re-committed with correct scope |
+| **Verification** | verified-local |
 
 ## When to Use
 
@@ -28,7 +64,6 @@ tags: [git, git-add, staging, git-add-all, address-review, automation-loop, shar
 - A commit you already made contains files you did not intend to touch (scratch `.md` artifacts, unrelated edits, unexpected deletions)
 - You need to un-bundle a too-broad signed commit without discarding the other party's uncommitted work
 - You are reviewing whether an agent's commit diff is correctly scoped to only the files the agent actually edited
-- You are implementing a "salvage in-progress changes" path for a REUSED worktree — specifically the pattern: `git add -A` → salvage commit → `reset --hard origin/{branch}` → `cherry-pick` that salvage commit back (the cherry-pick can CONFLICT on unrelated state swept in by `add -A`, hard-failing the whole issue)
 
 ## Verified Workflow
 
@@ -82,27 +117,6 @@ git log --show-signature -1      # look for "Good signature"
    git log --show-signature -1
    ```
 
-### Verified-Workflow Note: Salvage-Commit in Reused Worktrees
-
-When a reused worktree has in-progress changes that need to be preserved across a `reset --hard` re-sync:
-
-- Use `git add -u` (stages TRACKED modifications only) — NOT `git add -A` (which also sweeps in untracked leftover state and deletions)
-- After `reset --hard origin/{branch}`, re-apply the salvage commit via `git cherry-pick -S {sha}` — but wrap this in `try/except`: on conflict, run `git cherry-pick --abort` (check=False) and log a WARNING, then return normally
-- A salvage-restore conflict is NOT fatal; the agent re-runs and regenerates its edits anyway; failing the whole issue over a salvage conflict is wrong
-
-```python
-# Salvage: preserve in-progress changes across re-sync (correct pattern)
-result = subprocess.run(["git", "add", "-u"], ...)      # tracked mods only
-subprocess.run(["git", "commit", "-S", "-m", "chore: preserve reused worktree changes"], ...)
-salvage_sha = subprocess.run(["git", "rev-parse", "HEAD"], ...).stdout.strip()
-subprocess.run(["git", "reset", "--hard", f"origin/{branch}"], ...)
-try:
-    subprocess.run(["git", "cherry-pick", "-S", salvage_sha], check=True, ...)
-except subprocess.CalledProcessError:
-    subprocess.run(["git", "cherry-pick", "--abort"], check=False, ...)
-    logger.warning("Salvage cherry-pick conflicted; agent will regenerate edits")
-```
-
 ### Recovery: Un-bundling a Too-Broad Commit
 
 If you already committed too many files, recover without losing the other party's changes:
@@ -137,8 +151,6 @@ git log --show-signature -1
 | `git add -A` then `git commit -S` in the loop's shared worktree | Staged all changes at once before committing the address-review fix | Committed 9 files instead of 2: swept up pre-existing unrelated dirty state — `.claude-address-review-1219.md` (loop scratch artifact), modified `.pre-commit-config.yaml`, `CONTRIBUTING.md`, `hephaestus/ci/precommit.py`, a test file, and DELETED two files that still exist on `origin/main` | In any shared/loop worktree, `git add -A` is unsafe; always stage explicit paths only |
 | Trusting the worktree was clean because the session "started fresh" | Assumed no pre-existing dirty state at the start of an address-review turn | The loop-runner had pre-staged/modified files from a prior or sibling operation; the working tree was NOT clean at turn start | Never assume a loop worktree is clean; run `git status --short` every turn before staging |
 | Recovering with `git reset --hard` | (Hypothetical: using --hard to undo an over-broad commit) | `--hard` resets the working tree to HEAD, destroying all uncommitted changes — including the other party's dirty files that were never yours to delete | Recover with `git reset --soft` and selective re-stage; never `--hard` when the worktree contains others' uncommitted work |
-| `git add -A` in the salvage-commit path of a reused worktree, then `cherry-pick` after `reset --hard` | Salvage path used `git add -A` to capture in-progress changes before `reset --hard origin/{branch}`, then re-applied via `git cherry-pick -S {sha}` | Cherry-pick CONFLICTED on the unrelated leftover state swept in by `add -A`; the conflict hard-failed issue #1289 entirely (not just the salvage) | Use `git add -u` (tracked modifications only) in salvage paths; untracked leftover state must not enter the salvage commit |
-| Treating the salvage cherry-pick as fatal (`check=True`) | `subprocess.run(["git", "cherry-pick", ...], check=True)` — any conflict raised `CalledProcessError` and propagated up as an issue failure | Salvage is best-effort; the agent regenerates its edits on the next run anyway; making it fatal loses the entire issue over a non-critical restore step | Wrap the cherry-pick in `try/except`; on conflict, `git cherry-pick --abort` (check=False) + `logger.warning`; return normally |
 
 ## Results & Parameters
 
@@ -203,4 +215,7 @@ This skill complements the team practice of always working in an isolated worktr
 | Project | Context | Details |
 | --------- | --------- | --------- |
 | ProjectHephaestus | PR #1252 address-review of issue #1219 | Address-review fix targeted only `scripts/check_license_compatibility.py` and `tests/unit/scripts/test_check_license_compatibility.py`; `git add -A` swept up 7 additional unrelated files (scratch `.md`, sibling edits, two unrelated deletions); recovered with `git reset --soft HEAD~1` + selective re-stage + `git commit -S` |
-| ProjectHephaestus | PR #1371 / issue #1369 (salvage cherry-pick conflict) | Reused-worktree salvage path used `git add -A`, swept unrelated untracked state into salvage commit; `cherry-pick` after `reset --hard` conflicted, hard-failing issue #1289; fixed to `git add -u` + non-fatal `try/except` cherry-pick abort |
+
+## v1.0.0 (2026-06-12)
+
+Initial version.


### PR DESCRIPTION
## Summary

- Amends `skills/tooling-stage-only-your-own-files-in-shared-worktree.md` from v1.0.0 → v1.1.0
- Creates first `.history` file for this skill (`skills/tooling-stage-only-your-own-files-in-shared-worktree.history`)
- Adds two new **Failed Attempts** rows covering the reused-worktree salvage-commit + cherry-pick-conflict variant
- Adds **Verified-Workflow Note** documenting `git add -u` vs `git add -A` in salvage paths, and non-fatal cherry-pick abort pattern
- Extends **"Use when"** description to cover the reused-worktree salvage scenario
- Adds **Verified On** row citing ProjectHephaestus PR #1371 / issue #1369
- Bumps `verification` from `verified-local` → `verified-ci`

## New Learning

In the automation loop's reused-worktree "preserve in-progress changes" salvage path:

```python
# BROKEN (old):
git add -A                            # swept UNRELATED leftover state
git commit -S -m "chore: preserve..."
git reset --hard origin/{branch}
git cherry-pick -S {sha}              # CONFLICT → hard-failed issue #1289
```

Fix (PR #1371):
1. `git add -A` → `git add -u` (tracked modifications only; leaves unrelated untracked state out)
2. Wrap cherry-pick in try/except — on conflict: `git cherry-pick --abort` (check=False) + `logger.warning`; return normally

## Verification

- `python3 scripts/validate_plugins.py` → 397/397 valid
- Commit signed: `Good signature from "Micah Villmow <4211002+mvillmow@users.noreply.github.com>"`
- Source: ProjectHephaestus PR #1371 (verified-ci, merged to main)

Closes #2553