### PR TITLE
feat: amend planning-verify-assumptions-before-enforcement-gate skill (v1.2.0)

### DIFF
--- a/skills/planning-verify-assumptions-before-enforcement-gate.history
+++ b/skills/planning-verify-assumptions-before-enforcement-gate.history
@@ -1,5 +1,32 @@
 # planning-verify-assumptions-before-enforcement-gate — History
 
+## v1.2.0 (2026-06-19)
+
+**Changed by:** Third NOGO of issue #179 (prior two NOGOs — submodule scope, dead pytest harness — were fixed; this round fixed a matcher-vs-edit window mismatch). Forked `origin/main` because v1.1.0 (PR #2605) was already MERGED.
+**Verification:** unverified
+
+### What changed
+
+- Added 2 new Failed Attempts rows:
+  - Sized the matcher look-back window (`ANON_LOOKBACK = 1`, `lines[max(0,i-1):i+1]`) without reconciling it against the edit's offset; the edit placed a 2-line comment block above `GF_AUTH_ANONYMOUS_ENABLED`, landing the `e2e-only` marker at `i-2` — outside the window. The plan's own "re-run gate → GREEN" step would have failed. Fix: widen to `ANON_LOOKBACK = 2` and keep the marker as the first comment line (`i-2`).
+  - The self-test's passing fixture put the marker at `i-1` (more lenient than the shipped `i-2` layout), giving false confidence. Fix: self-test must mirror the byte-for-byte shipped layout plus a boundary negative (`i-3` must fail) to pin the window size.
+- Added the PRIMARY lesson "matcher-vs-edit contract" and SECONDARY lesson "self-test must mirror the shipped layout" as Detailed Steps 11–12, plus Quick Reference steps 10–11.
+- Added the GENERAL through-line of all three NOGOs (verify the gate against the POST-FIX tree, not just the pre-fix tree) as a When-to-Use bullet, a callout after Detailed Step 12, and a Results bullet.
+- Updated Overview Objective/Outcome to reflect the third NOGO and the matcher-vs-edit fix.
+- Updated Results & Parameters with the matcher-vs-edit contract facts, self-test-mirrors-shipped-layout fixtures, and a refreshed Open-reviewer-tasks list (added the i-2-fragility risk; restated verification stays unverified).
+- Updated description (added through-line + trigger 6) and tags (`matcher-vs-edit-contract`, `post-fix-tree`, `lookback-window`, `self-test-mirrors-shipped-layout`).
+- Bumped version 1.1.0 → 1.2.0 (minor: new findings + new failed attempts; existing recommendation extended, not replaced).
+
+### Why
+
+The plan for issue #179 was NOGO'd a third time. After the first two NOGOs (submodule scope, dead pytest harness) were fixed, this round surfaced a self-inflicted correctness bug: the enforcement gate's matcher window did not cover the exact line offset where the plan's own edit lands the required `e2e-only` marker, so the new CI gate would have been red on the very tree the plan produces. The fix reconciles both sides of the matcher-vs-edit contract and makes the self-test mirror the shipped layout. All three NOGOs share one root cause — an assumption about the gate's runtime behavior never checked against the concrete artifact the plan ships — so this is an amendment (minor bump), not a new skill. Verification stays `unverified`: the gate script was still not executed in CI.
+
+### Previous version (v1.1.0) snapshot
+
+The full v1.1.0 body (description, Overview, When to Use, Proposed + Verified Workflow with 9-step Quick Reference and Detailed Steps 1–10, an 8-row Failed Attempts table, and Results & Parameters) is preserved in PR #2605 / the v1.1.0 commit. The v1.2.0 body above supersedes it, preserving all original rows and adding 2 new Failed Attempts (matcher-vs-edit window mismatch, lenient self-test fixture) plus Detailed Steps 11–12 and the post-fix-tree through-line.
+
+---
+
 ## v1.1.0 (2026-06-19)
 
 **Changed by:** Re-planning of issue #179 after a NOGO review (stacks on PR #2603, which created v1.0.0 and was already merged).

