### PR TITLE
feat: add planning-verify-issue-premise-before-implementing skill

### DIFF
--- a/skills/planning-verify-issue-premise-before-implementing.md
+++ b/skills/planning-verify-issue-premise-before-implementing.md
@@ -1,0 +1,129 @@
+---
+name: planning-verify-issue-premise-before-implementing
+description: "When an issue's premise references an artifact (script, file, committed config) that may not exist on the working branch, VERIFY the artifact's existence FIRST (git ls-files | grep, direct path checks), then re-scope the plan around the issue's INTENT rather than building the assumed artifact. Issue bodies written as follow-ups to assumed-prior work routinely carry invalid premises: the named file never landed, the stated failure mode is impossible, or the intent is ALREADY satisfied by existing tooling. Distinguish the literal ask (build script X, wire it into CI) from the intent (catch drift before merge); when the literal artifact is absent or redundant, satisfy the intent with what already exists. Building an assumed-but-absent artifact can be NET-NEGATIVE when it introduces a NEW source of truth to police — check it against the project's single-source-of-truth principle. Also verify the target CI job's setup steps before changing its run: invocation: a deliberately pixi-free / stdlib-only job breaks if you naively wrap everything in just/pixi run. Use when: (1) planning an issue that names a specific script/file/artifact as already-existing context, (2) the issue is framed as a follow-up to a prior issue/PR you have not independently confirmed, (3) the issue's stated failure mode depends on a build step or committed file you have not inspected, (4) you are tempted to build the literal artifact the issue asks for, (5) you are about to change a CI job's run: command without reading its setup steps, (6) a fix would add a second generator/source for data that already has a canonical source."
+category: architecture
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [planning, issue-premise, verify-before-implementing, requirements-drift, single-source-of-truth, ci-gate, re-scope, intent-vs-literal-ask, follow-up-issue, pixi-free-job, unverified-assumptions, dependency-sync]
+---
+
+# Planning: Verify the Issue Premise Before Implementing
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-19 |
+| **Objective** | Capture durable planning discipline for issues whose premise names an artifact that may not exist on the working branch — verify existence first, then plan around the issue's intent, not its assumed artifact |
+| **Outcome** | Plan produced for ProjectHermes #556: do NOT build the assumed `sync_requirements.py` + `requirements.txt`; instead add a `just check-reqs` alias to existing `check_dep_sync.py` and recommend re-scoping/closing the issue |
+| **Verification** | unverified — PLANNING session only; no code written or executed, no CI run, GitHub issues not fetched directly |
+| **History** | n/a (initial version) |
+
+## When to Use
+
+- An issue's body cites a specific script, file, or committed config as already-existing context (e.g. "the existing `scripts/sync_requirements.py --check`" or "the committed `requirements.txt`").
+- The issue is framed as a follow-up to a prior issue/PR (e.g. "follow-up from #354") whose deliverables you have not independently confirmed landed.
+- The issue's stated failure mode depends on a build step or committed file you have not inspected ("the Docker build will silently use stale pins from a committed `requirements.txt`").
+- You are about to plan building the literal artifact the issue asks for, before confirming an equivalent does not already exist.
+- You are about to change a CI job's `run:` invocation (e.g. wrap it in `just`/`pixi run`) without reading the job's `setup-*` steps.
+- A proposed fix would add a SECOND generator/source for data that already has a canonical source (pixi + pyproject as single source of truth).
+
+## Verified Workflow
+
+> **Warning:** This workflow has NOT been validated end-to-end. It was produced in a
+> PLANNING session — no code was written or executed, CI never ran, and the referenced
+> GitHub issues were NOT fetched directly (the issue body was trusted as pasted into the
+> task prompt). The section is titled "Verified Workflow" only to satisfy the marketplace
+> validator. Treat every step below as a **Proposed Workflow / hypothesis** until CI and a
+> human planner confirm it.
+
+### Quick Reference
+
+```bash
+# 1. EXISTENCE CHECK every artifact the issue names, on the working branch:
+git ls-files | grep -iE 'requirements|sync_req'      # -> empty == it does NOT exist here
+ls scripts/                                           # what scripts ACTUALLY exist
+test -f requirements.txt && echo "present" || echo "ABSENT"
+
+# 2. Find the artifact that ALREADY satisfies the intent (here: drift detection):
+git ls-files | grep -i dep                            # -> scripts/check_dep_sync.py
+grep -rn 'check_dep_sync' .github/ justfile           # is it already a CI gate + local recipe?
+
+# 3. Confirm the stated failure mode is even POSSIBLE — read the build:
+sed -n '1,20p' Dockerfile                              # does the build read a committed file,
+                                                       # or generate deps at build time from pyproject?
+
+# 4. Read the TARGET CI job's setup before touching its run: invocation:
+#    a stdlib-only / pixi-free job breaks if you wrap it in just/pixi run.
+grep -nB3 -A8 'deps-version-sync' .github/workflows/_required.yml
+```
+
+### Detailed Steps
+
+1. **Run existence checks on EVERY file/script/artifact the issue names — before writing any plan.** Issue bodies written against assumed-prior work are a recurring source of invalid premises. For #556 the premise was that `scripts/sync_requirements.py --check` and a committed `requirements.txt` existed (a follow-up from #354). On branch `90-170-171-auto-impl`, `git ls-files | grep -iE 'requirements|sync_req'` returned nothing — NEITHER existed; only `scripts/check_dep_sync.py` was present.
+
+2. **Test whether the issue's stated failure mode is even possible by reading the relevant source.** #556 claimed "Docker build will silently use stale pins from a committed `requirements.txt`." Reading `Dockerfile:11` showed the build GENERATES its dependency list at build time from `pyproject.toml [project.dependencies]` via inline `tomllib` — it consumes NO committed requirements file. The failure mode could not occur, so the premise was doubly invalid.
+
+3. **Separate the issue's literal ask from its intent.** Literal ask: "build `sync_requirements.py`, wire it into a `check-reqs` CI step." Intent: "catch dependency drift before merge." For #556 the intent was ALREADY satisfied: `check_dep_sync.py` was wired as a required CI gate in the `deps-version-sync` job (`_required.yml:399-402`) and exposed locally as `just dep-check` (`justfile:111`).
+
+4. **When the literal artifact is absent or redundant, satisfy the intent with what already exists — do not build the assumed artifact.** Building `requirements.txt` + a sync script would create a NEW source of dependency truth to police, violating the "pixi + pyproject = single source of truth" principle. A net-NEGATIVE outcome: you would introduce the very drift the issue wants to prevent. The minimal reconciliation that honors the issue's named entry point: add a `just check-reqs` alias that calls the existing `check_dep_sync.py`, and recommend re-scoping or closing the issue.
+
+5. **Before changing a CI job's `run:` invocation, read its setup steps.** The `deps-version-sync` job uses `actions/setup-python` only (no pixi), and `check_dep_sync.py` is deliberately stdlib-only (`tomllib`). A naive "wrap everything in `just`/`pixi run`" change would break a deliberately pixi-free job. Verify the job's `setup-*` steps before touching its `run:` line.
+
+6. **Flag a "decline to build the literal ask" recommendation as a human-ratify decision.** Recommending "re-scope or close #556" is a judgment call. An automated pipeline could mishandle a plan that declines to build what the issue literally asks for, so the plan must surface this as a decision requiring human ratification, not silently drop the issue's literal scope.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust the issue body's premise | Assumed `scripts/sync_requirements.py` and a committed `requirements.txt` existed because the issue (#556) described them as the existing follow-up context from #354 | The premise was invalid on the branch — `git ls-files \| grep -iE 'requirements\|sync_req'` returned nothing; neither artifact existed | Run existence checks (`git ls-files \| grep`, direct path tests) on every named artifact BEFORE planning; issue bodies written against assumed-prior work routinely carry invalid premises |
+| Build the assumed `requirements.txt` + sync script | Considered implementing the literal ask: generate a committed `requirements.txt` and a `sync_requirements.py --check` to police it in CI | Would introduce a NEW source of dependency truth, violating the project's "pixi + pyproject = single source of truth" principle — net-negative, manufacturing the very drift surface the issue wanted to eliminate | Satisfy the issue's INTENT with existing tooling (`check_dep_sync.py`), don't build a redundant artifact; check any new artifact against single-source-of-truth principles |
+| Trust the "follow-up from #354" lineage | Relied on the issue's claim that #556 followed from #354 and that #354 shipped the assumed deliverables | #354's actual deliverables were never verified against GitHub — the issues were not fetched directly, only the pasted issue body was trusted | Fetch linked/parent issues from the source of truth (`gh issue view`) before treating their stated deliverables as fact |
+| Assume "build the named CI step" means wrap it in just/pixi | Treated adding the `check-reqs` CI gate as "invoke the checker via `just`/`pixi run` in the existing job" | The `deps-version-sync` job uses `actions/setup-python` only and `check_dep_sync.py` is deliberately stdlib-only (`tomllib`); wrapping it in pixi would break a deliberately pixi-free job | Read a CI job's `setup-*` steps before changing its `run:` invocation; some jobs are intentionally toolchain-minimal |
+| Branch-scoped existence check read as repo-history claim | Concluded "the sync script never landed" from a single working-branch `git ls-files` | Existence was only checked on `90-170-171-auto-impl`, not on `main` or other branches / repo history — the "never landed" claim is branch-scoped, not repo-scoped | Scope existence claims to what you actually checked; to claim repo-wide absence, search `main` and history (`git log --all -- <path>`), not just the current branch |
+
+## Results & Parameters
+
+### Existence-check commands (proposed, branch-scoped)
+
+```bash
+# On branch 90-170-171-auto-impl (ProjectHermes):
+git ls-files | grep -iE 'requirements|sync_req'   # -> (empty)  : assumed artifacts ABSENT
+git ls-files | grep -i dep                         # -> scripts/check_dep_sync.py : the real tool
+```
+
+### The reconciliation actually planned (minimal, intent-preserving)
+
+```makefile
+# justfile — alias the issue's named entry point to the EXISTING checker
+# (do NOT build sync_requirements.py / requirements.txt)
+check-reqs: dep-check        # `just check-reqs` -> scripts/check_dep_sync.py
+```
+
+### What already satisfied the intent (verified by reading files, not executing)
+
+- `scripts/check_dep_sync.py` — stdlib-only (`tomllib`) drift checker.
+- `.github/workflows/_required.yml:399-402` — `deps-version-sync` job runs it as a REQUIRED gate, using `actions/setup-python` (no pixi).
+- `justfile:111` — `just dep-check` exposes it locally.
+- `Dockerfile:11` — generates deps from `pyproject.toml [project.dependencies]` via inline `tomllib`; consumes no committed requirements file (so #556's stated failure mode is impossible).
+
+### Most uncertain assumptions (honest risks)
+
+- **GitHub issues not fetched.** #556 and #354 were NOT fetched via `gh issue view`; the issue body was trusted as pasted into the task prompt. The "follow-up from #354" lineage and #354's actual deliverables were never verified against GitHub.
+- **Existence claim is branch-scoped, not repo-scoped.** `sync_requirements.py` / `requirements.txt` absence was checked only on `90-170-171-auto-impl`, not on `main` or in repo history. The "never landed" claim is branch-scoped.
+- **No command was executed end-to-end.** `just --evaluate`, `just check-reqs`, and `python3 scripts/check_dep_sync.py` were never run during planning. Verification level is unverified / verified-by-reading at best.
+- **"Re-scope or close #556" is a human-ratify judgment call.** An automated pipeline could mishandle a plan that declines to build the literal ask. The decision to NOT build the named artifact should be ratified by a human planner, not auto-applied.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHermes | Issue #556 ("Add check-reqs to CI pipeline to catch requirements drift") — planning session on branch `90-170-171-auto-impl` | Unverified. Assumed `sync_requirements.py` + `requirements.txt` did not exist on the branch; the stated Docker failure mode was impossible (`Dockerfile:11` builds deps from `pyproject.toml`); intent already satisfied by `check_dep_sync.py` (`_required.yml:399-402`, `justfile:111`). Plan: add `just check-reqs` alias, recommend re-scoping/closing the issue. |
+
+## References
+
+- [planning-verify-integration-point-exists-before-guarding.md](planning-verify-integration-point-exists-before-guarding.md)
+- [planning-check-already-shipped-before-planning.md](planning-check-already-shipped-before-planning.md)
+- [planning-verify-live-state-before-assuming-work-remains.md](planning-verify-live-state-before-assuming-work-remains.md)


### PR DESCRIPTION
## Summary

New flat skill `planning-verify-issue-premise-before-implementing` (category: architecture, version 1.0.0, verification: unverified).

**Core lesson:** When an issue's premise references an artifact that does not exist on the working branch, verify the artifact's existence FIRST, then re-scope the plan around the issue's intent rather than building the assumed artifact.

## Evidence (ProjectHermes #556 — "Add check-reqs to CI to catch requirements drift")

- The issue assumed `scripts/sync_requirements.py --check` and a committed `requirements.txt` existed (follow-up from #354). On branch `90-170-171-auto-impl`, neither existed — `git ls-files | grep -iE 'requirements|sync_req'` returned nothing; only `scripts/check_dep_sync.py` was present.
- The stated failure mode ("Docker build silently uses stale pins from a committed requirements.txt") was impossible: `Dockerfile:11` generates deps at build time from `pyproject.toml` via inline `tomllib`.
- The intent (catch drift before merge) was already satisfied: `check_dep_sync.py` is a required CI gate (`_required.yml:399-402`) and `just dep-check` (`justfile:111`).
- Resolution: add a `just check-reqs` alias to the existing checker; recommend re-scoping/closing the issue. Do NOT build a redundant second source of dependency truth.

## Heuristics encoded
1. Existence-check every named artifact before planning.
2. Separate literal ask from intent; satisfy intent with existing tooling when the literal artifact is absent/redundant.
3. An assumed-but-absent artifact can be net-negative (new single-source-of-truth violation).
4. Read a CI job's setup steps before changing its `run:` invocation (the `deps-version-sync` job is deliberately pixi-free / stdlib-only).

## Honest risks captured
- Issues #556/#354 were not fetched directly (issue body trusted as pasted).
- Existence claim is branch-scoped, not repo-history-scoped.
- No command run end-to-end during planning.
- "Re-scope or close" is a human-ratify judgment call.

## Validation
`python3 scripts/validate_plugins.py` → 429/429 valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)