### PR TITLE
feat: amend planning-verify-live-state-before-assuming-work-remains skill (v1.1.0)

### DIFF
--- a/skills/planning-verify-live-state-before-assuming-work-remains.history
+++ b/skills/planning-verify-live-state-before-assuming-work-remains.history
@@ -1,0 +1,61 @@
+<!-- markdownlint-disable MD024 -->
+# planning-verify-live-state-before-assuming-work-remains — History
+
+## v1.1.0 (2026-06-19)
+
+**Changed by:** Re-planning of GitHub issue #24 ("Standardize default branch across ecosystem") after a NOGO review (same session, after PR #2583).
+**Verification:** verified-local
+
+### What changed
+
+- Added 2 new Failed Attempts rows:
+  - The 5-repo-scan false negative: verifying only the named repos missed `ProjectKeystone`'s
+    orphan `refs/heads/master` (Keystone was NOT one of the named 5; it already defaulted to `main`).
+  - The unverified expected-value annotation: asserted a grep would return count `4`; running it
+    returned `3` (the 4th `master` literal was a trailing `# master` comment the regex cannot match).
+- Strengthened verification guidance: write fail-loud checks (`--jq 'any()'` boolean) rather than
+  `grep 'Not Found' || echo 'Not Found'`; verify "already-applied" claims by direct live read
+  (`gh api .../rulesets`) rather than inference from config files.
+- Updated Results & Parameters with the directly-read live ruleset value
+  (`homeric-main-baseline`, active, id 15556483) and the ProjectKeystone orphan-master facts.
+- Added a cross-link to the new sibling skill
+  `planning-verify-full-population-not-just-named-entities`.
+- Added `history:` frontmatter field; bumped version 1.0.0 → 1.1.0; date stays 2026-06-19.
+
+### Why
+
+v1.0.0 verified live state per *named* entity and declared issue #24 complete. The reviewer
+flagged uneven coverage because the issue was ecosystem-wide. Extending the loop to all 15 repos
+found `ProjectKeystone`'s stale unprotected orphan `master` — the one real residue. The companion
+corrections (run-the-command-for-expected-values, fail-loud checks, direct-read over inference)
+directly strengthen this skill's verification discipline. The population-scoping headline is
+captured in the new sibling skill; the corrections live here.
+
+### Previous version (v1.0.0) snapshot
+
+```yaml
+name: planning-verify-live-state-before-assuming-work-remains
+description: "When an issue describes work to be done (a migration, rename, or config change), verify the LIVE external state FIRST with gh/grep before planning any edits — the work may already be complete, making the correct plan a verify-and-close plan with ZERO source edits. An issue body is a snapshot from when it was filed and drifts: the default branch, CI config, open-PR bases, and linked-issue states all change underneath it. Includes the gh-API gotcha that `gh api repos/ORG/REPO/branches/master` RETURNS the default branch via HTTP redirect for a MISSING branch (false positive that master exists) — use the `git/refs/heads` listing instead. Use when: (1) an issue/ticket describes a migration or change that may already be done, (2) planning work whose premise depends on live external state (default branch, CI config, issue status), (3) before recommending edits driven by an issue's stated assumptions, (4) before writing any 'Files to Modify' that exist only because the issue said so."
+category: tooling
+date: 2026-06-19
+version: "1.0.0"
+```
+
+Failed Attempts (v1.0.0, 3 rows):
+
+1. Trust the issue's repo table → stale snapshot; all repos already on `main`.
+2. Probe `branches/master` to test existence → redirects to default branch, false positive.
+3. Blind find/replace master→main → corrupts `--branch master` guards and `action@master` pins.
+
+Results & Parameters (v1.0.0) listed: all 15 repos default `main`; no `refs/heads/master` in the
+5 named repos; workflows target `main`; 0 non-main open PRs; 4 tracking issues CLOSED; FREE-plan
+org-rulesets 404 constraint; and three "uncertain assumptions" — notably (b) only the 5 named repos
+had refs exhaustively listed, the gap this amendment + sibling skill close.
+
+---
+
+## v1.0.0 (2026-06-19)
+
+**Initial version.** Created in PR #2583 from the issue #24 first-pass planning session: verify
+live external state (default branch, refs, CI triggers, open-PR bases, linked-issue states) with
+gh/grep before assuming an issue's described work remains undone.

--- a/skills/planning-verify-live-state-before-assuming-work-remains.md
+++ b/skills/planning-verify-live-state-before-assuming-work-remains.md
@@ -3,9 +3,10 @@ name: planning-verify-live-state-before-assuming-work-remains
 description: "When an issue describes work to be done (a migration, rename, or config change), verify the LIVE external state FIRST with gh/grep before planning any edits — the work may already be complete, making the correct plan a verify-and-close plan with ZERO source edits. An issue body is a snapshot from when it was filed and drifts: the default branch, CI config, open-PR bases, and linked-issue states all change underneath it. Includes the gh-API gotcha that `gh api repos/ORG/REPO/branches/master` RETURNS the default branch via HTTP redirect for a MISSING branch (false positive that master exists) — use the `git/refs/heads` listing instead. Use when: (1) an issue/ticket describes a migration or change that may already be done, (2) planning work whose premise depends on live external state (default branch, CI config, issue status), (3) before recommending edits driven by an issue's stated assumptions, (4) before writing any 'Files to Modify' that exist only because the issue said so."
 category: tooling
 date: 2026-06-19
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: planning-verify-live-state-before-assuming-work-remains.history
 tags: []
 ---
 