--- a/skills/planning-verify-assumptions-before-enforcement-gate.md
+++ b/skills/planning-verify-assumptions-before-enforcement-gate.md
@@ -1,9 +1,9 @@
 ---
 name: planning-verify-assumptions-before-enforcement-gate
-description: "When planning a fix for an audit/security/POLA finding that ends in a doc-config enforcement gate, verify the cited evidence location AND every infrastructure assumption BEFORE designing the gate — issue line-number citations, 'the e2e stack' descriptions, and 'add it to the existing CI/hook' advice are frequently imprecise. Scope the gate's file scan with `git ls-files` (the index) instead of filesystem `rglob` so submodules and gitignored worktrees are excluded for free; confirm the language's test runner is actually wired (a polyglot/meta-repo may have no pytest) and prefer a stdlib `--self-test`; resolve every risk in the plan body (a risk merely listed in a Learnings note does NOT count). Use when: (1) an issue cites a fail-open credential/config (e.g. GF_AUTH_ANONYMOUS_ENABLED, admin/admin) in 'the e2e stack' or by file:line, (2) you are about to scope a fix to docs + e2e while leaving 'real prod' alone, (3) you plan to add a doc-as-gate check (pygrep hook / scripts/check_*.py / CI step) that must catch a PRE-EXISTING finding, (4) the gate would scan a tree that contains submodules, (5) the plan leans on a pytest harness / python-at-hook-stage / regex-proximity assumption that was never confirmed on disk."
+description: "When planning a fix for an audit/security/POLA finding that ends in a doc-config enforcement gate, verify the cited evidence location AND every infrastructure assumption BEFORE designing the gate — issue line-number citations, 'the e2e stack' descriptions, and 'add it to the existing CI/hook' advice are frequently imprecise. THROUGH-LINE: verify the gate against the POST-FIX tree, not just the pre-fix tree. When a plan ships BOTH an enforcement-gate matcher AND the edit that must satisfy it, reconcile the matcher's look-back/look-ahead window against the EXACT line offsets the edit produces (the 'matcher-vs-edit contract'), and make every gate self-test mirror the byte-for-byte SHIPPED layout (plus a boundary negative). Scope the gate's file scan with `git ls-files` (the index) instead of filesystem `rglob` so submodules and gitignored worktrees are excluded for free; confirm the language's test runner is actually wired (a polyglot/meta-repo may have no pytest) and prefer a stdlib `--self-test`; resolve every risk in the plan body (a risk merely listed in a Learnings note does NOT count). Use when: (1) an issue cites a fail-open credential/config (e.g. GF_AUTH_ANONYMOUS_ENABLED, admin/admin) in 'the e2e stack' or by file:line, (2) you are about to scope a fix to docs + e2e while leaving 'real prod' alone, (3) you plan to add a doc-as-gate check (pygrep hook / scripts/check_*.py / CI step) that must catch a PRE-EXISTING finding, (4) the gate would scan a tree that contains submodules, (5) the plan leans on a pytest harness / python-at-hook-stage / regex-proximity assumption that was never confirmed on disk, (6) the plan ships a proximity/window matcher AND the edit that must land inside that window — reconcile the window size against the edit's exact line offset and self-test the shipped layout."
 category: documentation
 date: 2026-06-19
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: unverified
 history: planning-verify-assumptions-before-enforcement-gate.history
@@ -24,6 +24,10 @@ tags:
   - self-test
   - resolve-not-list-risks
   - unverified-assumptions
+  - matcher-vs-edit-contract
+  - post-fix-tree
+  - lookback-window
+  - self-test-mirrors-shipped-layout
 ---
 
 # Planning: Verify Assumptions Before Building a Doc-Config Enforcement Gate
@@ -33,8 +37,8 @@ tags:
 | Field | Value |
 | ------- | ------- |
 | **Date** | 2026-06-19 |
