### PR TITLE
Correct skill testing-jetstream-flaky-stream-state-leak to v2.0.0 (push-subscriber over-count)

### DIFF
--- a/skills/testing-jetstream-flaky-stream-state-leak.history
+++ b/skills/testing-jetstream-flaky-stream-state-leak.history
@@ -1,0 +1,165 @@
+<!-- markdownlint-disable MD024 -->
+# testing-jetstream-flaky-stream-state-leak — History
+
+## v2.0.0 (2026-06-19)
+
+**Changed by:** Second-round planning re-learning for ProjectHermes issue #532 after a reviewer
+NOGO'd the v1.0.0-based plan. The v1.0.0 hypothesis (stream/durable-consumer state leak fixed by an
+autouse `jsm.purge_stream` fixture) MIS-LOCATED the bug. This amends the same skill rather than
+duplicating it.
+**Verification:** unverified — the corrected plan was reasoned through but NOT executed; CI was not
+run and the failure was not reproduced this round either.
+
+### What changed
+
+- **MAJOR bump (1.0.0 → 2.0.0):** the core root-cause and primary recommendation are CORRECTED, not
+  merely extended. v1.0.0 recommended an autouse `jsm.purge_stream` fixture as the primary fix; that
+  fix is INERT for the actual failing tests (core NATS push subscribers never read JetStream
+  streams), and a reviewer NOGO'd the plan built on it.
+- Rewrote Overview/Objective: the durable learning is now "classify the subscriber type (core-NATS
+  push vs JetStream consumer) BEFORE choosing a fix." Core push delivery is live-only fan-out;
+  purging streams does nothing for it.
+- Rewrote the Verified Workflow as the corrected procedure: (1) CLASSIFY the subscriber, (2) for core
+  push subscribers narrow the broad wildcard subscription to the test-unique fully-qualified subject
+  AND replace `asyncio.sleep`-then-assert with a poll-until-count helper, (3) reserve
+  `DeliverPolicy.NEW`/purge for actual JetStream consumers (cross-RUN replay), (4) verify with a
+  full-suite repeat loop.
+- Replaced the Quick Reference snippet: removed the (inert) autouse purge fixture as the headline;
+  added the `wait_for_messages` poll helper, the wildcard→exact-subject narrowing principle, and the
+  `DeliverPolicy.NEW` pull_subscribe line scoped to JetStream consumers only.
+- Added 4 corrected Failed Attempts rows capturing the durable anti-patterns: diagnosing
+  `assert 2 == 1` as JetStream replay; trusting the issue's stated cause without classifying;
+  widening the wait while leaving the broad wildcard; applying `DeliverPolicy.NEW` to push tests.
+- Added `history:` frontmatter pointer; updated date 2026-06-19; kept `verification: unverified`
+  (still a planning hypothesis — the revised plan was not executed).
+- Added tags: push-subscriber, subject-overlap, wildcard-subscription, poll-until-count, fan-out.
+
+### Why
+
+The v1.0.0 skill encoded the issue's stated framing ("streams persist and deliver stale messages")
+as the root cause and recommended an autouse `jsm.purge_stream` fixture. A reviewer this round
+identified that the seven failing tests subscribe via core NATS `nc.subscribe("hi.agents.>", cb=...)`
+— core push subscribers receive LIVE fan-out only and never read a JetStream stream, so purging the
+stream cannot change their message count. The real over-count mechanism is a broad-wildcard
+subscription whose subject space overlaps what sibling tests publish, combined with a fixed
+`asyncio.sleep(0.1)` window during which a second live message lands, compounded by `unsubscribe()`
+being async fan-out (a broad subscriber can outlive its own test). The correct fix targets the push
+layer: narrow the subject to the test-unique fully-qualified subject and poll-until-count instead of
+sleep-then-assert. `DeliverPolicy.NEW` is only relevant to the one actual JetStream consumer
+(cross-run replay). Recording the correction durably is the highest-value learning of the round.
+
+### Previous full snapshot (v1.0.0)
+
+```markdown
+---
+name: testing-jetstream-flaky-stream-state-leak
+description: "Planning-reasoning checklist for diagnosing flaky JetStream/NATS integration tests whose root cause is suspected to be persistent broker stream / durable-consumer state leaking across test runs. Use when: (1) planning a fix for integration tests that fail intermittently with count-mismatch asserts (e.g. `assert 2 == 1`) only under full-suite or repeated runs; (2) the suspected cause is persistent broker/stream state (JetStream streams, durable consumers) leaking between runs; (3) choosing between purging shared state in an autouse fixture vs. making the subscriber consume only new messages (DeliverPolicy.NEW)."
+category: testing
+date: 2026-06-19
+version: "1.0.0"
+verification: unverified
+user-invocable: false
+tags:
+  - flaky
+  - integration-test
+  - jetstream
+  - nats
+  - test-isolation
+  - stream-state
+  - durable-consumer
+  - deliver-policy
+  - purge-stream
+  - planning
+  - autouse-fixture
+  - pytest
+---
+
+# Diagnosing Flaky JetStream/NATS Stream-State Leaks (Planning)
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-19 |
+| **Objective** | Avoid unverified root-cause and unverified-API mistakes when planning a fix for flaky JetStream/NATS integration tests that fail only under repeated/full-suite runs |
+| **Outcome** | Planning hypothesis only — failure was never reproduced; subscriber-type leak and nats-py API shapes were asserted but not confirmed |
+| **Verification** | unverified — planning skill only; no test was run and no failure was reproduced |
+
+## When to Use
+
+- Planning a fix for integration tests that fail intermittently with count-mismatch asserts (e.g. `assert 2 == 1`) **only** under full-suite or repeated runs (passes in isolation).
+- The suspected cause is persistent broker/stream state — JetStream streams or durable consumers — leaking across test runs.
+- Choosing between option (a) "purge shared state in an autouse fixture" and option (b) "make the subscriber consume only new messages" (e.g. `DeliverPolicy.NEW` / DeliverNew).
+- Any plan that asserts core NATS `subscribe()` and JetStream `pull_subscribe` behave identically with respect to history replay.
+
+## Verified Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+\`\`\`python
+# Autouse cleanup fixture — gated on the integration marker AND broker reachability.
+# Purges every shared stream before each integration test; true no-op otherwise.
+import pytest
+import pytest_asyncio
+
+@pytest_asyncio.fixture(autouse=True)
+async def _purge_jetstream(request):
+    # Gate 1: only run for integration tests.
+    if request.node.get_closest_marker("integration") is None:
+        yield
+        return
+    # Gate 2: never break the suite if the broker is down.
+    try:
+        import nats
+        nc = await nats.connect("nats://localhost:4222", connect_timeout=1)  # calibrate to CI
+    except Exception:
+        yield
+        return
+    js = nc.jetstream()
+    jsm = js  # JetStreamManager surface
+    try:
+        for stream in ("STREAM_A", "STREAM_B"):
+            try:
+                await jsm.purge_stream(stream)        # VERIFY this API on installed nats-py
+            except Exception:                          # tolerate NotFoundError (stream absent)
+                pass
+        yield
+    finally:
+        await nc.drain()
+
+# Durable consumer that ignores pre-existing stream content.
+from nats.js.api import ConsumerConfig, DeliverPolicy
+cfg = ConsumerConfig(deliver_policy=DeliverPolicy.NEW)   # VERIFY enum + kwarg on installed nats-py
+sub = await js.pull_subscribe("subject", durable="d", config=cfg)  # VERIFY config= kwarg
+\`\`\`
+
+\`\`\`bash
+# The load-bearing verification — a single green run does NOT prove a state-leak fix.
+for i in $(seq 1 20); do pytest <module> -m integration -q || break; done
+\`\`\`
+
+### Detailed Steps
+
+1. **REPRODUCE before diagnosing.** Run the suspected test in a tight loop and across the full suite to confirm the count-mismatch is real and depends on run order / run count. Do **not** treat the issue's stated symptom (`assert 2 == 1`) as proof of the mechanism — it only proves a count mismatch, not its cause.
+2. **Distinguish subscriber types empirically.** Determine whether the failing subscriber is core NATS `subscribe()` (live-only, no replay) or a JetStream `pull_subscribe` / push durable consumer (replays stream history and/or retains a delivery cursor). The root cause and the correct fix differ by type; conflating them mis-locates the bug.
+3. **Prefer BOTH defenses when cheap.** Add an autouse per-test purge fixture (`jsm.purge_stream(name)`, tolerating NotFoundError) for guaranteed-clean state, PLUS `DeliverPolicy.NEW` on durable consumers so they ignore pre-existing stream content. Belt-and-suspenders: a purge alone won't fix a durable consumer that already advanced its cursor, and DeliverNew alone won't help future or other subscribers.
+4. **Verify the nats-py API surface against the installed version** before committing the plan: confirm `jsm.purge_stream`, `ConsumerConfig` / `DeliverPolicy.NEW`, and that `pull_subscribe` accepts a `config=` kwarg. API names and kwargs drift across nats-py releases; an unverified kwarg fails at runtime.
+5. **Gate the autouse fixture correctly.** It must be a true no-op for unit tests and when the broker is unreachable — check the test marker (`request.node.get_closest_marker("integration")`) AND wrap `connect` in try/except. Otherwise it slows or breaks the entire non-integration suite.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust the issue's `assert 2 == 1` symptom as proof of the leak mechanism | Wrote the root-cause section from the symptom alone, without reproducing | The same symptom has multiple causes (subject overlap between tests, JetStream replay, durable cursor retention); the right fix can't be picked without reproduction | Reproduce and bisect the mechanism before asserting a single root cause |
+| Assume core NATS `subscribe()` and JetStream `pull_subscribe` behave the same w.r.t. replay | Reasoned about "stale messages" generically across subscriber types | Core `subscribe()` is live-only (no replay); only JetStream consumers replay history / retain cursors — conflating them mis-locates the bug | Identify the exact subscriber type per failing test before designing the fix |
+| Cite nats-py APIs (`purge_stream`, `DeliverPolicy.NEW`, `pull_subscribe(config=)`) from memory | Wrote fix snippets without checking the installed nats-py version | API names and kwargs drift across nats-py releases; an unverified kwarg fails at runtime | Grep the installed package / docs for the exact API before putting it in a plan |
+| Add an autouse cleanup fixture without gating | Fixture would connect to a broker for every test | Connecting to a broker on unit tests slows/breaks the non-integration suite | Gate autouse cleanup on the integration marker AND wrap connect in try/except for broker-down |
+
+## Results & Parameters
+
+- **Decision rule.** Option (a) purge fixture = guaranteed-clean state but pays a per-test broker round-trip cost; option (b) `DeliverPolicy.NEW` = cheap, no per-test connection, but only protects the consumers you change. Use **both** for durable-consumer tests.
+- **Verification that PROVES the fix.** A repeat loop (e.g. `for i in $(seq 1 20); do pytest <module> -m integration -q || break; done`) is the load-bearing check — a single green run does not prove a state-leak fix. Per-test isolation passing is NOT sufficient; pass-when-run-together-repeatedly is the criterion.
+- **Risk note.** `connect_timeout=1` in the fixture can itself become flaky on a slow / loaded CI broker — calibrate the connect timeout to CI, not localhost.
+```

