### PR TITLE
feat: amend verify-issue-premise-against-code-before-planning skill (v1.1.0)

### DIFF
--- a/skills/verify-issue-premise-against-code-before-planning.history
+++ b/skills/verify-issue-premise-against-code-before-planning.history
@@ -1,0 +1,55 @@
+# verify-issue-premise-against-code-before-planning — History
+
+## v1.1.0 (2026-06-19)
+
+**Changed by:** ProjectAgamemnon issue #248 planning session (revision after a NOGO). The FIRST
+plan fixed only ONE job (`pixi-check` in `.github/workflows/_required.yml`) and was NOGO'd: the
+issue's premise (`setup-pixi` with `cache: false` skips built-in save → `.pixi` re-downloaded on
+cold cache) ALSO applied to a SECOND job (`lint`, same file) that the plan had silently dropped.
+The dropped site was a direct consequence of narrowing the grep to an INCIDENTAL token
+(`pixi install --locked`) that the issue never named, instead of the issue's OWN premise token
+(`cache: false`).
+**Verification:** unverified — PLANNING session only. The revised plan (fix both `lint` +
+`pixi-check`, explicitly ratify deferral of the look-alike `security-dependency-scan`) was never
+implemented or run through CI.
+
+### What changed
+
+- Added the core ENUMERATE-AND-RATIFY lesson, complementary to v1.0.0's disambiguate-which-file
+  lesson: when an issue's premise describes a code PATTERN, enumerate EVERY site matching that
+  premise BEFORE scoping, and grep the issue's OWN premise token (`cache: false`), not an
+  incidental token from your first-found site (`pixi install --locked`). The incidental token is a
+  self-fulfilling filter that matches only the one job and silently drops siblings.
+- Added the unratified-scope-decision lesson: when multiple sites match, WHICH to fix is a DECISION
+  the reviewer must ratify. State each in-scope site AND each look-alike-but-excluded site with
+  explicit reasoning ("excluded because it has defect Y, not the issue's defect X"). A silent
+  omission of a matching site reads as an oversight and earns a NOGO.
+- Added the per-site-divergence caveat: matching sites can differ (the two jobs used DIFFERENT
+  cache keys `pixi-lint-*` vs `pixi-*` and different paths); a uniform/templated fix that ignores
+  divergence introduces a save-under-wrong-key bug.
+- Added a When-to-Use trigger for multi-site enumeration (recurring pattern across CI jobs / lint
+  rule / config key; especially after a single-site plan; especially when a sibling/look-alike
+  exists).
+- Added a Verified-Workflow "enumerate all matching sites + ratify exclusions" step and a Quick
+  Reference block grepping the premise token.
+- Added 2 Failed Attempts rows (incidental-token narrowing; silent single-site scoping) plus a
+  per-site-divergence row.
+- Recorded the revised plan's residual assumptions/risks in Results & Parameters for the reviewer.
+- Frontmatter: bumped `version` 1.0.0 → 1.1.0, added `history` field, broadened tags
+  (enumerate-all-sites, ratify-scope, under-scoping, self-fulfilling-narrowing, multi-site).
+
+## v1.0.0 (2026-06-19)
+
+**Changed by:** ProjectAgamemnon issue #248 planning session (initial). The issue's premise
+(`setup-pixi` + `cache: false` skipping built-in save, "fully re-downloads .pixi on cold cache")
+implied `python-client.yml`, but those jobs use the full `actions/cache@v4` (auto-saves) — NOT the
+issue's scenario. Grepping the INTERSECTION of `cache: false` + `pixi install --locked` resolved
+the described scenario to `_required.yml` job `pixi-check`, disambiguating the real target.
+**Verification:** unverified — planning session only; the plan was never implemented or CI-run.
+
+### What changed
+
+- Initial version. Core lesson: an issue's narration of "what the current code does" is a CLAIM to
+  verify, not ground truth — grep the distinctive premise tokens and confirm WHICH file/job
+  actually matches before writing a plan. Especially dangerous for follow-up issues (state may
+  have drifted) and CI/workflow issues (same step pattern across multiple workflow files).

--- a/skills/verify-issue-premise-against-code-before-planning.md
+++ b/skills/verify-issue-premise-against-code-before-planning.md
@@ -1,9 +1,10 @@
 ---
 name: verify-issue-premise-against-code-before-planning