-| **Objective** | Capture the planning discipline surfaced while planning a POLA/security fix for a fail-open Grafana credential finding (anonymous-viewer enabled / `admin/admin` default): how to verify the cited evidence location and every gate-design assumption BEFORE designing a doc-config enforcement gate. Amended after re-planning issue #179 following a NOGO review. |
-| **Outcome** | A PLAN (not executed code): disambiguated the real evidence location via grep, scoped the change to docs + e2e (left already-fail-closed prod alone), matched the repo's existing doc-as-gate pattern (pygrep hooks + CI `validate` job), chose a `scripts/check_*.py` over a regex hook for a two-sided assertion, scoped the scan to the git INDEX (`git ls-files`) so submodules drop out for free, made the gate SELF-TESTING via a stdlib `--self-test` (no pytest exists in this meta-repo), tightened the proximity regex to require an admonition token, and RESOLVED each prior risk in the plan body. A few runtime assumptions (git metadata present in CI, `git` on PATH at hook stage) remain reviewer risks. |
+| **Objective** | Capture the planning discipline surfaced while planning a POLA/security fix for a fail-open Grafana credential finding (anonymous-viewer enabled / `admin/admin` default): how to verify the cited evidence location and every gate-design assumption BEFORE designing a doc-config enforcement gate. Amended TWICE after successive NOGO reviews of issue #179; this v1.2.0 captures the third NOGO and the through-line of all three. |
+| **Outcome** | A PLAN (not executed code): disambiguated the real evidence location via grep, scoped the change to docs + e2e (left already-fail-closed prod alone), matched the repo's existing doc-as-gate pattern (pygrep hooks + CI `validate` job), chose a `scripts/check_*.py` over a regex hook for a two-sided assertion, scoped the scan to the git INDEX (`git ls-files`) so submodules drop out for free, made the gate SELF-TESTING via a stdlib `--self-test` (no pytest exists in this meta-repo), tightened the proximity regex to require an admonition token, RECONCILED the matcher's look-back window against the EXACT offset the edit produces (the third NOGO: a 1-line window missed a marker the edit placed at `i-2`; widened to 2 lines and kept the marker as the first comment line), made the self-test mirror the byte-for-byte SHIPPED layout (marker at `i-2` with an intervening comment, plus a boundary negative at `i-3`), and RESOLVED each prior risk in the plan body. A few runtime assumptions (git metadata present in CI, `git` on PATH at hook stage, the 2-line window being a deliberate-but-fragile contract) remain reviewer risks. |
 | **Verification** | unverified — this is a PLANNING learning. Nothing was executed end-to-end; the gate script was NOT run in CI (no PR run observed). The grep/read facts below were verified by READING the tree this session, but the proposed gate, self-test, and hook were NOT executed. |
 | **Category** | documentation / planning |
 | **History** | [changelog](./planning-verify-assumptions-before-enforcement-gate.history) |
@@ -51,6 +55,9 @@ tags:
 - You are about to write a `pixi run pytest ...` (or any test-runner) verification command — confirm that runner is actually wired before depending on it; in a polyglot/meta-repo it may not exist.
 - You are choosing between extending the repo's existing enforcement pattern and inventing new gate infra.
 - A reviewer NOGO'd a prior plan for "acknowledged but unresolved" risks — every risk must be resolved in the body, not merely listed in a notes section.
+- The plan ships BOTH a proximity/window matcher (e.g. `lines[max(0,i-N):i+1]`) AND the edit whose marker must fall inside that window — reconcile the window size `N` against the EXACT line offset the edit produces before finalizing.
+- You are about to write a gate self-test — make at least one fixture byte-for-byte identical to the layout the edit ships (not a more lenient layout), plus a boundary negative one line outside the window to pin its size.
+- **Through-line of every NOGO on a self-fixing gate plan:** verify the gate against the POST-FIX tree (the artifact the plan ships), not just the pre-fix tree. The recurring root cause is an assumption about the gate's runtime behavior that was never checked against the concrete artifact the plan produces.
 
 ## Proposed Workflow
 
@@ -102,6 +109,22 @@ python3 scripts/check_doc_config_gate.py --self-test   # builds temp git repos, 
 
 # 9. Tag a DELIBERATE e2e opt-in so the gate can distinguish it from an accidental prod regression.
 #   GF_AUTH_ANONYMOUS_ENABLED: "true"   # e2e-only: anonymous viewer for local harness
