### PR TITLE
feat: amend planning-verify-live-state-before-assuming-work-remains skill (v1.2.0)

### DIFF
--- a/skills/planning-verify-live-state-before-assuming-work-remains.history
+++ b/skills/planning-verify-live-state-before-assuming-work-remains.history
@@ -1,6 +1,50 @@
 <!-- markdownlint-disable MD024 -->
 # planning-verify-live-state-before-assuming-work-remains — History
 
+## v1.2.0 (2026-06-19)
+
+**Changed by:** Planning of GitHub issue #177 (Odysseus meta-repo) — flip GitHub rulesets from `enforcement: evaluate` to `active` + required-status-check context normalization. The plan was authored by STATIC file inspection only and never executed.
+**Verification:** verified-local for the existing core; the newly added issue #177 ruleset subsection is UNVERIFIED (static-only plan).
+
+### What changed
+
+- Added 6 new Failed Attempts rows, each framing an unverified assumption from the #177 plan as a
+  planning risk/lesson:
+  - Inferring "canonical files never enforce" from `apply-repo-rulesets.sh` / `justfile` defaults
+    instead of reading the live applied ruleset.
+  - Assuming required-status-check contexts are BARE job names (not workflow-prefixed) without
+    querying live state — the highest-risk assumption (wrong ⇒ bootstrap deadlock).
+  - Dropping the org's `typecheck` context as "safe" with no check that a workflow emits it.
+  - Silently reconciling the issue's 9-context claim to the files' 8.
+  - Deleting `-active.json` + the `--active` flag (irreversible; rollback/shadow-test path lost;
+    consumers only grepped within one repo) — scope creep on a "one-line" issue.
+  - Trusting `integration_id: 15368` = GitHub Actions app without independent confirmation.
+- Added a "Worked example: issue #177" subsection under Results & Parameters with an UNVERIFIED
+  warning, listing the most-uncertain assumptions, unverified external sources, reviewer-focus
+  risks (enforcement-by-runbook, irreversible deletes, scope creep), and the corrective `gh api`
+  workflow the plan should have used.
+- Extended the description with triggers (5) ruleset enforcement flip / required-check change from
+  static inspection, and (6) a "one-line" fix that also deletes files / removes flags / refactors.
+- Added two "When to Use" bullets and noted the unverified subsection in the Overview verification cell.
+- Bumped version 1.1.0 → 1.2.0 (minor: new findings + failed attempts + extended triggers); date 2026-06-19.
+
+### Why
+
+The #177 plan generalizes the v1.1.0 lesson "config is intent, not state" to a broader and
+higher-stakes surface: flipping a ruleset to `active` from static file reading alone, without
+`gh api` confirmation of the applied enforcement, the exact required-check context format, or
+consumers of soon-to-be-deleted files. Getting the context format wrong causes a bootstrap
+deadlock (PRs blocked with 0 failing checks). Same search surface as the existing skill (planning,
+ruleset, unverified, static, live state, gh api), so amended rather than split into a new file.
+
+### Previous version (v1.1.0) snapshot
+
+See git history (commit prior to skill/planning-verify-live-state-ruleset-enforcement) and the
+v1.1.0 entry below for the full prior content; the v1.2.0 change is purely additive (no rows or
+sections were removed or rewritten).
+
+---
+
 ## v1.1.0 (2026-06-19)
 
 **Changed by:** Re-planning of GitHub issue #24 ("Standardize default branch across ecosystem") after a NOGO review (same session, after PR #2583).

--- a/skills/planning-verify-live-state-before-assuming-work-remains.md
+++ b/skills/planning-verify-live-state-before-assuming-work-remains.md
@@ -1,9 +1,9 @@
 ---
 name: planning-verify-live-state-before-assuming-work-remains