-description: "An issue body that asserts 'the current code does X' is a CLAIM, not ground truth — before writing a plan, grep the repo for the distinctive tokens in the issue's premise and confirm WHICH file/job actually matches. Issues drift from code; follow-up issues especially describe a since-changed state, and CI/workflow issues are dangerous because the same step pattern appears in several workflow files. In ProjectAgamemnon #248 the premise said the repo used `setup-pixi` with `cache: false` skipping built-in save; grepping `cache: false` + `pixi install --locked` showed the described scenario lived in `_required.yml` job `pixi-check`, NOT the `python-client.yml` jobs the wording implied (those use the full `actions/cache@v4`, which auto-saves). Planning on the wording alone would have targeted the wrong job. Use when: (1) planning any issue whose description asserts current code structure/config, (2) the issue is a follow-up to a prior issue, (3) CI/workflow issues where similar steps appear in multiple workflow files, (4) the premise tokens may have already been fixed."
+description: "An issue body that asserts 'the current code does X' is a CLAIM, not ground truth — before writing a plan, grep the repo for the distinctive tokens in the issue's premise and confirm WHICH file/job actually matches, and ENUMERATE EVERY site that matches before scoping. Issues drift from code; follow-up issues especially describe a since-changed state, and CI/workflow issues are dangerous because the same step pattern appears in several workflow files AND in several jobs of one file. In ProjectAgamemnon #248 the premise said the repo used `setup-pixi` with `cache: false` skipping built-in save; grepping `cache: false` (the issue's OWN premise token) showed the scenario lived in TWO jobs of `_required.yml` (`lint` AND `pixi-check`), plus a look-alike `security-dependency-scan` with a DIFFERENT defect. A first plan that grepped the INCIDENTAL token `pixi install --locked` (which the issue never named) matched only `pixi-check`, silently dropped `lint`, and earned a NOGO. Use when: (1) planning any issue whose description asserts current code structure/config, (2) the issue is a follow-up to a prior issue, (3) CI/workflow issues where similar steps appear in multiple workflow files OR multiple jobs, (4) the premise tokens may have already been fixed, (5) the issue fixes a recurring code pattern likely present in more than one place — especially after a single-site plan or when a sibling/look-alike site exists."
 category: documentation
 date: 2026-06-19
-version: "1.0.0"
+version: "1.1.0"
+history: verify-issue-premise-against-code-before-planning.history
 user-invocable: false
 verification: unverified
 tags:
@@ -19,6 +20,11 @@ tags:
   - workflow-disambiguation
   - pixi
   - actions-cache
+  - enumerate-all-sites
+  - ratify-scope
+  - under-scoping
+  - self-fulfilling-narrowing
+  - multi-site
 ---
 
 # Verify the Issue Premise Against the Code Before Planning
@@ -28,14 +34,21 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-19 |
-| **Objective** | Capture a durable planning-discipline lesson: an issue's description of "what the current code does" is a CLAIM to verify against the actual files, not ground truth to plan on — grep the distinctive premise tokens to confirm WHICH file/job actually matches before writing a plan |
-| **Outcome** | Plan written for ProjectAgamemnon #248 ("Add pixi.lock restore-only cache fallback on miss"). The issue's premise (`setup-pixi` + `cache: false` skipping built-in save, "fully re-downloads .pixi on cold cache") implied `python-client.yml`, but those jobs use the full `actions/cache@v4` (auto-saves) — NOT the issue's scenario. Grepping `cache: false` + `pixi install --locked` returned only `_required.yml` job `pixi-check`, disambiguating the real target. Planning on the wording alone would have edited the wrong job |
-| **Verification** | unverified — PLANNING session only; the plan was never implemented or run through CI, and the proposed `actions/cache/restore@v5` + `actions/cache/save@v5` split was not executed end-to-end |
+| **Objective** | Capture a durable planning-discipline lesson: an issue's description of "what the current code does" is a CLAIM to verify against the actual files, not ground truth to plan on — grep the distinctive premise tokens to confirm WHICH file/job actually matches, AND enumerate EVERY site that matches the premise before scoping, ratifying in-scope and excluded sites explicitly |
+| **Outcome** | Plan written for ProjectAgamemnon #248 ("Add pixi.lock restore-only cache fallback on miss"). **(v1.0.0)** The premise implied `python-client.yml`, but those jobs use the full `actions/cache@v4` (auto-saves) — grepping the premise tokens disambiguated `_required.yml`. **(v1.1.0)** The FIRST revision of that plan fixed only ONE job (`pixi-check`) and got a NOGO: grepping the incidental token `pixi install --locked` (which the issue never named) silently dropped a SECOND matching job, `lint`. Grepping the issue's OWN premise token `cache: false` enumerated BOTH `lint` + `pixi-check` as in-scope and surfaced a look-alike `security-dependency-scan` (different defect) to ratify as out-of-scope |
+| **Verification** | unverified — PLANNING session only; neither the disambiguation plan nor the enumerate-and-ratify revision was implemented or run through CI, and the proposed `actions/cache/restore@v5` + `actions/cache/save@v5` split was not executed end-to-end |
 
 This is a planning-DISCIPLINE learning, distinct from the cache-mechanics skill
 `pixi-cache-true-unreliable`. The lesson is not "how cache syntax works" — it is "do not
 trust the issue's narration of the current code; grep the premise's distinctive tokens and
 plan against the file that actually matches."
