### PR TITLE
feat: amend planning-verify-issue-premise-before-implementing skill (v2.0.0)

### DIFF
--- a/skills/planning-verify-issue-premise-before-implementing.history
+++ b/skills/planning-verify-issue-premise-before-implementing.history
@@ -1,0 +1,88 @@
+# planning-verify-issue-premise-before-implementing — History
+
+## v2.0.0 (2026-06-19)
+
+**Changed by:** ProjectHermes issue #556 re-plan (plan-reviewer NOGO follow-up)
+**Verification:** unverified
+
+### What changed
+
+- **MAJOR bump (1.0.0 → 2.0.0): the v1.0.0 worked example reached a WRONG conclusion and is corrected here.** v1.0.0 concluded the assumed `scripts/sync_requirements.py` + `requirements.txt` "never landed" and recommended re-scoping/closing #556. A full scan of ALL remote branches overturned that: both files exist on `origin/354-auto-impl` (the prerequisite issue #354's own branch). The artifact was BUILT but not yet merged to `main`. The correct disposition flipped from "re-scope/close" to "the issue is valid; it is blocked on merge ordering."
+- Rewrote the central conclusion in Overview, Verified Workflow, Results, and Verified On to reflect the branch-scan correction.
+- Promoted the PRIMARY new lesson to step 1: a branch-scoped existence check is NOT a repo-scoped one. Before concluding "never built," scan `origin/main` AND every remote branch (`git ls-tree -r <ref> | grep`, looped over `git branch -r`).
+- Corrected the SECONDARY lesson: v1.0.0 asserted the CI check should run pixi-free (copying `check_dep_sync.py`). WRONG for `sync_requirements.py`, which shells out to `pixi list --json` and therefore REQUIRES pixi in CI. Read a script's `subprocess`/`import` calls before deciding its CI environment.
+- Added the TERTIARY lesson: a re-scope/close recommendation that "requires human ratification" is a NOGO trigger for plan reviewers. Reduce the decision to a deterministic runnable check (`git merge-base --is-ancestor`) instead of a discretionary sign-off.
+- Added 3 Failed Attempts rows (branch-scoped existence check; pixi-free CI assertion; human-ratify re-scope recommendation).
+- Refreshed the uncertain-assumptions / reviewer-risk list (pixi env on CI, merge-order enforcement, unconfirmed #354↔branch linkage, commands not executed end-to-end).
+- Added cross-reference to `git-unmerged-branch-file-access`.
+- Added `history:` frontmatter field.
+
+### Why
+
+The v1.0.0 plan was NOGO'd by a plan reviewer. A deeper investigation (scanning all remote branches) overturned its central conclusion. Capturing the correction as a durable lesson: the single most generalizable failure was treating a branch-scoped `git ls-files` as proof of repo-wide absence. Issues are frequently the CI-wiring/integration tail of a sibling issue whose code lives on an unmerged branch; concluding "never built" without scanning all branches produces a wrong disposition. Two secondary corrections (script-specific CI runtime deps; deterministic gate vs. discretionary sign-off) accompany it.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: planning-verify-issue-premise-before-implementing
+description: "When an issue's premise references an artifact (script, file, committed config) that may not exist on the working branch, VERIFY the artifact's existence FIRST (git ls-files | grep, direct path checks), then re-scope the plan around the issue's INTENT rather than building the assumed artifact. Issue bodies written as follow-ups to assumed-prior work routinely carry invalid premises: the named file never landed, the stated failure mode is impossible, or the intent is ALREADY satisfied by existing tooling. Distinguish the literal ask (build script X, wire it into CI) from the intent (catch drift before merge); when the literal artifact is absent or redundant, satisfy the intent with what already exists. Building an assumed-but-absent artifact can be NET-NEGATIVE when it introduces a NEW source of truth to police — check it against the project's single-source-of-truth principle. Also verify the target CI job's setup steps before changing its run: invocation: a deliberately pixi-free / stdlib-only job breaks if you naively wrap everything in just/pixi run. Use when: (1) planning an issue that names a specific script/file/artifact as already-existing context, (2) the issue is framed as a follow-up to a prior issue/PR you have not independently confirmed, (3) the issue's stated failure mode depends on a build step or committed file you have not inspected, (4) you are tempted to build the literal artifact the issue asks for, (5) you are about to change a CI job's run: command without reading its setup steps, (6) a fix would add a second generator/source for data that already has a canonical source."
+category: architecture
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [planning, issue-premise, verify-before-implementing, requirements-drift, single-source-of-truth, ci-gate, re-scope, intent-vs-literal-ask, follow-up-issue, pixi-free-job, unverified-assumptions, dependency-sync]
+---
+
+# Planning: Verify the Issue Premise Before Implementing
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-19 |
+| **Objective** | Capture durable planning discipline for issues whose premise names an artifact that may not exist on the working branch — verify existence first, then plan around the issue's intent, not its assumed artifact |
+| **Outcome** | Plan produced for ProjectHermes #556: do NOT build the assumed `sync_requirements.py` + `requirements.txt`; instead add a `just check-reqs` alias to existing `check_dep_sync.py` and recommend re-scoping/closing the issue |
+| **Verification** | unverified — PLANNING session only; no code written or executed, no CI run, GitHub issues not fetched directly |
+| **History** | n/a (initial version) |
+
+## When to Use
+
+- An issue's body cites a specific script, file, or committed config as already-existing context (e.g. "the existing `scripts/sync_requirements.py --check`" or "the committed `requirements.txt`").
+- The issue is framed as a follow-up to a prior issue/PR (e.g. "follow-up from #354") whose deliverables you have not independently confirmed landed.
+- The issue's stated failure mode depends on a build step or committed file you have not inspected ("the Docker build will silently use stale pins from a committed `requirements.txt`").
+- You are about to plan building the literal artifact the issue asks for, before confirming an equivalent does not already exist.
+- You are about to change a CI job's `run:` invocation (e.g. wrap it in `just`/`pixi run`) without reading the job's `setup-*` steps.
+- A proposed fix would add a SECOND generator/source for data that already has a canonical source (pixi + pyproject as single source of truth).
+
+## Verified Workflow
+
+> **Warning:** This workflow has NOT been validated end-to-end. It was produced in a
+> PLANNING session — no code was written or executed, CI never ran, and the referenced
+> GitHub issues were NOT fetched directly (the issue body was trusted as pasted into the
+> task prompt). The section is titled "Verified Workflow" only to satisfy the marketplace
+> validator. Treat every step below as a **Proposed Workflow / hypothesis** until CI and a
+> human planner confirm it.
+
+(... full v1.0.0 body preserved in git history at commit 0b808eb6; the central
+conclusion below was later found WRONG and corrected in v2.0.0 ...)
+
+## Failed Attempts (v1.0.0)
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Branch-scoped existence check read as repo-history claim | Concluded "the sync script never landed" from a single working-branch `git ls-files` | Existence was only checked on `90-170-171-auto-impl`, not on `main` or other branches / repo history — the "never landed" claim is branch-scoped, not repo-scoped | Scope existence claims to what you actually checked; to claim repo-wide absence, search `main` and history, not just the current branch |
+```
+
+> **NOTE (added in v2.0.0):** the v1.0.0 conclusion was WRONG. The files DID land — on
+> `origin/354-auto-impl`. v1.0.0 already listed "branch-scoped existence check" as a Failed
+> Attempt but treated it as a minor caveat; it was in fact the error that flipped the
+> disposition. See v2.0.0 for the corrected worked example. Full v1.0.0 text is in git at
+> commit `0b808eb6` (PR #2631).
+
+---
+
+## v1.0.0 (2026-06-19)
+
+**Initial version.** (PR #2631)

--- a/skills/planning-verify-issue-premise-before-implementing.md
+++ b/skills/planning-verify-issue-premise-before-implementing.md
@@ -1,12 +1,13 @@
 ---
 name: planning-verify-issue-premise-before-implementing
-description: "When an issue's premise references an artifact (script, file, committed config) that may not exist on the working branch, VERIFY the artifact's existence FIRST (git ls-files | grep, direct path checks), then re-scope the plan around the issue's INTENT rather than building the assumed artifact. Issue bodies written as follow-ups to assumed-prior work routinely carry invalid premises: the named file never landed, the stated failure mode is impossible, or the intent is ALREADY satisfied by existing tooling. Distinguish the literal ask (build script X, wire it into CI) from the intent (catch drift before merge); when the literal artifact is absent or redundant, satisfy the intent with what already exists. Building an assumed-but-absent artifact can be NET-NEGATIVE when it introduces a NEW source of truth to police — check it against the project's single-source-of-truth principle. Also verify the target CI job's setup steps before changing its run: invocation: a deliberately pixi-free / stdlib-only job breaks if you naively wrap everything in just/pixi run. Use when: (1) planning an issue that names a specific script/file/artifact as already-existing context, (2) the issue is framed as a follow-up to a prior issue/PR you have not independently confirmed, (3) the issue's stated failure mode depends on a build step or committed file you have not inspected, (4) you are tempted to build the literal artifact the issue asks for, (5) you are about to change a CI job's run: command without reading its setup steps, (6) a fix would add a second generator/source for data that already has a canonical source."
+description: "When an issue's premise references an artifact (script, file, committed config) that may not exist on the working branch, VERIFY existence FIRST — and do it REPO-WIDE, not just on the current branch. A branch-scoped `git ls-files | grep` that returns nothing does NOT prove the artifact was never built: it may live on a sibling unmerged branch (often the prerequisite issue's own `<n>-auto-impl` branch). Before concluding 'never landed,' scan origin/main AND every remote branch (`git ls-tree -r <ref> | grep`, looped over `git branch -r`). When the artifact exists on an unmerged branch, the issue is usually VALID and merely blocked on merge ordering — not a candidate for re-scope/close. Then: read the named check script's ACTUAL runtime deps (grep for subprocess/import/external-tool calls) before asserting its CI environment — two superficially similar drift-check scripts can have OPPOSITE needs (one stdlib-only/pixi-free, one shelling out to `pixi list --json`). Finally, when a plan's correctness hinges on a judgment call, reduce it to a DETERMINISTIC runnable check (`git merge-base --is-ancestor`, file existence, exit code) — a re-scope/close recommendation that 'requires human ratification' is a NOGO trigger for plan reviewers. Use when: (1) planning an issue that names a specific script/file/artifact as already-existing context, (2) the issue is a follow-up to a prior issue/PR whose deliverables you have not confirmed merged, (3) you are about to conclude an artifact 'never existed' from a current-branch check only, (4) you are about to assert a CI job's toolchain (pixi/node/stdlib) without reading the script's calls, (5) your plan's central decision needs human sign-off rather than a runnable gate."
 category: architecture
 date: 2026-06-19
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
 verification: unverified
-tags: [planning, issue-premise, verify-before-implementing, requirements-drift, single-source-of-truth, ci-gate, re-scope, intent-vs-literal-ask, follow-up-issue, pixi-free-job, unverified-assumptions, dependency-sync]
+history: planning-verify-issue-premise-before-implementing.history
+tags: [planning, issue-premise, verify-before-implementing, branch-scoped-vs-repo-scoped, scan-all-branches, unmerged-branch, merge-ordering, requirements-drift, single-source-of-truth, ci-gate, pixi, deterministic-gate, plan-reviewer-nogo, re-scope, intent-vs-literal-ask, follow-up-issue, unverified-assumptions, dependency-sync]
 ---
 
 # Planning: Verify the Issue Premise Before Implementing
@@ -16,114 +17,175 @@ tags: [planning, issue-premise, verify-before-implementing, requirements-drift, 
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-19 |
-| **Objective** | Capture durable planning discipline for issues whose premise names an artifact that may not exist on the working branch — verify existence first, then plan around the issue's intent, not its assumed artifact |
-| **Outcome** | Plan produced for ProjectHermes #556: do NOT build the assumed `sync_requirements.py` + `requirements.txt`; instead add a `just check-reqs` alias to existing `check_dep_sync.py` and recommend re-scoping/closing the issue |
-| **Verification** | unverified — PLANNING session only; no code written or executed, no CI run, GitHub issues not fetched directly |
-| **History** | n/a (initial version) |
+| **Objective** | Capture durable planning discipline for issues whose premise names an artifact that may not exist on the working branch — verify existence REPO-WIDE (all branches) before concluding it was never built, read a check script's real runtime deps before asserting its CI env, and reduce judgment-call dispositions to deterministic runnable gates |
+| **Outcome** | Plan REVISED for ProjectHermes #556: the assumed `sync_requirements.py` + `requirements.txt` DO exist — on `origin/354-auto-impl` (the prerequisite issue's branch), not on `main`. The issue is VALID and blocked on merge ordering, provable by `git merge-base --is-ancestor origin/354-auto-impl origin/main` (→ false). The earlier "re-scope/close" disposition (v1.0.0) was WRONG and is corrected here. |
+| **Verification** | unverified — PLANNING session only; no code written or executed end-to-end, no CI run, `gh pr view 354` failed (PR object not accessible), branch↔issue linkage inferred from naming convention |
+| **History** | v1.0.0 → v2.0.0 (MAJOR: the central worked-example conclusion was overturned). See `planning-verify-issue-premise-before-implementing.history`. |
+
+This skill's own v1.0.0 example is a cautionary tale: it concluded the named artifacts
+"never landed" from a single-branch `git ls-files`, and recommended re-scoping/closing the
+issue. **That was wrong.** A scan across all remote branches found both files on the
+prerequisite issue's `<n>-auto-impl` branch. The artifact was BUILT but not yet merged. The
+disposition flipped from "close the issue" to "the issue is valid; it is blocked on merge
+ordering." The three corrections below are the durable lessons.
 
 ## When to Use
 
 - An issue's body cites a specific script, file, or committed config as already-existing context (e.g. "the existing `scripts/sync_requirements.py --check`" or "the committed `requirements.txt`").
-- The issue is framed as a follow-up to a prior issue/PR (e.g. "follow-up from #354") whose deliverables you have not independently confirmed landed.
-- The issue's stated failure mode depends on a build step or committed file you have not inspected ("the Docker build will silently use stale pins from a committed `requirements.txt`").
-- You are about to plan building the literal artifact the issue asks for, before confirming an equivalent does not already exist.
-- You are about to change a CI job's `run:` invocation (e.g. wrap it in `just`/`pixi run`) without reading the job's `setup-*` steps.
-- A proposed fix would add a SECOND generator/source for data that already has a canonical source (pixi + pyproject as single source of truth).
+- The issue is framed as a follow-up to a prior issue/PR (e.g. "follow-up from #354") whose deliverables you have not independently confirmed MERGED.
+- You are about to conclude an artifact "never existed" / "never landed" from a check run only on the current working branch.
+- The issue's stated failure mode depends on a build step or committed file you have not inspected.
+- You are about to assert a CI job's toolchain needs (pixi / node / stdlib-only) without reading the check script's actual `subprocess`/`import`/external-tool calls.
+- Your plan's central decision is a judgment call (re-scope, close, defer) that would require human sign-off rather than a runnable gate.
 
 ## Verified Workflow
 
 > **Warning:** This workflow has NOT been validated end-to-end. It was produced in a
-> PLANNING session — no code was written or executed, CI never ran, and the referenced
-> GitHub issues were NOT fetched directly (the issue body was trusted as pasted into the
-> task prompt). The section is titled "Verified Workflow" only to satisfy the marketplace
-> validator. Treat every step below as a **Proposed Workflow / hypothesis** until CI and a
-> human planner confirm it.
+> PLANNING session — no code was written or executed end-to-end, CI never ran, `gh pr view 354`
+> failed (no accessible PR object), and the #354 ↔ `354-auto-impl` branch linkage was INFERRED
+> from naming convention, not confirmed via the PR API. The section is titled "Verified
+> Workflow" only to satisfy the marketplace validator. Treat every step below as a
+> **Proposed Workflow / hypothesis** until CI and a human planner confirm it.
 
 ### Quick Reference
 
 ```bash
-# 1. EXISTENCE CHECK every artifact the issue names, on the working branch:
-git ls-files | grep -iE 'requirements|sync_req'      # -> empty == it does NOT exist here
-ls scripts/                                           # what scripts ACTUALLY exist
-test -f requirements.txt && echo "present" || echo "ABSENT"
+# 1. EXISTENCE CHECK — REPO-WIDE, not just the current branch.
+#    A current-branch miss does NOT prove "never built."
+git ls-files | grep -iE 'requirements|sync_req'        # current branch only — INSUFFICIENT
+git ls-tree -r origin/main --name-only | grep -iE 'requirements|sync_req'   # check main too
+# ...then scan EVERY remote branch (the artifact often lives on the prereq issue's branch):
+for b in $(git branch -r --format='%(refname:short)' | grep -v HEAD); do
+  git ls-tree -r --name-only "$b" 2>/dev/null | grep -q sync_requirements \
+    && echo "FOUND in $b"
+done
+# -> FOUND in origin/354-auto-impl   (built, not yet merged to main)
 
-# 2. Find the artifact that ALREADY satisfies the intent (here: drift detection):
-git ls-files | grep -i dep                            # -> scripts/check_dep_sync.py
-grep -rn 'check_dep_sync' .github/ justfile           # is it already a CI gate + local recipe?
+# 2. If found on a sibling branch, the issue is VALID + blocked on merge order.
+#    Reduce that to a DETERMINISTIC gate instead of a "close the issue" recommendation:
+git merge-base --is-ancestor origin/354-auto-impl origin/main && echo MERGED || echo BLOCKED
+# -> BLOCKED  (false exit) == #354 not yet in main == #556 cannot land its CI job yet
 
-# 3. Confirm the stated failure mode is even POSSIBLE — read the build:
-sed -n '1,20p' Dockerfile                              # does the build read a committed file,
-                                                       # or generate deps at build time from pyproject?
-
-# 4. Read the TARGET CI job's setup before touching its run: invocation:
-#    a stdlib-only / pixi-free job breaks if you wrap it in just/pixi run.
-grep -nB3 -A8 'deps-version-sync' .github/workflows/_required.yml
+# 3. Read the check script's ACTUAL runtime deps BEFORE asserting its CI env:
+git show origin/354-auto-impl:scripts/sync_requirements.py | grep -nE 'subprocess|import |pixi|node'
+# -> subprocess.run(["pixi","list","--json"])  ==> needs pixi in CI (NOT a stdlib-only job)
+# contrast: check_dep_sync.py is tomllib-only ==> pixi-free. SAME repo, OPPOSITE CI needs.
 ```
 
 ### Detailed Steps
 
-1. **Run existence checks on EVERY file/script/artifact the issue names — before writing any plan.** Issue bodies written against assumed-prior work are a recurring source of invalid premises. For #556 the premise was that `scripts/sync_requirements.py --check` and a committed `requirements.txt` existed (a follow-up from #354). On branch `90-170-171-auto-impl`, `git ls-files | grep -iE 'requirements|sync_req'` returned nothing — NEITHER existed; only `scripts/check_dep_sync.py` was present.
+1. **Run existence checks REPO-WIDE before concluding an artifact "never landed."** A
+   current-branch `git ls-files | grep` returning nothing is a BRANCH-scoped fact, not a
+   REPO-scoped one. Check `origin/main` (`git ls-tree -r origin/main --name-only | grep`),
+   then loop over every remote branch (`for b in $(git branch -r ... | grep -v HEAD); do
+   git ls-tree -r --name-only "$b" | grep -q <artifact> && echo "FOUND in $b"; done`). For
+   #556 this found `scripts/sync_requirements.py` and `requirements.txt` on
+   `origin/354-auto-impl` — the prerequisite issue #354's own branch. The artifact was BUILT,
+   not absent. **Issues are frequently the CI-wiring / integration tail of a sibling issue
+   whose code lives on an unmerged branch.**
 
-2. **Test whether the issue's stated failure mode is even possible by reading the relevant source.** #556 claimed "Docker build will silently use stale pins from a committed `requirements.txt`." Reading `Dockerfile:11` showed the build GENERATES its dependency list at build time from `pyproject.toml [project.dependencies]` via inline `tomllib` — it consumes NO committed requirements file. The failure mode could not occur, so the premise was doubly invalid.
+2. **When the artifact exists on an unmerged branch, the correct disposition is usually "valid,
+   blocked on merge ordering" — NOT re-scope/close.** Reduce that to a deterministic gate the
+   implementer can run: `git merge-base --is-ancestor origin/354-auto-impl origin/main` returns
+   false (BLOCKED) while #354 is unmerged. This is a runnable fact, not a recommendation
+   requiring sign-off (see step 4).
 
-3. **Separate the issue's literal ask from its intent.** Literal ask: "build `sync_requirements.py`, wire it into a `check-reqs` CI step." Intent: "catch dependency drift before merge." For #556 the intent was ALREADY satisfied: `check_dep_sync.py` was wired as a required CI gate in the `deps-version-sync` job (`_required.yml:399-402`) and exposed locally as `just dep-check` (`justfile:111`).
+3. **Read the named check script's ACTUAL runtime dependencies before asserting its CI
+   environment.** Do not generalize the toolchain of a superficially similar script in the same
+   repo. `sync_requirements.py` shells out via `subprocess.run(["pixi","list","--json"])`, so its
+   CI job REQUIRES pixi setup. The repo's other drift checker, `check_dep_sync.py`, is
+   deliberately stdlib-only (`tomllib`) and runs pixi-free. **Two superficially similar
+   "drift check" scripts had OPPOSITE runtime requirements.** Grep the script for `subprocess`,
+   `import`, and external-tool names (`pixi`, `node`, `cargo`, ...) before deciding its job needs.
 
-4. **When the literal artifact is absent or redundant, satisfy the intent with what already exists — do not build the assumed artifact.** Building `requirements.txt` + a sync script would create a NEW source of dependency truth to police, violating the "pixi + pyproject = single source of truth" principle. A net-NEGATIVE outcome: you would introduce the very drift the issue wants to prevent. The minimal reconciliation that honors the issue's named entry point: add a `just check-reqs` alias that calls the existing `check_dep_sync.py`, and recommend re-scoping or closing the issue.
+4. **Reduce a plan's central judgment call to a deterministic runnable check.** The v1.0.0 plan
+   recommended re-scoping/closing #556 — a decision that "required human ratification." A plan
+   reviewer NOGO'd it precisely because a discretionary sign-off blocks the next stage from
+   auto-proceeding. Converting the decision into a hard, provable ordering dependency
+   (`git merge-base --is-ancestor ...` → false = blocked) removed the NOGO. A deterministic gate
+   the implementer can run is acceptable; a discretionary recommendation requiring sign-off is not.
 
-5. **Before changing a CI job's `run:` invocation, read its setup steps.** The `deps-version-sync` job uses `actions/setup-python` only (no pixi), and `check_dep_sync.py` is deliberately stdlib-only (`tomllib`). A naive "wrap everything in `just`/`pixi run`" change would break a deliberately pixi-free job. Verify the job's `setup-*` steps before touching its `run:` line.
+5. **Still separate the literal ask from the intent — but only AFTER the repo-wide existence
+   check.** v1.0.0 correctly noted that building a redundant artifact can violate a
+   single-source-of-truth principle. That reasoning is sound ONLY when the artifact is genuinely
+   absent or genuinely redundant. Here it was NEITHER — it existed on a sibling branch — so the
+   "satisfy intent with existing tooling, decline to build" path did not apply. Verify existence
+   repo-wide first; the intent-vs-literal analysis is downstream of that fact.
 
-6. **Flag a "decline to build the literal ask" recommendation as a human-ratify decision.** Recommending "re-scope or close #556" is a judgment call. An automated pipeline could mishandle a plan that declines to build what the issue literally asks for, so the plan must surface this as a decision requiring human ratification, not silently drop the issue's literal scope.
+6. **Fetch linked/parent issues from the source of truth — and flag when you could not.** The
+   #354 ↔ `354-auto-impl` linkage was inferred from branch naming because `gh pr view 354`
+   failed (no accessible PR object). Treat such inferences as assumptions, not facts, and surface
+   them as reviewer risks.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Trust the issue body's premise | Assumed `scripts/sync_requirements.py` and a committed `requirements.txt` existed because the issue (#556) described them as the existing follow-up context from #354 | The premise was invalid on the branch — `git ls-files \| grep -iE 'requirements\|sync_req'` returned nothing; neither artifact existed | Run existence checks (`git ls-files \| grep`, direct path tests) on every named artifact BEFORE planning; issue bodies written against assumed-prior work routinely carry invalid premises |
-| Build the assumed `requirements.txt` + sync script | Considered implementing the literal ask: generate a committed `requirements.txt` and a `sync_requirements.py --check` to police it in CI | Would introduce a NEW source of dependency truth, violating the project's "pixi + pyproject = single source of truth" principle — net-negative, manufacturing the very drift surface the issue wanted to eliminate | Satisfy the issue's INTENT with existing tooling (`check_dep_sync.py`), don't build a redundant artifact; check any new artifact against single-source-of-truth principles |
-| Trust the "follow-up from #354" lineage | Relied on the issue's claim that #556 followed from #354 and that #354 shipped the assumed deliverables | #354's actual deliverables were never verified against GitHub — the issues were not fetched directly, only the pasted issue body was trusted | Fetch linked/parent issues from the source of truth (`gh issue view`) before treating their stated deliverables as fact |
-| Assume "build the named CI step" means wrap it in just/pixi | Treated adding the `check-reqs` CI gate as "invoke the checker via `just`/`pixi run` in the existing job" | The `deps-version-sync` job uses `actions/setup-python` only and `check_dep_sync.py` is deliberately stdlib-only (`tomllib`); wrapping it in pixi would break a deliberately pixi-free job | Read a CI job's `setup-*` steps before changing its `run:` invocation; some jobs are intentionally toolchain-minimal |
-| Branch-scoped existence check read as repo-history claim | Concluded "the sync script never landed" from a single working-branch `git ls-files` | Existence was only checked on `90-170-171-auto-impl`, not on `main` or other branches / repo history — the "never landed" claim is branch-scoped, not repo-scoped | Scope existence claims to what you actually checked; to claim repo-wide absence, search `main` and history (`git log --all -- <path>`), not just the current branch |
+| Concluded artifact "never built" from `git ls-files` on current branch only | On branch `90-170-171-auto-impl`, `git ls-files \| grep -iE 'requirements\|sync_req'` returned nothing, so the v1.0.0 plan concluded `sync_requirements.py` / `requirements.txt` never landed and recommended re-scoping/closing #556 | Branch-scoped check missed the files, which exist on the sibling unmerged branch `origin/354-auto-impl`; "never built" was a wrong, branch-scoped claim that flipped the entire disposition | Scan `origin/main` AND all remote branches (`git ls-tree -r <ref> \| grep`, looped over `git branch -r`) before concluding an artifact is missing — issues are often the CI-wiring tail of a sibling issue's unmerged branch |
+| Asserted the CI job should be pixi-free (copied `check_dep_sync.py`'s pattern) | The first plan said the new check should run in a stdlib-only / pixi-free CI job, mirroring the repo's existing `check_dep_sync.py` (`tomllib` only) | `sync_requirements.py` calls `subprocess.run(["pixi","list","--json"])`, so it REQUIRES pixi in CI; the "stdlib checks run before pixi" heuristic does not generalize across two superficially similar scripts | Read the check script's `subprocess`/`import`/external-tool calls before deciding its CI env (pixi/node/etc.); same-repo drift checkers can have OPPOSITE runtime needs |
+| Recommended re-scoping/closing the issue, deferring to human ratification | v1.0.0's central decision was "recommend re-scoping or closing #556," surfaced as a human-ratify judgment call | Plan reviewer NOGO'd: a discretionary sign-off blocks the next stage from auto-proceeding | Reduce the decision to a deterministic runnable check (`git merge-base --is-ancestor origin/354-auto-impl origin/main` → false = blocked) instead of a recommendation requiring human judgment |
+| Trusted the "follow-up from #354" lineage via branch naming | Treated #556 ↔ #354 deliverables and the #354 ↔ `354-auto-impl` link as fact from naming convention | `gh pr view 354` failed (no accessible PR object); the linkage was inferred, never confirmed against the PR API | Fetch linked/parent issues/PRs from the source of truth; when the API call fails, flag the inferred linkage as a reviewer risk rather than a verified fact |
+| Assumed merge order without enforcing it | The plan assumes #354 merges BEFORE #556, since #556's new CI job references files that only exist post-#354 | The dependency is stated but not enforced; if merge order is reversed, the new `docker-deps` job references nonexistent files and fails | State the ordering as a deterministic gate AND note that the plan itself does not enforce merge order — call it out as the plan's main residual risk |
 
 ## Results & Parameters
 
-### Existence-check commands (proposed, branch-scoped)
+### Repo-wide existence scan (the correction)
 
 ```bash
-# On branch 90-170-171-auto-impl (ProjectHermes):
-git ls-files | grep -iE 'requirements|sync_req'   # -> (empty)  : assumed artifacts ABSENT
-git ls-files | grep -i dep                         # -> scripts/check_dep_sync.py : the real tool
+# WRONG (v1.0.0): current branch only -> empty -> "never landed" (false conclusion)
+git ls-files | grep -iE 'requirements|sync_req'        # (empty on 90-170-171-auto-impl)
+
+# RIGHT (v2.0.0): scan main + every remote branch
+git ls-tree -r origin/main --name-only | grep -iE 'requirements|sync_req'   # check main
+for b in $(git branch -r --format='%(refname:short)' | grep -v HEAD); do
+  git ls-tree -r --name-only "$b" 2>/dev/null | grep -q sync_requirements \
+    && echo "FOUND in $b"
+done
+# -> FOUND in origin/354-auto-impl   (BUILT, not yet merged to main)
 ```
 
-### The reconciliation actually planned (minimal, intent-preserving)
+### Deterministic disposition gate (replaces the human-ratify recommendation)
 
-```makefile
-# justfile — alias the issue's named entry point to the EXISTING checker
-# (do NOT build sync_requirements.py / requirements.txt)
-check-reqs: dep-check        # `just check-reqs` -> scripts/check_dep_sync.py
+```bash
+# Is the prerequisite branch already in main? false (BLOCKED) => #556 valid but cannot land yet.
+git merge-base --is-ancestor origin/354-auto-impl origin/main && echo MERGED || echo BLOCKED
 ```
 
-### What already satisfied the intent (verified by reading files, not executing)
+### Script-specific CI runtime deps (the second correction)
 
-- `scripts/check_dep_sync.py` — stdlib-only (`tomllib`) drift checker.
-- `.github/workflows/_required.yml:399-402` — `deps-version-sync` job runs it as a REQUIRED gate, using `actions/setup-python` (no pixi).
-- `justfile:111` — `just dep-check` exposes it locally.
-- `Dockerfile:11` — generates deps from `pyproject.toml [project.dependencies]` via inline `tomllib`; consumes no committed requirements file (so #556's stated failure mode is impossible).
+```bash
+git show origin/354-auto-impl:scripts/sync_requirements.py | grep -nE 'subprocess|pixi'
+# -> subprocess.run(["pixi","list","--json"])   ==> CI job needs pixi (NOT pixi-free)
+# contrast — same repo, OPPOSITE need:
+git show origin/main:scripts/check_dep_sync.py  | grep -nE 'import|subprocess'
+# -> tomllib only, no subprocess                ==> pixi-free job is correct for THIS one
+```
 
-### Most uncertain assumptions (honest risks)
+### Most uncertain assumptions (honest reviewer risks)
 
-- **GitHub issues not fetched.** #556 and #354 were NOT fetched via `gh issue view`; the issue body was trusted as pasted into the task prompt. The "follow-up from #354" lineage and #354's actual deliverables were never verified against GitHub.
-- **Existence claim is branch-scoped, not repo-scoped.** `sync_requirements.py` / `requirements.txt` absence was checked only on `90-170-171-auto-impl`, not on `main` or in repo history. The "never landed" claim is branch-scoped.
-- **No command was executed end-to-end.** `just --evaluate`, `just check-reqs`, and `python3 scripts/check_dep_sync.py` were never run during planning. Verification level is unverified / verified-by-reading at best.
-- **"Re-scope or close #556" is a human-ratify judgment call.** An automated pipeline could mishandle a plan that declines to build the literal ask. The decision to NOT build the named artifact should be ratified by a human planner, not auto-applied.
+- **`pixi list --json` may require an installed env on CI.** It may need `pixi install --locked`
+  on the CI pixi version; NOT verified. The plan defers this to the first CI run — the main
+  remaining unknown.
+- **Merge order is assumed, not enforced.** The plan assumes #354 merges before #556. Files
+  referenced by the new CI job exist only post-#354; if merge order is reversed, the `docker-deps`
+  job references nonexistent files and fails. The dependency is stated but the merge order is not
+  enforced by the plan itself.
+- **#354 ↔ branch linkage is inferred.** `gh pr view 354` failed (no accessible PR object); the
+  #354 ↔ `354-auto-impl` link was inferred from branch naming convention, not confirmed via the
+  PR API.
+- **No command executed end-to-end against #354's branch.** The verification commands would
+  require checking out `354-auto-impl`; they are proposed, not run. Verification level =
+  unverified.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHermes | Issue #556 ("Add check-reqs to CI pipeline to catch requirements drift") — planning session on branch `90-170-171-auto-impl` | Unverified. Assumed `sync_requirements.py` + `requirements.txt` did not exist on the branch; the stated Docker failure mode was impossible (`Dockerfile:11` builds deps from `pyproject.toml`); intent already satisfied by `check_dep_sync.py` (`_required.yml:399-402`, `justfile:111`). Plan: add `just check-reqs` alias, recommend re-scoping/closing the issue. |
+| ProjectHermes | Issue #556 ("Add check-reqs to CI to catch requirements drift") — re-plan after plan-reviewer NOGO, on branch `90-170-171-auto-impl` | Unverified. v1.0.0 concluded the assumed `sync_requirements.py` + `requirements.txt` "never landed" (branch-scoped `git ls-files`) and recommended closing the issue — WRONG. A scan of all remote branches found both on `origin/354-auto-impl`. Corrected disposition: issue is VALID, blocked on merge order (`git merge-base --is-ancestor origin/354-auto-impl origin/main` → false). `sync_requirements.py` calls `pixi list --json` so its CI job needs pixi (unlike stdlib-only `check_dep_sync.py`). `gh pr view 354` failed; branch linkage inferred. |
 
 ## References
 
+- [git-unmerged-branch-file-access.md](git-unmerged-branch-file-access.md) — read/plan against files that exist only on non-main branches (`git show origin/<branch>:path`, `git log --all`); the mechanics behind this skill's repo-wide existence scan.
 - [planning-verify-integration-point-exists-before-guarding.md](planning-verify-integration-point-exists-before-guarding.md)
-- [planning-check-already-shipped-before-planning.md](planning-check-already-shipped-before-planning.md)
 - [planning-verify-live-state-before-assuming-work-remains.md](planning-verify-live-state-before-assuming-work-remains.md)
+- [planning-verify-assumptions-before-enforcement-gate.md](planning-verify-assumptions-before-enforcement-gate.md)


### PR DESCRIPTION
## Summary

Amends `planning-verify-issue-premise-before-implementing` to **v2.0.0** (MAJOR). The v1.0.0 worked example reached a **WRONG conclusion**; a ProjectHermes #556 re-plan was NOGO'd by a plan reviewer, and a scan of all remote branches overturned the prior disposition.

### Primary correction — branch-scoped ≠ repo-scoped existence check
v1.0.0 concluded `sync_requirements.py` + `requirements.txt` "never landed" from a current-branch `git ls-files`. They actually exist on `origin/354-auto-impl` (the prerequisite issue's branch). The artifact was BUILT, not absent; the issue is **valid and blocked on merge ordering**, provable by `git merge-base --is-ancestor origin/354-auto-impl origin/main` (→ false). Before concluding "never built," scan `origin/main` AND every remote branch.

### Secondary — verify a script's real runtime deps before asserting CI env
`sync_requirements.py` shells out to `pixi list --json`, so its CI job **needs pixi** — unlike the stdlib-only `check_dep_sync.py`. Two superficially similar drift checkers, opposite CI needs.

### Tertiary — reduce judgment calls to deterministic gates
A re-scope/close recommendation that "requires human ratification" is a plan-reviewer NOGO trigger. Convert it to a runnable check (`merge-base --is-ancestor`).

## Changes
- Rewrote Overview / Workflow / Results / Verified On around the branch-scan correction
- Archived v1.0.0 to `.history`; added `history:` frontmatter
- Added 3 Failed Attempts rows (branch-scoped check, pixi-free CI assertion, human-ratify recommendation) plus merge-order risk
- Cross-referenced `git-unmerged-branch-file-access`
- `verification: unverified` (plan never executed end-to-end)

## Validation
`python3 scripts/validate_plugins.py` → **430/430 valid**

🤖 Generated with [Claude Code](https://claude.com/claude-code)