--- a/skills/testing-jetstream-flaky-stream-state-leak.md
+++ b/skills/testing-jetstream-flaky-stream-state-leak.md
@@ -1,111 +1,142 @@
 ---
 name: testing-jetstream-flaky-stream-state-leak
-description: "Planning-reasoning checklist for diagnosing flaky JetStream/NATS integration tests whose root cause is suspected to be persistent broker stream / durable-consumer state leaking across test runs. Use when: (1) planning a fix for integration tests that fail intermittently with count-mismatch asserts (e.g. `assert 2 == 1`) only under full-suite or repeated runs; (2) the suspected cause is persistent broker/stream state (JetStream streams, durable consumers) leaking between runs; (3) choosing between purging shared state in an autouse fixture vs. making the subscriber consume only new messages (DeliverPolicy.NEW)."
+description: "Planning-reasoning checklist for diagnosing flaky NATS/JetStream integration tests that assert an exact message count and intermittently OVER-count (e.g. `assert 2 == 1`) only under full-suite or repeated runs. Key correction: classify the subscriber type FIRST — a core NATS push subscriber (`nc.subscribe(...)`) receives live fan-out only and NEVER reads a JetStream stream, so purging streams is inert for it; only a JetStream consumer (`js.pull_subscribe`/`js.subscribe`) reads stream history. Use when: (1) a test asserts `len(received) == N` on a `nc.subscribe(...)` callback and flakes; (2) you are tempted to purge a JetStream stream to fix it — STOP and classify first; (3) tests use broad wildcard subjects (`hi.agents.>`, `hi.>`) and/or a fixed `asyncio.sleep` before the count assert."
 category: testing
 date: 2026-06-19