+
+**v1.1.0 extends the same theme from disambiguation to exhaustive enumeration.** v1.0.0
+answers "WHICH single file does this premise point to?". v1.1.0 answers "ALL N sites this
+premise matches — fix every in-scope one and ratify every excluded look-alike." The two
+failure modes are different: wrong-file (disambiguate) vs under-scoping / silently-dropped
+sibling (enumerate-and-ratify). Both share one root: grep the issue's OWN premise token, not
+an incidental token from your first-found site.
 
 > **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until
 > CI confirms.
@@ -53,6 +66,11 @@ plan against the file that actually matches."
   without confirming the described tokens actually live there.
 - The premise's distinctive tokens may have ALREADY been fixed — in which case the right plan
   is "state it's already addressed," not a no-op change.
+- **(v1.1.0)** Planning any issue that fixes a RECURRING code pattern — a CI workflow step
+  repeated across jobs, a lint rule, a config key — where the same pattern likely appears in
+  more than ONE place. Especially after you have already written a SINGLE-site plan, and
+  especially when a sibling or look-alike site exists in the same file/dir. The choice of which
+  sites to fix is a scope DECISION the reviewer must ratify; enumerate them all first.
 
 ## Verified Workflow
 
@@ -82,6 +100,27 @@ grep -rln 'pixi install --locked' .github/workflows/ \
 
 # 4. If the premise tokens DON'T match anywhere, the premise may be ALREADY-FIXED.
 #    State that explicitly in the plan instead of implementing a no-op.
