### PR TITLE
feat: amend planning-epic-verify-live-child-state skill (v1.1.0)

### DIFF
--- a/skills/planning-epic-verify-live-child-state.history
+++ b/skills/planning-epic-verify-live-child-state.history
@@ -1,0 +1,28 @@
+<!-- markdownlint-disable MD024 -->
+# planning-epic-verify-live-child-state — History
+
+## v1.0.0 (2026-06-19)
+
+Initial skill created in ProjectMnemosyne PR #2573 from the ProjectOdyssey epic #5191
+planning session (R0): re-verify the LIVE state of every child issue with `gh`
+(`state`, `stateReason`, merged PRs, `state:plan-go` labels) before planning an
+epic/tracking/umbrella issue, because the epic body is a snapshot that drifts.
+
+**Original date:** 2026-06-19
+**Original version:** 1.0.0
+
+```yaml
+name: planning-epic-verify-live-child-state
+description: "Before planning an epic/tracking/umbrella issue, query the LIVE state of every child issue with gh (state, stateReason, merged PRs, labels) instead of trusting the epic body's status table — the body is a snapshot and drifts. Most children may already be CLOSED+COMPLETED via merged PRs, reframing the epic from 'plan N fixes' to 'dispatch the few remaining state:plan-go children + close-out'. Use when: (1) planning an epic/tracking/umbrella issue, (2) re-planning after a NOGO on a tracking issue, (3) any issue whose body is a checklist of child issues, (4) deciding implementation order across linked issues."
+category: tooling
+date: 2026-06-19
+version: "1.0.0"
+```
+
+### v1.0.0 snapshot — Failed Attempts (5 rows)
+
+1. Trust the epic body's status table → 9 of 12 children already CLOSED+COMPLETED.
+2. Treat `state == CLOSED` as "done" → ignored `stateReason`; closed-as-`not planned` ≠ done.
+3. Re-plan `state:plan-go` children → discards reviewer-approved per-issue plans.
+4. Use the audit's original dependency graph verbatim → stale edges produced wrong ordering.
+5. Cite the audit's "approx" LOC → `any_tensor.mojo` had grown 4,241 → 4,373 lines.

--- a/skills/planning-epic-verify-live-child-state.md
+++ b/skills/planning-epic-verify-live-child-state.md
@@ -3,10 +3,11 @@ name: planning-epic-verify-live-child-state
 description: "Before planning an epic/tracking/umbrella issue, query the LIVE state of every child issue with gh (state, stateReason, merged PRs, labels) instead of trusting the epic body's status table — the body is a snapshot and drifts. Most children may already be CLOSED+COMPLETED via merged PRs, reframing the epic from 'plan N fixes' to 'dispatch the few remaining state:plan-go children + close-out'. Use when: (1) planning an epic/tracking/umbrella issue, (2) re-planning after a NOGO on a tracking issue, (3) any issue whose body is a checklist of child issues, (4) deciding implementation order across linked issues."
 category: tooling
 date: 2026-06-19
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
-tags: [epic, tracking-issue, child-issues, planning, gh-cli, state-plan-go, dependency-ordering, orchestration, audit-remediation, stale-body]
+history: planning-epic-verify-live-child-state.history
+tags: [epic, tracking-issue, child-issues, planning, gh-cli, state-plan-go, dependency-ordering, orchestration, audit-remediation, stale-body, verification-block, path-audit, freshness-gate]
 ---
 
 # Planning: Re-Verify Live Child-Issue State Before Planning an Epic