-description: "When an issue describes work to be done (a migration, rename, or config change), verify the LIVE external state FIRST with gh/grep before planning any edits — the work may already be complete, making the correct plan a verify-and-close plan with ZERO source edits. An issue body is a snapshot from when it was filed and drifts: the default branch, CI config, open-PR bases, and linked-issue states all change underneath it. Includes the gh-API gotcha that `gh api repos/ORG/REPO/branches/master` RETURNS the default branch via HTTP redirect for a MISSING branch (false positive that master exists) — use the `git/refs/heads` listing instead. Use when: (1) an issue/ticket describes a migration or change that may already be done, (2) planning work whose premise depends on live external state (default branch, CI config, issue status), (3) before recommending edits driven by an issue's stated assumptions, (4) before writing any 'Files to Modify' that exist only because the issue said so."
+description: "When an issue describes work to be done (a migration, rename, or config change), verify the LIVE external state FIRST with gh/grep before planning any edits — the work may already be complete, making the correct plan a verify-and-close plan with ZERO source edits. An issue body is a snapshot from when it was filed and drifts: the default branch, CI config, open-PR bases, and linked-issue states all change underneath it. Includes the gh-API gotcha that `gh api repos/ORG/REPO/branches/master` RETURNS the default branch via HTTP redirect for a MISSING branch (false positive that master exists) — use the `git/refs/heads` listing instead. Also covers the static-analysis-only planning trap: when fixing a 'one-line' GitHub ruleset enforcement/required-check issue purely by reading config files (e.g. flipping `enforcement: evaluate` → `active`), you have NOT confirmed what is actually applied to the live org/repo, whether required-status-check contexts are reported as bare job names vs workflow-prefixed, or whether deletes/refactors are reversible — all of which can cause a bootstrap deadlock (PRs BLOCKED with 0 failing checks). Use when: (1) an issue/ticket describes a migration or change that may already be done, (2) planning work whose premise depends on live external state (default branch, CI config, issue status), (3) before recommending edits driven by an issue's stated assumptions, (4) before writing any 'Files to Modify' that exist only because the issue said so, (5) planning a ruleset enforcement flip or required-status-check context change from static file inspection without querying `gh api .../rulesets`, (6) a 'one-line' config fix that also deletes files / removes flags / refactors scripts (scope-creep + irreversible-delete risk)."
 category: tooling
 date: 2026-06-19
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: verified-local
 history: planning-verify-live-state-before-assuming-work-remains.history
@@ -19,7 +19,7 @@ tags: []
 | **Date** | 2026-06-19 |
 | **Objective** | When planning an issue that asserts work needs doing (e.g. "5 repos still on master, CI broken"), determine whether that work is already complete BEFORE writing edits — and if it is, produce a verify-and-close plan with zero source changes instead of a rename plan |
 | **Outcome** | Successful: live-state verification of GitHub issue #24 ("Standardize default branch name across ecosystem") revealed the migration was ALREADY COMPLETE — all 15 repos default to `main`, no `master` refs exist, all workflows target `main`, all open PRs are based on `main`, all 4 linked tracking issues were already CLOSED. The plan correctly became "verify-and-close, zero source edits." |
-| **Verification** | verified-local (the gh/grep commands below were run this session and produced the cited outputs; not validated in ProjectMnemosyne CI) |
+| **Verification** | verified-local for the core branch-migration workflow (the gh/grep commands below were run this session and produced the cited outputs; not validated in ProjectMnemosyne CI). The v1.2.0 issue #177 ruleset-enforcement subsection is UNVERIFIED — a static-only plan, never executed; see the warning in that subsection. |
 | **History** | [changelog](./planning-verify-live-state-before-assuming-work-remains.history) |
 
 ## When to Use
@@ -28,6 +28,12 @@ tags: []
 - The task premise depends on live GitHub/CI state that drifts after the issue was filed (default branch, CI config, open-PR bases, linked-issue status).
 - Before writing any "Files to Modify" list whose entries exist only because the issue said the work was undone.
 - Planning a migration, rename, or config-standardization issue that may already have shipped.
+- Planning a GitHub ruleset enforcement flip (`evaluate`→`active`) or a required-status-check
+  context change from STATIC config inspection alone — without ever running `gh api .../rulesets`
+  to read what is actually applied, or confirming the exact context-string format GitHub reports.
+- A nominally "one-line" config fix whose plan also DELETES files, removes a flag/branch in a
+  script, or rewrites a runbook — weigh scope-creep and irreversible-delete/rollback risk before
+  bundling them with the minimal change.
 
 ## Verified Workflow
 
@@ -109,6 +115,12 @@ gh issue view N --repo "$ORG/$REPO" --json state --jq .state
 | Assert grep count without running it | Annotated a verification step "this grep returns count `4`" from eyeballing the tree | Running it returned `3` — the 4th `master` was a trailing `# master` comment the `@master\|--branch, master` regex cannot match. A reviewer running the command would conclude the check FAILED | Run the verification command and paste its real output as the expected value |
 | Fail-green existence check | `gh api .../branches/master 2>&1 \| grep -o 'Not Found' \|\| echo 'Not Found'` to test absence | Masks auth errors / rate-limits / any non-"Not Found" failure as a false-green "Not Found" | Use `gh api .../git/refs/heads --jq 'any(.ref=="refs/heads/master")'` — a clean boolean that emits nothing on API failure |
 | Infer ruleset "applied" from config | Claimed branch protection active from `justfile` + `configs/github/org-ruleset.json` | Reviewer rejected inference-as-evidence; config is intent, not live state | Verify already-applied via direct read `gh api repos/ORG/REPO/rulesets` (org-level 404s on FREE plan; repo-level authoritative) |