+
+# 5. (v1.1.0) ENUMERATE ALL SITES, then RATIFY scope. Grep the issue's OWN premise token —
+#    NOT an incidental token from the first site you found.
+grep -rn 'cache: false' .github/workflows/_required.yml   # the issue's premise token
+#    -> matches TWO jobs: `lint` (lines 72-89) AND `pixi-check` (lines 153-170). Both in-scope.
+#    A first plan grepped `pixi install --locked` (incidental, never named by the issue) and
+#    matched ONLY pixi-check -> silently dropped `lint` -> NOGO.
+
+#    For each match, CLASSIFY:
+#      in-scope    = matches the issue's EXACT defect (cache:false skips built-in save)
+#      look-alike  = matches the token but has a DIFFERENT defect, e.g.
+#                    security-dependency-scan: built-in setup-pixi caching is ON (no `cache:`
+#                    key) -> a separate broken-cache:true problem, OUT of scope for #248.
+
+#    In the PLAN, list EVERY in-scope site to fix AND EVERY excluded look-alike with reasons.
+#    A silent omission reads as an oversight (NOGO); an explicit ratified deferral does not.
+
+#    WATCH per-site DIVERGENCE before templating one fix across sites:
+#      lint  uses cache key `pixi-lint-*` and path clients/python/.pixi
+#      pixi-check uses cache key `pixi-*` and a different path
+#    A uniform save would write under a key the restore never looks up -> silent cache miss.
 ```
 
 ### Detailed Steps
@@ -118,12 +157,41 @@ grep -rln 'pixi install --locked' .github/workflows/ \
    by analogy, say so explicitly and mark it unverified — do not present an assumed ref
    resolution as confirmed.
 
+7. **(v1.1.0) Enumerate EVERY site matching the premise BEFORE scoping — grep the issue's OWN
+   premise token, not an incidental one.** The defining token is the one the ISSUE states
+   (`cache: false`). A distinctive token that merely happens to appear at your first-found site
+   (`pixi install --locked`) is a SELF-FULFILLING filter: it matches only that site and silently
+   excludes valid siblings. `grep -rn` the premise token across the relevant scope (whole file /
+   dir / repo) to list ALL candidate sites. In #248 the premise token `cache: false` matched TWO
+   jobs (`lint` and `pixi-check`) in the SAME file; the incidental-token grep matched only one,
+   dropped `lint`, and earned a NOGO.
+
+8. **(v1.1.0) Classify each candidate in-scope vs look-alike, and RATIFY the scope explicitly.**
+   For each match, decide: does it have the issue's EXACT defect (in-scope), or does it merely
+   share the token while having a DIFFERENT defect (look-alike, out of scope)? In #248
+   `security-dependency-scan` matched the area but had the built-in setup-pixi cache ON (no
+   `cache:` key) — a separate broken-`cache:true` problem, not #248's "`cache:false` skips save."
+   In the plan, list every in-scope site to fix AND every excluded look-alike WITH the reason
+   ("excluded because it has defect Y, not the issue's defect X"). Which sites to fix is a
+   DECISION the reviewer must ratify; a silent omission of a matching site reads as an oversight
+   (NOGO), an explicit ratified deferral does not.
+
+9. **(v1.1.0) Check per-site DIVERGENCE before applying a templated fix.** Sites matching the
+   same premise can still differ in their details. In #248 the two jobs used DIFFERENT cache keys
+   (`pixi-lint-*` vs `pixi-*`) and different paths. A uniform fix copied from one job would write
+   the save under a key the other job's restore never looks up — a silent save-under-wrong-key
+   cache miss. Inspect each in-scope site's specifics and fit the fix to each, rather than
+   templating one site's parameters across all.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Took the issue's "`cache: false` skips save" premise at face value | Assumed it referred to `python-client.yml` | Those jobs use the full `actions/cache@v4`, which auto-saves — not the issue's scenario | Grep the premise tokens; don't assume the first pixi workflow is the target |
 | Assumed `actions/cache/restore` + `/save` share the parent action's pinned SHA | Pinned both sub-actions to `27d5ce7...# v5.0.5` without independently verifying the sub-action paths resolve at that commit | Unverified — sub-action path resolution at a pinned SHA was assumed, not checked against the GitHub Actions API/marketplace | Flag SHA-pin-by-analogy assumptions as a reviewer risk; verify the ref resolves before relying on it |
+| **(v1.1.0)** Scoped the fix by grepping `pixi install --locked` | Assumed that token defined the issue's target job | It's incidental to ONE job; the issue's real premise token is `cache: false`, which also matched the `lint` job — silently dropped → NOGO | Grep the issue's OWN premise token, not a distinctive token from your first-found site |
+| **(v1.1.0)** Fixed only the first matching job and didn't mention the others | Treated single-site as obviously-complete | Reviewer reads a dropped matching sibling as an oversight; ambiguous scope must be surfaced, not silently resolved | Enumerate all sites; ratify which are in/out of scope with reasons |
+| **(v1.1.0)** Considered treating all pixi-cache jobs uniformly | Would have copied one job's cache key to all | `lint` and `pixi-check` use DIFFERENT keys (`pixi-lint-*` vs `pixi-*`) and paths; a uniform save would write under a key the restore never looks up | Check per-site divergence before applying a templated fix |
 
 ## Results & Parameters
 
@@ -151,6 +219,29 @@ grep -rln 'pixi install --locked' .github/workflows/ | xargs grep -l 'cache: fal
   snapshot and may drift.
 - **SCOPE DECISION:** `python-client.yml` jobs deliberately left out of scope (they auto-save via
   the full action). Reviewer should confirm that exclusion is intended for #248.