-version: "1.0.0"
+version: "2.0.0"
 verification: unverified
 user-invocable: false
+history: testing-jetstream-flaky-stream-state-leak.history
 tags:
   - flaky
   - integration-test
   - jetstream
   - nats
   - test-isolation
-  - stream-state
-  - durable-consumer
+  - push-subscriber
+  - subject-overlap
+  - wildcard-subscription
+  - poll-until-count
+  - fan-out
   - deliver-policy
+  - durable-consumer
   - purge-stream
   - planning
-  - autouse-fixture
   - pytest
 ---
 
-# Diagnosing Flaky JetStream/NATS Stream-State Leaks (Planning)
+# Diagnosing Flaky NATS Push-Subscriber Over-Count (Planning)
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-19 |
-| **Objective** | Avoid unverified root-cause and unverified-API mistakes when planning a fix for flaky JetStream/NATS integration tests that fail only under repeated/full-suite runs |
-| **Outcome** | Planning hypothesis only — failure was never reproduced; subscriber-type leak and nats-py API shapes were asserted but not confirmed |
-| **Verification** | unverified — planning skill only; no test was run and no failure was reproduced |
+| **Objective** | Diagnose and fix flaky NATS integration tests that assert exact message counts and intermittently OVER-count (`assert 2 == 1`). Core correction: distinguish core-NATS push delivery (live-only) from JetStream consumers (stream-backed) BEFORE choosing a fix. |
+| **Outcome** | Planning hypothesis (corrected) — the v1.0.0 "purge the JetStream stream" plan was NOGO'd because core push subscribers never read streams; the over-count is live cross-test fan-out on a broad wildcard subscription. The revised plan was reasoned through but NOT executed. |
+| **Verification** | unverified — corrected planning hypothesis; no test was run, CI was not run, and the failure was not reproduced this round. |
+| **History** | [changelog](./testing-jetstream-flaky-stream-state-leak.history) |
 
 ## When to Use
 