+| (#177, UNVERIFIED) Infer "canonical files never enforce" from script defaults | Read `apply-repo-rulesets.sh:32` + `justfile:667` and concluded the apply path defaults to the evaluate-mode JSON, so the canonical files never enforce in practice | The plan was static-only — no `gh api .../rulesets` run against the live org. What is *applied* may differ from what the script *would* apply | The premise "the canonical files never enforce" must be confirmed by reading the LIVE applied ruleset (`gh api`), not by reading the apply script. Default-in-code ≠ state-in-org |
+| (#177, UNVERIFIED) Assume required-check contexts are BARE job names | Planned the org ruleset to use bare `lint` + `integration_id: 15368`, "fixing" the org file's workflow-prefixed `Required Checks / lint` form, citing canonical-checks.md "Verified 2026-04-26" | Never queried how GitHub reports the contexts for THIS org/repo. Org vs repo rulesets can behave differently; the prefixed form may have been deliberate. Wrong guess ⇒ bootstrap deadlock: PRs BLOCKED with 0 failing checks | Confirm the exact context string GitHub expects by reading the live applied ruleset and/or a recent merged PR's check names — do not trust a doc's "verified on date" note or assume org==repo format |
+| (#177, UNVERIFIED) Drop the org's `typecheck` context as "safe" | Removed `typecheck` because it's absent from the 8-check canonical list and the repo file | No check that some workflow emits or depends on `typecheck`; absence from a doc list ≠ absence from CI | Before dropping a required context, grep the actual workflows for a job/check that produces it; a context no live workflow emits, if kept under `active`, deadlocks every PR |
+| (#177, UNVERIFIED) Silently reconcile 9-vs-8 context count | Issue said "9 required status check contexts"; canonical list + repo file had 8; plan quietly used 8 | Never established which count is authoritative; a silent reconcile hides a real discrepancy from the reviewer | When the issue's stated count disagrees with the files, surface the mismatch explicitly and verify the live ruleset's count rather than picking one silently |
+| (#177, UNVERIFIED) Delete `-active.json` + the `--active` flag as cleanup | Plan removed `org-ruleset-active.json`/`repo-ruleset-active.json` and the `--active`/`ENFORCEMENT` branching, verified "byte-identical except line 4" by reading the 4 files | Files can drift; the delete is irreversible and removes the evaluate-mode shadow-testing path (changes the rollback story). Only grepped within Odysseus — never across submodules/external automation for consumers | Before deleting a config or removing a flag, grep ALL consumers (submodules + external CI/automation), not just the current repo; and weigh whether the deleted path is a rollback/shadow-test capability worth keeping. Scope-creep on a "one-line" issue: a reviewer may prefer the minimal line-4-only change |
+| (#177, UNVERIFIED) Trust `integration_id: 15368` = GitHub Actions app | Carried `integration_id: 15368` from the existing repo file + team KB as the GitHub Actions app id | Taken from a file + KB, not independently confirmed against the live app installation | Confirm an app/integration id against the live install (`gh api .../installations` or the applied ruleset) before relying on it in an enforcing ruleset |
 
 ## Results & Parameters
 
@@ -143,3 +155,49 @@ verification loop to the whole population when an issue is ecosystem-wide.
 **Residual notes:**
 - The closing step (closing issue #24) was specified in the plan but NOT executed by the planner —
   it remains an action for the implementer.
+
+### Worked example: issue #177 ruleset enforcement flip (UNVERIFIED, static-only plan)
+
+> **Warning:** This subsection documents a PLANNING-PROCESS learning from a plan that was authored
+> by static file inspection only and never executed or CI-validated. Treat each item below as an
+> unverified assumption / reviewer-risk, not a confirmed fact. The live org/repo ruleset state was
+> NEVER queried with `gh api` during planning.
+
+**Plan summary (Odysseus meta-repo, HomericIntelligence):** flip
+`configs/github/org-ruleset.json` and `configs/github/repo-ruleset.json` from
+`"enforcement": "evaluate"` (logs hits, does not block) to `"active"`; delete duplicate
+`-active.json` files plus the `--active`/`ENFORCEMENT` branching in `apply-repo-rulesets.sh`;
+normalize org-ruleset contexts to bare-name + `integration_id: 15368`; drop a stale `typecheck`
+context; update the justfile and rollout runbook; add a documented pre-flight check.
+
+**Highest-risk assumption (bootstrap deadlock):** flipping to `active` with any required-status-check
+context that no workflow emits on `main` — or in a context-string format GitHub does not report —
+BLOCKS every PR with 0 failing checks. The required-check format (bare `lint` vs prefixed
+`Required Checks / lint`) was assumed bare from a doc + KB, never confirmed against the live
+applied ruleset. The repo file used bare+`integration_id`; the org file used prefixed — the
+divergence might be intentional, not a bug.
+
+**External sources relied on WITHOUT direct verification:**
+- Live GitHub org/repo ruleset state — never queried via `gh api .../rulesets` (entire plan static).
+- `integration_id: 15368` = GitHub Actions app id — taken from the repo file + team KB.
+- canonical-checks.md's "Verified 2026-04-26: GitHub reports bare names" — trusted as-is.
+- Whether any consumer (other CI workflow, submodule, external automation) references the
+  `-active.json` files before deleting them — only grepped within Odysseus.
+- The 9-vs-8 required-context count: issue says 9, canonical list + repo file have 8; reconciled
+  to 8 without confirming which is authoritative.
+
+**Reviewer focus / risks (what to weigh, beyond the assumptions):**
+- *Enforcement-by-runbook vs by-code:* the pre-flight (confirm every active context is emitted by a
+  live `main` workflow) is documented in the runbook but NOT enforced in code/CI — is a runbook step
+  sufficient guard against the bootstrap deadlock?
+- *Irreversible deletes:* removing `-active.json` + the `--active` flag eliminates the evaluate-mode
+  shadow-testing path and changes the rollback story.
+- *Scope creep:* the issue is narrowly "flip enforcement to active"; the plan also refactors scripts,
+  edits the justfile, deletes files, and rewrites a runbook. A reviewer may prefer the minimal
+  line-4-only change.
+
+**Corrective action the plan SHOULD have taken (apply this skill):** before flipping to `active`,
+run `gh api repos/HomericIntelligence/<repo>/rulesets` (and `/rulesets/<id>`) to read the live
+enforcement state and the exact `required_status_checks` context strings + integration ids; grep
+the live `.github/workflows/*` for every context to be made required; surface the 9-vs-8 mismatch
+explicitly; and grep all submodules/external automation for `-active.json` consumers before deleting.


### PR DESCRIPTION
## Summary

Amends existing skill from v1.1.0 to v1.2.0.

Generalizes the 'config is intent, not state' lesson to a higher-stakes surface: planning a GitHub ruleset enforcement flip (`enforcement: evaluate` -> `active`) and required-status-check context changes by STATIC file inspection only, without querying live org/repo state via `gh api .../rulesets`. Worked example is GitHub issue #177 (Odysseus meta-repo).

- 6 new Failed Attempts rows, each framing an unverified #177 assumption as a planning risk/lesson
- New 'Worked example: issue #177' subsection (carrying an UNVERIFIED warning) covering the bootstrap-deadlock risk, irreversible deletes, scope creep, and the corrective `gh api` workflow
- Extended description triggers + When-to-Use bullets for ruleset enforcement flips and 'one-line' fixes that also delete files / remove flags / refactor scripts

## Verification Level

**verified-local** for the existing core branch-migration workflow; the **unverified** issue #177 ruleset subsection is explicitly marked (static-only plan, never executed). Frontmatter `verification` stays `verified-local`; the new material carries an inline unverified warning per the skill template.

## Key Findings

**Planning risks captured (issue #177)**:
- Highest-risk: assuming required-check contexts are bare job names (not workflow-prefixed) without live confirmation -> wrong guess deadlocks every PR (BLOCKED, 0 failing checks)
- Inferring 'canonical files never enforce' from script/justfile defaults instead of the live applied ruleset
- Dropping the `typecheck` context as 'safe' with no check a workflow emits it
- Silently reconciling the issue's 9-context claim to the files' 8
- Deleting `-active.json` + the `--active` flag: irreversible, rollback/shadow-test path lost, consumers only grepped within one repo (scope creep on a 'one-line' issue)

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (412/412 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords (ruleset, enforcement, unverified, static, gh api)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>