+
+### (v1.1.0) Enumerate-and-ratify residuals from the REVISED plan (for the reviewer)
+
+The revised plan grepped the issue's own premise token `cache: false` and enumerated TWO in-scope
+jobs (`lint`, `pixi-check`) plus one ratified exclusion. The residual uncertainties:
+
+- **ASSUMPTION:** `lint` and `pixi-check` are the COMPLETE set of in-scope sites, and
+  `security-dependency-scan` is the only look-alike. Based on grepping `cache: false` + reading the
+  one workflow file `_required.yml`; OTHER workflow files (e.g. `python-client.yml`) were judged out
+  of scope (they use the full `actions/cache@v4` action, which auto-saves) — reviewer should confirm
+  that whole-repo judgment.
+- **UNVERIFIED:** `actions/cache/save@v4` (tag-pinned, used in the `lint` job) behaves like the
+  v5.0.5 SHA-pinned save sub-action re: no `restore-keys` input — assumed by analogy across major
+  versions, not checked against v4 docs.
+- **ASSUMPTION:** the `lint` save placed after `pixi run typecheck` captures a fully-materialised
+  `clients/python/.pixi` (typecheck triggers the install). If `setup-pixi` with `cache:false` does
+  NOT install the env (only `pixi run` does), the env is present by save time — but the exact
+  materialisation point was reasoned, not traced.
+- **ASSUMPTION:** line numbers (`_required.yml:72-89`, `:153-170`, `:381-395`) are a snapshot and may
+  drift.
+- **SCOPE DECISION needing ratification:** `security-dependency-scan` deferred as a separate
+  follow-up (different defect: built-in setup-pixi caching active, no `cache:` key). Confirm that
+  deferral is intended for #248.
 
 ### Related skills
 


### PR DESCRIPTION
## Summary

Amends `verify-issue-premise-against-code-before-planning` from **v1.0.0 → v1.1.0**, extending its theme from *disambiguate-which-file* to *exhaustive enumerate-and-ratify*.

**The durable learning:** when fixing an issue whose premise describes a recurring code pattern, enumerate **EVERY** site matching that premise **before** scoping — and grep the issue's **OWN** premise token (`cache: false`), not an incidental token from one candidate site (`pixi install --locked`).

Two failure modes this prevents (both seen in ProjectAgamemnon #248, which earned a NOGO):
1. **Self-fulfilling narrowing** — filtering by a distinctive token that happens to appear at your first-found site silently excludes valid siblings. The first plan grepped `pixi install --locked`, matched only `pixi-check`, and silently dropped the sibling `lint` job (same file, same defect). Grep the token the ISSUE states.
2. **Unratified scope decisions** — when multiple sites match, WHICH to fix is a decision the reviewer must ratify. State each in-scope site AND each look-alike-but-excluded site (`security-dependency-scan` — built-in setup-pixi cache ON, a *different* defect) with explicit reasoning. A silent omission reads as an oversight; an explicit ratified deferral does not.

Also adds a **per-site divergence** caveat: the two in-scope jobs used different cache keys (`pixi-lint-*` vs `pixi-*`) and paths, so a uniform templated fix would save under a key the restore never looks up.

This is distinct from v1.0.0's wrong-file disambiguation: different failure (under-scoping / dropped sites vs wrong-file), different mechanism (enumerate-and-ratify vs disambiguate). Consolidated into the same skill since the search keywords (premise, grep, scope, #248, pixi, `cache: false`) clearly overlap.

## Changes
- Frontmatter: `version` 1.0.0 → 1.1.0; added `history` field; broadened tags (enumerate-all-sites, ratify-scope, under-scoping, self-fulfilling-narrowing, multi-site).
- New `.history` file archiving v1.0.0 and recording the v1.1.0 change.
- New When-to-Use trigger (multi-site enumeration), Quick Reference block, three Detailed Steps, three Failed Attempts rows, and an enumerate-and-ratify residuals section in Results & Parameters.

## Verification
**unverified** — planning session only; the revised plan was not implemented or run through CI. The skill carries the standard unverified warning blockquote.

Validation: `python3 scripts/validate_plugins.py` → 437/437 valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)