@@ -19,6 +20,7 @@ tags: []
 | **Objective** | When planning an issue that asserts work needs doing (e.g. "5 repos still on master, CI broken"), determine whether that work is already complete BEFORE writing edits — and if it is, produce a verify-and-close plan with zero source changes instead of a rename plan |
 | **Outcome** | Successful: live-state verification of GitHub issue #24 ("Standardize default branch name across ecosystem") revealed the migration was ALREADY COMPLETE — all 15 repos default to `main`, no `master` refs exist, all workflows target `main`, all open PRs are based on `main`, all 4 linked tracking issues were already CLOSED. The plan correctly became "verify-and-close, zero source edits." |
 | **Verification** | verified-local (the gh/grep commands below were run this session and produced the cited outputs; not validated in ProjectMnemosyne CI) |
+| **History** | [changelog](./planning-verify-live-state-before-assuming-work-remains.history) |
 
 ## When to Use
 
@@ -46,6 +48,10 @@ gh repo view "$ORG/$REPO" --json defaultBranchRef --jq .defaultBranchRef.name
 gh api "repos/$ORG/$REPO/git/refs/heads" --jq '.[].ref'
 #   GOTCHA: `gh api repos/$ORG/$REPO/branches/master` returns the DEFAULT
 #   branch via HTTP redirect for a missing branch → FALSE POSITIVE.