+
+# 10. MATCHER-vs-EDIT CONTRACT — when the plan ships BOTH the matcher AND the edit it must accept,
+#     reconcile the window against the EXACT offset the edit produces. Verify against the POST-FIX tree.
+#   Failure: gate look-back window covered only 1 line above the flag ...
+ANON_LOOKBACK = 1; context = lines[max(0, i-1):i+1]    # BAD: covers only i-1
+#   ... but the docker-compose.e2e.yml edit placed a TWO-line comment block above the flag,
+#   so the required `e2e-only` marker landed at i-2 — OUTSIDE the window. The plan's own
+#   "step 6: re-run gate -> GREEN" would have FAILED; the new CI gate would be red on the very tree
+#   the plan produces (a self-inflicted correctness bug).
+ANON_LOOKBACK = 2; context = lines[max(0, i-2):i+1]    # FIX: widen to 2, keep marker as the FIRST comment line (i-2)
+
+# 11. SELF-TEST must mirror the SHIPPED layout, not a more lenient one.
+#   The prior passing fixture put the marker at i-1 (immediately above the flag) — more lenient than the
+#   edit ships (i-2 with an intervening comment). It passed while the real edit would have FAILED.
+#   Add: (a) a fixture byte-for-byte == the shipped edit (marker at i-2, comment at i-1) that PASSES, and
+#        (b) a boundary NEGATIVE (marker at i-3) that must FAIL — pins the window size.
 ```
 
 ### Detailed Steps
@@ -165,6 +188,37 @@ python3 scripts/check_doc_config_gate.py --self-test   # builds temp git repos, 
     notes were left unfixed in the body. Each surfaced risk must be RESOLVED (changed
     approach + verification) in the plan body, not merely acknowledged.
 
+11. **Reconcile the matcher window against the EXACT offset the edit produces (the
+    matcher-vs-edit contract).** When the same plan ships BOTH an enforcement-gate
+    matcher AND the edit that must satisfy it, the matcher's look-back/look-ahead window
+    must cover the precise line offset where the edit lands the required token. The third
+    NOGO was caused by exactly this mismatch: the compose rule used a 1-line look-back
+    window `context = lines[max(0,i-1):i+1]` (covers only the line immediately above the
+    flag), but the `docker-compose.e2e.yml` edit placed a TWO-line comment block above
+    `GF_AUTH_ANONYMOUS_ENABLED`, so the required `e2e-only` marker landed at offset `i-2` —
+    OUTSIDE the window. The plan's own "step 6: re-run gate → GREEN" would have FAILED; the
+    new CI gate would be red on the very tree the plan produces. Fix: widen the window to 2
+    lines (`ANON_LOOKBACK = 2`, `lines[max(0,i-2):i+1]`) AND keep the marker as the FIRST of
+    the two comment lines (`i-2`) so it sits inside the window. Both sides of the contract
+    must be reconciled — do not adjust only one.
+
+12. **Make every gate self-test mirror the byte-for-byte SHIPPED layout, plus a boundary
+    negative.** A self-test that does not mirror the shipped layout gives FALSE confidence:
+    the prior self-test's passing case put the marker immediately above the flag (`i-1`) — a
+    more lenient layout than the edit actually ships (`i-2`). It passed while the real edit
+    would have failed. Every gate self-test must include (a) a fixture whose byte-for-byte
+    layout matches the EXACT edit the plan applies (here: marker at `i-2` with an intervening
+    comment at `i-1`) that PASSES, and (b) a boundary NEGATIVE case (marker at `i-3` must
+    FAIL) to pin the window size.
+
+> **Through-line of all three NOGOs:** before finalizing an enforcement-gate plan, verify the
+> gate against the POST-FIX tree, not just the pre-fix tree. The three distinct ways this plan
+> initially broke the post-fix tree — (1) scanned unfixable submodule files (`rglob` vs
+> `git ls-files`), (2) referenced a nonexistent test runner (pytest vs stdlib self-test), (3)
+> the matcher window didn't cover the marker offset the edit produces — all share one root
+> cause: an assumption about the gate's runtime behavior that was never checked against the
+> concrete artifact the plan ships.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -177,6 +231,8 @@ python3 scripts/check_doc_config_gate.py --self-test   # builds temp git repos, 
 | Assumed `python3` / `git` resolves at the pre-commit / CI hook stage | Plan used a `language: system` hook that shells out to `python3` and the self-test shells out to `git init` in a tempdir | Other repo hooks use `pygrep` / bash; `python3` and `git`-on-PATH availability at hook stage and `git` metadata presence in CI were never confirmed on this PR | Confirm the interpreter AND `git` are present (and metadata fetched by `actions/checkout`) in the pre-commit/CI environment before depending on them |
 | Assumed adding `GF_SECURITY_ADMIN_PASSWORD` to e2e is harmless | Plan injected a real admin password var into the e2e stack | The existing e2e harness/login flow may rely on `admin/admin`; injecting a password could break login expectations | Check what the e2e harness expects for Grafana login before changing its credentials |
 | Took prior-learnings skills as accurate prior art | Referenced `python-logging-and-silent-error-patterns`, `doc-config-drift-check`, `security-md-version-sync`, `security-scanning-and-supply-chain-hardening` from the issue | Their on-disk content was NOT opened during planning — they were trusted sight-unseen | Open referenced prior-learnings on disk before building a plan on top of them |
+| Sized the matcher window without reconciling it against the edit's offset | Compose rule used a 1-line look-back `context = lines[max(0,i-1):i+1]` (covers only the line above the flag) while the same plan's edit placed a TWO-line comment block above `GF_AUTH_ANONYMOUS_ENABLED`, landing the `e2e-only` marker at `i-2` | The marker fell OUTSIDE the window, so the plan's own "step 6: re-run gate → GREEN" would have FAILED — the new CI gate would be red on the very tree the plan produces (a self-inflicted correctness bug) | Matcher-vs-edit contract: when a plan ships BOTH the matcher AND the edit that must satisfy it, reconcile the window against the EXACT offset the edit produces (widen to `ANON_LOOKBACK = 2`, `lines[max(0,i-2):i+1]`, marker as the first comment line) — verify against the POST-FIX tree |
+| Wrote a self-test that did not mirror the SHIPPED edit layout | The passing fixture put the marker immediately above the flag (`i-1`) — a more lenient layout than the edit ships (`i-2` with an intervening comment) | The self-test passed while the real edit would have failed → false confidence; the lenient fixture never exercised the i-2 case the plan actually produces | Every gate self-test must include a fixture byte-for-byte matching the shipped edit (marker at `i-2`, comment at `i-1`) that PASSES plus a boundary negative (marker at `i-3` must FAIL) to pin the window size |
 
 > Every row above is an UNVERIFIED assumption baked into the plan, framed as a reviewer task: confirm the "Lesson Learned" / "verify Y first" column before relying on the gate.
 
@@ -193,9 +249,13 @@ python3 scripts/check_doc_config_gate.py --self-test   # builds temp git repos, 
 - **Proximity regex (tightened):** require an admonition token (`warning`/`caution`/`important`) AND a rotate/change verb; negative test asserts a bare verb (e.g. "we rotate logs nightly") does NOT pass.
 - **Scan mode:** full-index (NOT diff-only) — required to catch a pre-existing finding (issue #179) that a diff-only gate would miss.
 - **Opt-in marker:** `# e2e-only:` on a deliberate e2e relaxation so the gate distinguishes it from an accidental prod regression. NEW convention — documented only inline + in the gate's error text.