-- Planning a fix for integration tests that fail intermittently with count-mismatch asserts (e.g. `assert 2 == 1`) **only** under full-suite or repeated runs (passes in isolation).
-- The suspected cause is persistent broker/stream state — JetStream streams or durable consumers — leaking across test runs.
-- Choosing between option (a) "purge shared state in an autouse fixture" and option (b) "make the subscriber consume only new messages" (e.g. `DeliverPolicy.NEW` / DeliverNew).
-- Any plan that asserts core NATS `subscribe()` and JetStream `pull_subscribe` behave identically with respect to history replay.
+- An integration test asserts `len(received) == N` on a `nc.subscribe(...)` callback and flakes only under full-suite / repeated runs (passes in isolation), surfacing as an over-count like `assert 2 == 1`.
+- You are tempted to "purge the JetStream stream" to fix it — **STOP** and first classify the subscriber type. Purging a stream is INERT for a core NATS push subscriber.
+- Tests use broad wildcard subjects (`hi.agents.>`, `hi.>`) and/or a fixed `asyncio.sleep(0.x)` before the count assert.
+- A plan (or an issue) claims "streams persist and deliver stale messages" — treat that as a hypothesis and verify the subscriber type against the code before acting on it.
 
 ## Verified Workflow
 
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+> **Warning:** This workflow has not been validated end-to-end. The corrected plan was reasoned
+> through but NOT executed — no test, no CI run, no reproduction. Treat as a hypothesis until CI
+> confirms.
 
 ### Quick Reference
 
 ```python
-# Autouse cleanup fixture — gated on the integration marker AND broker reachability.
-# Purges every shared stream before each integration test; true no-op otherwise.
-import pytest
-import pytest_asyncio
+# Poll-until-count helper — replaces `asyncio.sleep(0.x)`-then-assert.
+# Returns as soon as enough messages have arrived, so a generous timeout
+# can't be starved by CI load, yet an exact-count assert still catches over-delivery.
+import asyncio
 
-@pytest_asyncio.fixture(autouse=True)
-async def _purge_jetstream(request):
-    # Gate 1: only run for integration tests.
-    if request.node.get_closest_marker("integration") is None:
-        yield
-        return
-    # Gate 2: never break the suite if the broker is down.
-    try:
-        import nats
-        nc = await nats.connect("nats://localhost:4222", connect_timeout=1)  # calibrate to CI
-    except Exception:
-        yield
-        return
-    js = nc.jetstream()
-    jsm = js  # JetStreamManager surface
-    try:
-        for stream in ("STREAM_A", "STREAM_B"):
-            try:
-                await jsm.purge_stream(stream)        # VERIFY this API on installed nats-py
-            except Exception:                          # tolerate NotFoundError (stream absent)
-                pass
-        yield
-    finally:
-        await nc.drain()
+async def wait_for_messages(received, expected, timeout=5.0, poll_interval=0.01):
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if len(received) >= expected:
+            return
+        await asyncio.sleep(poll_interval)
+    # fall through on timeout; the caller's exact-count assert reports the shortfall
 
-# Durable consumer that ignores pre-existing stream content.
+# Subject narrowing (the source fix): wildcard -> the test-unique fully-qualified subject.
+#   BEFORE:  await nc.subscribe("hi.agents.>", cb=on_msg)          # matches OTHER tests' publishes
+#   AFTER:   await nc.subscribe("hi.agents.prod-host.my-agent.created", cb=on_msg)  # test-unique
+
+# DeliverPolicy.NEW belongs ONLY to an actual JetStream consumer (cross-RUN replay), not push tests.
 from nats.js.api import ConsumerConfig, DeliverPolicy
-cfg = ConsumerConfig(deliver_policy=DeliverPolicy.NEW)   # VERIFY enum + kwarg on installed nats-py
-sub = await js.pull_subscribe("subject", durable="d", config=cfg)  # VERIFY config= kwarg
+cfg = ConsumerConfig(deliver_policy=DeliverPolicy.NEW)
+sub = await js.pull_subscribe("subject", durable="d", config=cfg)
 ```
 
 ```bash
-# The load-bearing verification — a single green run does NOT prove a state-leak fix.
-for i in $(seq 1 20); do pytest <module> -m integration -q || break; done
+# Load-bearing verification — run UNDER full-suite pressure, repeatedly.
+# A single green run and per-test isolation are NOT sufficient.
+for i in $(seq 1 30); do pytest <module> -m integration -q || break; done
 ```
 
 ### Detailed Steps
 
