### PR TITLE
feat: amend verify-audit-issue-reproduces-before-fixing skill (v2.0.0)

### DIFF
--- a/skills/verify-audit-issue-reproduces-before-fixing.history
+++ b/skills/verify-audit-issue-reproduces-before-fixing.history
@@ -1,0 +1,234 @@
+# verify-audit-issue-reproduces-before-fixing — History
+
+## v2.0.0 (2026-06-19)
+
+**Changed by:** Same session as v1.0.0 (ProjectKeystone issue #26 audit-finding planning). A plan
+reviewer proved v1.0.0's central claim FALSE and a re-investigation corrected it.
+**Verification:** verified-local
+
+### What changed
+
+- **Core recommendation OVERTURNED (major bump).** v1.0.0 concluded issue #26 was
+  "non-reproducible / the cited content NEVER existed." That is wrong. The audit was ACCURATE at
+  filing: commit `a3878c3` (`git show a3878c3:README.md`) contains the audit's exact backtick-wrapped
+  strings at the exact cited lines 7/14/16. The corrected disposition is **already-resolved, citing
+  provenance commit `a3878c3`** — materially different and better than "phantom finding."
+- New headline workflow: when audited content is ABSENT from the current file, search the CORRECT
+  refs (`origin/main`, not a stale pin) with the EXACT audited strings across `git log --all` BEFORE
+  concluding "never existed." Distinguish existed-then-removed from never-existed.
+- Added `git merge-base --is-ancestor <sha> origin/main` as the classifier between
+  removal-by-a-main-lineage-commit and an orphaned/abandoned lineage. For #26 it returned false:
+  `a3878c3` is NOT an ancestor of `origin/main` (which descends from a different root `2e9f216`), so
+  the terminology was removed by history replacement (ai-maestro scaffold lineage abandoned on
+  re-scope to a C++ transport library, per ADR-006), NOT a linear edit.
+- Added live-tip inspection + pin-staleness quantification: the pin first inspected (`3185bc9`) was
+  37 commits behind `origin/main` (`git rev-list --count 3185bc9..origin/main` → 37). Always
+  `git fetch origin` and inspect `git show origin/main:README.md`.
+- Rewrote Quick Reference around `git fetch` / `git show origin/main:` / `git rev-list --count` /
+  `git log --all -S'<exact substring>'` / `git show <sha>:README.md` / `git merge-base --is-ancestor`.
+- Reworked Failed Attempts: added the "misread empty `-S` result as never-existed" row and the
+  "inspected stale pin" row (both now the headline failures); added "plain `-S` misses orphaned
+  lineages" and "assumed any removal is a linear edit on main" rows.
+- Updated description, tags, Overview, Results & Parameters, decision tree, and Risks to the corrected
+  framing. Added `history:` frontmatter field. Bumped `version` 1.0.0 → 2.0.0. Date 2026-06-19.
+
+### Why
+
+v1.0.0's `git log -S'marked done'` / `-S'todo'` searches under-matched for two reasons: (a) they ran
+only on the stale detached-pin's reachable history (not `--all`, not `origin/main`), and (b) the
+phrasings did not match the actual backtick-wrapped strings (``is `done` ``, ``still `todo` ``). The
+empty result was misread as "content never existed," producing a wrong "phantom finding" close. A plan
+reviewer flagged this; re-investigation with `git log --all -S'<exact substring>'` found `a3878c3`,
+`git show` confirmed the exact lines, and `git merge-base --is-ancestor` classified the removal as a
+history replacement. The corrected close (already-resolved, provenance `a3878c3`) confirms the audit
+tooling was correct, instead of wrongly eroding trust in it.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: verify-audit-issue-reproduces-before-fixing
+description: "Verify an audit issue actually reproduces against the live file BEFORE planning a fix — treat audit line numbers and quoted strings as claims, not facts. Run the repro greps DURING planning; the legitimate outcome may be 'no edit, recommend closing as non-reproducible.' Use git log -S to distinguish a stale finding (content NEVER existed) from an already-fixed one (content existed, removed in a later commit). Use when: (1) an audit/auto-generated issue cites file:line coordinates and quoted offending strings, (2) the offending token is a common English word (done/todo/fix) that could be benign prose, (3) you are tempted to write a 'Files to Modify' section before grepping, (4) deciding whether to close an issue as non-reproducible."
+category: documentation
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - audit-finding
+  - non-reproducible
+  - premise-verification
+  - line-number-drift
+  - git-log-pickaxe
+  - planning-methodology
+  - close-as-cannot-reproduce
+  - token-vs-status-value
+  - stale-finding
+---
+
+# Verify an Audit Issue Reproduces Before Fixing
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-19 |
+| **Objective** | Before planning a fix for an audit-filed issue, prove the finding actually reproduces against the live working tree — rather than trusting the issue's cited line numbers and quoted strings as facts |
+| **Outcome** | A repeatable planning discipline: run repro greps + `git log -S` during planning; for issue #26 the outcome was correctly "non-reproducible, recommend closing — no edit" because the cited content never existed in the file or its history |
+| **Verification** | verified-local |
+
+Verified locally only — CI validation pending. The greps, `awk` line dumps, and `git log -S`
+pickaxe searches documented below were actually executed against the live working tree this
+session and their outputs confirmed the finding did not reproduce. No CI ran, and the cross-repo
+assumptions in Results & Parameters (submodule pin freshness, the Agamemnon canonical status set,
+and whether the audit targeted a different/old path) remain unverified.
+
+## When to Use
+
+- An audit or auto-generated issue cites `file:line` coordinates **and** quotes specific offending
+  strings (e.g. "lines 7/14/16 use `done`/`todo` instead of `completed`/`pending`").
+- You are about to write a "Files to Modify" section based on the issue body without having opened
+  the file yet.
+- The offending token is a common English word (`done`, `todo`, `fix`, `wip`) that can legitimately
+  appear in prose/comments, so a raw grep hit is not proof of a real defect.
+- You need to decide between "this is a stale finding that never existed" vs "this was already fixed
+  in a later commit" vs "the finding genuinely holds."
+- The issue may have targeted a **different file**, an old fork/path, or a stale submodule pin that
+  no longer maps to the current file.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Whole-file scan for the offending tokens (NOT just the cited lines).
+#    Audit line numbers drift or are entirely wrong — scan the whole file.
+grep -niE '\b(done|todo)\b' README.md            # expect: NO MATCHES if non-reproducible
+
+# 2. Dump the ACTUAL content of the cited lines to see what is really there.
+awk 'NR>=1&&NR<=20{printf "%d: %s\n",NR,$0}' README.md
+
+# 3. Pickaxe the file HISTORY — did the cited content EVER exist?
+#    Empty in BOTH directions => never existed (stale finding), not "fixed later".
+git log --oneline -S'marked done' -- README.md   # expect: EMPTY
+git log -S'todo' -- README.md                     # expect: EMPTY
+
+# 4. Confirm what the REAL canonical values are in the actual source of truth.
+grep -niE 'completed|pending|in_progress|backlog|review' src/keystone/models.py
+#   e.g. TERMINAL_STATUSES = frozenset({"completed","failed","error","cancelled"})  (models.py:9)
+
+# 5. Disambiguate common-English-word hits from real status-value misuse.
+#    "all neighbors done" / "removed when done" are PROSE, not a status value.
+grep -niE '\b(done|todo)\b' src/keystone/*.py    # then read each hit IN CONTEXT
+```
+
+### Detailed Steps
+
+1. **Scan the whole file, never only the cited lines.** Audit line numbers drift or are simply
+   wrong. Run `grep -niE '\b(token)\b' <file>` over the entire file. In issue #26 the audit claimed
+   `ProjectKeystone/README.md` lines 7/14/16 used `done`/`todo`; the whole-file grep returned
+   **zero matches**. Lines 7/14/16 were actually a blank line, a `## Overview` heading, and a
+   project-description sentence in a 435-line C++20 HMAS document — none mentioning task status.
+
+2. **Dump the actual cited-line content.** Use `awk 'NR>=A&&NR<=B{printf "%d: %s\n",NR,$0}' <file>`
+   (or `sed -n 'A,Bp'`) to print exactly what lives at the cited coordinates. This converts the
+   audit's claim into an observation. If the lines contain nothing resembling the quoted strings,
+   the finding does not reproduce.
+
+3. **Pickaxe the history with `git log -S` — in BOTH directions of interpretation.** This is the
+   decisive diagnostic that distinguishes two very different situations:
+   - `git log -S'<quoted string>' -- <file>` returns **empty** → the content NEVER existed in this
+     file's history → the finding is **stale/fabricated**, recommend closing as non-reproducible.
+   - `git log -S'<quoted string>' -- <file>` returns a **commit** → the content existed and was
+     removed/changed in a later commit → the finding was **already fixed** (different skill:
+     `stale-plan-already-resolved`).
+
+     For issue #26 BOTH `git log --oneline -S'marked done' -- README.md` and
+     `git log -S'todo' -- README.md` were empty — ruling out "already fixed in a later commit" too.
+
+4. **Confirm the real canonical values from the actual source of truth.** Do not assume the audit's
+   "should be X" is correct either. Grep the real model/source:
+   `grep -niE 'completed|pending|in_progress|backlog|review' src/keystone/models.py` confirmed the
+   canonical statuses (`TERMINAL_STATUSES = frozenset({"completed","failed","error","cancelled"})`
+   at `models.py:9`) — i.e. the real source already uses canonical values.
+
+5. **Disambiguate token-as-English-word from token-as-status-value.** When the offending token is a
+   common word, a raw grep hit is not proof. For issue #26 the only `done` hits in
+   `src/keystone/*.py` were ordinary English in comments ("all neighbors done", "removed when done")
+   — NOT status-value misuse. Read each hit in context before concluding.
+
+6. **Write the conclusion the evidence supports — including "no edit."** A legitimate planning
+   outcome is "non-reproducible; recommend closing." Do not author a "Files to Modify" section to
+   satisfy a template when the finding does not reproduce. Cite the exact commands and their empty
+   outputs so a reviewer can re-run them.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust the audit's cited lines 7/14/16 as fact | Was about to plan edits at the quoted coordinates | Those lines were a blank line, a `## Overview` heading, and a description sentence — none mentioned task status | Treat audit line numbers and quoted strings as claims; open and grep the live file first |
+| Grep only the cited lines | Would have checked just lines 7/14/16 for `done`/`todo` | Audit line numbers drift or are wrong; a narrow check can miss real hits OR confirm a phantom | Scan the WHOLE file (and history), never only the cited line numbers |
+| Assume "not present now" means "already fixed in a later commit" | Considered closing as already-resolved | `git log -S'marked done'` and `git log -S'todo'` were BOTH empty — the content never existed; "already fixed" was the wrong conclusion | Use `git log -S` to check whether cited content EVER existed; empty = stale finding, not already-fixed |
+| Treat every `done`/`todo` grep hit as a status-value defect | Grepped `src/keystone/*.py` for `done`/`todo` and saw hits | The hits were ordinary English in comments ("all neighbors done", "removed when done"), not status values | When the token is a common English word, filter benign prose/comment hits from real status-value misuse before concluding |
+| Author a "Files to Modify" section to fit the plan template | Felt obligated to produce edits for the issue | The finding did not reproduce; any edit would be fabricated | A legitimate planning outcome is "no edit; recommend closing as non-reproducible" — run the repro greps BEFORE writing any fix section |
+
+## Results & Parameters
+
+Concrete facts from the issue #26 planning session (ProjectKeystone `README.md`):
+
+| Parameter | Value |
+|-----------|-------|
+| Whole-file token scan | `grep -niE '\b(done\|todo)\b' README.md` → **NO MATCHES** |
+| Cited-line dump | `awk 'NR>=1&&NR<=20{printf "%d: %s\n",NR,$0}' README.md` → line 7 blank, line 14 `## Overview`, line 16 a description sentence |
+| History pickaxe (decisive) | `git log --oneline -S'marked done' -- README.md` → **EMPTY**; `git log -S'todo' -- README.md` → **EMPTY** (content never existed) |
+| Canonical statuses (real source) | `grep -niE 'completed\|pending\|in_progress\|backlog\|review' src/keystone/models.py` → `TERMINAL_STATUSES = frozenset({"completed","failed","error","cancelled"})` at `models.py:9` |
+| Benign token hits | only `done` in `src/keystone/*.py` comments: "all neighbors done", "removed when done" — prose, not status values |
+| README reality | 435-line C++20 HMAS document; cited lines 7/14/16 unrelated to task status |
+| Conclusion | **Non-reproducible** — recommend closing issue #26; no file edit |
+| Verification level | verified-local (greps + git-log executed and confirmed this session; no CI) |
+
+### Decision tree
+
+```
+Audit issue cites file:line + quoted offending string
+│
+├─ 1. grep -niE '\b(token)\b' <whole file>
+│   ├─ NO matches → likely non-reproducible → go to 2
+│   └─ matches → read in context (token = status value, or just English?) → go to 4
+│
+├─ 2. git log -S'<quoted string>' -- <file>
+│   ├─ EMPTY → content NEVER existed → STALE finding → close as non-reproducible
+│   └─ commit found → content existed, removed later → ALREADY FIXED
+│       └─ (use skill: stale-plan-already-resolved)
+│
+├─ 3. Confirm real canonical values in the actual source of truth (don't trust the
+│      audit's "should be X" either): grep the model/source file.
+│
+└─ 4. Token = common English word?
+    ├─ yes → filter benign prose/comment hits from real status-value misuse
+    └─ no  → a hit is strong evidence the finding reproduces
+```
+
+### Risks for the plan reviewer (most uncertain assumptions)
+
+- **Audit may have targeted a DIFFERENT file/path.** The plan assumed the audit's premise was simply
+  wrong. Not fully excluded: the audit may have targeted an OLD fork/path (e.g. an ai-maestro-era
+  README) that no longer maps to this submodule's current README. The plan relied on the issue's own
+  file path (`README.md`) being the intended target.
+- **Submodule pin may be stale.** Inspection relied on the submodule being pinned at the correct
+  integration SHA (detached HEAD `3185bc9`). If Odysseus's pin is stale, the "live file" inspected
+  may differ from a fresh clone of ProjectKeystone `main`. The plan did NOT independently fetch and
+  compare ProjectKeystone's `main` tip — do that before final close.
+- **Canonical status set was taken as given.** The ProjectAgamemnon REST API canonical set
+  (`backlog, pending, in_progress, review, completed`) came from the issue body + Prior Learnings,
+  NOT verified against the actual Agamemnon API contract/source. Re-verify against source if the
+  close decision hinges on it.
+```
+
+---
+
+## v1.0.0 (2026-06-19)
+
+**Initial version.** Created in PR #2582. Concluded issue #26 was "non-reproducible / never existed"
+based on empty `git log -S` searches run against a stale detached pin with non-exact phrasings. This
+conclusion was later proven FALSE and is corrected in v2.0.0.

--- a/skills/verify-audit-issue-reproduces-before-fixing.md
+++ b/skills/verify-audit-issue-reproduces-before-fixing.md
@@ -1,21 +1,24 @@
 ---
 name: verify-audit-issue-reproduces-before-fixing
-description: "Verify an audit issue actually reproduces against the live file BEFORE planning a fix — treat audit line numbers and quoted strings as claims, not facts. Run the repro greps DURING planning; the legitimate outcome may be 'no edit, recommend closing as non-reproducible.' Use git log -S to distinguish a stale finding (content NEVER existed) from an already-fixed one (content existed, removed in a later commit). Use when: (1) an audit/auto-generated issue cites file:line coordinates and quoted offending strings, (2) the offending token is a common English word (done/todo/fix) that could be benign prose, (3) you are tempted to write a 'Files to Modify' section before grepping, (4) deciding whether to close an issue as non-reproducible."
+description: "When an audit issue's cited content is ABSENT from the current file, do NOT conclude 'never existed / non-reproducible' until you have searched the CORRECT refs (live origin/main, not a stale pin) with the EXACT audited strings across `git log --all`. Content may have existed and been REMOVED — and the disposition 'already-resolved, provenance commit X' is materially different and better than 'phantom finding.' Use `git merge-base --is-ancestor` to distinguish removal-by-a-main-lineage-commit from an orphaned/abandoned lineage. Use when: (1) an audit/auto-generated issue cites file:line + quoted offending strings that are not in the file now, (2) you inspected a submodule pin / detached HEAD instead of origin/main, (3) your `git log -S` came back empty and you are tempted to call the finding phantom, (4) deciding how to close an audit issue."
 category: documentation
 date: 2026-06-19
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
 verification: verified-local
+history: verify-audit-issue-reproduces-before-fixing.history
 tags:
   - audit-finding
-  - non-reproducible
+  - already-resolved
+  - provenance-commit
   - premise-verification
-  - line-number-drift
-  - git-log-pickaxe
+  - git-log-pickaxe-all
+  - git-merge-base-ancestry
+  - stale-submodule-pin
+  - live-tip-inspection
+  - orphaned-lineage
+  - history-replacement
   - planning-methodology
-  - close-as-cannot-reproduce
-  - token-vs-status-value
-  - stale-finding
 ---
 
 # Verify an Audit Issue Reproduces Before Fixing
@@ -25,153 +28,182 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-19 |
-| **Objective** | Before planning a fix for an audit-filed issue, prove the finding actually reproduces against the live working tree — rather than trusting the issue's cited line numbers and quoted strings as facts |
-| **Outcome** | A repeatable planning discipline: run repro greps + `git log -S` during planning; for issue #26 the outcome was correctly "non-reproducible, recommend closing — no edit" because the cited content never existed in the file or its history |
+| **Objective** | Before planning a fix for (or closing) an audit-filed issue, determine whether the cited content is genuinely a phantom or whether it EXISTED and was removed — by searching the correct refs (`origin/main`, full `--all` history) with the exact audited strings, and classifying the removal mechanism |
+| **Outcome** | A repeatable planning discipline. For issue #26 the corrected outcome was **already-resolved, citing provenance commit `a3878c3`** — the audit was ACCURATE at filing; the terminology existed and was removed by history replacement. This OVERTURNS the v1.0.0 conclusion of "non-reproducible / never existed" |
 | **Verification** | verified-local |
+| **History** | [changelog](./verify-audit-issue-reproduces-before-fixing.history) |
 
-Verified locally only — CI validation pending. The greps, `awk` line dumps, and `git log -S`
-pickaxe searches documented below were actually executed against the live working tree this
-session and their outputs confirmed the finding did not reproduce. No CI ran, and the cross-repo
-assumptions in Results & Parameters (submodule pin freshness, the Agamemnon canonical status set,
-and whether the audit targeted a different/old path) remain unverified.
+**Verified locally only — CI validation pending.** Every git command in the Verified Workflow
+(`git fetch`, `git show origin/main:README.md`, `git rev-list --count <pin>..origin/main`,
+`git log --all -S`, `git show <sha>:README.md`, `git merge-base --is-ancestor`) was actually executed
+against the live working tree + freshly fetched origin this session and the outputs confirmed the
+corrected disposition. No CI ran. Two assumptions remain unverified (see Risks): the canonical status
+set was taken from the issue body (not the live Agamemnon API contract), and the "removed per ADR-006
+re-scope" causal story is INFERRED from lineage + content, not from a single attributable diff
+(because the lineages are disjoint).
 
 ## When to Use
 
 - An audit or auto-generated issue cites `file:line` coordinates **and** quotes specific offending
-  strings (e.g. "lines 7/14/16 use `done`/`todo` instead of `completed`/`pending`").
-- You are about to write a "Files to Modify" section based on the issue body without having opened
-  the file yet.
-- The offending token is a common English word (`done`, `todo`, `fix`, `wip`) that can legitimately
-  appear in prose/comments, so a raw grep hit is not proof of a real defect.
-- You need to decide between "this is a stale finding that never existed" vs "this was already fixed
-  in a later commit" vs "the finding genuinely holds."
-- The issue may have targeted a **different file**, an old fork/path, or a stale submodule pin that
-  no longer maps to the current file.
+  strings, but those strings are **not present in the file you are looking at now**.
+- You inspected a **submodule pin / detached HEAD** (or any non-`origin/main` ref) and are about to
+  conclude the finding is phantom — you have not yet checked the LIVE tip.
+- Your first `git log -S'...'` came back **empty** and you are tempted to write "never existed /
+  non-reproducible." (This is exactly how v1.0.0 of this skill got it WRONG.)
+- The offending token is a common English word (`done`, `todo`, `fix`, `wip`) that can appear in
+  prose, so you must search the EXACT audited substring (including backticks), not a loose word.
+- You need to decide between "phantom finding," "already-resolved (existed, then removed)," and
+  "finding genuinely holds — needs a fix."
 
 ## Verified Workflow
+
+**Headline: when audited content is absent, search the CORRECT refs (`origin/main`, `--all`) with the
+EXACT audited strings BEFORE concluding "never existed." Content that existed-then-was-removed closes
+as "already-resolved, provenance commit X" — a materially different and better disposition than
+"phantom finding." Use `git merge-base --is-ancestor` to tell removal-on-the-main-lineage apart from
+an orphaned/abandoned lineage.**
 
 ### Quick Reference
 
 ```bash
-# 1. Whole-file scan for the offending tokens (NOT just the cited lines).
-#    Audit line numbers drift or are entirely wrong — scan the whole file.
-grep -niE '\b(done|todo)\b' README.md            # expect: NO MATCHES if non-reproducible
+# 0. Fetch and inspect the LIVE tip, not the pinned/detached SHA you happen to be on.
+git fetch origin
+git show origin/main:README.md | grep -niE '\b(done|todo)\b'   # what is canonical NOW
 
-# 2. Dump the ACTUAL content of the cited lines to see what is really there.
-awk 'NR>=1&&NR<=20{printf "%d: %s\n",NR,$0}' README.md
+# 1. Quantify how stale the pin you first inspected is (don't trust a detached HEAD).
+git rev-list --count <pin-sha>..origin/main                    # e.g. 37 commits behind
 
-# 3. Pickaxe the file HISTORY — did the cited content EVER exist?
-#    Empty in BOTH directions => never existed (stale finding), not "fixed later".
-git log --oneline -S'marked done' -- README.md   # expect: EMPTY
-git log -S'todo' -- README.md                     # expect: EMPTY
+# 2. Pickaxe the FULL history with the EXACT audited substring (note --all, not just HEAD).
+#    Use the real backtick-wrapped strings, not loose words.
+git log --all --oneline -S'is `done`'   -- README.md           # finds where it EXISTED
+git log --all --oneline -S'still `todo`' -- README.md
+git log --all --oneline -S'marked done' -- README.md
 
-# 4. Confirm what the REAL canonical values are in the actual source of truth.
+# 3. Confirm the EXACT cited lines in the commit that contained them.
+git show <found-sha>:README.md | awk 'NR==7||NR==14||NR==16{printf "%d: %s\n",NR,$0}'
+
+# 4. Classify the removal mechanism: linear edit on main vs orphaned/abandoned lineage.
+git merge-base --is-ancestor <found-sha> origin/main \
+  && echo "ancestor → removed by a commit ON the main lineage" \
+  || echo "NOT ancestor → orphaned/abandoned lineage (history replacement)"
+
+# 5. (only if classifying as still-broken) confirm the real canonical values in source of truth.
 grep -niE 'completed|pending|in_progress|backlog|review' src/keystone/models.py
-#   e.g. TERMINAL_STATUSES = frozenset({"completed","failed","error","cancelled"})  (models.py:9)
-
-# 5. Disambiguate common-English-word hits from real status-value misuse.
-#    "all neighbors done" / "removed when done" are PROSE, not a status value.
-grep -niE '\b(done|todo)\b' src/keystone/*.py    # then read each hit IN CONTEXT
 ```
 
 ### Detailed Steps
 
-1. **Scan the whole file, never only the cited lines.** Audit line numbers drift or are simply
-   wrong. Run `grep -niE '\b(token)\b' <file>` over the entire file. In issue #26 the audit claimed
-   `ProjectKeystone/README.md` lines 7/14/16 used `done`/`todo`; the whole-file grep returned
-   **zero matches**. Lines 7/14/16 were actually a blank line, a `## Overview` heading, and a
-   project-description sentence in a 435-line C++20 HMAS document — none mentioning task status.
+1. **Fetch and inspect the LIVE tip — never just the pin you landed on.** A submodule pin or detached
+   HEAD can be many commits behind. In issue #26 the pin first inspected (`3185bc9`) was **37 commits
+   behind** `origin/main` (`git rev-list --count 3185bc9..origin/main` → 37). Always
+   `git fetch origin` and inspect `git show origin/main:README.md` before judging "what the file
+   says now."
 
-2. **Dump the actual cited-line content.** Use `awk 'NR>=A&&NR<=B{printf "%d: %s\n",NR,$0}' <file>`
-   (or `sed -n 'A,Bp'`) to print exactly what lives at the cited coordinates. This converts the
-   audit's claim into an observation. If the lines contain nothing resembling the quoted strings,
-   the finding does not reproduce.
+2. **Quantify pin staleness explicitly.** `git rev-list --count <pin>..origin/main` turns "I think
+   the pin is old" into a number. A non-trivial count means the file you inspected is NOT the live
+   file, and any "non-reproducible" claim built on it is unsafe.
 
-3. **Pickaxe the history with `git log -S` — in BOTH directions of interpretation.** This is the
-   decisive diagnostic that distinguishes two very different situations:
-   - `git log -S'<quoted string>' -- <file>` returns **empty** → the content NEVER existed in this
-     file's history → the finding is **stale/fabricated**, recommend closing as non-reproducible.
-   - `git log -S'<quoted string>' -- <file>` returns a **commit** → the content existed and was
-     removed/changed in a later commit → the finding was **already fixed** (different skill:
-     `stale-plan-already-resolved`).
+3. **Pickaxe the FULL history with the EXACT audited substring.** This is the step v1.0.0 botched.
+   Two failure modes to avoid:
+   - **Wrong refs:** a plain `git log -S` only searches the history reachable from your current
+     (possibly stale, detached) HEAD. Use `git log --all -S'...'` so abandoned/orphaned lineages are
+     searched too.
+   - **Wrong string:** the audit quoted backtick-wrapped status values (``is `done` ``,
+     ``still `todo` ``). Loose searches like `-S'marked done'` / `-S'todo'` UNDER-matched. Search the
+     exact audited substring.
 
-     For issue #26 BOTH `git log --oneline -S'marked done' -- README.md` and
-     `git log -S'todo' -- README.md` were empty — ruling out "already fixed in a later commit" too.
+     For issue #26, searching the exact strings across `--all` FOUND commit `a3878c3`, which
+     `git show a3878c3:README.md` proves contained the audit's exact strings at the exact cited lines:
+     - L7: "When a task is marked done, Keystone traverses the DAG…"
+     - L14: "When a task's status transitions to `done`, Keystone identifies the affected team."
+     - L16: "Identifies tasks where every dependency is `done` and the task itself is still `todo`."
 
-4. **Confirm the real canonical values from the actual source of truth.** Do not assume the audit's
-   "should be X" is correct either. Grep the real model/source:
-   `grep -niE 'completed|pending|in_progress|backlog|review' src/keystone/models.py` confirmed the
-   canonical statuses (`TERMINAL_STATUSES = frozenset({"completed","failed","error","cancelled"})`
-   at `models.py:9`) — i.e. the real source already uses canonical values.
+     So the audit was **ACCURATE at filing** — the content existed. Empty was a search artifact, not
+     proof of absence.
 
-5. **Disambiguate token-as-English-word from token-as-status-value.** When the offending token is a
-   common word, a raw grep hit is not proof. For issue #26 the only `done` hits in
-   `src/keystone/*.py` were ordinary English in comments ("all neighbors done", "removed when done")
-   — NOT status-value misuse. Read each hit in context before concluding.
+4. **Confirm the exact cited lines in the commit that contained them.**
+   `git show <found-sha>:README.md | awk 'NR==7||NR==14||NR==16'` converts "it existed somewhere" into
+   "it existed at exactly the audited coordinates," which is what makes the provenance citation solid.
 
-6. **Write the conclusion the evidence supports — including "no edit."** A legitimate planning
-   outcome is "non-reproducible; recommend closing." Do not author a "Files to Modify" section to
-   satisfy a template when the finding does not reproduce. Cite the exact commands and their empty
-   outputs so a reviewer can re-run them.
+5. **Classify the removal mechanism with `git merge-base --is-ancestor`.** This distinguishes two very
+   different removal stories:
+   - `git merge-base --is-ancestor <found-sha> origin/main` → **true** → the content was removed by a
+     commit ON the main lineage (a normal linear edit). The diff is attributable.
+   - → **false** → the found commit is **NOT** on the main lineage; the terminology was removed by
+     **history replacement** — the old lineage was abandoned and `origin/main` descends from a
+     different root.
+
+     For issue #26 it returned **false**: `a3878c3` is not an ancestor of `origin/main`, which
+     descends from a different root `2e9f216` ("Initial commit"). The ai-maestro scaffold lineage was
+     abandoned when ProjectKeystone was re-scoped to a C++ transport library (per ADR-006). There is
+     therefore NO single attributable diff that removed the terminology — the lineages are disjoint.
+
+6. **Write the disposition the evidence supports — prefer provenance over phantom.** When content
+   existed and was removed, close as **already-resolved, citing the provenance commit** (here
+   `a3878c3`). This CONFIRMS the audit tooling was correct, rather than wrongly signaling a phantom
+   finding and eroding trust in the audit. Cite the exact commands and SHAs so a reviewer can re-run
+   them. Only if the live `origin/main` STILL contains the offending strings do you proceed to plan an
+   actual edit (step 5 of Quick Reference confirms the canonical values).
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Trust the audit's cited lines 7/14/16 as fact | Was about to plan edits at the quoted coordinates | Those lines were a blank line, a `## Overview` heading, and a description sentence — none mentioned task status | Treat audit line numbers and quoted strings as claims; open and grep the live file first |
-| Grep only the cited lines | Would have checked just lines 7/14/16 for `done`/`todo` | Audit line numbers drift or are wrong; a narrow check can miss real hits OR confirm a phantom | Scan the WHOLE file (and history), never only the cited line numbers |
-| Assume "not present now" means "already fixed in a later commit" | Considered closing as already-resolved | `git log -S'marked done'` and `git log -S'todo'` were BOTH empty — the content never existed; "already fixed" was the wrong conclusion | Use `git log -S` to check whether cited content EVER existed; empty = stale finding, not already-fixed |
-| Treat every `done`/`todo` grep hit as a status-value defect | Grepped `src/keystone/*.py` for `done`/`todo` and saw hits | The hits were ordinary English in comments ("all neighbors done", "removed when done"), not status values | When the token is a common English word, filter benign prose/comment hits from real status-value misuse before concluding |
-| Author a "Files to Modify" section to fit the plan template | Felt obligated to produce edits for the issue | The finding did not reproduce; any edit would be fabricated | A legitimate planning outcome is "no edit; recommend closing as non-reproducible" — run the repro greps BEFORE writing any fix section |
+| Misread an empty `git log -S` as "content never existed" | Ran `git log -S'marked done'` / `-S'todo'` and got no results, then concluded the finding was phantom / non-reproducible (this was v1.0.0's core, later-overturned claim) | The searches (a) ran only on a stale detached-pin's reachable history — not `--all`, not `origin/main` — and (b) used loose phrasings, not the actual backtick-wrapped strings (``is `done` ``, ``still `todo` ``). The exact strings DID exist, in commit `a3878c3` | Empty `-S` output is NOT proof of absence. Search `git log --all -S'<exact substring>'`, inspect candidates with `git show <sha>:README.md`, and check ancestry with `git merge-base --is-ancestor` before ever saying "never existed" |
+| Inspected the stale submodule pin instead of the live tip | Judged "what the file says now" from the detached pin `3185bc9` | `3185bc9` was **37 commits behind** `origin/main` (`git rev-list --count 3185bc9..origin/main` → 37); the pinned file was not the live file | Always `git fetch origin` and inspect `git show origin/main:README.md`; quantify pin staleness with `git rev-list --count <pin>..origin/main` |
+| Assumed "absent now" implies "phantom / never existed" | Jumped to a non-reproducible close once the strings were not in the current file | The strings existed historically (`a3878c3`); absent-now means removed, not phantom. "Already-resolved, provenance commit X" is the correct and better disposition | Distinguish existed-then-removed from never-existed; the former closes with provenance, confirming the audit was right |
+| Trusted a plain `git log -S` to cover all history | Searched only HEAD-reachable history | A detached/stale HEAD does not reach abandoned/orphaned lineages where the content may live | Use `git log --all -S` so orphaned lineages (history replacement) are searched |
+| Assumed any removal is a linear edit on main | Looked for "the commit that removed it" expecting an attributable diff | `a3878c3` is NOT an ancestor of `origin/main` (different root `2e9f216`); removal was by history replacement (re-scope per ADR-006), so no single diff removed it | Use `git merge-base --is-ancestor <sha> origin/main` to tell removal-on-main from orphaned/abandoned lineage |
 
 ## Results & Parameters
 
-Concrete facts from the issue #26 planning session (ProjectKeystone `README.md`):
+Corrected facts from the issue #26 planning session (ProjectKeystone `README.md`,
+`done`/`todo` vs canonical `completed`/`pending`):
 
 | Parameter | Value |
 |-----------|-------|
-| Whole-file token scan | `grep -niE '\b(done\|todo)\b' README.md` → **NO MATCHES** |
-| Cited-line dump | `awk 'NR>=1&&NR<=20{printf "%d: %s\n",NR,$0}' README.md` → line 7 blank, line 14 `## Overview`, line 16 a description sentence |
-| History pickaxe (decisive) | `git log --oneline -S'marked done' -- README.md` → **EMPTY**; `git log -S'todo' -- README.md` → **EMPTY** (content never existed) |
-| Canonical statuses (real source) | `grep -niE 'completed\|pending\|in_progress\|backlog\|review' src/keystone/models.py` → `TERMINAL_STATUSES = frozenset({"completed","failed","error","cancelled"})` at `models.py:9` |
-| Benign token hits | only `done` in `src/keystone/*.py` comments: "all neighbors done", "removed when done" — prose, not status values |
-| README reality | 435-line C++20 HMAS document; cited lines 7/14/16 unrelated to task status |
-| Conclusion | **Non-reproducible** — recommend closing issue #26; no file edit |
-| Verification level | verified-local (greps + git-log executed and confirmed this session; no CI) |
+| Live-tip inspection | `git fetch origin` then `git show origin/main:README.md \| grep -niE '\b(done\|todo)\b'` → canonical terminology now (no audited strings) |
+| Pin staleness | `git rev-list --count 3185bc9..origin/main` → **37** (pin first inspected was 37 commits behind) |
+| History pickaxe (decisive) | `git log --all --oneline -S'is \`done\`' -- README.md` and `-S'still \`todo\`'` → **FOUND commit `a3878c3`** (exact audited strings existed) |
+| Provenance commit | `git show a3878c3:README.md` → L7 "marked done … traverses the DAG", L14 "transitions to `done`", L16 "every dependency is `done` … still `todo`" — exact cited lines 7/14/16 |
+| Removal mechanism | `git merge-base --is-ancestor a3878c3 origin/main` → **false (NOT ancestor)**; `origin/main` descends from different root `2e9f216` ("Initial commit") → history replacement, not linear edit |
+| Causal story (inferred) | ai-maestro scaffold lineage abandoned when ProjectKeystone re-scoped to a C++ transport library (per ADR-006); no single attributable diff (disjoint lineages) |
+| Canonical statuses | `backlog/pending/in_progress/review/completed` — from issue body, NOT verified against live Agamemnon API contract |
+| Audit accuracy | **ACCURATE at filing** — content existed at the cited coordinates in `a3878c3` |
+| Conclusion | **Already-resolved** — close issue #26 citing provenance commit `a3878c3`; no file edit (live tip already canonical) |
+| Verification level | verified-local (all git commands above executed against live tree + fetched origin this session; no CI) |
 
 ### Decision tree
 
 ```
-Audit issue cites file:line + quoted offending string
+Audit issue cites file:line + quoted offending string, but string is ABSENT from the file now
 │
-├─ 1. grep -niE '\b(token)\b' <whole file>
-│   ├─ NO matches → likely non-reproducible → go to 2
-│   └─ matches → read in context (token = status value, or just English?) → go to 4
+├─ 0. git fetch origin; inspect git show origin/main:README.md (the LIVE tip)
+│   ├─ string STILL present on origin/main → finding HOLDS → plan a real fix
+│   └─ string absent on origin/main → go to 1
 │
-├─ 2. git log -S'<quoted string>' -- <file>
-│   ├─ EMPTY → content NEVER existed → STALE finding → close as non-reproducible
-│   └─ commit found → content existed, removed later → ALREADY FIXED
-│       └─ (use skill: stale-plan-already-resolved)
+├─ 1. Was the ref you first inspected a stale pin?
+│      git rev-list --count <pin>..origin/main  (non-zero ⇒ inspected the wrong file)
 │
-├─ 3. Confirm real canonical values in the actual source of truth (don't trust the
-│      audit's "should be X" either): grep the model/source file.
+├─ 2. git log --all -S'<EXACT audited substring incl. backticks>' -- <file>
+│   ├─ EMPTY (and you used --all + exact string) → genuinely never existed → phantom
+│   └─ commit <sha> found → content EXISTED → confirm with git show <sha>:file → go to 3
 │
-└─ 4. Token = common English word?
-    ├─ yes → filter benign prose/comment hits from real status-value misuse
-    └─ no  → a hit is strong evidence the finding reproduces
+├─ 3. git merge-base --is-ancestor <sha> origin/main
+│   ├─ ancestor → removed by a commit ON main (attributable linear edit)
+│   └─ NOT ancestor → orphaned/abandoned lineage (history replacement); no single diff
+│
+└─ 4. Disposition: CLOSE as already-resolved, citing provenance commit <sha>.
+       (Confirms the audit was correct — better than signalling a phantom finding.)
 ```
 
 ### Risks for the plan reviewer (most uncertain assumptions)
 
-- **Audit may have targeted a DIFFERENT file/path.** The plan assumed the audit's premise was simply
-  wrong. Not fully excluded: the audit may have targeted an OLD fork/path (e.g. an ai-maestro-era
-  README) that no longer maps to this submodule's current README. The plan relied on the issue's own
-  file path (`README.md`) being the intended target.
-- **Submodule pin may be stale.** Inspection relied on the submodule being pinned at the correct
-  integration SHA (detached HEAD `3185bc9`). If Odysseus's pin is stale, the "live file" inspected
-  may differ from a fresh clone of ProjectKeystone `main`. The plan did NOT independently fetch and
-  compare ProjectKeystone's `main` tip — do that before final close.
-- **Canonical status set was taken as given.** The ProjectAgamemnon REST API canonical set
-  (`backlog, pending, in_progress, review, completed`) came from the issue body + Prior Learnings,
-  NOT verified against the actual Agamemnon API contract/source. Re-verify against source if the
-  close decision hinges on it.
+- **Canonical status set not verified against the live API.** The set
+  (`backlog/pending/in_progress/review/completed`) was taken from the issue body, NOT checked against
+  the live ProjectAgamemnon API contract/source. This has **zero impact** when the disposition is a
+  no-op already-resolved close, but flag it — if a future close hinges on the canonical set, verify it.
+- **Causal "removed per ADR-006 re-scope" story is inferred, not attributed.** Because the
+  ai-maestro-scaffold lineage and `origin/main` are **disjoint** (different roots), there is no single
+  diff that removed the terminology. The re-scope explanation is inferred from the lineage split plus
+  the README content change, not read from one attributable commit. Present it as inference, not fact.


### PR DESCRIPTION
## Summary

Amends existing skill `verify-audit-issue-reproduces-before-fixing` from **v1.0.0 to v2.0.0** (major: a core recommendation changed). Previous version is archived in `verify-audit-issue-reproduces-before-fixing.history`.

v1.0.0 concluded ProjectKeystone issue #26 was "non-reproducible / the cited content NEVER existed." A plan reviewer proved that FALSE. The audit was **accurate at filing**: the cited content existed in commit `a3878c3` and was removed by **history replacement**, so the correct disposition is **already-resolved, provenance commit `a3878c3`** — not a phantom finding.

- When audited content is absent now, search the CORRECT refs (`origin/main`, `git log --all`) with the EXACT audited strings before concluding "never existed"
- Distinguish existed-then-removed (close with provenance) from never-existed (phantom)
- Use `git merge-base --is-ancestor` to classify removal: main-lineage edit vs orphaned/abandoned lineage
- Inspect the LIVE tip, not a stale pin (the pin first inspected was 37 commits behind)

## Verification Level

**verified-local** — all git commands (`git fetch`, `git show origin/main:`, `git rev-list --count`, `git log --all -S`, `git show <sha>:README.md`, `git merge-base --is-ancestor`) were executed against the live tree + fetched origin this session. No CI ran. Canonical status set and ADR-006 causal story remain unverified (noted in Risks).

## Key Findings

**What Worked**:
- `git log --all -S'<exact backtick-wrapped substring>'` found commit `a3878c3` where the content existed
- `git merge-base --is-ancestor a3878c3 origin/main` returned false, identifying history replacement (disjoint root `2e9f216`)

**What Failed (now captured as Failed Attempts)**:
- Misread an empty `git log -S` as "never existed" → it ran on a stale detached pin with non-exact phrasings
- Inspected the stale submodule pin (`3185bc9`, 37 commits behind) instead of `origin/main`

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (409/409 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>