+#   FAIL-LOUD form (clean boolean, emits nothing on API failure):
+gh api "repos/$ORG/$REPO/git/refs/heads" --jq 'any(.ref=="refs/heads/master")'
+#   Do NOT use `... 2>&1 | grep 'Not Found' || echo 'Not Found'` — it masks
+#   auth errors / rate-limits as a false-green "Not Found".
 
 # 3. Workflow triggers still reference the old branch?
 grep -rEn "branches:\s*\[?\s*[\"']?(main|master)" .github/workflows/*.yml
@@ -76,10 +82,21 @@ gh issue view N --repo "$ORG/$REPO" --json state --jq .state
    depending on the old branch.
 6. **Check linked/tracking issue states** — if the tracking issues are already CLOSED, the work was
    already accepted and closed out; do not re-plan it.
-7. **Decide the deliverable from the evidence.** If every check shows the work is complete, write a
-   forward-looking verify-and-close plan (state the verification commands and their outputs, then the
-   single close step) with an explicit "zero source edits" note — not a rename plan, and not a bare
-   retrospective status note.
+7. **Run every verification command and paste its REAL output as the expected value.** Never
+   annotate a check with a guessed count or boolean — a wrong expected value makes a reviewer
+   running the exact command conclude the check FAILED (this round: an asserted grep count of `4`
+   was actually `3`; a trailing `# master` comment is not matched by `@master|--branch, master`).
+8. **Verify "already-applied" claims by a direct live read, not inference.** A justfile + config
+   file is intent, not state. Read the live API (`gh api repos/$ORG/$REPO/rulesets`) — see Results.
+9. **Scope the verification loop to the whole population, not just named entities.** If the issue
+   is ecosystem-wide ("all repos"), enumerate the full set yourself and loop every check over all
+   of it — see the companion skill
+   `planning-verify-full-population-not-just-named-entities`. The unnamed members are where residue
+   hides (this round: `ProjectKeystone`, not one of the 5 named repos, held the orphan `master`).
+10. **Decide the deliverable from the evidence.** If every check shows the work is complete, write a
+    forward-looking verify-and-close plan (state the verification commands and their outputs, then the
+    single close step) with an explicit "zero source edits" note — not a rename plan, and not a bare
+    retrospective status note.
 
 ## Failed Attempts
 
@@ -88,6 +105,10 @@ gh issue view N --repo "$ORG/$REPO" --json state --jq .state
 | Trust the issue's repo table | Took the issue's "these 5 repos use master" table at face value and started listing rename edits | The table was a stale snapshot; all repos had already migrated to `main` — the rename would have been a no-op against current state | Always verify `defaultBranchRef` live per repo before planning any rename |
 | Probe `branches/master` to test existence | `gh api repos/ORG/REPO/branches/master` to check whether a `master` branch still exists | For a missing branch GitHub HTTP-redirects to the default branch and returns 200 with the default branch's data → false positive that `master` exists | Use `gh api repos/ORG/REPO/git/refs/heads --jq '.[].ref'` and check for `refs/heads/master`; absence proves non-existence |
 | Blind find/replace master→main | Considered a tree-wide literal `master`→`main` substitution to "do the migration" | Corrupts non-branch uses: `no-commit-to-branch --branch master` guards and third-party `action@master` pins are not branch refs of this repo | Semantically classify every `master` literal; only rewrite actual local branch refs |
+| Verify only the 5 named repos | Listed refs for only the 5 repos the issue named as "on master," then declared the ecosystem migration complete | The issue was ecosystem-wide; a 5-of-15 scan structurally cannot find residue in the unnamed 10. `ProjectKeystone` (NOT one of the 5; already defaulting to `main`) still held a stale unprotected orphan `refs/heads/master` — the one real residue | Scope the loop to the full population; see companion skill `planning-verify-full-population-not-just-named-entities` |
+| Assert grep count without running it | Annotated a verification step "this grep returns count `4`" from eyeballing the tree | Running it returned `3` — the 4th `master` was a trailing `# master` comment the `@master\|--branch, master` regex cannot match. A reviewer running the command would conclude the check FAILED | Run the verification command and paste its real output as the expected value |
+| Fail-green existence check | `gh api .../branches/master 2>&1 \| grep -o 'Not Found' \|\| echo 'Not Found'` to test absence | Masks auth errors / rate-limits / any non-"Not Found" failure as a false-green "Not Found" | Use `gh api .../git/refs/heads --jq 'any(.ref=="refs/heads/master")'` — a clean boolean that emits nothing on API failure |
+| Infer ruleset "applied" from config | Claimed branch protection active from `justfile` + `configs/github/org-ruleset.json` | Reviewer rejected inference-as-evidence; config is intent, not live state | Verify already-applied via direct read `gh api repos/ORG/REPO/rulesets` (org-level 404s on FREE plan; repo-level authoritative) |
 
 ## Results & Parameters
 
@@ -103,12 +124,22 @@ gh issue view N --repo "$ORG/$REPO" --json state --jq .state
 `gh api orgs/ORG/rulesets` returns 404/403. Use **repo-level** rulesets
 (`gh api repos/ORG/REPO/rulesets`) instead of org-level endpoints.
 
-**Uncertain assumptions of THIS plan (flag for the reviewer):**
-- (a) The repo-level `homeric-main-baseline` ruleset's live enforcement/target was NOT directly
-  inspected — the org rulesets endpoint 404'd on the FREE plan. Its existence/intent was inferred
-  from `justfile:683` + `configs/github/org-ruleset.json`, NOT confirmed against the live API.
-- (b) Only the 5 named repos had their refs exhaustively listed (`git/refs/heads`). The other 10 repos
-  were checked via `defaultBranchRef` only — sufficient to confirm `main` is default, but their full
-  ref lists were not enumerated for stray `master` branches.
-- (c) The closing step (closing issue #24) was specified in the plan but NOT executed by the planner —
+**Ruleset confirmed by DIRECT live read (2026-06-19), replacing the prior inference:**
+
+```json
+{ "name": "homeric-main-baseline", "target": "branch", "enforcement": "active", "id": 15556483 }
+```
+
+**Population-scope correction (re-plan after NOGO):** the migration was NOT fully complete.
+Extending the ref-listing loop from the 5 named repos to all 15 surfaced one residue:
+- `ProjectKeystone` — default already `main` (hence NOT in the named 5), but still carrying a stale
+  `refs/heads/master`: `protected == false`, `gh pr list --base master ... --jq length == 0`,
+  `compare/main...master` → "No common ancestor" (orphan). Safe to delete via
+  `gh api -X DELETE repos/HomericIntelligence/ProjectKeystone/git/refs/heads/master`.
+
+**Companion skill:** `planning-verify-full-population-not-just-named-entities` — scope the
+verification loop to the whole population when an issue is ecosystem-wide.
+
+**Residual notes:**
+- The closing step (closing issue #24) was specified in the plan but NOT executed by the planner —
   it remains an action for the implementer.


### PR DESCRIPTION
## Summary

Amends existing skill from v1.0.0 to v1.1.0, strengthening its verification discipline with corrections from the issue #24 re-plan after a NOGO review.

- Fail-loud existence check (`gh api .../git/refs/heads --jq 'any()'`) replacing the `grep 'Not Found' || echo` false-green pattern.
- Run verification commands for real expected values (an asserted grep count of 4 was actually 3 — a trailing `# master` comment the regex cannot match).
- Verify already-applied claims by direct live read, not inference: replaced the inferred ruleset assumption with the directly-read value `{name: homeric-main-baseline, target: branch, enforcement: active, id: 15556483}`.
- Documented ProjectKeystone's orphan `master` residue that the 5-repo scan missed; cross-linked the new companion skill `planning-verify-full-population-not-just-named-entities`.

## Verification Level

**verified-local** — all gh/grep commands were run this session and produced the cited outputs; not validated in ProjectMnemosyne CI.

## Key Findings

**What Worked**:
- Direct `gh api repos/ORG/REPO/rulesets` read (org-level 404s on FREE plan; repo-level authoritative).
- Fail-loud boolean checks that emit nothing on API failure.

**What Failed**:
- Asserting grep count without running it (4 vs actual 3).
- `grep 'Not Found' || echo 'Not Found'` masking API failures as green.
- Inferring ruleset 'applied' from config files (reviewer rejected).
- Verifying only the 5 named repos (missed ProjectKeystone's orphan master).

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (409/409)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>