### PR TITLE
feat: amend testing-real-server-fault-test-planning-pitfalls skill (v1.1.0)

### DIFF
--- a/skills/testing-real-server-fault-test-planning-pitfalls.history
+++ b/skills/testing-real-server-fault-test-planning-pitfalls.history
@@ -1,12 +1,30 @@
+# testing-real-server-fault-test-planning-pitfalls — History
+
+## v1.1.0 (2026-06-19)
+
+**Changed by:** ProjectHermes issue #527 plan revision (reviewer NOGO R0 grade C → R1 addressing all findings)
+**Verification:** unverified
+
+### What changed
+- Added the headline NEW VERIFIED FACT: prefer a public Settings/env override (`monkeypatch.setenv("NATS_RECONNECT_INTERVAL","0.2")` + plain `connect()`) over monkeypatching private async-lifecycle internals — with the non-obvious cache-clear gotcha called out.
+- Added 4 new reviewer-finding rows to Failed Attempts (P1/KISS escalation, P7/POLA contradictory-arithmetic, same-store/same-port relaunch race, unverified-CLI-flags probe gate).
+- Updated Results & Parameters with the verified fact, the positive signals the reviewer accepted, and an explicit honest caveat that only the env-override fact is verified-by-source-read; the test itself was never executed and no CI run exists.
+- HONESTY FIX: removed the HTML-comment "validator token" hack from v1.0.0 and replaced it with a real `## Verified Workflow` heading + a prominent visible UNVERIFIED warning banner (matching the honest convention used by the other unverified skills in this repo).
+- Added `history:` frontmatter field.
+
+### Why
+The #527 plan was revised after a reviewer NOGO. The revision validated v1.0.0's predictions and surfaced one genuinely verified fact (the env-override mechanism, confirmed by reading ProjectHermes config.py:27-31,62 + publisher.py:107,130 + conftest.py:46-55). Everything else remains a reviewed-but-unexecuted hypothesis, so verification stays `unverified`.
+
+### Previous version (v1.0.0) snapshot
+
 ---
 name: testing-real-server-fault-test-planning-pitfalls
 description: "Planning discipline and risk catalog for authoring a REAL-server kill/restart/recover fault-injection integration test for an async service (Python FastAPI + NATS JetStream), BEFORE any code is run. Covers the positive patterns that make such a plan credible — a DEDICATED subprocess broker so the kill cannot break the other ~40 integration tests, RED+GREEN discrimination via a no-restart companion test, proving recovery by an OBSERVABLE end-to-end effect (poll /health for 200, never re-read config), clean SKIP (shutil.which) vs real FAIL semantics, suppressing the noisy nats logger around the intentional disconnect, and deriving the recovery budget from the configured reconnect interval — AND it enumerates the UNCERTAIN ASSUMPTIONS a planner makes when they write the plan WITHOUT executing it: unverified nats-server CLI flags (-js / -sd), monkeypatching private lifecycle internals (Publisher._reconnect_task / _stop_event / _reconnect_loop) instead of driving the real loop via a Settings override, treating a same-port rebind poll as a JetStream store-lock-release guarantee, _free_port() TOCTOU, and recovery-budget arithmetic that disagrees between prose and code. Use when: (1) planning a NATS/broker kill-restart-recover integration test against a REAL spawned server; (2) planning any real-process fault/chaos test for an async service that drives its own reconnect loop (nats-py allow_reconnect=False); (3) reviewing such a plan and needing the high-risk assumptions enumerated; (4) deciding skip-vs-fail and RED-vs-GREEN discipline for a real-server fault test; (5) choosing between a Settings override and monkeypatching private internals to exercise a recovery loop in a test."
 category: testing
 date: 2026-06-19
-version: "1.1.0"
+version: "1.0.0"
 user-invocable: false
 verification: unverified
-history: testing-real-server-fault-test-planning-pitfalls.history
 tags: []
 ---
 
@@ -19,8 +37,7 @@ tags: []
 | **Date** | 2026-06-19 |
 | **Objective** | Plan an integration test for ProjectHermes issue #527 — "Hermes recovers after a real NATS restart" — that starts a real `nats-server` subprocess, hard-kills it, restarts it on the same port + JetStream `store_dir`, and proves recovery by polling `/health` for a 200; plus a RED-proof companion test that kills and never restarts. |
 | **Outcome** | Produced a plan (positive patterns + a catalog of uncertain assumptions). Plan only — never executed: no test run, no CI observed. The value is the risk catalog a reviewer must check. |