@@ -17,9 +18,9 @@ tags: [epic, tracking-issue, child-issues, planning, gh-cli, state-plan-go, depe
 |-------|-------|
 | **Date** | 2026-06-19 |
 | **Objective** | Produce a correct implementation plan for an epic/tracking issue whose body lists many child issues — without re-planning children that have already shipped |
-| **Outcome** | Successful — the epic body listed all 12 numbered children as "Open" (written 2026-03-28), but a live `gh` sweep showed 9 were already CLOSED+COMPLETED via merged PRs; the plan correctly scoped to ONLY the 3 remaining `state:plan-go` children in re-validated dependency order |
-| **Verification** | verified-local — the read-only `gh`/`wc` state sweep was executed and returned the cited results; the downstream child PRs are not yet merged, so end-to-end epic closure is not CI-confirmed |
-| **Source** | ProjectOdyssey epic #5191 (strict-mode audit, 13/12 child findings) planning session |
+| **Outcome** | R0 NOGO (grade C) — the live `gh` sweep was correct (9 of 12 children already CLOSED+COMPLETED) but the plan INVENTED test paths in the Verification block and assumed an "extend" issue was net-new; R1 re-plan added a Verification-block path audit + a child-plan freshness gate + a capability-absence check and scoped to the 3 remaining `state:plan-go` children in re-validated dependency order |
+| **Verification** | verified-local — the read-only `gh`/`find`/`wc`/`grep` queries were executed this session and returned the cited results; the downstream child PRs are not yet merged, so end-to-end epic closure is not CI-confirmed |
+| **Source** | ProjectOdyssey epic #5191 (strict-mode audit, 13/12 child findings) planning session — R0 NOGO → R1 re-plan |
 
 The epic body is a **snapshot** that drifts as children move. The deliverable for an epic is
 **orchestration + close-out criteria**, not code — "Files to Create/Modify: None in this epic;
@@ -54,6 +55,21 @@ gh issue view "<n>" --json labels --jq '.labels[].name'
 
 # 4. Ground every "approx" number in a FRESH measurement (audit numbers go stale).
 wc -l path/to/file_the_audit_counted.mojo   # cite the fresh count, not the audit's
+
+# 5. VERIFICATION-BLOCK PATH AUDIT — confirm EVERY test path BEFORE writing it.
+#    The Verification block IS the only deliverable of an epic plan; a single
+#    invented path = file-not-found when the reviewer runs it = NOGO.
+find tests -name 'test_<topic>*.mojo'        # substitute the real path or drop the claim
+
+# 6. FRESHNESS GATE — read each approved child's latest plan and confirm its cited
+#    paths/line-counts still resolve before dispatching (plans CAN go stale).
+gh issue view "<child>" --comments --json comments \
+  --jq '.comments[-1].body' | grep -nE '<line-count>|<cited path>'
+wc -l <cited file>                            # confirm the child's cited count is current
+
+# 7. CAPABILITY-ABSENCE CHECK before scoping an "extend" issue as net-new. Read the
+#    target file; zero keyword matches = genuinely absent = reframe as "extend struct X".
+grep -nE 'tmp|rename|atomic|resume|recover|--fresh|retry' path/to/target.mojo
 ```
 
 ### Detailed Steps
@@ -81,7 +97,32 @@ wc -l path/to/file_the_audit_counted.mojo   # cite the fresh count, not the audi
 5. **Re-measure every "approx" the audit cited.** Audit numbers drift: #5191 said
    `any_tensor.mojo` was 4,241 lines; `wc -l` showed it had GROWN to 4,373. Cite the fresh number.
 
-6. **Shape the epic plan as orchestration, not code.** Objective = "drive remaining approved
+6. **Audit every test path in the Verification block before finalizing.** For a tracking/epic
+   plan the Verification block IS the only deliverable, so every path must be real. For EACH test
+   path you intend to cite, run `find tests -name '<glob>'` (or `ls`) and substitute the confirmed
+   path or drop the claim. NEVER infer a test path from a sibling's directory shape — in #5191 R0
+   the plan invented `tests/models/test_anytensor_conversion.mojo` and
+   `tests/training/test_checkpoint.mojo` from the repo's apparent convention; neither existed (real
+   tests live under `tests/projectodyssey/tensor/` and `tests/projectodyssey/training/`), the
+   reviewer ran the commands, hit file-not-found, and NOGO'd at grade C (major).
+
+7. **Run a FRESHNESS GATE on each approved child plan — don't trust the `state:plan-go` label
+   alone.** An approved-plan label is not proof the plan is still current; child plans CAN go stale
+   (e.g. cite an old line count). Read each child's latest plan comment
+   (`gh issue view <n> --comments --jq '.comments[-1].body'`) and confirm its cited paths/line-counts
+   still resolve (`wc -l`, `grep -n`) before dispatching. In #5191 R1 the child plans WERE current
+   (cited `any_tensor.mojo:4383-4413`, a ≤3,000-line target with a #5181-merge contingency, and real
+   test paths) — but that had to be VERIFIED, not assumed.
+
+8. **Check for capability ABSENCE before scoping an "extend" issue as net-new work.** Read the
+   target file and `grep` for the specific capabilities the issue adds — zero matches = genuinely
+   absent = reframe as "extend struct X at file:line", citing the current method inventory. In
+   #5191 the plan treated #5184 (checkpoint recovery) as if `checkpoint.mojo` were empty, but
+   `CheckpointManager` already existed (381 lines: save/load/metadata), risking duplicate/wrong-scope
+   work; `grep -nE 'tmp|rename|atomic|resume|recover|--fresh|retry'` confirmed the recovery
+   primitives were absent and the issue was genuinely an extension.
+
+9. **Shape the epic plan as orchestration, not code.** Objective = "drive remaining approved
    children to merged PRs + close-out". Files to Create/Modify = "None in this epic; changes live
    in the children's own approved plans." Implementation Order = dispatch each open child via the
    repo's `impl <n>` skill in dependency order, gate each dependent child behind its prerequisite's
@@ -96,6 +137,9 @@ wc -l path/to/file_the_audit_counted.mojo   # cite the fresh count, not the audi
 | Re-plan `state:plan-go` children | Considered generating fresh plans for the 3 open children | Discards reviewer-approved per-issue plans — the epic must defer to the children's existing plans, not regenerate them | `state:plan-go` = ready to implement; the epic dispatches, it does not re-plan |
 | Use the audit's original dependency graph verbatim | Ordered work by the audit's stated dependency edges | Stale edges (an already-merged dependency, an already-closed downstream) produced a wrong ordering | Re-validate every dependency edge against current child state; merged deps unblock dependents, closed downstreams terminate branches |
 | Cite the audit's "approx" LOC | Carried the audit's "4,241 lines" for `any_tensor.mojo` into the plan | The file had GROWN to 4,373 lines since the audit | Re-measure with `wc -l` and cite the fresh number, never the audit's stale approximation |
+| Invented plausible test paths in the Verification block | Wrote `tests/models/test_anytensor_conversion.mojo` and `tests/training/test_checkpoint.mojo` from memory of the repo's apparent convention | Neither existed; real tests live under `tests/projectodyssey/tensor/` and `tests/projectodyssey/training/`. Reviewer ran the commands → file-not-found, NOGO (major) | For a tracking/epic plan the Verification block IS the only deliverable — EVERY path must be confirmed with `find tests -name '<glob>'` or `ls` BEFORE writing it. Never infer a test path from a sibling's directory shape |
+| Assumed a referenced "extend" issue was net-new work without reading the target file | Planned #5184 (checkpoint recovery) as if `checkpoint.mojo` were empty | `CheckpointManager` already existed (381 lines, save/load/metadata) — risk of duplicate work / wrong scope | Read the target file and `grep -nE 'tmp\|rename\|atomic\|resume\|recover\|--fresh\|retry'` for the specific capabilities the issue adds; zero matches = genuinely absent = reframe as "extend struct X at file:line" citing the current method inventory |
+| Deferred to children's `state:plan-go` labels without reading the child plan bodies | Trusted the approved-plan label as proof the child plans were current | Child plans CAN go stale (e.g. cite an old line count); reviewer flagged this as an unmitigated risk | Add a FRESHNESS GATE: read each child's latest plan comment (`gh issue view <n> --comments --jq '.comments[-1].body'`) and confirm its cited paths/line-counts still resolve (`wc -l`, `grep -n`) before dispatching. In #5191 R1 the child plans were current (cited `any_tensor.mojo:4383-4413`, ≤3,000 target with a #5181-merge contingency, real test paths) — but that had to be VERIFIED, not assumed |
 
 ## Results & Parameters
 
@@ -119,6 +163,20 @@ gh issue view "<n>" --json labels --jq '.labels[].name'
 
 # Fresh measurement (audit said 4,241; reality had grown)
 wc -l src/projectodyssey/core/any_tensor.mojo   # → 4373
+
+# Verification-block path audit (cite ONLY confirmed paths)
+find tests -name 'test_*.mojo'                  # filter by topic; real tensor/training tests
+#   live under tests/projectodyssey/tensor/ and tests/projectodyssey/training/, NOT
+#   tests/models/ or tests/training/ (invented paths that NOGO'd R0)
+
+# Freshness gate (confirm an approved child plan's cited facts still resolve)
+gh issue view <child> --comments --json comments --jq '.comments[-1].body' \
+  | grep -nE '<line-count>|<path>'
+wc -l <cited file>                              # confirm the child's cited count is current
+
+# Capability-absence check before scoping an "extend" issue
+grep -nE 'tmp|rename|atomic|resume|recover|--fresh|retry' \
+  src/projectodyssey/training/checkpoint.mojo   # zero matches → net-new → reframe as extend
 ```
 
 ### Epic plan shape (the deliverable)
@@ -145,4 +203,4 @@ Close-out:            re-verify all children CLOSED+COMPLETED, then close the ep
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectOdyssey | Epic #5191 strict-mode audit (13/12 child findings) planning session, 2026-06-19 | Read-only `gh`/`wc` state sweep executed: 9 of 12 children CLOSED+COMPLETED via merged PRs, 3 open children carry `state:plan-go`; dispatch/close-out steps are proposed (verified-local) |
+| ProjectOdyssey | Epic #5191 planning — R0 NOGO (grade C, invented test paths) → R1 re-plan with path audit + freshness gate, 2026-06-19 | Read-only `gh`/`find`/`wc`/`grep` queries executed: 9 of 12 children CLOSED+COMPLETED via merged PRs, 3 open children carry `state:plan-go`; R0 NOGO'd on invented Verification paths (`tests/models/...`, `tests/training/...` — real tests under `tests/projectodyssey/{tensor,training}/`); R1 added path audit, child-plan freshness gate, and a capability-absence check (`CheckpointManager` already 381 lines). Dispatch/close-out steps are proposed; downstream child PRs not yet merged (verified-local) |


### PR DESCRIPTION
## Summary

Amends the `planning-epic-verify-live-child-state` skill (created in PR #2573, now on `main`)
to fold in NEW durable failure modes discovered when the plan-reviewer NOGO'd the first attempt
(R0, grade C) at planning ProjectOdyssey epic #5191. Bumps `1.0.0 → 1.1.0`.

## New learnings (this session = the C/NOGO re-plan round)

1. **Invented test paths in the Verification block** — wrote `tests/models/test_anytensor_conversion.mojo`
   and `tests/training/test_checkpoint.mojo` from the repo's apparent convention; neither existed
   (real tests live under `tests/projectodyssey/{tensor,training}/`). Reviewer ran the commands →
   file-not-found → NOGO (major). **Lesson:** the Verification block IS the only deliverable of an
   epic plan; confirm EVERY path with `find tests -name '<glob>'` before writing it.
2. **Assumed an "extend" issue was net-new without reading the target file** — planned #5184
   (checkpoint recovery) as if `checkpoint.mojo` were empty, but `CheckpointManager` already existed
   (381 lines). **Lesson:** `grep` for the specific capabilities the issue adds; zero matches =
   genuinely absent = reframe as "extend struct X at file:line".
3. **Deferred to children's `state:plan-go` labels without reading the child plan bodies** — child
   plans CAN go stale. **Lesson:** add a FRESHNESS GATE — read each child's latest plan comment and
   confirm its cited paths/line-counts still resolve before dispatching.

## Changes Made

- Bumped `version` 1.0.0 → 1.1.0; added `history: planning-epic-verify-live-child-state.history`; new tags.
- Extended the Verified Workflow with a Verification-block path-audit step (#6), a freshness-gate
  step (#7), and a capability-absence check (#8).
- Added matching commands to the Quick Reference and Results & Parameters.
- Added 3 new Failed Attempts rows.
- Wrote the v1.0.0 snapshot into the new `.history` file.
- Updated Overview/Verified On to reflect the R0 NOGO → R1 re-plan round.

## Files Modified

- `skills/planning-epic-verify-live-child-state.md`
- `skills/planning-epic-verify-live-child-state.history` (new)

## Verification

- `python3 scripts/validate_plugins.py` → **402/402 valid**
- `markdownlint-cli2` → **0 errors**
- Verification level: **verified-local** (read-only `gh`/`find`/`wc`/`grep` queries executed this
  session; downstream child PRs not yet merged, so epic close-out is not CI-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)