### PR TITLE
feat: amend audit-remediation-verify-evidence-before-planning skill (v1.1.0)

### DIFF
--- a/skills/audit-remediation-verify-evidence-before-planning.history
+++ b/skills/audit-remediation-verify-evidence-before-planning.history
@@ -1,18 +1,58 @@
+# Changelog: audit-remediation-verify-evidence-before-planning
+
+## v1.0.0 -> v1.1.0 (2026-06-19)
+
+- **Version:** 1.0.0 -> 1.1.0 (MINOR — adds new findings/failed-attempts, not a rewrite)
+- **Date:** 2026-06-19
+- **Changed by:** Odysseus issue #25 re-plan after reviewer NOGO (fabricated canonical-names row)
+- **Verification level:** verified-local
+- **What changed:**
+  - Added a "When to Use" trigger for authoring docs/tables that CLAIM canonical
+    names or values — every cell must be code-traceable.
+  - Extended the Verified Workflow with a step requiring each canonical-table cell
+    to be read from the source of truth, distinguishing the model/field layer
+    (Pydantic `assign_to`) from the serialization/wire layer (JSON `assigneeAgentId`),
+    and adding a positive (cell == code) AND negative (guessed-wrong name absent)
+    check rather than relying on the deprecated-token drift guard.
+  - Added Quick Reference greps for both layers plus a negative grep.
+  - Added three Failed Attempts rows (fabricated canonical row; conflating model
+    field with wire key; trusting the drift guard to catch a wrong canonical name).
+  - Corrected Results & Parameters: the real mapping is model `subject`/`assign_to`/
+    `blocked_by` (models.py:38,40,41) -> wire `subject`/`assigneeAgentId`/`blockedBy`
+    (agamemnon_client.py:207,211,214,216); deprecated forms are `title`/`depends_on`
+    only. The prior v1.0.0 wrongly listed `assignee_agent_id`/`assigneeAgentId` as a
+    canonical field — there is no `assignee_agent_id` field.
+  - Added `history` frontmatter field and a History reference line in the body.
+- **Why:**
+  - A FIRST re-plan for Odysseus issue #25 added a "Canonical Workflow Field Names"
+    table to docs/architecture.md but fabricated a row: canonical `assignee_agent_id`
+    / wire `assigneeAgentId` / deprecated `assigned_to (legacy)`. A reviewer caught
+    this as a MAJOR P7/POLA finding. The real Pydantic field is `assign_to`
+    (models.py:40), serialized over the wire as `assigneeAgentId`
+    (agamemnon_client.py:211,214). There is NO `assignee_agent_id` field and NO
+    `assigned_to (legacy)` deprecated form — both were unverified guesses.
+  - The existing drift guard only greps for the OLD tokens (`title`/`depends_on`),
+    so it could never catch a wrong NEW canonical name introduced in the doc. The
+    sharper lesson: a canonical table you author must be code-traceable cell-by-cell,
+    with both a positive and a negative check.
+
+---
+
+## Snapshot: v1.0.0 (previous version)
+
+```markdown
 ---
 name: audit-remediation-verify-evidence-before-planning
 description: "Before planning a fix for a cross-repo audit/remediation issue, verify the audit's cited evidence (file:line) against the live tree — audit findings go stale once the target repo is independently remediated. Use when: (1) planning a fix for an audit-filed issue with file:line evidence, (2) the issue spans multiple repos or submodules, (3) the issue recommends doc/field-name changes that may already be done."
 category: architecture
 date: 2026-06-19
-version: "1.1.0"
+version: "1.0.0"
 user-invocable: false
 verification: verified-local
-history: audit-remediation-verify-evidence-before-planning.history
 tags: []
 ---
 
 # Audit Remediation: Verify Evidence Before Planning
-
-**History:** [changelog](./audit-remediation-verify-evidence-before-planning.history)
 
 ## Overview
 
@@ -24,8 +64,6 @@ tags: []
 | **Verification** | verified-local |
 
 > **Verification note:** The evidence-verification steps below (grep against the live tree, confirming canonical names in the Pydantic source of truth) were genuinely RUN this session and confirmed the target docs were already remediated — that is what `verified-local` attests to. The downstream implementation (the architecture.md section + the drift-guard script wired into `just ci`) was **planned only**, not executed or CI-validated. Do not read this as `verified-ci`.
->
-> **v1.1.0 note:** The canonical mapping (`subject`/`assign_to`/`blocked_by` model fields serialized as `subject`/`assigneeAgentId`/`blockedBy`) was verified this session by reading BOTH `models.py` AND `agamemnon_client.py` against the live tree. The corresponding architecture.md table edit itself was **planned only**, not executed or CI-validated.
 
 ## When to Use
 
@@ -33,7 +71,6 @@ tags: []
 - The issue spans multiple repos, especially when some are git submodules owned by other repos.
 - The recommendation is a doc/field-name/role-description change that another team may have already fixed.
 - Any "documentation drift" or "X docs show deprecated Y" issue.
-- Authoring a doc/table that CLAIMS canonical names or values — every cell must be code-traceable.
 
 ## Verified Workflow
 
@@ -45,7 +82,6 @@ The evidence-verification phase (steps 1-3) was actually executed against the li
 4. **Scope by ownership.** Do NOT edit files inside git submodules from the meta-repo — they are owned by their own repo and must be PR'd there (or a referencing issue filed). One PR per owned repo.
 5. **If the cited target is already remediated, say so explicitly.** State it in the plan and in the PR body, then pivot the plan to (a) the still-actionable owned-repo recommendation and (b) a drift-prevention guard so the deprecated form cannot silently return.
 6. **Match the repo's EXISTING check pattern for the guard.** Here that meant a bash script under `scripts/` plus a `just` recipe wired into `just ci` — not a new framework. A meta-repo with "no application code" should not get a pytest harness just for a doc check.
-7. **When you author a canonical-names/values table, read EACH cell from the source of truth, and distinguish the model/field layer from the serialization/wire layer** (e.g. Pydantic `assign_to` vs JSON `assigneeAgentId` in the REST client). Never invent a "deprecated/legacy" variant for a field that is current. A drift guard that only matches the OLD tokens will not catch a wrong NEW canonical name — so add a positive check (table cell == code) and a negative check (guessed-wrong name is absent).
 
 ### Quick Reference
 
@@ -56,13 +92,6 @@ grep -nE '^[[:space:]]*-?[[:space:]]*(title|depends_on):' <cited-docs>
 grep -nE 'subject:|blocked_by:' src/<pkg>/models.py
 # 3. Check ownership before editing — submodules are off-limits from the meta-repo
 git submodule status
-# 4. When authoring a canonical table: verify BOTH layers cell-by-cell
-#    model/field layer (Pydantic / YAML)
-grep -nE 'assign_to|subject|blocked_by' src/<pkg>/models.py
-#    serialization/wire layer (JSON keys in the REST client) — these can DIFFER
-grep -nE 'assigneeAgentId|blockedBy|"subject"' src/<pkg>/<rest_client>.py
-# 5. Negative check — the guessed-wrong canonical name must be ABSENT from the doc
-! grep -nE '<guessed-wrong-name>' <doc>   # e.g. ! grep -nE 'assignee_agent_id' docs/architecture.md
 ```
 
 ## Failed Attempts