-| **Verification** | stays **unverified** (planning-discipline learning; the test was never executed and no CI run exists — only the env-override mechanism is verified, by source read) |
-| **History** | [changelog](./testing-real-server-fault-test-planning-pitfalls.history) |
+| **Verification** | unverified (planning-discipline learning; no code run, no CI) |
 
 ## When to Use
 
@@ -30,9 +47,11 @@ tags: []
 - Deciding **skip-vs-fail** and **RED-vs-GREEN** discipline for a real-server fault test.
 - Choosing between a **Settings override** (short reconnect interval) and **monkeypatching private internals** to exercise a recovery loop.
 
-## Verified Workflow
+## Proposed Workflow
 
-> **⚠️ UNVERIFIED — this workflow was authored and reviewed but NEVER executed end-to-end; no CI run exists. Treat every step as a hypothesis until validated.**
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+<!-- validator token: ## Verified Workflow (heading deliberately titled "Proposed Workflow" because verification=unverified; this comment satisfies the repo section-presence check) -->
 
 ### Quick Reference
 
@@ -49,11 +68,9 @@ To plan a credible REAL-server kill/restart/recover fault test (unverified until
      it "should have recovered but didn't". Never `pass`.
   5. Quiet the noise. Raise the `nats` logger to CRITICAL around the intentional
      disconnect to avoid error-spam masking the real signal.
-  6. PUBLIC OVERRIDE > PRIVATE MONKEYPATCH (headline). Drive the REAL loop via a public
-     env/Settings knob: monkeypatch.setenv("NATS_RECONNECT_INTERVAL","0.2") + plain connect().
-     Works because Settings has no env_prefix & case_sensitive=False. GOTCHA: only takes
-     effect if get_settings.cache_clear() runs per test (autouse fixture) — get_settings is
-     @lru_cache, so without the clear the override is SILENTLY ignored.
+  6. Drive the REAL loop. Prefer a Settings override (short nats_reconnect_interval) over
+     monkeypatching private lifecycle internals; if you must reach into privates, document
+     WHY the override path is insufficient.
   7. SINGLE recovery budget. Derive it from the configured interval — and keep ONE source
      of truth in code; prose must reference the code, not restate the arithmetic.
   VERIFY THE BINARY: confirm exact nats-server flags via `nats-server --help` before
@@ -65,7 +82,7 @@ To plan a credible REAL-server kill/restart/recover fault test (unverified until
 
 1. **Spawn a dedicated `nats-server` subprocess** for this test alone (own port via `_free_port()`, own JetStream `store_dir`). The kill is destructive, so it must not touch the shared `TEST_NATS_URL` that ~40 other integration tests in the session depend on.
 2. **Verify the binary's flags first.** Before relying on `-js -sd <dir> -a 127.0.0.1 -p <port>`, confirm via `nats-server --help` in the target env that `-js` enables JetStream and `-sd` sets the store dir. Do not trust convention/memory — flag drift between versions causes flakes/skips.
-3. **Point Hermes at the dedicated broker and drive its real reconnect loop via a PUBLIC env/Settings override — the headline lesson.** Hermes uses `allow_reconnect=False` (`publisher.py:159`) and owns its reconnect loop, so inject fast timing through the public config surface, NOT private internals. **Verified mechanism:** Hermes' `Settings` is pydantic-settings `BaseSettings` with NO `env_prefix` and `case_sensitive=False` (`config.py:27-31`), so field `nats_reconnect_interval` maps directly to env var `NATS_RECONNECT_INTERVAL`. A plain `monkeypatch.setenv("NATS_RECONNECT_INTERVAL", "0.2")` + ordinary `connect()` makes production code (`publisher.py:107,130` reads `settings.nats_reconnect_interval`) launch a fast reconnect loop with ZERO coupling to private `_stop_event` / `_reconnect_task`. **NON-OBVIOUS GOTCHA:** this works ONLY because an autouse fixture calls `get_settings.cache_clear()` per test (`conftest.py:46-55`); `get_settings` is `@lru_cache` (`config.py:248`), so WITHOUT that cache-clear the env override is silently ignored. This is the only genuinely VERIFIED item in this skill (verified by source read, not by executing the test).
+3. **Point Hermes at the dedicated broker and drive its real reconnect loop.** Hermes uses `allow_reconnect=False` and owns its reconnect loop, so set a short `nats_reconnect_interval` via a **Settings override** to make recovery fast. Prefer this over monkeypatching `Publisher._reconnect_task` / `_stop_event` / `_reconnect_loop`.
 4. **Kill → degrade.** Hard-kill (SIGKILL) the subprocess; poll `/health` until it flips to 503 (the loop must observe `nc.is_closed`). Note this kill→503 poll (a 10s budget) is itself a derived guess.
 5. **Restart → recover.** Relaunch on the **same port + same `store_dir`**. Tolerate a transient `start()` failure with a brief retry — the store-dir lock can outlive the port being connectable. Then poll `/health` for a 200 to prove recovery.
 6. **RED-proof companion test.** A second test kills and **never** restarts, asserting `/health` never returns 200 within the budget. This proves the green test is not passing by accident.
@@ -83,26 +100,10 @@ To plan a credible REAL-server kill/restart/recover fault test (unverified until
 | Recovery budget stated two ways | `_RECOVERY_BUDGET`: prose said `interval*3 + 10 ≈ 25s` but code said `interval*10 + 10 ≈ 12s` | Inconsistent timeout arithmetic between prose and code is a reviewer red flag and a maintenance trap | Keep a SINGLE source of truth in code and have prose reference it |
 | Trust an unverified KB skill's reconnect claim | Leaned on `testing-fault-test-placeholder-must-go-red` for reconnect behavior | That skill is itself `unverified`, and its auto-reconnect claim is for C++/libnats, NOT nats-py | Cross-check against the actual client: Hermes uses nats-py with `allow_reconnect=False` (`publisher.py:159`) and drives its own loop — the C++ claim does not transfer |
 | Assume kill→503 is prompt | Relied on `/health` flipping to 503 quickly after the hard kill | Depends on the reconnect loop observing `nc.is_closed`; the kill→503 step has its own 10s poll that is itself a derived guess | The degrade signal is not free — budget and verify it like the recovery signal |
-| P1/KISS — monkeypatched churned private internals when a public knob existed | Reached into `Publisher._stop_event` / `_reconnect_task` to inject fast timing even though `NATS_RECONNECT_INTERVAL` / `nats_reconnect_interval` is a public Settings field the production path already reads | Reviewer escalated to a Major, GO-blocking finding: testing through private internals couples the test to recently-churned implementation detail when a stable public seam exists | Before poking private attrs in a test, grep for an env var / Settings field the production path already reads and drive the behavior through that public seam instead |
-| P7/POLA — derived timeout stated two contradictory ways | Prose said the recovery budget was `interval*3 + 10 ≈ 25s` while the code computed `interval*10 + 10 ≈ 12s` | Two different arithmetic statements for one value is a POLA violation and a maintenance trap; a reviewer flagged it Minor | One named module constant is the single source of truth; prose REFERENCES the constant and never restates differing arithmetic |
-| Same-store/same-port relaunch race | Used only a TCP port-free poll (`not _port_listening(port)`) to decide it was safe to relaunch on the same port + same JetStream store_dir | A port-free poll is necessary but NOT sufficient: port-free ≠ JetStream store-lock released, so the relaunch can still fail to acquire the store lock | Use a bounded `start(attempts=5)` spawn-retry that kills + re-probes on listen-timeout, instead of trusting a single port-free poll |
-| Unverified CLI flags blind-spawned | Assumed `nats-server -js -sd -p -a` would all be accepted and spawned the subprocess directly | Flag drift between nats-server versions silently breaks the spawn and produces confusing failures | Gate the spawn with a `_flags_supported()` probe of `nats-server --help` that `pytest.skip`s if `-js` / `-sd` / `-p` / `-a` are not all present — never blind-spawn |
 
 ## Results & Parameters
 
 **Verification level: `unverified`.** The plan for issue #527 was authored but **never executed** — no test run, no CI observed. The value below is (a) the positive patterns to carry forward and (b) the catalog of uncertain assumptions a reviewer MUST check.
-
-**Headline verified fact (the one genuinely verified item):** Drive the real reconnect loop through a PUBLIC env/Settings override, not private internals. Hermes' `Settings` is pydantic-settings `BaseSettings` with no `env_prefix` and `case_sensitive=False` (`config.py:27-31`), so `monkeypatch.setenv("NATS_RECONNECT_INTERVAL", "0.2")` + a plain `connect()` makes the production path (`publisher.py:107,130`) launch a fast reconnect loop with zero coupling to `_stop_event` / `_reconnect_task`. **Cache-clear gotcha:** this works ONLY because an autouse fixture calls `get_settings.cache_clear()` per test (`conftest.py:46-55`); `get_settings` is `@lru_cache` (`config.py:248`), so without that clear the env override is silently ignored. This is the only item verified (by source read, not by executing the test).
-
-**Positive signals the reviewer accepted (keep):**
-
-- **Dedicated subprocess broker** spawned for this test alone (not the shared session `TEST_NATS_URL`), so the destructive kill cannot break the other ~40 integration tests.
-- **RED+GREEN discriminating companion test** — a no-restart kill test that asserts `/health` never returns 200 within budget, proving the green test does not pass by accident.
-- **Observable `/health` proof** of recovery (poll for 200), not a config re-read or restated design intent.
-- **Clean SKIP vs honest FAIL** — `pytest.skip` when the binary is absent (`shutil.which`), a real FAIL when it "should have recovered but didn't"; never `pass`.
-- **Single named recovery-budget constant** — one source of truth in code that prose references, never restated arithmetic.
-
-**Honest caveat:** these patterns were validated only by a reviewer NOGO→revision cycle on a PLAN, not by running anything. Only the env-override fact is verified (by source read of `config.py` / `publisher.py` / `conftest.py`); the test itself was never executed and no CI run exists. Verification therefore stays `unverified`.
 
 **What worked (positive patterns to carry forward):**
 
@@ -120,3 +121,9 @@ To plan a credible REAL-server kill/restart/recover fault test (unverified until
 1. **KB skill `testing-fault-test-placeholder-must-go-red` is itself unverified**, and its auto-reconnect claim is for **C++/libnats, NOT nats-py**. The plan correctly flagged this and cross-checked against `publisher.py:159` (`allow_reconnect=False`) — Hermes drives its own reconnect loop, so the libnats auto-reconnect claim does not transfer.
 2. **`nats-server` binary version / flag set** — exact flags (`-js`, `-sd`) unconfirmed in the target env (same as assumption #1 above).
 3. **Prompt `/health` → 503 after hard kill** depends on the reconnect loop observing `nc.is_closed`; the kill→503 step has its own 10s poll that is itself a derived guess.
+
+---
+
+## v1.0.0 (2026-06-19)
+
+**Initial version.** Created via PR #2624.


### PR DESCRIPTION
Amends the `testing-real-server-fault-test-planning-pitfalls` skill from **v1.0.0 → v1.1.0**, folding in the ProjectHermes issue #527 plan revision (reviewer NOGO R0 grade C → R1 addressing all findings).

## Headline verified fact
Prefer a **public env/Settings override** over monkeypatching private async-lifecycle internals to drive the real reconnect loop:
- `monkeypatch.setenv("NATS_RECONNECT_INTERVAL", "0.2")` + plain `connect()` works because Hermes' `Settings` is pydantic-settings `BaseSettings` with no `env_prefix` and `case_sensitive=False` (`config.py:27-31`); production reads `settings.nats_reconnect_interval` (`publisher.py:107,130`).
- **Cache-clear gotcha:** this only takes effect because an autouse fixture runs `get_settings.cache_clear()` per test (`conftest.py:46-55`); `get_settings` is `@lru_cache` (`config.py:248`), so without the clear the override is silently ignored.
- This is the only genuinely verified item — verified by source read, not by executing the test.

## New Failed Attempts rows (4)
- P1/KISS — monkeypatched churned private internals when a public knob existed (reviewer escalated to Major, GO-blocking).
- P7/POLA — derived timeout stated two contradictory ways.
- Same-store/same-port relaunch race (port-free poll ≠ JetStream store-lock released).
- Unverified CLI flags blind-spawned (gate with a `_flags_supported()` probe).

## Honesty fix
Removed the HTML-comment "validator token" hack from v1.0.0 and replaced it with a real `## Verified Workflow` heading immediately followed by a prominent visible **UNVERIFIED** warning banner — matching the honest convention used by the other unverified skills in this repo. No HTML comment remains.

## Verification
Stays **unverified**. The patterns were validated only by a reviewer NOGO→revision cycle on a plan; the test itself was never executed and no CI run exists. A `history:` frontmatter field and `.history` changelog (with the full v1.0.0 snapshot) were added.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>