+- **Matcher-vs-edit contract (third NOGO + fix):** the compose look-back window was sized as `ANON_LOOKBACK = 1` → `context = lines[max(0,i-1):i+1]` (covers only `i-1`), but the edit placed a TWO-line comment block above `GF_AUTH_ANONYMOUS_ENABLED`, landing the `e2e-only` marker at `i-2` (outside the window). FIX: `ANON_LOOKBACK = 2` → `lines[max(0,i-2):i+1]`, marker kept as the FIRST of the two comment lines (`i-2`). Reconcile the window against the EXACT offset the edit produces; verify against the POST-FIX tree.
+- **Self-test mirrors shipped layout:** required fixtures — (a) PASS case byte-for-byte == the shipped edit (marker at `i-2`, intervening comment at `i-1`); (b) boundary NEGATIVE (marker at `i-3` must FAIL) to pin window size. The prior self-test's lenient PASS case (marker at `i-1`) gave false confidence because the real edit ships `i-2`.
+- **Through-line (all three NOGOs):** verify the gate against the POST-FIX tree, not just the pre-fix tree. The three defects — (1) `rglob` scanned unfixable submodule files (→ `git ls-files`), (2) referenced a nonexistent pytest runner (→ stdlib `--self-test`), (3) matcher window did not cover the marker offset the edit produces (→ widen to 2 + i-2 marker) — share one root cause: an assumption about the gate's runtime behavior never checked against the concrete artifact the plan ships.
 - **Open reviewer tasks (UNVERIFIED):**
   - `git ls-files` needs git metadata present at gate runtime — confirmed locally, but in CI it depends on `actions/checkout` fetching the repo (not run in CI yet). Outside a git work tree, `git rev-parse --show-toplevel` fails.
   - The self-test shells out to `git init`/`git add` in a tempdir; assumes `git` is on PATH in CI and pre-commit envs (true here, not guaranteed universally).
   - The `e2e-only` marker convention is new — a future editor unaware of it could delete the marker, after which the gate would (correctly) fail; the convention is not documented beyond the inline comment + gate error text.