@@ -72,19 +101,13 @@ grep -nE 'assigneeAgentId|blockedBy|"subject"' src/<pkg>/<rest_client>.py
 | Trusting the audit's file:line evidence as current | Issue cited `CLAUDE.md:55-58` / `README.md:62-69` as showing `title`/`depends_on` | The submodule had already been remediated independently; those lines now use `subject`/`blocked_by` | Always re-read cited evidence against the live tree before planning |
 | Grepping for `title`/`depends_on` and treating every hit as a violation | Raw grep flagged JSON-Schema `"title":` labels and a `test_unknown_depends_on_raises` method name | These are not documented workflow fields — false positives | Anchor the pattern to field-key syntax and eyeball each hit in context |
 | Assuming the meta-repo can fix the submodule's docs in this PR | Planned to edit `provisioning/ProjectTelemachy` docs from Odysseus | Submodules are owned by their own repos; editing their working tree from the meta-repo is wrong scope | Scope edits by ownership; PR the owning repo or file a referencing issue |
-| Filling a canonical-names table from memory/issue text | Wrote canonical=`assignee_agent_id`, deprecated=`assigned_to (legacy)` | Source of truth has `assign_to` (model) serialized as `assigneeAgentId`; the guessed names existed nowhere | Read every table cell verbatim from code before writing it |
-| Assuming the model field name equals the wire/JSON key | Conflated Pydantic `assign_to` with the REST payload key | They differ: the client maps `spec.assign_to` -> `assigneeAgentId` | Always check the serialization layer (REST client) separately from the model |
-| Trusting a drift guard to catch a wrong canonical name | Guard only greps deprecated `title`/`depends_on` | A fabricated canonical name passes the guard silently | Verify the canonical table with a positive (cell==code) AND negative (guessed-wrong absent) check, not just the deprecated-token guard |
 
 ## Results & Parameters
 