-1. **REPRODUCE before diagnosing.** Run the suspected test in a tight loop and across the full suite to confirm the count-mismatch is real and depends on run order / run count. Do **not** treat the issue's stated symptom (`assert 2 == 1`) as proof of the mechanism — it only proves a count mismatch, not its cause.
-2. **Distinguish subscriber types empirically.** Determine whether the failing subscriber is core NATS `subscribe()` (live-only, no replay) or a JetStream `pull_subscribe` / push durable consumer (replays stream history and/or retains a delivery cursor). The root cause and the correct fix differ by type; conflating them mis-locates the bug.
-3. **Prefer BOTH defenses when cheap.** Add an autouse per-test purge fixture (`jsm.purge_stream(name)`, tolerating NotFoundError) for guaranteed-clean state, PLUS `DeliverPolicy.NEW` on durable consumers so they ignore pre-existing stream content. Belt-and-suspenders: a purge alone won't fix a durable consumer that already advanced its cursor, and DeliverNew alone won't help future or other subscribers.
-4. **Verify the nats-py API surface against the installed version** before committing the plan: confirm `jsm.purge_stream`, `ConsumerConfig` / `DeliverPolicy.NEW`, and that `pull_subscribe` accepts a `config=` kwarg. API names and kwargs drift across nats-py releases; an unverified kwarg fails at runtime.
-5. **Gate the autouse fixture correctly.** It must be a true no-op for unit tests and when the broker is unreachable — check the test marker (`request.node.get_closest_marker("integration")`) AND wrap `connect` in try/except. Otherwise it slows or breaks the entire non-integration suite.
+1. **CLASSIFY the failing subscriber FIRST.** Grep the test for `subscribe(` and whether a
+   `js` / `jetstream()` object is involved. Is it core NATS `nc.subscribe()` (live fan-out, no
+   stream read) or a JetStream consumer `js.pull_subscribe` / `js.subscribe` (reads stream
+   history, retains a cursor across runs)? The root cause and correct fix differ by type;
+   conflating them mis-locates the bug. **A core push subscriber NEVER reads a JetStream stream.**
+2. **If it is a CORE push subscriber** the over-count is live cross-test fan-out, NOT stream
+   replay. Do **not** purge streams — it is inert. Instead, two-part fix on the push layer:
+   (a) **narrow the subscription** from the wildcard (`hi.agents.>`) to the exact fully-qualified
+   subject the test itself publishes (e.g. `hi.agents.prod-host.my-agent.created`), so no sibling
+   test's live publish can match; (b) **replace `asyncio.sleep(0.x)`-then-assert** with a
+   poll-until-count helper that returns as soon as `len(received) >= expected` on a generous
+   timeout (~5s), so load can't starve a real delivery while an exact-count assert still catches
+   over-delivery.
+3. **If it is a JetStream consumer** cross-RUN replay / cursor retention IS possible. Use
+   `config=ConsumerConfig(deliver_policy=DeliverPolicy.NEW)` so it ignores pre-existing stream
+   content; optionally purge the stream for a guaranteed-clean start. `DeliverPolicy.NEW` is a
+   JetStream-consumer concept and has NO effect on a core push subscriber — never apply it to push
+   tests to "fix" them.
+4. **Understand WHY the push over-count happens** so the fix is at the source: a broad-wildcard
+   subscription's subject space OVERLAPS what sibling/adjacent tests publish; the fixed
+   `asyncio.sleep(0.1)` window lets a second live message from another test land before the
+   assert; and `sub.unsubscribe()` is async fan-out, so a broad subscriber can outlive its own
+   test and still receive a foreign message. Narrowing the subject eliminates the overlap at the
+   source; a longer wait alone does not.
+5. **VERIFY under full-suite pressure, repeatedly.** Run a repeat loop
+   (`for i in $(seq 1 30); do pytest <module> -m integration -q || break; done`) — a single green
+   run and per-test isolation passing are NOT sufficient. Pass-when-run-together-repeatedly is the
+   criterion.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Trust the issue's `assert 2 == 1` symptom as proof of the leak mechanism | Wrote the root-cause section from the symptom alone, without reproducing | The same symptom has multiple causes (subject overlap between tests, JetStream replay, durable cursor retention); the right fix can't be picked without reproduction | Reproduce and bisect the mechanism before asserting a single root cause |
-| Assume core NATS `subscribe()` and JetStream `pull_subscribe` behave the same w.r.t. replay | Reasoned about "stale messages" generically across subscriber types | Core `subscribe()` is live-only (no replay); only JetStream consumers replay history / retain cursors — conflating them mis-locates the bug | Identify the exact subscriber type per failing test before designing the fix |
-| Cite nats-py APIs (`purge_stream`, `DeliverPolicy.NEW`, `pull_subscribe(config=)`) from memory | Wrote fix snippets without checking the installed nats-py version | API names and kwargs drift across nats-py releases; an unverified kwarg fails at runtime | Grep the installed package / docs for the exact API before putting it in a plan |
-| Add an autouse cleanup fixture without gating | Fixture would connect to a broker for every test | Connecting to a broker on unit tests slows/breaks the non-integration suite | Gate autouse cleanup on the integration marker AND wrap connect in try/except for broker-down |
+| Diagnosing `assert 2 == 1` as JetStream stream replay | Wrote an autouse `jsm.purge_stream` fixture as the primary fix (v1.0.0) | Core NATS push subscribers never read streams; the purge is inert — the plan was NOGO'd for a fix whose mechanism cannot affect the symptom | Classify subscriber type (core push vs JetStream consumer) BEFORE choosing a stream-level vs subscription-level fix |
+| Trusting the issue's stated cause ("streams persist and deliver stale messages") without classifying the subscriber | Built the whole plan on the issue's framing | The issue conflated two subscriber types; the seven failing tests were core push subscribers, not stream readers | Treat the issue's root-cause claim as a hypothesis; verify the subscriber type against the code |
+| Widening the wait or only swapping the sleep, leaving the broad wildcard subscription | (considered) just polling longer on `hi.agents.>` | A longer wait still receives a sibling test's live message on the wildcard; the over-count persists | Eliminate the non-determinism at the source — narrow the subject so foreign messages can't match |
+| Applying `DeliverPolicy.NEW` to "fix" the push-subscriber tests | (considered) blanket DeliverNew across the failing tests | DeliverNew is a JetStream-consumer concept; it has no effect on a core push subscriber | Scope DeliverNew to actual JetStream consumers only (cross-run replay), not push tests |
 
 ## Results & Parameters
 
