### PR TITLE
feat: amend architecture-container-secret-cmdline-leak-fix skill (v1.1.0)

### DIFF
--- a/skills/architecture-container-secret-cmdline-leak-fix.history
+++ b/skills/architecture-container-secret-cmdline-leak-fix.history
@@ -1,0 +1,68 @@
+<!-- markdownlint-disable MD024 -->
+# architecture-container-secret-cmdline-leak-fix — History
+
+## v1.1.0 (2026-06-19)
+
+**Changed by:** Re-planning of Odysseus issue #180 after a reviewer NOGO (the v1.0.0 plan from PR #2607 was the basis; this amends the same skill rather than duplicating it).
+**Verification:** unverified
+
+### What changed
+
+- Added 4 new Failed Attempts rows (prior rows preserved):
+  - Asserting removal of `-e ANTHROPIC_API_KEY` is behavior-neutral for ALL workers — false, because the single and multi workers run different binaries (mounted standalone `claude-host` vs image-baked npm `claude`) with different auth paths. Lesson: confirm each call site's binary before sharing a safety argument.
+  - Proving the fix with a cmdline string-absence test only — does not validate auth still works; green = false confidence. Lesson: add a live runtime auth probe via the real command-builder.
+  - Citing `pixi run pytest` as the verification runner — no pytest in the repo (ctest-only / shell-script e2e). Lesson: verify the runner exists and match the dir's test idiom.
+  - Removing the secret entirely when it must still reach the container — breaks auth where the env var is the only path. Lesson: use podman name-only `-e VAR`.
+- Reframed the central remediation from "DELETE the line (KISS)" to "podman/docker name-only `-e VAR` is the minimal behavior-preserving fix" — value read from podman's own env and injected, only the NAME on the cmdline (verified via `podman run --help`, podman 4.9.3); deletion reserved for sites where the value is provably unused (the single worker's OAuth path).
+- Added the asymmetric-binary finding (verified by grep: `claude-myrmidon.py:257` runs `claude-host`; `claude-myrmidon-multi.py:289` runs npm `claude` with no `claude-host` mount) as the root cause of the NOGO, woven into When-to-Use, the Quick Reference, Detailed Steps 3–4, and Results.
+- Added the name-only `-e` pre-flight-warning caveat (silently injects nothing if the host env lacks the var).
+- Added the runner-existence/test-idiom check (Odysseus has no pytest; `[tasks] test = "just test"` runs ctest; e2e is `e2e/tests/**/*.sh`).
+- Updated Results & Parameters: kept the prior "uncertain assumptions", added a "Resolved / refined" subsection (asymmetric binaries verified, name-only `-e` verified, runner absence verified) and an explicit "Still UNVERIFIED" list (a: multi worker npm `claude` auth never run end-to-end; b: achaean-claude image entrypoint/Dockerfile not inspected; c: live probe needs podman+image+key, none guaranteed in CI; d: hosts lacking OAuth creds for the single worker).
+- Updated description and tags (`env-name-only`, `per-callsite-binary`, `auth-regression-test`, `verify-the-runner`).
+- Added `history` frontmatter field and an Overview History row.
+- Bumped version 1.0.0 → 1.1.0 (minor: new findings + new failed attempts, same topic and search surface; existing recommendation refined, not replaced).
+
+### Why
+
+The v1.0.0 plan (PR #2607) assumed deleting `-e ANTHROPIC_API_KEY` was behavior-neutral across both workers. A reviewer NOGO surfaced that the two workers invoke structurally different binaries with different auth paths, so the single safety argument did not hold. The refined plan adopts podman name-only `-e` (keeps the value off the cmdline but still injects it), replaces the string-absence test with a real runtime auth probe, and verifies the test runner actually exists. These refine the same topic, so this is an amendment (minor bump), not a new skill. Verification stays `unverified` — the plan was never executed end-to-end and CI never ran it.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: architecture-container-secret-cmdline-leak-fix
+description: "Use when: (1) a secret like ANTHROPIC_API_KEY is passed to a container via `-e VAR=value` on a podman/docker run command line, (2) planning to fix a credential leak observable through `ps auxww` or `/proc/<pid>/cmdline`, (3) deciding whether to relocate a secret to a file vs. delete it because the CLI authenticates via mounted OAuth credentials instead."
+category: architecture
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [security, secrets, container, podman, docker, cmdline-leak, anthropic-api-key, oauth, credentials, proc, planning]
+---
+
+# Container Secret on Command Line Leak — Delete-Before-Relocate Fix
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-19 |
+| **Objective** | Plan the fix for a secret (ANTHROPIC_API_KEY) leaking to all host users via the container command line (`ps auxww` / `/proc/<pid>/cmdline`) for GitHub issue #180 in the Odysseus repo |
+| **Outcome** | Plan produced: the KISS fix is to DELETE the `-e ANTHROPIC_API_KEY=...` line (the standalone `claude`/`claude-host` CLI authenticates via mounted OAuth credential files), not relocate it. Plan was NOT executed; CI never ran it. |
+| **Verification** | unverified — implementation plan only; container was never run with the env var removed |
+
+## When to Use
+
+- A secret is injected into a container with `-e SECRET=value` on the `podman run` / `docker run` command line
+- A security review flags that the secret is readable via `ps auxww`, `ps -ef`, or `/proc/<pid>/cmdline` by any host user for the process lifetime
+- You are about to "fix" the leak by moving the secret to a different `-e` var or another command-line mechanism (this is the same class of bug)
+- You are deciding between relocating a secret to a file vs. deleting it entirely
+- The containerized CLI may authenticate via mounted OAuth credentials (`~/.claude/.credentials.json`, `~/.claude.json`) and may ignore the env var altogether
+- Planning a regression test for a secret-on-cmdline leak and judging whether that test actually proves the fix is safe
+
+## Verified Workflow
+
+> **Warning (Proposed Workflow):** This workflow has NOT been validated end-to-end. It is an implementation plan for issue #180 that was never executed, and CI never ran it. Treat every step as a hypothesis until a live container run confirms auth still works. Verification level: `unverified`.
+
+(Quick Reference, Steps, Failed Attempts table, and Results & Parameters — including the UNCERTAIN ASSUMPTIONS section, the Parameters/Facts block, and the Test Plan Checklist — are preserved in PR #2607 / the v1.0.0 commit. The v1.1.0 body above supersedes this content, preserving all original Failed Attempts rows and the uncertain-assumptions subsection while adding the asymmetric-binary finding, the name-only `-e` fix, the runtime auth probe, and the verify-the-runner check.)
+```

--- a/skills/architecture-container-secret-cmdline-leak-fix.md
+++ b/skills/architecture-container-secret-cmdline-leak-fix.md
@@ -1,12 +1,13 @@
 ---
 name: architecture-container-secret-cmdline-leak-fix
-description: "Use when: (1) a secret like ANTHROPIC_API_KEY is passed to a container via `-e VAR=value` on a podman/docker run command line, (2) planning to fix a credential leak observable through `ps auxww` or `/proc/<pid>/cmdline`, (3) deciding whether to relocate a secret to a file vs. delete it because the CLI authenticates via mounted OAuth credentials instead."
+description: "Use when: (1) a secret like ANTHROPIC_API_KEY is passed to a container via `-e VAR=value` on a podman/docker run command line, (2) planning to fix a credential leak observable through `ps auxww` or `/proc/<pid>/cmdline`, (3) deciding whether to relocate a secret to a file, delete it, or switch to name-only `-e VAR` because the value must still reach the container, (4) a 'safe to remove/change' argument is about to be applied across multiple call sites — confirm each site invokes the SAME binary/auth path first, (5) writing a regression test for a credential change — a string-absence test is NOT an auth-regression test, (6) citing a test runner in a verification plan — confirm the runner actually exists in pixi.toml/justfile."
 category: architecture
 date: 2026-06-19
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: unverified
-tags: [security, secrets, container, podman, docker, cmdline-leak, anthropic-api-key, oauth, credentials, proc, planning]
+history: architecture-container-secret-cmdline-leak-fix.history
+tags: [security, secrets, container, podman, docker, cmdline-leak, anthropic-api-key, oauth, credentials, proc, planning, env-name-only, per-callsite-binary, auth-regression-test, verify-the-runner]
 ---
 
 # Container Secret on Command Line Leak — Delete-Before-Relocate Fix
@@ -17,17 +18,20 @@ tags: [security, secrets, container, podman, docker, cmdline-leak, anthropic-api
 |-------|-------|
 | **Date** | 2026-06-19 |
 | **Objective** | Plan the fix for a secret (ANTHROPIC_API_KEY) leaking to all host users via the container command line (`ps auxww` / `/proc/<pid>/cmdline`) for GitHub issue #180 in the Odysseus repo |
-| **Outcome** | Plan produced: the KISS fix is to DELETE the `-e ANTHROPIC_API_KEY=...` line (the standalone `claude`/`claude-host` CLI authenticates via mounted OAuth credential files), not relocate it. Plan was NOT executed; CI never ran it. |
-| **Verification** | unverified — implementation plan only; container was never run with the env var removed |
+| **Outcome** | Plan refined after a reviewer NOGO: do NOT share one "safe to remove" argument across structurally different workers — the single worker runs the mounted standalone `claude-host` (OAuth-capable, env var droppable) while the multi worker runs the image-baked npm `claude` with no `claude-host` mount and an unverified auth path. The behavior-preserving fix is podman/docker name-only `-e VAR` (value off the cmdline, still injected). Plan was NOT executed; CI never ran it. |
+| **Verification** | unverified — implementation plan only; the container was never run with the change applied |
+| **History** | [changelog](./architecture-container-secret-cmdline-leak-fix.history) |
 
 ## When to Use
 
 - A secret is injected into a container with `-e SECRET=value` on the `podman run` / `docker run` command line
 - A security review flags that the secret is readable via `ps auxww`, `ps -ef`, or `/proc/<pid>/cmdline` by any host user for the process lifetime
 - You are about to "fix" the leak by moving the secret to a different `-e` var or another command-line mechanism (this is the same class of bug)
-- You are deciding between relocating a secret to a file vs. deleting it entirely
-- The containerized CLI may authenticate via mounted OAuth credentials (`~/.claude/.credentials.json`, `~/.claude.json`) and may ignore the env var altogether
-- Planning a regression test for a secret-on-cmdline leak and judging whether that test actually proves the fix is safe
+- You are deciding between relocating a secret to a file, deleting it entirely, or switching to name-only `-e VAR`
+- You are about to apply a single "safe to remove/change this argument" judgement across MULTIPLE call sites — first confirm each site invokes the SAME binary and auth path
+- The containerized CLI may authenticate via mounted OAuth credentials (`~/.claude/.credentials.json`, `~/.claude.json`) and may ignore the env var altogether — but a sibling worker may run a different binary that does NOT
+- Planning a regression test for a secret-on-cmdline leak and judging whether that test actually proves auth still works (it does not — a string-absence test is not an auth-regression test)
+- Citing a test runner in a verification plan — confirm the runner actually exists in `pixi.toml` / `justfile` and matches the directory's test idiom
 
 ## Verified Workflow
 
@@ -40,41 +44,55 @@ tags: [security, secrets, container, podman, docker, cmdline-leak, anthropic-api
 ps auxww | grep -i ANTHROPIC_API_KEY          # any host user sees it
 cat /proc/<container-runtime-pid>/cmdline | tr '\0' ' '   # also exposes it
 
-# 2. BEFORE relocating the secret to a file, ask: is it needed AT ALL?
-#    Many CLIs (standalone `claude` / `claude-host`) auth via OAuth from mounted creds
-#    and IGNORE ANTHROPIC_API_KEY. If so, the KISS fix is to DELETE the line.
-
-# 3. Find every injection site (do NOT assume there are only two).
+# 2. Find every injection site (do NOT assume there are only two) AND the binary each site runs.
 grep -rn ANTHROPIC_API_KEY e2e/*.py            # found exactly 2 here — but see scope caveat below
 grep -rn ANTHROPIC_API_KEY .                   # also check Dockerfiles, entrypoints, Nomad HCL, compose
+#  CRITICAL: the two workers run DIFFERENT binaries with DIFFERENT auth paths:
+#    claude-myrmidon.py:257       -> runs the MOUNTED standalone `claude-host` (OAuth-capable)
+#    claude-myrmidon-multi.py:289 -> runs the IMAGE-BAKED npm `claude` (@anthropic-ai/claude-code), NO claude-host mount
+#  Do NOT share one "safe to drop the env var" argument across both.
 
-# 4. Verify the credential files exist and are already bind-mounted into the container.
-ls -l ~/.claude/.credentials.json ~/.claude.json   # 0600 expected
+# 3. Choose the MINIMAL behavior-preserving fix when the value must still reach the container:
+#    podman/docker name-only `-e VAR` (no =value). The value is read from podman's OWN
+#    environment and injected; only the NAME lands on the cmdline. Verified: `podman run --help`
+#    (podman 4.9.3). Alternatives: --env-file, --env-host.
+#    -e VAR=$ANTHROPIC_API_KEY   # LEAKS the value on the cmdline (bad)
+#    -e ANTHROPIC_API_KEY        # name-only: value injected from host env, NOT on cmdline (good)
 
-# 5. Confirm the in-container UID can READ the 0600 creds.
-#    --userns=keep-id maps host UID into the container; chmod o+r (S_IROTH) makes
-#    0600 -> 0604 so the mapped UID can read them. Verify BOTH are in place.
+# 4. CAVEAT: name-only `-e VAR` silently injects NOTHING if the host env lacks the var.
+#    Add a pre-flight check that WARNS when unset (the value is no longer eyeball-visible).
+[ -n "${ANTHROPIC_API_KEY:-}" ] || echo "WARN: ANTHROPIC_API_KEY unset; name-only -e injects nothing"
 
-# 6. DELETE the `-e ANTHROPIC_API_KEY=...` line (KISS) rather than relocating it.
-#    Then RUN the container and confirm auth still works — the unit test does NOT prove this.
+# 5. Verify the test runner EXISTS before citing it.
+grep -nE 'pytest|test' pixi.toml justfile      # Odysseus: NO pytest; [tasks] test = "just test" -> ctest only
+ls e2e/tests/**/*.sh                            # the e2e idiom here is standalone bash scripts
+
+# 6. A string-absence test is NOT an auth-regression test. Build the PRODUCTION command via the
+#    actual command-builder and run it against the real image, asserting non-error (gated on
+#    runtime/image availability so it skips cleanly without them — but present as a runnable step).
 ```
 
 ### Steps (Proposed)
 
 1. Reproduce / confirm the leak: the secret appears in `ps auxww` and `/proc/<pid>/cmdline` because it is an `-e VAR=value` argument on the `podman run` line. The exposure lasts the entire process lifetime and is visible to every host user.
-2. Challenge the relocation reflex: relocating the value to a secret file is the standard remediation, but FIRST determine whether the value is even consumed. The standalone `claude` / `claude-host` binary is believed to authenticate purely via OAuth from mounted credential files (`~/.claude/.credentials.json`, `~/.claude.json`) and to ignore `ANTHROPIC_API_KEY`. If true, the simplest correct fix is to delete the line.
-3. Enumerate all injection sites with `grep -rn ANTHROPIC_API_KEY` — including Dockerfiles, container entrypoints, Nomad HCL, and compose env, not just the Python e2e harness.
-4. Verify the credential files exist on the host and are already bind-mounted read-only into the container.
-5. Verify readability inside the container: `--userns=keep-id` maps the host UID, and `chmod o+r` (S_IROTH) on the 0600 credentials makes them readable by the in-container UID.
-6. Delete the `-e ANTHROPIC_API_KEY=...` line.
-7. Add a regression test asserting the secret string is absent from the assembled command list — BUT treat this as necessary-not-sufficient (see Failed Attempts). Require a live container auth dry-run before merge.
+2. Enumerate all injection sites with `grep -rn ANTHROPIC_API_KEY` — including Dockerfiles, container entrypoints, Nomad HCL, and compose env, not just the Python e2e harness.
+3. **For each injection site, confirm the actual binary it invokes BEFORE generalizing any safety argument.** Here the two workers differ: `claude-myrmidon.py:257` runs the mounted standalone `claude-host` (OAuth-capable, can drop the env var), while `claude-myrmidon-multi.py:289` runs the image-baked npm `claude` (`@anthropic-ai/claude-code`) with NO `claude-host` mount — its auth path was never verified, so the env var may be its only working auth. The first plan's fatal flaw was assuming removing `-e ANTHROPIC_API_KEY` was behavior-neutral for both.
+4. Pick the minimal behavior-preserving fix: switch `-e ANTHROPIC_API_KEY=$VALUE` to name-only `-e ANTHROPIC_API_KEY`. The value is read from podman's own process environment and injected into the container; only the variable NAME lands on the command line, so `ps auxww` / `/proc/<pid>/cmdline` no longer expose the value. This is preferable to removal when you cannot prove the value is unused. (`--env-file` / `--env-host` are alternatives.)
+5. Add a pre-flight check that WARNS when `ANTHROPIC_API_KEY` is unset on the host — name-only `-e` silently injects nothing, and the value is no longer eyeball-visible in the command.
+6. (Only where you can PROVE the value is unused — e.g. the single worker's `claude-host` OAuth path) deleting the line is acceptable; verify the mounted OAuth credential files exist, are bind-mounted, and are readable by the in-container UID (`--userns=keep-id` maps the host UID; `chmod o+r` makes a 0600 file readable as the mapped UID).
+7. Verify the test runner exists and matches the directory idiom: grep `pixi.toml` / `justfile` (Odysseus has NO pytest — `[tasks] test = "just test"` runs ctest against C++ submodules; the e2e idiom is standalone bash scripts under `e2e/tests/**/*.sh`).
+8. Add a regression test asserting the secret value is absent from the assembled command list — BUT treat this as necessary-not-sufficient. Pair it with a real runtime auth probe: build the production command via the actual command-builder function (not a hand-rolled one), run it against the real image, and assert a non-error result, gated on runtime/image availability so it skips cleanly in CI without them.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Relocate the secret to a different `-e` var / pass it via the command line differently | Move ANTHROPIC_API_KEY to another env flag still set on the `podman run` line, or otherwise keep it as a process argument | Still leaks — any `-e VAR=value` argument is visible via `ps auxww` and `/proc/<pid>/cmdline` to all host users; it is the same class of bug | Command-line args are world-readable on the host. The fix must remove the value from the command line entirely (file, stdin, or delete), not move it to another flag |
-| Treat a unit test asserting absence from the command list as sufficient proof | Add a pytest asserting `ANTHROPIC_API_KEY` is not in the assembled command args | Proves the string is gone from the cmdline but proves NOTHING about whether auth still works; a green suite gives false confidence | A regression test for a leak must be paired with a live auth check; absence-of-string ≠ functionality-preserved |
+| Assert removal of `-e ANTHROPIC_API_KEY` is behavior-neutral for all workers | Applied one "safe to remove the env var" judgement to BOTH `claude-myrmidon.py` and `claude-myrmidon-multi.py` | Wrong: the workers run different binaries with different auth paths — the single worker invokes the mounted standalone `claude-host` (OAuth, env var droppable), the multi worker invokes the image-baked npm `claude` with NO `claude-host` mount, whose auth was never verified | Before generalizing a "safe to remove/change" argument across call sites, confirm each site invokes the SAME binary/auth path — grep the actual invoked command per site |
+| Prove the fix with a cmdline string-absence test only | Add a test asserting `ANTHROPIC_API_KEY` is not in the assembled command args | Proves the leak is closed but proves NOTHING about whether auth still works after the change; a green test = false confidence | Add a live runtime auth probe: build the production command via the real command-builder and run it against the real image, gated on availability |
+| Cite `pixi run pytest` as the verification runner | Wrote the verification plan around `pixi run pytest` | This repo (Odysseus) has NO pytest: `pixi.toml [dependencies]` has none, `[tasks] test = "just test"`, and `just test` runs ctest against C++ submodules only; the e2e idiom is standalone bash scripts | Verify the runner exists (grep `pixi.toml` / `justfile`) and match the directory's existing test idiom before writing verification commands |
+| Remove the secret entirely when it must still reach the container | Delete the `-e ANTHROPIC_API_KEY` line everywhere as the KISS fix | Breaks auth where the env var is the only working path (e.g. the multi worker's npm `claude`) | Use podman/docker name-only `-e VAR` so the value stays off the cmdline but is still injected from the host environment |
+| Relocate the secret to a different `-e` var / pass it via the command line differently | Move ANTHROPIC_API_KEY to another env flag still set as `-e VAR=value` on the `podman run` line | Still leaks — any `-e VAR=value` argument is visible via `ps auxww` and `/proc/<pid>/cmdline` to all host users; same class of bug | Command-line args are world-readable. Remove the VALUE from the cmdline (name-only `-e`, file, stdin, or delete), not move it to another flag |
+| Treat a unit test asserting absence from the command list as sufficient proof | Add a pytest asserting `ANTHROPIC_API_KEY` is not in the assembled command args | Proves the string is gone but nothing about whether auth still works; a green suite gives false confidence | A regression test for a leak must be paired with a live auth check; absence-of-string ≠ functionality-preserved |
 | Pass per-process secrets the host can observe (team KB) | Inject secrets as process arguments / env on the run line for any host-visible process | Other host users can read `/proc/<pid>/environ` and `/proc/<pid>/cmdline`; secrets belong in files with restrictive perms or runtime secret stores | Never put secrets where a host process listing can reveal them |
 | Rely on ANTHROPIC_API_KEY pre-flight checks for the containerized CLI (team KB) | Gate the container start on the env var being set, assuming the CLI needs it | The standalone `claude`/`claude-host` CLI authenticates via OAuth credential files and ignores the env var; the pre-flight check guards a value the binary never reads | Verify what the binary actually consumes before adding guards or relocating values around it |
 
@@ -82,13 +100,22 @@ ls -l ~/.claude/.credentials.json ~/.claude.json   # 0600 expected
 
 ### UNCERTAIN ASSUMPTIONS / UNVERIFIED RELIANCES (read this first, reviewer)
 
-This is the most important section. The plan rests on the following claims that were NOT validated by running the container:
+This is the most important section. The plan rests on the following claims that were NOT validated by running the container.
 
-- **Unverified runtime claim — the binary ignores the env var.** The plan asserts `claude-host` authenticates purely via OAuth and "does not use" `ANTHROPIC_API_KEY`. This came from a team skill (`test-matrix-and-e2e-infrastructure`) and from local file existence (`~/.claude/.credentials.json`), NOT from running the container with the env var removed. If the binary falls back to the env var in some code path, deleting the line breaks auth. The regression would only surface at container runtime, which the proposed pytest does NOT exercise.
-- **Test coverage gap.** The proposed test proves the secret is not on the command line; it proves nothing about whether auth still works. A green suite would give false confidence. The reviewer should require a live dry-run / actual container auth check before merge.
-- **Two-file scope assumption.** The plan relied on `grep -n ANTHROPIC_API_KEY e2e/*.py` finding exactly two injection sites. If the secret also flows through the achaean-claude image entrypoint, a Dockerfile, Nomad HCL, or compose env, those were NOT inspected — the achaean-claude image/entrypoint was not in the checkout (the glob returned no files). The reviewer should confirm the image itself does not expect the env var.
+**Resolved / refined since v1.0.0:**
+
+- **Asymmetric binary finding — now verified by grep.** The two workers invoke different binaries: `claude-myrmidon.py:257` runs the mounted standalone `claude-host`; `claude-myrmidon-multi.py:289` runs the image-baked npm `claude` (`@anthropic-ai/claude-code`) with no `claude-host` mount. A single "safe to remove the env var" argument does NOT hold across both.
+- **Name-only `-e VAR` is behavior-preserving — verified via `podman run --help` (podman 4.9.3).** Name-only `-e VAR` reads the value from podman's own process environment and injects it; only the variable NAME lands on the command line, so `ps auxww` / `/proc/<pid>/cmdline` no longer expose the value. Caveat: it silently injects nothing if the host env lacks the var — a pre-flight warning is required because the value is no longer eyeball-visible.
+- **Test runner absence — verified.** Odysseus has NO pytest: `pixi.toml [dependencies]` has none, `[tasks] test = "just test"`, `just test` runs ctest against C++ submodules only; the e2e idiom is standalone bash scripts (`e2e/tests/**/*.sh`).
+
+**Still UNVERIFIED — the reviewer should watch these:**
+
+- **(a) Multi worker auth path never run.** Name-only `-e` is intended to PRESERVE the multi worker's npm `claude` auth, but the multi worker was never run end-to-end with the change applied. The regression would only surface at container runtime, which no proposed test exercises.
+- **(b) achaean-claude image not inspected.** The image entrypoint / Dockerfile were not in the checkout, so whether the image itself expects `ANTHROPIC_API_KEY` is unconfirmed. Confirm the image does not require the env var.
+- **(c) Live auth probe requires unavailable inputs.** The runtime auth probe requires podman + the achaean-claude image + a populated key — none guaranteed in CI. Present it as a runnable acceptance step gated on availability, not a commented-out optional.
+- **(d) Hosts lacking OAuth creds.** For the single worker's `claude-host` OAuth path, hosts without populated OAuth credentials would break if the env var were removed with no fallback. Name-only `-e` mitigates this only where the host env actually has the key.
+- **Test coverage gap.** A string-absence test proves the secret is off the cmdline; it proves nothing about whether auth still works. A green suite gives false confidence. Require a live auth probe before merge.
 - **Stale, untouched code (deferred).** `claude-myrmidon.py:217` hardcodes standalone version `2.1.120`, which does not exist locally (only 2.1.176–178 are present); a glob fallback masks the mismatch. Out of scope for #180 but flagged for a follow-up.
-- **Local-environment generalization.** Credential file existence and permissions were verified on ONE dev machine. Other hosts running these workers may not have OAuth credentials populated; on those hosts, deleting the env var with no fallback could break auth.
 
 ### Parameters / Facts Established
 
@@ -98,26 +125,43 @@ Observable via:     ps auxww | ps -ef | /proc/<pid>/cmdline | /proc/<pid>/enviro
 Audience:           every host user, for the full process lifetime
 Issue:              GitHub #180 (Odysseus repo) — plan only, NOT executed
 
-Credential files (host, dev machine):
+Two workers, two binaries, two auth paths (verified by grep):
+  claude-myrmidon.py:257        -> mounted standalone `claude-host`  (OAuth-capable; env var droppable)
+  claude-myrmidon-multi.py:289  -> image-baked npm `claude`          (@anthropic-ai/claude-code; auth path UNVERIFIED)
+
+Behavior-preserving fix (verified via `podman run --help`, podman 4.9.3):
+  -e ANTHROPIC_API_KEY=$VALUE   # LEAKS the value on the cmdline
+  -e ANTHROPIC_API_KEY          # name-only: value read from podman's env, injected; NAME-ONLY on cmdline
+  Alternatives:                 --env-file, --env-host
+  Caveat:                       name-only -e injects NOTHING if host env lacks the var -> add pre-flight warn
+
+Credential files (host, dev machine — for the single worker's OAuth path):
   ~/.claude/.credentials.json    perms 0600 (must be o+r / 0604 for in-container UID)
   ~/.claude.json                 perms 0600
-
-Container access mechanics:
   --userns=keep-id   maps host UID into container so mounted creds are owned by it
   chmod o+r          adds S_IROTH so a 0600 file becomes readable by the mapped UID
 
-Injection sites found:   2 (in e2e/*.py)  — UNVERIFIED as complete; image not in checkout
-KISS fix chosen:         DELETE the `-e ANTHROPIC_API_KEY=...` line (do not relocate)
-Required before merge:    live container auth dry-run (NOT covered by proposed pytest)
+Test runner reality (verified):
+  pixi.toml [dependencies]: NO pytest
+  [tasks] test = "just test"  ->  ctest against C++ submodules only
+  e2e idiom: standalone bash scripts under e2e/tests/**/*.sh
+
+Injection sites found:   2 (in e2e/*.py)  — UNVERIFIED as complete; achaean-claude image not in checkout
+Fix chosen:              name-only `-e ANTHROPIC_API_KEY` (value off cmdline, still injected)
+Required before merge:    live container auth probe via the real command-builder (NOT covered by string-absence test)
 ```
 
 ### Test Plan Checklist (for the reviewer)
 
 ```
-[ ] Regression test: ANTHROPIC_API_KEY absent from assembled command args
-[ ] LIVE container auth dry-run WITHOUT the env var (the load-bearing check)
+[ ] Regression test: ANTHROPIC_API_KEY VALUE absent from assembled command args (necessary, not sufficient)
+[ ] LIVE container auth probe built via the real command-builder, run vs the real image (the load-bearing check)
+[ ] Confirm BOTH workers' binaries before sharing any safety argument (claude-host vs npm claude)
+[ ] Confirm name-only `-e` preserves the multi worker's npm `claude` auth (run it end-to-end)
+[ ] Pre-flight warning when ANTHROPIC_API_KEY is unset on the host
 [ ] grep -rn ANTHROPIC_API_KEY across Dockerfiles / entrypoints / Nomad HCL / compose
-[ ] Confirm achaean-claude image entrypoint does not require the env var
-[ ] Confirm OAuth creds exist + are readable in-container on ALL target hosts
+[ ] Confirm achaean-claude image entrypoint does not require the env var (image not in checkout)
+[ ] Confirm OAuth creds exist + are readable in-container on ALL target hosts (single worker)
+[ ] Verify the cited test runner exists (pixi.toml/justfile) and matches the dir's test idiom
 [ ] Follow-up: claude-myrmidon.py:217 hardcoded version 2.1.120 mismatch
 ```


### PR DESCRIPTION
## Summary

Amends the `architecture-container-secret-cmdline-leak-fix` skill from v1.0.0 (PR #2607) to v1.1.0 after a reviewer NOGO on the Odysseus issue #180 plan. Same topic and search surface — this is an amendment (minor bump), not a duplicate.

### Key deltas (v1.0.0 -> v1.1.0)
- **Asymmetric per-binary safety argument:** the single worker (`claude-myrmidon.py:257`) runs the mounted standalone `claude-host` (OAuth-capable), but the multi worker (`claude-myrmidon-multi.py:289`) runs the image-baked npm `claude` with no `claude-host` mount and an unverified auth path. A single 'safe to remove the env var' judgement does NOT hold across both — this was the NOGO root cause.
- **podman name-only `-e VAR` fix:** the minimal behavior-preserving remediation — value read from podman's own env and injected, only the NAME on the cmdline (verified via `podman run --help`, podman 4.9.3). Deletion reserved for provably-unused sites. Caveat: name-only `-e` silently injects nothing if the host env lacks the var -> add a pre-flight warning.
- **Runtime auth probe vs string-absence:** a string-absence test proves the leak is closed but nothing about auth still working — add a live probe via the real command-builder against the real image, gated on availability.
- **Verify-the-runner-exists:** the prior plan cited `pixi run pytest`; Odysseus has no pytest (`[tasks] test = "just test"` runs ctest; e2e is `e2e/tests/**/*.sh`).

### Bookkeeping
- 4 new Failed Attempts rows appended (prior rows preserved).
- `history` frontmatter + Overview History row added; `.history` file created with a v1.1.0 entry and a v1.0.0 snapshot (newest first).
- `version` -> 1.1.0, `date` -> 2026-06-19.
- **Verification: unverified** — the plan was never executed end-to-end and CI never ran it.

### Test plan checklist (for the reviewer)
- [ ] Regression test: secret VALUE absent from assembled command args (necessary, not sufficient)
- [ ] LIVE container auth probe via the real command-builder vs the real image (load-bearing)
- [ ] Confirm BOTH workers' binaries before sharing any safety argument
- [ ] Confirm name-only `-e` preserves the multi worker's npm `claude` auth (run end-to-end)
- [ ] Pre-flight warning when ANTHROPIC_API_KEY is unset on the host
- [ ] grep -rn ANTHROPIC_API_KEY across Dockerfiles / entrypoints / Nomad HCL / compose
- [ ] Confirm achaean-claude image entrypoint does not require the env var
- [ ] Confirm OAuth creds exist + readable in-container on ALL target hosts (single worker)
- [ ] Verify the cited test runner exists and matches the dir's test idiom

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>