### PR TITLE
feat(skill): actions-cache-restore-save-split-on-success (planning, unverified)

### DIFF
--- a/skills/actions-cache-restore-save-split-on-success.md
+++ b/skills/actions-cache-restore-save-split-on-success.md
@@ -1,0 +1,221 @@
+---
+name: actions-cache-restore-save-split-on-success
+description: "Plan converting combined actions/cache@vN (which uses the action's built-in post-job save, firing unconditionally even after a failed build) into explicit actions/cache/restore@vN (early, unconditional) + actions/cache/save@vN (gated on if: success()), so a failed or partial build never poisons a build-output (FetchContent / build/_deps / Conan) cache. Use when: (1) planning or implementing finer cache-write control in GitHub Actions, (2) preventing a failed build from saving a corrupt build/_deps or Conan cache, (3) a CI-hardening review touches actions/cache blocks, (4) you must decide which cache blocks are worth splitting (high-risk build output vs low-risk early-written deps) and how to AND the success() gate with an existing skip guard. PLANNING learning — captures the uncertain assumptions a reviewer must confirm (cache-primary-key output name, glob resolution timing, block/file counts that drift, success() not catching exit-0 partial artifacts)."
+category: ci-cd
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags:
+  - github-actions
+  - actions-cache
+  - cache-restore
+  - cache-save
+  - success-gate
+  - post-job-save
+  - cache-poisoning
+  - fetchcontent
+  - build-output-cache
+  - conan-cache
+  - cache-primary-key
+  - workflow-hardening
+  - planning-methodology
+  - unverified-assumptions
+  - regression-guard
+---
+
+# Planning: Split actions/cache into restore + save Gated on success()
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-19 |
+| **Objective** | Capture how to PLAN converting combined `actions/cache@vN` (which relies on the action's built-in post-job save, firing unconditionally even after a failed build) into explicit `actions/cache/restore@vN` (early, unconditional) + `actions/cache/save@vN` (gated `if: success()`), so failed/partial builds never poison build-output (`build/_deps` / FetchContent / Conan) caches. Produced for ProjectAgamemnon issue #244 (split 26 cache blocks across 6 workflow files). |
+| **Outcome** | A PLAN (not executed code, CI never ran): the restore/save split pattern, per-block major-version matching, compound `if:` handling for steps with existing skip guards, a single-Python-pass bulk-edit discipline, a PyYAML regression guard, and — most importantly — the uncertain planning assumptions a reviewer MUST confirm before implementing. |
+| **Verification** | unverified — this is a PLANNING learning. Nothing was executed end-to-end; no PR run was observed; `actionlint` / `check-jsonschema` were NOT run; the `cache-primary-key` output name and glob-resolution timing were NOT verified against the action's source/docs. Treat every "ASSUMPTION" / risk row as an open reviewer task. |
+| **Category** | ci-cd / planning |
+
+> **Verification note:** No code was written or run for this learning. The "26 blocks / 6 files" inventory and per-block line numbers came from grep at a point in time and drift as workflows change. The downstream split, the regression guard, and the YAML edits were **planned only**. Confirm every assumption in "Risks & Uncertain Assumptions" before implementing.
+
+## When to Use
+
+- Planning or implementing finer cache-write control in GitHub Actions — you want a cache to be saved ONLY when the build succeeded.
+- Preventing a failed or partial build from saving a corrupt `build/_deps` / FetchContent / Conan cache that later poisons green runs by restoring broken artifacts.
+- A CI-hardening review touches `actions/cache` blocks and you need to decide whether the combined action's unconditional post-job save is acceptable.
+- Deciding WHICH cache blocks are worth splitting: high-risk build-output caches (written late, after the build that can fail) vs low-risk caches written early before any fallible step.
+- A restore step already carries an `if:` skip guard and you need to AND the `success()` gate with it on the save side.
+- Doing a bulk edit across many workflow files and needing a discipline that avoids the prior KB failure mode (parallel Edit calls / unquoted `rm` lost or garbled edits).
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+>
+> **Heading note:** The repository validator (`scripts/validate_plugins.py`) hard-requires the literal section string `## Verified Workflow`, so the canonical steps are emitted under that heading to keep validation green. This skill is a PLANNING methodology captured at `unverified` level. Read the steps below as **proposed**, per the warning.
+
+## Verified Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```yaml
+# BEFORE — combined block: built-in post-job save fires UNCONDITIONALLY, even after a failed build.
+- name: Cache build deps
+  uses: actions/cache@v4
+  with:
+    path: build/_deps
+    key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt') }}
+
+# AFTER — restore (early, unconditional) + save (late, gated on success()).
+# RESTORE: keep original name + `with:` verbatim, add a unique `id:`, switch uses -> .../restore@vN.
+- name: Cache build deps
+  id: cache-build-deps                 # NEW: unique id so the save can reference its primary key
+  uses: actions/cache/restore@v4       # major version MATCHES the original block (do not bulk-bump)
+  with:
+    path: build/_deps                  # verbatim from the original block
+    key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt') }}
+
+# ... build / test steps ...
+
+# SAVE: appended at the END of the job, AFTER build/test. Gated on success().
+- name: Save build deps cache
+  if: success()
+  uses: actions/cache/save@v4          # SAME major version as the restore
+  with:
+    path: build/_deps                  # MUST exactly match the restore path
+    key: ${{ steps.cache-build-deps.outputs.cache-primary-key }}  # reuse restore's key — no drift
+```
+
+```yaml
+# COMPOUND CONDITION — when the restore step already has an `if:` skip guard, AND it with success():
+- name: Restore pixi env
+  id: cache-pixi
+  if: steps.detect.outputs.skip == 'false'
+  uses: actions/cache/restore@v5
+  with:
+    path: .pixi
+    key: ${{ runner.os }}-pixi-${{ hashFiles('pixi.lock') }}
+# ...
+- name: Save pixi env cache
+  if: success() && steps.detect.outputs.skip == 'false'   # AND success() with the ORIGINAL guard
+  uses: actions/cache/save@v5
+  with:
+    path: .pixi
+    key: ${{ steps.cache-pixi.outputs.cache-primary-key }}
+```
+
+```python
+# REGRESSION GUARD — scripts/check_cache_save_gating.py (PyYAML). Fails CI if any cache/save@
+# step lacks success() in its if:, or if a combined actions/cache@ reappears.
+import sys, glob, yaml
+
+errors = []
+for path in glob.glob(".github/**/*.yml", recursive=True) + glob.glob(".github/**/*.yaml", recursive=True):
+    with open(path) as f:
+        try:
+            doc = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            errors.append(f"{path}: YAML parse error: {e}")
+            continue
+    for job in (doc or {}).get("jobs", {}).values():
+        for step in (job or {}).get("steps", []) or []:
+            uses = str(step.get("uses", ""))
+            cond = str(step.get("if", ""))
+            if uses.startswith("actions/cache@"):
+                errors.append(f"{path}: combined 'actions/cache@' reappeared in step "
+                              f"'{step.get('name', uses)}' — must split into restore + save")
+            if uses.startswith("actions/cache/save@") and "success()" not in cond:
+                errors.append(f"{path}: 'cache/save' step '{step.get('name', uses)}' "
+                              f"missing success() gate (if: {cond!r})")
+
+if errors:
+    print("\n".join(errors)); sys.exit(1)
+print("OK: all cache/save steps gated on success(); no combined actions/cache@ found")
+```
+
+```bash
+# BULK EDIT DISCIPLINE — do the conversion in a SINGLE Python pass, never parallel Edit calls
+# or unquoted rm (a prior KB lesson: those lost/garbled edits). Then validate:
+actionlint .github/workflows/*.yml
+check-jsonschema --schemafile <github-workflow-schema> .github/workflows/*.yml
+python3 scripts/check_cache_save_gating.py
+```
+
+### Detailed Steps
+
+1. **Convert the restore side first, preserving the original block verbatim.** Keep the
+   step's `name:` and entire `with:` (path + key + any restore-keys) unchanged. Add a unique
+   `id:` (the save will reference `steps.<id>.outputs.cache-primary-key`). Switch only
+   `uses: actions/cache@vN` → `uses: actions/cache/restore@vN`. The restore stays early and
+   unconditional (or keeps its existing skip guard).
+
+2. **Append the save step at the END of the job, after build/test, gated on `if: success()`.**
+   Use `uses: actions/cache/save@vN` with the SAME major version as the restore. The `path:`
+   MUST exactly match the restore's path. Set `key: ${{ steps.<id>.outputs.cache-primary-key }}`
+   so the save reuses the restore's resolved key — never re-type the `hashFiles()` expression
+   independently (that drifts when only one side is later edited).
+
+3. **Match the `actions/cache` major version per-block to what the repo already pins.** Do NOT
+   bulk-bump every block to one version. If the repo mixes `@v4` and one SHA-pinned `@v5`, the
+   v5 block splits to `restore@v5` / `save@v5` and the v4 blocks split to `restore@v4` / `save@v4`.
+
+4. **Handle compound conditions.** When a restore step already carries an `if:` (e.g. a skip
+   guard `steps.detect.outputs.skip == 'false'`), the save must AND it with `success()`:
+   `if: success() && steps.detect.outputs.skip == 'false'`. A bare `if: success()` would run the
+   save on jobs the restore deliberately skipped.
+
+5. **Do all YAML edits in a SINGLE Python pass.** Never use parallel Edit calls or unquoted `rm`
+   for the bulk conversion — a prior KB failure mode lost/garbled edits. Drive the conversion from
+   one script that reads, transforms, and writes each file once.
+
+6. **Validate before commit.** Run `actionlint` and `check-jsonschema` (GitHub workflow schema)
+   over every edited workflow, plus the regression guard below.
+
+7. **Add a regression guard script (PyYAML).** `scripts/check_cache_save_gating.py` fails CI if
+   any `actions/cache/save@` step lacks `success()` in its `if:`, or if a combined
+   `actions/cache@` block reappears. Wire it into CI / pre-commit so the split cannot regress.
+
+8. **Decide scope deliberately.** High-risk caches (build output written LATE, after a fallible
+   build — FetchContent / `build/_deps`) are the ones that benefit most from the gate. Low-risk
+   caches written EARLY (e.g. a Conan download cache populated before any build step) may not be
+   worth the churn. This is a judgment call the reviewer should weigh, not an automatic "split all".
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| Relying on the combined action's built-in post-job save | Left `actions/cache@vN` as a single block | The built-in save fires UNCONDITIONALLY in the post-job phase, even after a failed build — it can cache corrupt/partial build state (e.g. half-written `build/_deps`) that poisons later green runs | Split into `restore@vN` (early, unconditional) + `save@vN` gated on `if: success()` so only a successful build writes the cache |
+| Bumping every cache block to one major version | Bulk-rewrote all blocks to a single `actions/cache@vN` major during the split | Diverges from the repo's mixed pinning convention (e.g. `@v4` everywhere plus one SHA-pinned `@v5`); a bulk bump is an unrelated, unreviewed change | Match the major version PER-BLOCK to what the repo already pins — split each block to the same `restore@vN` / `save@vN` it used before |
+| Hardcoding the save `key:` independently of the restore | Re-typed the `hashFiles(...)` expression on the save step | Key drift: when someone later edits only one side's `hashFiles()`, restore and save compute different keys and the cache silently never hits | Reuse the restore's resolved key via `key: ${{ steps.<id>.outputs.cache-primary-key }}` |
+| Putting a bare `if: success()` on saves whose restore had a skip guard | Save used `if: success()` while the restore used `if: ...skip == 'false'` | The save then runs on jobs the restore deliberately skipped, attempting to save a cache that was never restored / built for | AND the `success()` gate with the original condition: `if: success() && steps.detect.outputs.skip == 'false'` |
+| Bulk-editing workflow YAML via parallel Edit calls / unquoted rm | Applied many concurrent Edit operations (and an unquoted `rm`) across the 6 workflow files | Prior KB lesson: parallel edits and unquoted `rm` lost or garbled edits, leaving workflows in an inconsistent half-converted state | Do the entire conversion in a SINGLE Python pass (read → transform → write once per file), then validate with `actionlint` + `check-jsonschema` |
+
+## Results & Parameters
+
+- **Pattern (restore + save):**
+  - RESTORE: keep `name:` + `with:` verbatim, add a unique `id:`, switch `uses:` → `actions/cache/restore@vN`; stays early and unconditional (or keeps its existing skip guard).
+  - SAVE: appended at the END of the job (after build/test), `if: success()`, `uses: actions/cache/save@vN` (SAME major as restore), `path:` exactly matching restore, `key: ${{ steps.<id>.outputs.cache-primary-key }}`.
+- **Per-block version matching:** never bulk-bump; a `@v4` block → `restore@v4`/`save@v4`, a SHA-pinned `@v5` block → `restore@v5`/`save@v5`.
+- **Compound condition:** `if: success() && steps.detect.outputs.skip == 'false'` when the restore already had a skip guard.
+- **Bulk edit:** single Python pass, never parallel Edit calls or unquoted `rm`. Validate with `actionlint` + `check-jsonschema`.
+- **Regression guard:** `scripts/check_cache_save_gating.py` (PyYAML) fails CI if any `cache/save@` lacks `success()` in `if:`, or if a combined `actions/cache@` reappears (snippet in Quick Reference).
+- **Scope judgment:** high-risk build-output caches (FetchContent / `build/_deps`, written after a fallible build) benefit most; low-risk early-written Conan caches may not be worth the churn.
+- **Inventory (point-in-time, DRIFTS):** issue #244 cited 26 cache blocks across 6 workflow files. Re-grep before implementing — counts and per-block line numbers change as workflows change.
+
+### Risks & Uncertain Assumptions
+
+These are the durable PLANNING learnings — each is an open reviewer task, none was verified during planning:
+
+1. **`cache-primary-key` output name — UNVERIFIED.** It is believed to be the documented output of `actions/cache/restore`, but this was NOT verified against the action's docs/source during planning. A reviewer MUST confirm the exact output name AND that it is populated on a cache MISS (otherwise the save `key:` would be empty on the first run).
+2. **Glob path resolution timing — UNVERIFIED.** For path GLOBS like `build/**/_deps`, `actions/cache/save` resolves the glob at SAVE time against the post-build tree. Restore-vs-save glob-resolution timing was ASSUMED equivalent, not verified — a glob that matched at restore may match a different (or empty) set at save.
+3. **"26 blocks / 6 files" + line numbers DRIFT.** This inventory came from grep at a point in time. Workflows change; re-grep immediately before implementing rather than trusting the plan's counts/offsets.
+4. **`if: success()` does not catch exit-0 partial artifacts — NARROW.** `success()` gates on prior STEPS in the job succeeding (exit 0). Cache poisoning can STILL occur if a build step exits 0 while producing a partial/corrupt artifact — `success()` will not catch that. The gate reduces, not eliminates, poisoning risk.
+5. **Conan-cache split is a judgment call.** Whether splitting the low-risk Conan cache (written early, before fallible steps) is worth the churn vs splitting ONLY the high-risk FetchContent / build-output caches is a scope decision the reviewer should weigh.
+6. **Scope boundary (out of scope) — confirm with reviewer.** The plan intentionally leaves `setup-pixi cache: true` and composite-action extraction OUT of scope. Confirm the reviewer agrees this boundary is correct before implementing.
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| HomericIntelligence/ProjectAgamemnon | Issue #244 — split 26 combined `actions/cache@v4` blocks across 6 workflow files into restore + save gated on `if: success()` | unverified — PLAN only; CI never ran; `actionlint` / `check-jsonschema` not executed; `cache-primary-key` output name and glob timing not verified against action source. Treat all assumptions as open reviewer tasks. |


### PR DESCRIPTION
## Summary

New skill `actions-cache-restore-save-split-on-success` (category `ci-cd`). Captures how to PLAN converting combined `actions/cache@vN` (built-in post-job save fires unconditionally even after a failed build) into explicit `actions/cache/restore@vN` (early, unconditional) + `actions/cache/save@vN` (gated `if: success()`), so failed/partial builds never poison build-output (FetchContent / `build/_deps` / Conan) caches.

Sourced from ProjectAgamemnon issue #244 (split 26 cache blocks across 6 workflow files).

## Verification Level

`unverified` — this is a PLANNING learning. CI pending: nothing was executed end-to-end, no PR run was observed, `actionlint` / `check-jsonschema` were not run, and the `cache-primary-key` output name and glob-resolution timing were not verified against the action's source/docs. The skill uses `## Proposed Workflow` (with the standard not-validated warning) and emits canonical steps under the validator-required `## Verified Workflow` heading.

## Key Findings

- Pattern: restore keeps `name:`+`with:` verbatim, adds a unique `id:`, switches `uses:` to `.../restore@vN`; save is appended at end of job, `if: success()`, SAME major version, matching `path:`, `key: ${{ steps.<id>.outputs.cache-primary-key }}` (no key drift).
- Match cache major version PER-BLOCK to the repo's existing pinning; never bulk-bump.
- Compound guard: AND `success()` with any existing restore `if:` skip guard.
- Single Python pass for bulk YAML edits (prior KB failure mode: parallel edits / unquoted rm lost edits); PyYAML regression guard fails CI if a `cache/save@` lacks `success()` or a combined `actions/cache@` reappears.
- Risks & Uncertain Assumptions (the durable planning learnings) documented explicitly for the reviewer: `cache-primary-key` output name unverified, glob resolution timing assumed-not-verified, drifting block/file counts, `success()` not catching exit-0 partial artifacts, Conan-cache scope judgment, and the out-of-scope boundary (`setup-pixi cache: true`, composite extraction).

## Test Plan

- `python3 scripts/validate_plugins.py` → Valid: 436/436 (includes the new skill).
- Pre-commit hooks passed on push.