-- **Decision rule.** Option (a) purge fixture = guaranteed-clean state but pays a per-test broker round-trip cost; option (b) `DeliverPolicy.NEW` = cheap, no per-test connection, but only protects the consumers you change. Use **both** for durable-consumer tests.
-- **Verification that PROVES the fix.** A repeat loop (e.g. `for i in $(seq 1 20); do pytest <module> -m integration -q || break; done`) is the load-bearing check — a single green run does not prove a state-leak fix. Per-test isolation passing is NOT sufficient; pass-when-run-together-repeatedly is the criterion.
-- **Risk note.** `connect_timeout=1` in the fixture can itself become flaky on a slow / loaded CI broker — calibrate the connect timeout to CI, not localhost.
+- **Decision table (subscriber type → correct fix).**
+  - **Core push subscriber** (`nc.subscribe(...)`, live fan-out, no stream read): narrow the
+    subject from the wildcard to the test-unique fully-qualified subject **+** poll-until-count.
+    Purging streams and `DeliverPolicy.NEW` are inert here.
+  - **JetStream consumer** (`js.pull_subscribe` / `js.subscribe`, reads stream history): use
+    `DeliverPolicy.NEW` (+ optional `jsm.purge_stream` for a guaranteed-clean stream) to ignore
+    pre-existing content across runs.
+- **Poll helper params.** `wait_for_messages(received, expected, timeout=5.0, poll_interval=0.01)`
+  — `timeout=5.0s` is generous so CI load can't starve a real delivery; `poll_interval=0.01s`;
+  it returns at `>= expected` so an exact-count assert still catches over-delivery.
+- **Verification.** The repeat loop
+  `for i in $(seq 1 30); do pytest <module> -m integration -q || break; done` is load-bearing; a
+  single green run and per-test isolation are NOT sufficient.
+- **nats-py API note (verified by reviewer this round).** `jsm.purge_stream`, `ConsumerConfig`,
+  `DeliverPolicy.NEW`, and `pull_subscribe(config=...)` are all real API surface in nats-py — but
+  they apply to JetStream consumers only, not to core push subscribers.