+  - The fix relies on the marker being EXACTLY at `i-2`; if a future editor inserts another comment line, the marker slides to `i-3` and the gate (correctly) goes red — the 2-line window is a deliberate-but-fragile contract documented only inline.
   - e2e login dependence on `admin/admin`; on-disk content of the four referenced prior-learnings skills.
-  - End-to-end verification level is **unverified**: the plan was produced and its grep-facts verified, but the gate script was NOT executed in CI (no PR run observed).
+  - End-to-end verification level is **unverified**: the plan and its line-offset arithmetic were reasoned through and grep-checked, but the gate script was NOT executed in CI on this repo (no PR run observed). Keep `verification: unverified`.


### PR DESCRIPTION
## Summary

Amends the existing skill from **v1.1.0 → v1.2.0** (minor). v1.1.0 (PR #2605) was already MERGED, so this forks `origin/main` and amends the v1.1.0 content in place.

Third NOGO of issue #179. The prior two NOGOs (submodule scope, dead pytest harness) were fixed in v1.0.0/v1.1.0. This round captures a self-inflicted correctness bug in the enforcement-gate plan and the through-line of all three NOGOs.

- **Matcher-vs-edit contract (primary):** when a plan ships BOTH an enforcement-gate matcher AND the edit that must satisfy it, reconcile the matcher's look-back window against the EXACT line offset the edit produces. The gate's 1-line window `lines[max(0,i-1):i+1]` missed the `e2e-only` marker the edit placed at `i-2` (two-line comment block above `GF_AUTH_ANONYMOUS_ENABLED`); the plan's own 're-run gate → GREEN' step would have failed. Fix: widen to `ANON_LOOKBACK = 2`, keep the marker as the first comment line (`i-2`).
- **Self-test mirrors shipped layout (secondary):** the prior self-test put the marker at `i-1` — more lenient than the shipped `i-2` layout — giving false confidence. Every gate self-test must mirror the byte-for-byte shipped layout plus a boundary negative (`i-3` must fail).
- **Through-line:** verify the gate against the POST-FIX tree, not just the pre-fix tree. All three NOGOs share one root cause — an assumption about the gate's runtime behavior never checked against the concrete artifact the plan ships.

## Verification Level

**unverified** — this is a PLANNING learning. The plan and its line-offset arithmetic were reasoned through and grep-checked, but the gate script was NOT executed in CI on this repo. Verification stays `unverified` per the skill body.

## Key Findings

**What Worked**:
- Reconciling both sides of the matcher-vs-edit contract (window size AND marker offset).
- A self-test fixture that mirrors the shipped edit byte-for-byte, plus a boundary negative to pin the window size.

**What Failed**:
- 1-line look-back window vs a marker the edit lands at `i-2` → gate red on the post-fix tree.
- A lenient self-test fixture (marker at `i-1`) that passed while the real edit would have failed.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (418/418 valid, exit 0)
- [x] markdownlint-cli2 on .md + .history (0 errors)
- [x] pre-commit on changed files (passed)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>