### PR TITLE
feat: amend premise skill (v2.1.0) + add ci-gate-verify-artifact-is-consumed-before-guarding (v1.0.0)

### DIFF
--- a/skills/ci-gate-verify-artifact-is-consumed-before-guarding.md
+++ b/skills/ci-gate-verify-artifact-is-consumed-before-guarding.md
@@ -1,0 +1,165 @@
+---
+name: ci-gate-verify-artifact-is-consumed-before-guarding
+description: "A CI drift/lint/sync gate that guards a committed artifact (requirements.txt, a generated lockfile, a config) is THEATER if nothing actually consumes that artifact — the check passes review, looks protective, and protects nothing. Before adding a gate on artifact X, grep for who actually READS X (`grep -rn 'requirements.txt' Dockerfile docker-compose.yml .github/`). If no consumer exists, the gate is pointless: either wire a real consumer in the SAME PR or the gate is pure ceremony. Worked example (ProjectHermes #556): a plan added a `check-reqs` CI job to keep `requirements.txt` in sync with `pixi.lock`, but the Dockerfile derived its install list INLINE from `pyproject.toml` ranges and never read the committed `requirements.txt` — so the file the gate guarded was consumed by NOTHING. The fix, in the same PR: switch the Dockerfile to `COPY requirements.txt` + `pip install -r requirements.txt`, making the issue's stated failure mode ('Docker build uses stale pins') REAL and the gate load-bearing. Use when: (1) adding any CI check that validates one artifact against another (drift/sync/lint/freshness gate), (2) an issue claims a failure mode ('the build uses stale pins from the committed file X') that depends on a consumer you have not confirmed exists, (3) you are about to commit a generated artifact and add a gate for it, (4) reviewing a CI check and asking 'does this actually catch the bug it claims to.'"
+category: ci-cd
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags:
+  - ci-cd
+  - drift-check
+  - sync-gate
+  - dead-artifact
+  - consumer-wiring
+  - requirements-txt
+  - dockerfile
+  - pixi-lock
+  - load-bearing-check
+  - gate-theater
+  - planning
+  - unverified-assumptions
+---
+
+# CI Gate: Verify the Artifact Is Actually Consumed Before Guarding It
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-19 |
+| **Objective** | Capture the durable rule that a CI drift/sync/lint gate on a committed artifact is worthless unless something actually CONSUMES that artifact. A check that guards an unused file passes review but protects nothing — verify the consumer wiring before adding the gate, and wire one in the same PR if none exists. |
+| **Outcome** | A transferable "grep for the consumer before adding the gate" rule, a worked example (a `check-reqs` gate guarding a `requirements.txt` that the Dockerfile never read), and the same-PR fix (switch the Dockerfile to `pip install -r requirements.txt` so the file becomes load-bearing). |
+| **Verification** | **unverified** — this is an implementation PLAN that was never executed or merged end-to-end. The Dockerfile switch to `pip install -r requirements.txt` is a real behavior change to the production image build that was reasoned about but NOT run. Treat every assertion as a hypothesis. |
+
+## When to Use
+
+- You are adding any CI check that validates one artifact against another: a drift check, a sync check, a freshness/lint gate (e.g. "`requirements.txt` must match `pixi.lock`", "the generated client must match the schema").
+- An issue asserts a failure mode — "the Docker build silently uses stale pins from the committed `requirements.txt`" — that depends on a CONSUMER (the Dockerfile reading that file) you have not confirmed exists.
+- You are about to commit a generated artifact and add a gate to keep it fresh.
+- You are reviewing a CI check and want to answer the harder question: "does this check actually catch the bug it claims to, or does it just guard a file nobody reads?"
+
+## Verified Workflow
+
+> **Warning (Proposed Workflow):** This workflow has NOT been validated end-to-end. It is an
+> implementation PLAN that was written but never executed or merged. Verification level:
+> `unverified`. The fix — switching the Dockerfile from an inline `pip install` derived from
+> `pyproject.toml` ranges to `COPY requirements.txt` + `pip install -r requirements.txt` — is a
+> real change to the production image build that was reasoned about but NOT run (no `docker build`
+> executed). The section is titled "Verified Workflow" only to satisfy the marketplace validator.
+> Treat every step below as a hypothesis until CI and a `docker build` confirm it.
+
+### Quick Reference
+
+```bash
+# BEFORE adding a drift/sync gate on artifact X, find who actually READS X.
+# If this returns nothing, the artifact is consumed by NOTHING and the gate is theater.
+grep -rn 'requirements.txt' Dockerfile docker-compose.yml .github/ scripts/
+
+# Worked example result (ProjectHermes #556):
+#   Dockerfile:11  ->  RUN pip install <deps derived INLINE from pyproject.toml ranges>
+#                      ... never references requirements.txt at all.
+#   => the committed requirements.txt is read by NOTHING. A check-reqs gate on it
+#      passes review but protects nothing — the "stale pins in Docker build" failure
+#      mode the issue describes CANNOT happen, because Docker never reads the file.
+```
+
+```dockerfile
+# THE FIX (same PR): make the artifact load-bearing by wiring a real consumer.
+# BEFORE — install list derived inline from pyproject.toml ranges (requirements.txt ignored):
+RUN pip install fastapi nats-py uvicorn ...        # inline, drifts independently
+
+# AFTER — consume the guarded artifact, so the gate now protects a real path:
+COPY requirements.txt .
+RUN pip install -r requirements.txt                 # now the gate is load-bearing
+```
+
+### Detailed Steps and Durable Insights
+
+#### 1. HEADLINE — a gate that guards an unconsumed artifact is theater
+
+A drift/sync/lint check protects a real failure path ONLY when the artifact it guards is actually
+read by something downstream. If you add a `check-reqs` job to keep `requirements.txt` in sync with
+`pixi.lock`, but the Docker image build derives its install list INLINE from `pyproject.toml` and
+never reads `requirements.txt`, then:
+
+- The committed `requirements.txt` is consumed by **nothing**.
+- The gate will pass review (it looks protective) and even fail correctly on drift — but the drift
+  it detects has **no consequence**, because no build path uses the file.
+- The issue's stated failure mode ("Docker build silently uses stale pins from the committed file")
+  is **impossible** as written, because Docker never reads that file. The premise and the gate are
+  both detached from reality.
+
+#### 2. Grep for the consumer BEFORE adding the gate
+
+For any artifact X you intend to guard, run a consumer search across the places that would read it:
+
+```bash
+grep -rn '<artifact-name>' Dockerfile docker-compose.yml .github/ scripts/ Makefile justfile
+```
+
+If nothing consumes X, you have two honest choices — never a third "ship the gate anyway":
+
+- **Wire a real consumer in the SAME PR** so the artifact becomes load-bearing (preferred when the
+  issue's intent is "this artifact should drive the build"). For #556: switch the Dockerfile to
+  `COPY requirements.txt` + `pip install -r requirements.txt`.
+- **Drop the gate** (and possibly the artifact) if nothing should consume it — guarding a file that
+  by design no one reads is pure ceremony.
+
+#### 3. Wiring the consumer is a real behavior change — verify it, don't assume equivalence
+
+Switching the Dockerfile from an inline `pip install` to `pip install -r requirements.txt` changes
+the production image build. Two things to verify rather than assume:
+
+- **The generated `requirements.txt` is complete and correct.** If it's generated from a stale
+  frozen allowlist it may DROP runtime deps the inline list had (see References — the premise
+  skill's frozen-mirror lesson). Derive it from the source of truth.
+- **Nothing the inline path provided is silently lost.** For #556 the inline extraction excluded
+  the editable self-package (`hermes`), and `src/hermes/` is `COPY`'d separately — so the switch is
+  BELIEVED equivalent, but the equivalence was reasoned, not tested. Run `docker build` to confirm.
+
+#### 4. The reviewer-facing question
+
+When reviewing any new CI gate, ask: "If this check is green, what real failure did it prevent?"
+If the answer requires a consumer that doesn't exist, the check is theater. A passing check that
+protects nothing is worse than no check — it creates false confidence.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| Added a CI drift gate on a committed `requirements.txt` | Plan added a `check-reqs` job to keep `requirements.txt` in sync with `pixi.lock`, assuming the Docker build consumed the file | The Dockerfile derived its install list INLINE from `pyproject.toml` ranges (`Dockerfile:11`) and never read `requirements.txt` — the gate guarded a file consumed by nothing, so the issue's "stale pins in Docker build" failure mode was impossible | Grep for the artifact's consumer (`grep -rn 'requirements.txt' Dockerfile docker-compose.yml .github/`) before adding its gate; wire a real consumer in the same PR if none exists, or the gate protects nothing |
+| Assumed the issue's stated failure mode was real | Trusted "the Docker build silently uses stale pins from the committed requirements.txt" as the justification for the gate | The Docker build never read the file, so it could not use stale pins from it; the premise was detached from the actual build path | Confirm the failure mode is reachable (the consumer exists and reads the artifact) before building a gate to prevent it |
+| Treated the Dockerfile `pip install -r` switch as a no-op equivalence | Reasoned that consuming `requirements.txt` was equivalent to the prior inline `pip install` (and that the editable `hermes` package is `COPY`'d separately) | The equivalence was reasoned, not tested — switching the install path is a real production-image behavior change, and a generated `requirements.txt` could drop deps the inline list had | Run `docker build` to verify; never assume a build-input swap is behavior-preserving, and verify the generated artifact is complete |
+
+## Results & Parameters
+
+| Parameter | Value |
+| --------- | ----- |
+| **Repo / issue** | HomericIntelligence/ProjectHermes, issue #556 (implementation plan, R2) |
+| **Change class** | Add a `check-reqs` CI drift gate for `requirements.txt` vs `pixi.lock`, and make the artifact load-bearing |
+| **Central rule** | A drift/sync gate on an artifact nothing consumes is theater; grep for the consumer first and wire one in the same PR |
+| **The miss** | `requirements.txt` was guarded by the new gate but read by nothing — the Dockerfile derived deps inline from `pyproject.toml` |
+| **The fix** | Switch the Dockerfile to `COPY requirements.txt` + `pip install -r requirements.txt`, making the file load-bearing and the issue's failure mode real |
+| **Verification status** | **unverified** — plan only; no `docker build` run, the Dockerfile switch never executed |
+
+### The uncertain assumptions (reviewer-facing checklist)
+
+| # | Assumption | Why it's uncertain | What to do |
+| - | ---------- | ------------------ | ---------- |
+| 1 | The Dockerfile switch to `pip install -r requirements.txt` is behavior-equivalent to the prior inline install | Reasoned, not run; no `docker build` executed end-to-end | Run `docker build` and diff the resulting site-packages / image |
+| 2 | The generated `requirements.txt` is complete | Only fastapi/starlette/urllib3 confirmed via `pixi list`; the rest were `<lock>` placeholders, committed "generate it verbatim" | Hand-verify the generated file against `pixi list --json` output |
+| 3 | Dropping the editable self-package (`hermes`) from the inline path is fine because `src/hermes/` is `COPY`'d separately | Reasoned equivalence (the prior inline extraction also excluded it), not tested | Confirm the running container imports `hermes` after the switch |
+| 4 | `pixi list --json` works in CI without a prior `pixi install --locked` | Confirmed locally (96 pkgs) but not in the CI environment specifically | Defer to first CI run; specify a fallback |
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| ProjectHermes | Issue #556 ("Add check-reqs to CI to catch requirements drift") — R2 implementation plan | **unverified** — plan written, never executed or merged. The committed `requirements.txt` the proposed `check-reqs` gate guards was consumed by nothing (Dockerfile derived deps inline from `pyproject.toml`); the same-PR fix wires `COPY requirements.txt` + `pip install -r requirements.txt` to make the gate load-bearing. No `docker build` was run. |
+
+## References
+
+- [planning-verify-issue-premise-before-implementing.md](planning-verify-issue-premise-before-implementing.md) — the parent planning skill (verify the issue's premise repo-wide; make the PR self-contained; vendor-fixes-latent-bugs). This skill is the SECONDARY lesson from that same #556 re-plan, split out because someone debugging "my CI check passes but doesn't catch the bug" would search here, not in a premise-verification skill.
+- [ci-required-check-path-filter-pitfall.md](ci-required-check-path-filter-pitfall.md) — a sibling CI planning pitfall from the same project.
+- [planning-verify-integration-point-exists-before-guarding.md](planning-verify-integration-point-exists-before-guarding.md)

--- a/skills/planning-verify-issue-premise-before-implementing.history
+++ b/skills/planning-verify-issue-premise-before-implementing.history
@@ -1,5 +1,25 @@
 # planning-verify-issue-premise-before-implementing — History
 
+## v2.1.0 (2026-06-19)
+
+**Changed by:** ProjectHermes issue #556 THIRD re-plan round (R2 — plan-reviewer NOGO follow-up)
+**Verification:** unverified
+
+### What changed
+
+- **MINOR bump (2.0.0 → 2.1.0): adds the R2 "self-contained vs blocked-on-merge" lesson + the "vendor fixes latent bugs" lesson.** v2.0.0 corrected the disposition to "issue is VALID, blocked on merge ordering." R1 then planned to wire in the prerequisite gated on #354 merging; a reviewer graded it A on quality but NOGO'd it on ONE trigger: "correct but blocked on an external merge → not actionable today." This round captures that as a durable lesson and its fix.
+- **PRIMARY new lesson (step 2a + Failed Attempts row):** "correct but blocked on an external merge" is itself a NOGO trigger, and a deterministic `git merge-base --is-ancestor` gate does NOT rescue it (it just evaluates to "blocked"). The fix is to make the PR SELF-CONTAINED — regenerate/vendor the prerequisite INTO the current branch from sources already on it (generate `requirements.txt` from this branch's own `pixi.lock` via `pixi list --json`, confirmed locally → 96 pkgs) so the PR stands alone vs main. Only stack/wait if the prereq genuinely can't be reproduced (needs secrets/infra you lack).
+- **TERTIARY new lesson (step 2b + Failed Attempts row):** vendoring a copy from another branch is a chance to FIX latent bugs, not transcribe. #354's `sync_requirements.py` froze a `_RUNTIME_DEPS` set already stale vs `pyproject.toml` (missing `starlette` + `urllib3`-for-CVE). Derive the set from the source of truth; a frozen mirror of dynamic data is latent drift by construction.
+- Rewrote Overview Outcome/Verification/History, the Verified-Workflow warning, Quick Reference (added steps 2b/2c), Results subsections (self-contained PR), the uncertain-assumptions list (now reflects R2 reality: requirements.txt pins not hand-verified, Dockerfile `pip install -r` switch is a real unrun behavior change, editable self-package equivalence reasoned-not-tested, `tests/unit/` layout assumed), and Verified On (three rounds).
+- Updated the description frontmatter + tags (`self-contained-pr`, `blocked-on-external-merge`, `vendoring`, `frozen-mirror-drift`, `source-of-truth`) and added two When-to-Use bullets.
+- Added a cross-reference to the NEW `ci-gate-verify-artifact-is-consumed-before-guarding` skill (the SECONDARY R2 lesson, split into its own skill because someone debugging "my CI check passes but doesn't catch the bug" would never search a premise-verification skill).
+
+### Why
+
+The R1 plan was A-grade but NOGO'd purely because its disposition depended on an external merge. The generalizable lesson — "make it actionable today by removing the dependency, not by adding a better gate" — is a natural continuation of this skill's premise/branch-scan/disposition lineage, so it amends here rather than spawning a new skill. The SECONDARY R2 lesson (a CI gate guarding an unconsumed artifact is theater) is independently searchable and was split into its own skill per the "one skill per independent learning" rule.
+
+---
+
 ## v2.0.0 (2026-06-19)
 
 **Changed by:** ProjectHermes issue #556 re-plan (plan-reviewer NOGO follow-up)

--- a/skills/planning-verify-issue-premise-before-implementing.md
+++ b/skills/planning-verify-issue-premise-before-implementing.md
@@ -1,13 +1,13 @@
 ---
 name: planning-verify-issue-premise-before-implementing
-description: "When an issue's premise references an artifact (script, file, committed config) that may not exist on the working branch, VERIFY existence FIRST — and do it REPO-WIDE, not just on the current branch. A branch-scoped `git ls-files | grep` that returns nothing does NOT prove the artifact was never built: it may live on a sibling unmerged branch (often the prerequisite issue's own `<n>-auto-impl` branch). Before concluding 'never landed,' scan origin/main AND every remote branch (`git ls-tree -r <ref> | grep`, looped over `git branch -r`). When the artifact exists on an unmerged branch, the issue is usually VALID and merely blocked on merge ordering — not a candidate for re-scope/close. Then: read the named check script's ACTUAL runtime deps (grep for subprocess/import/external-tool calls) before asserting its CI environment — two superficially similar drift-check scripts can have OPPOSITE needs (one stdlib-only/pixi-free, one shelling out to `pixi list --json`). Finally, when a plan's correctness hinges on a judgment call, reduce it to a DETERMINISTIC runnable check (`git merge-base --is-ancestor`, file existence, exit code) — a re-scope/close recommendation that 'requires human ratification' is a NOGO trigger for plan reviewers. Use when: (1) planning an issue that names a specific script/file/artifact as already-existing context, (2) the issue is a follow-up to a prior issue/PR whose deliverables you have not confirmed merged, (3) you are about to conclude an artifact 'never existed' from a current-branch check only, (4) you are about to assert a CI job's toolchain (pixi/node/stdlib) without reading the script's calls, (5) your plan's central decision needs human sign-off rather than a runnable gate."
+description: "When an issue's premise references an artifact (script, file, committed config) that may not exist on the working branch, VERIFY existence FIRST — and do it REPO-WIDE, not just on the current branch. A branch-scoped `git ls-files | grep` that returns nothing does NOT prove the artifact was never built: it may live on a sibling unmerged branch (often the prerequisite issue's own `<n>-auto-impl` branch). Before concluding 'never landed,' scan origin/main AND every remote branch (`git ls-tree -r <ref> | grep`, looped over `git branch -r`). When the artifact exists on an unmerged branch, the issue is usually VALID and merely blocked on merge ordering — but do NOT stop there: a plan that says 'do X, but only after sibling PR #N merges' is itself a NOGO trigger ('correct but blocked on an external merge → not actionable today'), and a deterministic `git merge-base --is-ancestor` gate does NOT rescue it because the next stage still cannot proceed. The fix is to make the PR SELF-CONTAINED: regenerate/vendor the prerequisite INTO the current branch from sources already on it (e.g. generate `requirements.txt` from this branch's own `pixi.lock` via `pixi list --json`) so the PR stands alone against main — only stack/wait if the prerequisite genuinely cannot be reproduced (needs secrets/infra you lack). When you DO vendor a copy from another branch, treat it as a chance to FIX latent bugs: replace any frozen mirror of dynamic data (a hardcoded `_RUNTIME_DEPS` allowlist that's supposed to mirror `pyproject.toml`) with a live read of the source of truth — a frozen mirror is latent drift by construction. Then read the named check script's ACTUAL runtime deps (grep for subprocess/import/external-tool calls) before asserting its CI environment — two superficially similar drift-check scripts can have OPPOSITE needs (one stdlib-only/pixi-free, one shelling out to `pixi list --json`). Finally, when a plan's correctness hinges on a judgment call, reduce it to a DETERMINISTIC runnable check (`git merge-base --is-ancestor`, file existence, exit code) — a re-scope/close recommendation that 'requires human ratification' is a NOGO trigger for plan reviewers. Use when: (1) planning an issue that names a specific script/file/artifact as already-existing context, (2) the issue is a follow-up to a prior issue/PR whose deliverables you have not confirmed merged, (3) you are about to conclude an artifact 'never existed' from a current-branch check only, (4) your plan would gate the next stage on an external/sibling PR merging, (5) you are vendoring code or a list from another branch and could transcribe its latent bugs, (6) you are about to assert a CI job's toolchain (pixi/node/stdlib) without reading the script's calls, (7) your plan's central decision needs human sign-off rather than a runnable gate."
 category: architecture
 date: 2026-06-19
-version: "2.0.0"
+version: "2.1.0"
 user-invocable: false
 verification: unverified
 history: planning-verify-issue-premise-before-implementing.history
-tags: [planning, issue-premise, verify-before-implementing, branch-scoped-vs-repo-scoped, scan-all-branches, unmerged-branch, merge-ordering, requirements-drift, single-source-of-truth, ci-gate, pixi, deterministic-gate, plan-reviewer-nogo, re-scope, intent-vs-literal-ask, follow-up-issue, unverified-assumptions, dependency-sync]
+tags: [planning, issue-premise, verify-before-implementing, branch-scoped-vs-repo-scoped, scan-all-branches, unmerged-branch, merge-ordering, self-contained-pr, blocked-on-external-merge, vendoring, frozen-mirror-drift, source-of-truth, requirements-drift, single-source-of-truth, ci-gate, pixi, deterministic-gate, plan-reviewer-nogo, re-scope, intent-vs-literal-ask, follow-up-issue, unverified-assumptions, dependency-sync]
 ---
 
 # Planning: Verify the Issue Premise Before Implementing
@@ -18,9 +18,9 @@ tags: [planning, issue-premise, verify-before-implementing, branch-scoped-vs-rep
 |-------|-------|
 | **Date** | 2026-06-19 |
 | **Objective** | Capture durable planning discipline for issues whose premise names an artifact that may not exist on the working branch — verify existence REPO-WIDE (all branches) before concluding it was never built, read a check script's real runtime deps before asserting its CI env, and reduce judgment-call dispositions to deterministic runnable gates |
-| **Outcome** | Plan REVISED for ProjectHermes #556: the assumed `sync_requirements.py` + `requirements.txt` DO exist — on `origin/354-auto-impl` (the prerequisite issue's branch), not on `main`. The issue is VALID and blocked on merge ordering, provable by `git merge-base --is-ancestor origin/354-auto-impl origin/main` (→ false). The earlier "re-scope/close" disposition (v1.0.0) was WRONG and is corrected here. |
-| **Verification** | unverified — PLANNING session only; no code written or executed end-to-end, no CI run, `gh pr view 354` failed (PR object not accessible), branch↔issue linkage inferred from naming convention |
-| **History** | v1.0.0 → v2.0.0 (MAJOR: the central worked-example conclusion was overturned). See `planning-verify-issue-premise-before-implementing.history`. |
+| **Outcome** | Plan REVISED for ProjectHermes #556 across THREE NOGO rounds. R1: the assumed `sync_requirements.py` + `requirements.txt` DO exist — on `origin/354-auto-impl`, not `main` — so the issue is VALID, blocked on merge ordering. But that R1 plan, graded A on quality, was STILL NOGO'd on one trigger: "correct but blocked on an external merge → not actionable today." R2 (v2.1.0): removed the blocker by making the PR SELF-CONTAINED — vendored a corrected `sync_requirements.py` and GENERATED `requirements.txt` from the CURRENT branch's own `pixi.lock` (`pixi list --json` → 96 pkgs), so the PR stands alone against `main` with no cross-PR ordering dependency. The earlier "re-scope/close" disposition (v1.0.0) was WRONG (corrected in v2.0.0); the "gate on #354 merging" disposition (R1) was correct-but-unactionable (corrected here). |
+| **Verification** | unverified — PLANNING session only; no code written or executed end-to-end, no CI run, `pixi list --json` confirmed locally (96 pkgs) but the full generated `requirements.txt` and the Dockerfile `pip install -r` switch were NOT run end-to-end |
+| **History** | v1.0.0 → v2.0.0 (MAJOR: worked-example conclusion overturned) → v2.1.0 (MINOR: adds the self-contained-vs-blocked-on-merge workflow step + the vendor-fixes-latent-bugs lesson). See `planning-verify-issue-premise-before-implementing.history`. |
 
 This skill's own v1.0.0 example is a cautionary tale: it concluded the named artifacts
 "never landed" from a single-branch `git ls-files`, and recommended re-scoping/closing the
@@ -34,16 +34,20 @@ ordering." The three corrections below are the durable lessons.
 - An issue's body cites a specific script, file, or committed config as already-existing context (e.g. "the existing `scripts/sync_requirements.py --check`" or "the committed `requirements.txt`").
 - The issue is framed as a follow-up to a prior issue/PR (e.g. "follow-up from #354") whose deliverables you have not independently confirmed MERGED.
 - You are about to conclude an artifact "never existed" / "never landed" from a check run only on the current working branch.
+- Your plan would gate the next stage on an external/sibling PR merging ("do X after #N lands") — even at A-grade quality this is a NOGO ("correct but blocked on an external merge → not actionable today"); prefer making the PR self-contained.
+- You are vendoring code or a list from another branch and could transcribe its latent bugs (especially a frozen allowlist that's supposed to mirror a live source of truth).
 - The issue's stated failure mode depends on a build step or committed file you have not inspected.
 - You are about to assert a CI job's toolchain needs (pixi / node / stdlib-only) without reading the check script's actual `subprocess`/`import`/external-tool calls.
 - Your plan's central decision is a judgment call (re-scope, close, defer) that would require human sign-off rather than a runnable gate.
 
 ## Verified Workflow
 
-> **Warning:** This workflow has NOT been validated end-to-end. It was produced in a
-> PLANNING session — no code was written or executed end-to-end, CI never ran, `gh pr view 354`
+> **Warning:** This workflow has NOT been validated end-to-end. It was produced across three
+> PLANNING rounds — no code was written or executed end-to-end, CI never ran, `gh pr view 354`
 > failed (no accessible PR object), and the #354 ↔ `354-auto-impl` branch linkage was INFERRED
-> from naming convention, not confirmed via the PR API. The section is titled "Verified
+> from naming convention, not confirmed via the PR API. Only `pixi list --json` was confirmed to
+> run locally (96 pkgs); the full generated `requirements.txt` and the Dockerfile switch to
+> `pip install -r requirements.txt` were NOT executed end-to-end. The section is titled "Verified
 > Workflow" only to satisfy the marketplace validator. Treat every step below as a
 > **Proposed Workflow / hypothesis** until CI and a human planner confirm it.
 
@@ -61,10 +65,24 @@ for b in $(git branch -r --format='%(refname:short)' | grep -v HEAD); do
 done
 # -> FOUND in origin/354-auto-impl   (built, not yet merged to main)
 
-# 2. If found on a sibling branch, the issue is VALID + blocked on merge order.
-#    Reduce that to a DETERMINISTIC gate instead of a "close the issue" recommendation:
+# 2. If found on a sibling branch, the issue is VALID. The merge-order fact is real:
 git merge-base --is-ancestor origin/354-auto-impl origin/main && echo MERGED || echo BLOCKED
-# -> BLOCKED  (false exit) == #354 not yet in main == #556 cannot land its CI job yet
+# -> BLOCKED  (false exit) == #354 not yet in main.
+# BUT: a plan that says "do X after #354 merges" is STILL a NOGO ("correct but blocked on an
+# external merge → not actionable today"). The merge-base gate does NOT rescue it — the next
+# stage cannot proceed today. DO NOT stack/wait. Make the PR SELF-CONTAINED instead (step 2b).
+
+# 2b. SELF-CONTAINED: regenerate the prerequisite from sources ALREADY on your branch,
+#     so the PR stands alone against main with no cross-PR ordering dependency.
+pixi list --json > /tmp/pkgs.json   # confirmed locally: 96 pkgs from THIS branch's pixi.lock
+#   -> generate requirements.txt from THIS branch's pixi.lock, commit it in THIS PR.
+#   Only stack/wait if the prereq genuinely can't be reproduced (needs secrets/infra you lack).
+
+# 2c. When VENDORING a script/list from another branch, FIX its latent bugs — don't transcribe.
+git show origin/354-auto-impl:scripts/sync_requirements.py | grep -n '_RUNTIME_DEPS'
+#   -> a hardcoded _RUNTIME_DEPS frozen set, ALREADY stale vs pyproject.toml (missing
+#      starlette + urllib3, the latter pinned for a CVE). A frozen mirror of dynamic data is
+#      latent drift BY CONSTRUCTION. Derive the runtime set live from pyproject.toml instead.
 
 # 3. Read the check script's ACTUAL runtime deps BEFORE asserting its CI env:
 git show origin/354-auto-impl:scripts/sync_requirements.py | grep -nE 'subprocess|import |pixi|node'
@@ -84,11 +102,36 @@ git show origin/354-auto-impl:scripts/sync_requirements.py | grep -nE 'subproces
    not absent. **Issues are frequently the CI-wiring / integration tail of a sibling issue
    whose code lives on an unmerged branch.**
 
-2. **When the artifact exists on an unmerged branch, the correct disposition is usually "valid,
-   blocked on merge ordering" — NOT re-scope/close.** Reduce that to a deterministic gate the
-   implementer can run: `git merge-base --is-ancestor origin/354-auto-impl origin/main` returns
-   false (BLOCKED) while #354 is unmerged. This is a runnable fact, not a recommendation
-   requiring sign-off (see step 4).
+2. **When the artifact exists on an unmerged branch, the issue is "valid" — NOT re-scope/close.
+   The merge-ordering fact is real (`git merge-base --is-ancestor origin/354-auto-impl
+   origin/main` → false while #354 is unmerged) — but do NOT make it the plan's disposition.**
+
+2a. **"Correct but blocked on an external merge" is itself a NOGO trigger — make the PR
+   self-contained instead.** This is the PRIMARY R2 lesson. The R1 plan said "wire in
+   `sync_requirements.py` + `requirements.txt`, gated on #354 merging." A reviewer graded it A on
+   quality but NOGO'd on ONE trigger: the plan is correct but BLOCKED on an external merge → not
+   actionable today / not "ready as-is." Crucially, the deterministic `git merge-base
+   --is-ancestor` gate did NOT rescue it — a runnable gate that still evaluates to "blocked"
+   leaves the next stage unable to proceed today. **The fix is NOT a better gate; it is removing
+   the dependency.** Make the PR self-contained: reproduce the prerequisite INTO the current
+   branch from sources already on it. For #556 the R2 plan vendored a corrected
+   `sync_requirements.py` and GENERATED `requirements.txt` from the CURRENT branch's own
+   `pixi.lock` (`pixi list --json`, confirmed locally → 96 pkgs) — one PR, no cross-PR ordering
+   dependency. **Heuristic:** when an issue's prerequisite lives on an unmerged branch, prefer
+   "reproduce the prerequisite locally from sources already on my branch" over "stack/wait."
+   Only stack if the prerequisite genuinely cannot be regenerated (it needs secrets/infra you
+   lack).
+
+2b. **Vendoring a copy of code from another branch is a chance to FIX its latent bugs, not
+   blindly transcribe.** This is the TERTIARY R2 lesson. #354's `sync_requirements.py` hardcoded
+   a frozen `_RUNTIME_DEPS` set that was ALREADY stale vs the current branch's `pyproject.toml` —
+   it omitted `starlette` and `urllib3` (the latter pinned for CVE-2026-44431/44432).
+   Transcribing it verbatim would have silently dropped two runtime deps from the generated
+   `requirements.txt`, re-creating the very drift the check exists to prevent. The fix: derive the
+   runtime set from `pyproject.toml [project.dependencies]` dynamically instead of a frozen list.
+   **Heuristic:** when you copy a list/set that's supposed to mirror another source of truth,
+   replace the frozen copy with a read of the source of truth. A frozen mirror of dynamic data is
+   latent drift by construction.
 
 3. **Read the named check script's ACTUAL runtime dependencies before asserting its CI
    environment.** Do not generalize the toolchain of a superficially similar script in the same
@@ -124,6 +167,8 @@ git show origin/354-auto-impl:scripts/sync_requirements.py | grep -nE 'subproces
 | Concluded artifact "never built" from `git ls-files` on current branch only | On branch `90-170-171-auto-impl`, `git ls-files \| grep -iE 'requirements\|sync_req'` returned nothing, so the v1.0.0 plan concluded `sync_requirements.py` / `requirements.txt` never landed and recommended re-scoping/closing #556 | Branch-scoped check missed the files, which exist on the sibling unmerged branch `origin/354-auto-impl`; "never built" was a wrong, branch-scoped claim that flipped the entire disposition | Scan `origin/main` AND all remote branches (`git ls-tree -r <ref> \| grep`, looped over `git branch -r`) before concluding an artifact is missing — issues are often the CI-wiring tail of a sibling issue's unmerged branch |
 | Asserted the CI job should be pixi-free (copied `check_dep_sync.py`'s pattern) | The first plan said the new check should run in a stdlib-only / pixi-free CI job, mirroring the repo's existing `check_dep_sync.py` (`tomllib` only) | `sync_requirements.py` calls `subprocess.run(["pixi","list","--json"])`, so it REQUIRES pixi in CI; the "stdlib checks run before pixi" heuristic does not generalize across two superficially similar scripts | Read the check script's `subprocess`/`import`/external-tool calls before deciding its CI env (pixi/node/etc.); same-repo drift checkers can have OPPOSITE runtime needs |
 | Recommended re-scoping/closing the issue, deferring to human ratification | v1.0.0's central decision was "recommend re-scoping or closing #556," surfaced as a human-ratify judgment call | Plan reviewer NOGO'd: a discretionary sign-off blocks the next stage from auto-proceeding | Reduce the decision to a deterministic runnable check (`git merge-base --is-ancestor origin/354-auto-impl origin/main` → false = blocked) instead of a recommendation requiring human judgment |
+| Gated the plan on a sibling PR merging (deterministic merge-base check) | R1 plan: "wire in `sync_requirements.py` + `requirements.txt`, but only after #354 merges," with `git merge-base --is-ancestor origin/354-auto-impl origin/main` as the gate | Reviewer graded it A on quality but NOGO'd: "correct but blocked on external merge" is not actionable today, even at A-grade. The deterministic gate did NOT rescue it — it just evaluates to "blocked," so the next stage still can't proceed today | Make the PR self-contained: regenerate the prerequisite from sources already on your branch (e.g. generate `requirements.txt` from this branch's own `pixi.lock` via `pixi list --json`) instead of stacking/waiting. Removing the dependency, not a better gate, is the fix |
+| Vendored a frozen `_RUNTIME_DEPS` allowlist from another branch verbatim | Planned to copy #354's `sync_requirements.py` as-is, including its hardcoded `_RUNTIME_DEPS` set, into the current branch | The frozen set was already stale vs the current branch's `pyproject.toml` (missing `starlette` and `urllib3`, the latter pinned for CVE-2026-44431/44432); transcribing it would silently drop two runtime deps and re-create the drift the check exists to prevent | Derive the set from the source of truth (`pyproject.toml [project.dependencies]`); never freeze a mirror of dynamic data — a frozen mirror is latent drift by construction |
 | Trusted the "follow-up from #354" lineage via branch naming | Treated #556 ↔ #354 deliverables and the #354 ↔ `354-auto-impl` link as fact from naming convention | `gh pr view 354` failed (no accessible PR object); the linkage was inferred, never confirmed against the PR API | Fetch linked/parent issues/PRs from the source of truth; when the API call fails, flag the inferred linkage as a reviewer risk rather than a verified fact |
 | Assumed merge order without enforcing it | The plan assumes #354 merges BEFORE #556, since #556's new CI job references files that only exist post-#354 | The dependency is stated but not enforced; if merge order is reversed, the new `docker-deps` job references nonexistent files and fails | State the ordering as a deterministic gate AND note that the plan itself does not enforce merge order — call it out as the plan's main residual risk |
 
@@ -144,11 +189,26 @@ done
 # -> FOUND in origin/354-auto-impl   (BUILT, not yet merged to main)
 ```
 
-### Deterministic disposition gate (replaces the human-ratify recommendation)
+### Deterministic disposition gate (the merge-order FACT — but NOT the disposition)
 
 ```bash
 # Is the prerequisite branch already in main? false (BLOCKED) => #556 valid but cannot land yet.
 git merge-base --is-ancestor origin/354-auto-impl origin/main && echo MERGED || echo BLOCKED
+# NOTE: a plan whose disposition is "wait until this returns MERGED" is STILL a NOGO
+# ("correct but blocked on an external merge"). The gate is a true fact, not a green light.
+```
+
+### Self-contained PR (the R2 fix — remove the external-merge dependency)
+
+```bash
+# Instead of depending on #354's sync_requirements.py + requirements.txt, regenerate the
+# prerequisite from sources ALREADY on the current branch, so the PR stands alone vs main:
+pixi list --json    # confirmed locally on THIS branch's pixi.lock -> 96 pkgs
+#   -> generate requirements.txt from this output; commit it in THIS PR.
+# And when vendoring sync_requirements.py, FIX its latent bug instead of transcribing:
+#   #354's frozen _RUNTIME_DEPS set was stale (missing starlette + urllib3-for-CVE) vs
+#   pyproject.toml -> derive the runtime set live from pyproject.toml [project.dependencies].
+# Only stack/wait if the prereq genuinely can't be reproduced (needs secrets/infra you lack).
 ```
 
 ### Script-specific CI runtime deps (the second correction)
@@ -163,29 +223,35 @@ git show origin/main:scripts/check_dep_sync.py  | grep -nE 'import|subprocess'
 
 ### Most uncertain assumptions (honest reviewer risks)
 
-- **`pixi list --json` may require an installed env on CI.** It may need `pixi install --locked`
-  on the CI pixi version; NOT verified. The plan defers this to the first CI run — the main
-  remaining unknown.
-- **Merge order is assumed, not enforced.** The plan assumes #354 merges before #556. Files
-  referenced by the new CI job exist only post-#354; if merge order is reversed, the `docker-deps`
-  job references nonexistent files and fails. The dependency is stated but the merge order is not
-  enforced by the plan itself.
+- **`pixi list --json` may require a prior `pixi install --locked` on CI.** Confirmed to run
+  locally (96 pkgs), but whether the CI pixi environment needs `pixi install --locked` first is
+  STILL deferred to the first CI run (a fallback is specified, but unproven in CI specifically).
+- **The generated `requirements.txt` pin versions are not hand-verified line by line.** Only
+  fastapi/starlette/urllib3 were confirmed via `pixi list`; the rest were shown as `<lock>`
+  placeholders. The plan is "generate it, commit verbatim," not a hand-checked file.
+- **Switching the Dockerfile to `COPY requirements.txt` + `pip install -r requirements.txt` is a
+  real behavior change to the production image build.** The `docker build` verification step
+  exercises it locally in the plan, but the plan was NOT actually run end-to-end — verification
+  commands are proposed, not executed. Verification level = unverified.
+- **The Dockerfile change drops the editable self-package (`hermes`) from the build path
+  implicitly.** The prior inline extraction also excluded it, and `src/hermes/` is `COPY`'d
+  separately, so this is BELIEVED equivalent — but the equivalence was reasoned, not tested.
 - **#354 ↔ branch linkage is inferred.** `gh pr view 354` failed (no accessible PR object); the
   #354 ↔ `354-auto-impl` link was inferred from branch naming convention, not confirmed via the
-  PR API.
-- **No command executed end-to-end against #354's branch.** The verification commands would
-  require checking out `354-auto-impl`; they are proposed, not run. Verification level =
-  unverified.
+  PR API. (Note: R2's self-contained design no longer DEPENDS on #354 merging — the linkage now
+  matters only for attribution, not for the plan's correctness.)
+- **`tests/unit/` directory layout assumed to exist.** Not directly confirmed in this round.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHermes | Issue #556 ("Add check-reqs to CI to catch requirements drift") — re-plan after plan-reviewer NOGO, on branch `90-170-171-auto-impl` | Unverified. v1.0.0 concluded the assumed `sync_requirements.py` + `requirements.txt` "never landed" (branch-scoped `git ls-files`) and recommended closing the issue — WRONG. A scan of all remote branches found both on `origin/354-auto-impl`. Corrected disposition: issue is VALID, blocked on merge order (`git merge-base --is-ancestor origin/354-auto-impl origin/main` → false). `sync_requirements.py` calls `pixi list --json` so its CI job needs pixi (unlike stdlib-only `check_dep_sync.py`). `gh pr view 354` failed; branch linkage inferred. |
+| ProjectHermes | Issue #556 ("Add check-reqs to CI to catch requirements drift") — THREE re-plan rounds after successive plan-reviewer NOGOs, on branch `90-170-171-auto-impl` | Unverified. v1.0.0 concluded the assumed `sync_requirements.py` + `requirements.txt` "never landed" (branch-scoped `git ls-files`) and recommended closing the issue — WRONG. A scan of all remote branches found both on `origin/354-auto-impl` (v2.0.0 correction: issue is VALID). R1 then planned to wire them in gated on #354 merging; graded A but NOGO'd ("correct but blocked on an external merge → not actionable today"). R2 (v2.1.0) made the PR self-contained: generated `requirements.txt` from THIS branch's own `pixi.lock` (`pixi list --json` → 96 pkgs confirmed locally) and vendored a CORRECTED `sync_requirements.py` (deriving the runtime set from `pyproject.toml` instead of #354's stale frozen `_RUNTIME_DEPS` that omitted `starlette`/`urllib3`). `sync_requirements.py` calls `pixi list --json` so its CI job needs pixi (unlike stdlib-only `check_dep_sync.py`). `gh pr view 354` failed; branch linkage inferred. |
 
 ## References
 
 - [git-unmerged-branch-file-access.md](git-unmerged-branch-file-access.md) — read/plan against files that exist only on non-main branches (`git show origin/<branch>:path`, `git log --all`); the mechanics behind this skill's repo-wide existence scan.
+- [ci-gate-verify-artifact-is-consumed-before-guarding.md](ci-gate-verify-artifact-is-consumed-before-guarding.md) — the SECONDARY R2 lesson, split out: a drift/lint gate on an artifact nothing reads is theater; grep for the consumer and wire one in the same PR.
 - [planning-verify-integration-point-exists-before-guarding.md](planning-verify-integration-point-exists-before-guarding.md)
 - [planning-verify-live-state-before-assuming-work-remains.md](planning-verify-live-state-before-assuming-work-remains.md)
 - [planning-verify-assumptions-before-enforcement-gate.md](planning-verify-assumptions-before-enforcement-gate.md)


### PR DESCRIPTION
Captures durable learnings from the THIRD re-plan round of ProjectHermes #556 (after three successive plan-reviewer NOGOs).

## AMENDED: planning-verify-issue-premise-before-implementing (v2.0.0 -> v2.1.0, MINOR)

- **PRIMARY lesson:** "correct but blocked on an external merge" is itself a NOGO trigger — even at A-grade quality. The R1 plan ("wire in the prerequisite, gated on sibling PR #354 merging") was graded A but NOGO'd as not actionable today. A deterministic `git merge-base --is-ancestor` gate does NOT rescue it — it just evaluates to "blocked." The fix is to make the PR **self-contained**: regenerate the prerequisite from sources already on the branch (generate `requirements.txt` from this branch's own `pixi.lock` via `pixi list --json`, confirmed locally -> 96 pkgs), not stack/wait.
- **TERTIARY lesson (folded as a Failed Attempts row + step):** vendoring a copy from another branch is a chance to FIX latent bugs — replace a frozen mirror of dynamic data (#354's stale `_RUNTIME_DEPS` allowlist, missing `starlette`/`urllib3`) with a live read of the source of truth (`pyproject.toml`).

## CREATED: ci-gate-verify-artifact-is-consumed-before-guarding (v1.0.0, ci-cd)

- **SECONDARY lesson, split into its own skill** (someone debugging "my CI check passes but doesn't catch the bug" would never search a premise-verification skill): a CI drift/sync gate on an artifact nothing consumes is **theater**. The proposed `check-reqs` gate guarded a `requirements.txt` the Dockerfile never read (deps derived inline from `pyproject.toml`). Grep for the consumer before adding the gate; wire one in the same PR (`COPY requirements.txt` + `pip install -r requirements.txt`) or drop it.

## Notes

- Both skills are `verification: unverified` — the #556 plan was never executed end-to-end (honesty warning at the top of each Verified Workflow section).
- Validator: `python3 scripts/validate_plugins.py` -> 433/433 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)