-- **Canonical field names — TWO layers (verified by reading `models.py` AND `agamemnon_client.py` this session):**
-  - Model / YAML field (Pydantic source of truth): `subject` (models.py:38), `assign_to` (models.py:40), `blocked_by` (models.py:41).
-  - JSON wire key (REST client serialization): `subject` (agamemnon_client.py:207), `assigneeAgentId` (agamemnon_client.py:211,214), `blockedBy` (agamemnon_client.py:216).
-  - The model field `assign_to` is serialized as `assigneeAgentId`; **the two layers differ and must be read separately**. There is NO `assignee_agent_id` field anywhere.
-  - Deprecated forms (the only ones that exist): `title` (-> `subject`) and `depends_on` (-> `blocked_by`). There is NO `assigned_to (legacy)` deprecated form — that was a fabricated guess caught by a reviewer.
+- **Canonical field names** (Agamemnon REST contract / Telemachy `TaskSpec`): `subject` (not `title`), `blocked_by`/`blockedBy` (not `depends_on`), `assignee_agent_id`/`assigneeAgentId`.
 - **Drift-guard pattern:** first-party-only file list via
   `git ls-files -- '*.md' | awk '!/^(infrastructure|control|provisioning|ci-cd|research|shared|testing)\//'`;
   field-key regex `^[[:space:]]*-?[[:space:]]*(title|depends_on):`;
   exit `0` clean / `1` drift / `2` usage; wire into `just ci`.
 - **Submodule dirs in this ecosystem to exclude from first-party scans:** `infrastructure/` `control/` `provisioning/` `ci-cd/` `research/` `shared/` `testing/`.
+```


### PR DESCRIPTION
## Summary

Amends the existing `audit-remediation-verify-evidence-before-planning` skill (v1.0.0 -> v1.1.0, MINOR) with a sharper, related lesson surfaced during the Odysseus issue #25 re-plan after a reviewer NOGO.

**The durable learning:** when a doc you author CLAIMS canonical names/values, every cell must be read verbatim from the source of truth — including the wire/serialization layer, not just the model. Distinguish the Pydantic/YAML field name (`assign_to`) from the JSON wire key (`assigneeAgentId`). Do NOT invent a "deprecated legacy" form for a field that is current. A drift guard that only greps the OLD tokens (`title`/`depends_on`) will not catch a wrong canonical name you introduce, so the canonical table itself must be code-traceable cell-by-cell, with a positive check (table == code) AND a negative check (the guessed-wrong name is absent).

## What changed
- New "When to Use" trigger for authoring canonical-names/values tables.
- New Verified Workflow step 7 (read each cell from source of truth; distinguish model vs wire layer; positive + negative checks).
- Quick Reference greps for both layers plus a negative grep.
- Three new Failed Attempts rows (fabricated canonical row; conflating model field with wire key; trusting the drift guard).
- Corrected Results & Parameters: model `subject`/`assign_to`/`blocked_by` (models.py:38,40,41) -> wire `subject`/`assigneeAgentId`/`blockedBy` (agamemnon_client.py:207,211,214,216); deprecated forms `title`/`depends_on` only. The prior v1.0.0 wrongly listed `assignee_agent_id`.
- Added `history` frontmatter + `.history` changelog with a full v1.0.0 snapshot.

## Verification
- `python3 scripts/validate_plugins.py` -> 409/409 valid.
- Verification level kept at `verified-local`: the field-name greps were genuinely run against the live tree (models.py AND agamemnon_client.py); the architecture.md doc edit itself was planned-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)