### PR DESCRIPTION
## Summary

Second-round planning re-learning for ProjectHermes issue #532 (flaky NATS/JetStream integration tests). This **corrects** the v1.0.0 root-cause hypothesis, which was NOGO'd by a reviewer.

- **v1.0.0 (wrong):** `assert 2 == 1` flakiness was JetStream stream/durable-consumer state leaking across runs, fixable by an autouse `jsm.purge_stream` fixture.
- **v2.0.0 (corrected):** the failing tests are **core NATS push subscribers** (`nc.subscribe(...)`), which receive **live fan-out only** and never read a JetStream stream — so purging streams is inert. The over-count comes from a broad-wildcard subscription (`hi.agents.>`) overlapping sibling tests' publishes plus a fixed `asyncio.sleep` window. Correct fix: **narrow the subject** to the test-unique fully-qualified subject **+ poll-until-count**; reserve `DeliverPolicy.NEW` for actual JetStream consumers (cross-run replay).

## Changes

- **MAJOR bump 1.0.0 → 2.0.0** — root cause and primary recommendation are corrected, not merely extended.
- Snapshot of v1.0.0 written to `testing-jetstream-flaky-stream-state-leak.history` (newest at top); `history:` frontmatter pointer added.
- Rewrote Overview / When to Use / Verified Workflow / Failed Attempts / Results around the corrected diagnosis.
- Added `wait_for_messages` poll helper, the wildcard→exact-subject narrowing principle, and the JetStream-only `DeliverPolicy.NEW` line to Quick Reference.
- `verification: unverified` retained — the revised plan was reasoned through but NOT executed; CI was not run.

## Validation

`python3 scripts/validate_plugins.py` → **426/426 valid, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)