### PR TITLE
skill(ci-cd): amend actions-cache-restore-save-split-on-success to v1.1.0

### DIFF
--- a/skills/actions-cache-restore-save-split-on-success.history
+++ b/skills/actions-cache-restore-save-split-on-success.history
@@ -1,0 +1,135 @@
+# actions-cache-restore-save-split-on-success -- History
+
+## v1.1.0 (2026-06-19)
+
+**Changed by:** ProjectAgamemnon #244 re-plan after NOGO
+**Verification:** unverified (still a PLAN; CI never ran)
+
+### What changed
+- Added five durable PLANNING-process learnings produced by re-planning after the first plan drew a NOGO:
+  1. **Completeness / sum-check discipline** on "fix all N occurrences" issues — derive N from a grep, write an explicit per-file accounting that PROVABLY sums to N, and re-grep right before implementing. (First plan claimed "all 26 / 6 files" but summed to 21, silently dropping 5 blocks: `_required.yml:517`/`:526` and all 3 `python-client.yml` blocks.)
+  2. **A plan's verification gate must pass against the artifact the plan produces** — dry-run each acceptance command against the planned end-state; add count-assertions (expect N restore + N save + N key-reuses) so the arithmetic is internally consistent. (First plan's grep-zero gate still matched the 5 dropped blocks → failed its own gate.)
+  3. **`cache-primary-key` is now VERIFIED, not assumed** — fetched `actions/cache/restore` docs: the output is "Cache primary key passed in the input to use in subsequent steps of the workflow," set whenever the action runs (NOT conditional on hit/miss), so reusing it as the save `key:` is safe on both hit and miss.
+  4. **Turn deferred judgment calls into stated decisions** — split ALL combined blocks (including the low-risk Conan cache) with rationale: any remaining combined `actions/cache@` fails the grep-zero gate, and a failed `conan install` can partially poison `~/.conan2`.
+  5. Reinforced the compound-`if:` rule for save steps that inherit a skip guard.
+- Added four new Failed Attempts rows (sum-check drop, self-contradicting gate, unverified linchpin shipped, undecided Conan option).
+- Added Detailed Steps 1-4 covering the new process disciplines (sum-check, self-consistent verification, verify-linchpin, decide-with-rationale); renumbered the implementation steps to 5-11.
+- Added a "COMPLETENESS + SELF-CONSISTENT VERIFICATION" bash block to Quick Reference (grep-derived N, per-file accounting, count-assertions).
+- Results & Parameters: added completeness/sum-check, self-consistent verification, the verified `cache-primary-key` fact (with quoted doc string), and the explicit "split all" scope decision.
+- Risks & Uncertain Assumptions: moved `cache-primary-key` from an open risk to "Previously uncertain, now verified"; kept glob-timing, drifting-inventory, exit-0-partial-artifact, and out-of-scope-boundary risks.
+- Bumped version 1.0.0 -> 1.1.0; added `history:` frontmatter field; refreshed description/tags to cover the process disciplines; updated the "Verified On" row to note the re-plan-after-NOGO context.
+
+### Why
+This was the SECOND `/learn` pass for the same issue (#244). The first plan (v1.0.0) drew a NOGO
+in review because (a) it claimed full coverage while its per-file breakdown silently dropped 5
+cache blocks, (b) its own acceptance grep would still have matched those dropped blocks (the plan
+failed its own gate), (c) it shipped the `cache-primary-key` linchpin as an unverified assumption,
+and (d) it left the Conan-cache split as an open option rather than a decision. The re-plan fixed
+all four. These are durable, reusable planning lessons — not specific to cache splitting — so they
+are folded into the skill rather than discarded.
+
+### Previous version (v1.0.0) snapshot
+---
+name: actions-cache-restore-save-split-on-success
+description: "Plan converting combined actions/cache@vN (which uses the action's built-in post-job save, firing unconditionally even after a failed build) into explicit actions/cache/restore@vN (early, unconditional) + actions/cache/save@vN (gated on if: success()), so a failed or partial build never poisons a build-output (FetchContent / build/_deps / Conan) cache. Use when: (1) planning or implementing finer cache-write control in GitHub Actions, (2) preventing a failed build from saving a corrupt build/_deps or Conan cache, (3) a CI-hardening review touches actions/cache blocks, (4) you must decide which cache blocks are worth splitting (high-risk build output vs low-risk early-written deps) and how to AND the success() gate with an existing skip guard. PLANNING learning — captures the uncertain assumptions a reviewer must confirm (cache-primary-key output name, glob resolution timing, block/file counts that drift, success() not catching exit-0 partial artifacts)."
+category: ci-cd
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags:
+  - github-actions
+  - actions-cache
+  - cache-restore
+  - cache-save
+  - success-gate
+  - post-job-save
+  - cache-poisoning
+  - fetchcontent
+  - build-output-cache
+  - conan-cache
+  - cache-primary-key
+  - workflow-hardening
+  - planning-methodology
+  - unverified-assumptions
+  - regression-guard
+---
+
+# Planning: Split actions/cache into restore + save Gated on success()
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-19 |
+| **Objective** | Capture how to PLAN converting combined `actions/cache@vN` (which relies on the action's built-in post-job save, firing unconditionally even after a failed build) into explicit `actions/cache/restore@vN` (early, unconditional) + `actions/cache/save@vN` (gated `if: success()`), so failed/partial builds never poison build-output (`build/_deps` / FetchContent / Conan) caches. Produced for ProjectAgamemnon issue #244 (split 26 cache blocks across 6 workflow files). |
+| **Outcome** | A PLAN (not executed code, CI never ran): the restore/save split pattern, per-block major-version matching, compound `if:` handling for steps with existing skip guards, a single-Python-pass bulk-edit discipline, a PyYAML regression guard, and — most importantly — the uncertain planning assumptions a reviewer MUST confirm before implementing. |
+| **Verification** | unverified — this is a PLANNING learning. Nothing was executed end-to-end; no PR run was observed; `actionlint` / `check-jsonschema` were NOT run; the `cache-primary-key` output name and glob-resolution timing were NOT verified against the action's source/docs. Treat every "ASSUMPTION" / risk row as an open reviewer task. |
+| **Category** | ci-cd / planning |
+
+> **Verification note:** No code was written or run for this learning. The "26 blocks / 6 files" inventory and per-block line numbers came from grep at a point in time and drift as workflows change. The downstream split, the regression guard, and the YAML edits were **planned only**. Confirm every assumption in "Risks & Uncertain Assumptions" before implementing.
+
+## When to Use
+
+- Planning or implementing finer cache-write control in GitHub Actions — you want a cache to be saved ONLY when the build succeeded.
+- Preventing a failed or partial build from saving a corrupt `build/_deps` / FetchContent / Conan cache that later poisons green runs by restoring broken artifacts.
+- A CI-hardening review touches `actions/cache` blocks and you need to decide whether the combined action's unconditional post-job save is acceptable.
+- Deciding WHICH cache blocks are worth splitting: high-risk build-output caches (written late, after the build that can fail) vs low-risk caches written early before any fallible step.
+- A restore step already carries an `if:` skip guard and you need to AND the `success()` gate with it on the save side.
+- Doing a bulk edit across many workflow files and needing a discipline that avoids the prior KB failure mode (parallel Edit calls / unquoted `rm` lost or garbled edits).
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+>
+> **Heading note:** The repository validator (`scripts/validate_plugins.py`) hard-requires the literal section string `## Verified Workflow`, so the canonical steps are emitted under that heading to keep validation green. This skill is a PLANNING methodology captured at `unverified` level. Read the steps below as **proposed**, per the warning.
+
+## Verified Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+(YAML restore/save snippet, compound-if pixi snippet, PyYAML regression-guard script, and bulk-edit/validate bash block — preserved verbatim in v1.1.0 Quick Reference; omitted here for brevity.)
+
+### Detailed Steps
+
+1. **Convert the restore side first, preserving the original block verbatim.** Keep the step's `name:` and entire `with:` (path + key + any restore-keys) unchanged. Add a unique `id:`. Switch only `uses: actions/cache@vN` → `uses: actions/cache/restore@vN`. The restore stays early and unconditional (or keeps its existing skip guard).
+2. **Append the save step at the END of the job, after build/test, gated on `if: success()`.** `uses: actions/cache/save@vN` with the SAME major version as the restore. `path:` MUST exactly match the restore's path. `key: ${{ steps.<id>.outputs.cache-primary-key }}` so the save reuses the restore's resolved key.
+3. **Match the `actions/cache` major version per-block to what the repo already pins.** Do NOT bulk-bump.
+4. **Handle compound conditions.** `if: success() && steps.detect.outputs.skip == 'false'` when the restore already had a skip guard.
+5. **Do all YAML edits in a SINGLE Python pass.** Never parallel Edit calls or unquoted `rm`.
+6. **Validate before commit.** `actionlint` + `check-jsonschema` over every edited workflow, plus the regression guard.
+7. **Add a regression guard script (PyYAML).** `scripts/check_cache_save_gating.py` fails CI if any `cache/save@` lacks `success()` in `if:`, or a combined `actions/cache@` reappears.
+8. **Decide scope deliberately.** High-risk caches (build output written LATE) benefit most; low-risk early-written caches (e.g. a Conan download cache) may not be worth the churn — a judgment call for the reviewer, NOT an automatic "split all".
+
+## Failed Attempts (v1.0.0)
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| Relying on the combined action's built-in post-job save | Left `actions/cache@vN` as a single block | Built-in save fires UNCONDITIONALLY in post-job, even after a failed build — caches corrupt/partial build state that poisons later green runs | Split into `restore@vN` (early, unconditional) + `save@vN` gated on `if: success()` |
+| Bumping every cache block to one major version | Bulk-rewrote all blocks to a single major | Diverges from the repo's mixed pinning convention; an unrelated, unreviewed change | Match the major version PER-BLOCK to what the repo already pins |
+| Hardcoding the save `key:` independently of the restore | Re-typed the `hashFiles(...)` expression on the save step | Key drift: editing only one side's `hashFiles()` makes restore/save compute different keys; cache silently never hits | Reuse the restore's resolved key via `key: ${{ steps.<id>.outputs.cache-primary-key }}` |
+| Bare `if: success()` on saves whose restore had a skip guard | Save used `if: success()` while restore used `if: ...skip == 'false'` | Save runs on jobs the restore deliberately skipped | AND the gate: `if: success() && steps.detect.outputs.skip == 'false'` |
+| Bulk-editing YAML via parallel Edit calls / unquoted rm | Many concurrent Edits (and an unquoted `rm`) across the 6 files | Prior KB lesson: parallel edits and unquoted `rm` lost or garbled edits | Do the entire conversion in a SINGLE Python pass, then validate |
+
+## Results & Parameters (v1.0.0)
+
+- Pattern (restore + save), per-block version matching, compound condition, single-Python-pass bulk edit, `scripts/check_cache_save_gating.py` regression guard, scope judgment (high-risk build-output vs low-risk Conan), and the point-in-time "26 blocks / 6 files" inventory that DRIFTS.
+
+### Risks & Uncertain Assumptions (v1.0.0)
+
+1. **`cache-primary-key` output name — UNVERIFIED.** Believed to be the documented output of `actions/cache/restore`; NOT verified. Confirm the exact output name AND that it is populated on a cache MISS.
+2. **Glob path resolution timing — UNVERIFIED.** Restore-vs-save glob-resolution timing ASSUMED equivalent.
+3. **"26 blocks / 6 files" + line numbers DRIFT.** Re-grep immediately before implementing.
+4. **`if: success()` does not catch exit-0 partial artifacts — NARROW.** Gate reduces, not eliminates, poisoning risk.
+5. **Conan-cache split is a judgment call.** Whether splitting the low-risk Conan cache is worth the churn.
+6. **Scope boundary (out of scope) — confirm with reviewer.** `setup-pixi cache: true` and composite-action extraction left OUT of scope.
+
+## Verified On (v1.0.0)
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| HomericIntelligence/ProjectAgamemnon | Issue #244 — split 26 combined `actions/cache@v4` blocks across 6 workflow files into restore + save gated on `if: success()` | unverified — PLAN only; CI never ran; `cache-primary-key` output name and glob timing not verified against action source. |
+
+---

--- a/skills/actions-cache-restore-save-split-on-success.md
+++ b/skills/actions-cache-restore-save-split-on-success.md
@@ -1,11 +1,12 @@
 ---
 name: actions-cache-restore-save-split-on-success
-description: "Plan converting combined actions/cache@vN (which uses the action's built-in post-job save, firing unconditionally even after a failed build) into explicit actions/cache/restore@vN (early, unconditional) + actions/cache/save@vN (gated on if: success()), so a failed or partial build never poisons a build-output (FetchContent / build/_deps / Conan) cache. Use when: (1) planning or implementing finer cache-write control in GitHub Actions, (2) preventing a failed build from saving a corrupt build/_deps or Conan cache, (3) a CI-hardening review touches actions/cache blocks, (4) you must decide which cache blocks are worth splitting (high-risk build output vs low-risk early-written deps) and how to AND the success() gate with an existing skip guard. PLANNING learning — captures the uncertain assumptions a reviewer must confirm (cache-primary-key output name, glob resolution timing, block/file counts that drift, success() not catching exit-0 partial artifacts)."
+description: "Plan converting combined actions/cache@vN (which uses the action's built-in post-job save, firing unconditionally even after a failed build) into explicit actions/cache/restore@vN (early, unconditional) + actions/cache/save@vN (gated on if: success()), so a failed or partial build never poisons a build-output (FetchContent / build/_deps / Conan) cache. Use when: (1) planning or implementing finer cache-write control in GitHub Actions, (2) preventing a failed build from saving a corrupt build/_deps or Conan cache, (3) a CI-hardening review touches actions/cache blocks, (4) you must enumerate EVERY combined block on a 'fix all N occurrences' issue and prove the per-file accounting sums to N before claiming coverage, (5) you must decide which cache blocks to split and how to AND the success() gate with an existing skip guard. PLANNING learning — captures completeness/sum-check discipline, the rule that a plan's acceptance command must pass against the artifact the plan produces, verifying design linchpins (cache-primary-key) against the action docs rather than shipping them as assumptions, and stating decisions (split all) with rationale instead of leaving options."
 category: ci-cd
 date: 2026-06-19
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: unverified
+history: actions-cache-restore-save-split-on-success.history
 tags:
   - github-actions
   - actions-cache
@@ -20,7 +21,10 @@ tags:
   - cache-primary-key
   - workflow-hardening
   - planning-methodology
-  - unverified-assumptions
+  - completeness-discipline
+  - sum-check
+  - self-consistent-verification
+  - verify-linchpin
   - regression-guard
 ---
 
@@ -31,20 +35,21 @@ tags:
 | Field | Value |
 | ------- | ------- |
 | **Date** | 2026-06-19 |
-| **Objective** | Capture how to PLAN converting combined `actions/cache@vN` (which relies on the action's built-in post-job save, firing unconditionally even after a failed build) into explicit `actions/cache/restore@vN` (early, unconditional) + `actions/cache/save@vN` (gated `if: success()`), so failed/partial builds never poison build-output (`build/_deps` / FetchContent / Conan) caches. Produced for ProjectAgamemnon issue #244 (split 26 cache blocks across 6 workflow files). |
-| **Outcome** | A PLAN (not executed code, CI never ran): the restore/save split pattern, per-block major-version matching, compound `if:` handling for steps with existing skip guards, a single-Python-pass bulk-edit discipline, a PyYAML regression guard, and — most importantly — the uncertain planning assumptions a reviewer MUST confirm before implementing. |
-| **Verification** | unverified — this is a PLANNING learning. Nothing was executed end-to-end; no PR run was observed; `actionlint` / `check-jsonschema` were NOT run; the `cache-primary-key` output name and glob-resolution timing were NOT verified against the action's source/docs. Treat every "ASSUMPTION" / risk row as an open reviewer task. |
+| **Objective** | Capture how to PLAN converting combined `actions/cache@vN` (which relies on the action's built-in post-job save, firing unconditionally even after a failed build) into explicit `actions/cache/restore@vN` (early, unconditional) + `actions/cache/save@vN` (gated `if: success()`), so failed/partial builds never poison build-output (`build/_deps` / FetchContent / Conan) caches. Produced for ProjectAgamemnon issue #244 (split every combined cache block across the workflow files). |
+| **Outcome** | A PLAN (not executed code, CI never ran): the restore/save split pattern, per-block major-version matching, compound `if:` handling for steps with existing skip guards, a single-Python-pass bulk-edit discipline, a PyYAML regression guard, AND the planning-process disciplines that turned a first-pass NOGO into a passing re-plan: grep-derived completeness with an explicit per-file accounting that sums to N, a verification section that passes against the artifact the plan produces, verifying the `cache-primary-key` linchpin against the action docs, and stating the "split all" decision with rationale. |
+| **Verification** | unverified — this is a PLANNING learning. Nothing was executed end-to-end; no PR run was observed; `actionlint` / `check-jsonschema` were NOT run. The `cache-primary-key` linchpin WAS verified against the `actions/cache/restore` action docs (see Results). Treat every remaining "ASSUMPTION" / risk row as an open reviewer task. |
 | **Category** | ci-cd / planning |
 
-> **Verification note:** No code was written or run for this learning. The "26 blocks / 6 files" inventory and per-block line numbers came from grep at a point in time and drift as workflows change. The downstream split, the regression guard, and the YAML edits were **planned only**. Confirm every assumption in "Risks & Uncertain Assumptions" before implementing.
+> **Verification note:** No code was written or run for this learning. The block-count inventory and per-block line numbers came from grep at a point in time and drift as workflows change — re-grep immediately before implementing. The downstream split, the regression guard, and the YAML edits were **planned only**. Confirm every assumption in "Risks & Uncertain Assumptions" before implementing.
 
 ## When to Use
 
 - Planning or implementing finer cache-write control in GitHub Actions — you want a cache to be saved ONLY when the build succeeded.
 - Preventing a failed or partial build from saving a corrupt `build/_deps` / FetchContent / Conan cache that later poisons green runs by restoring broken artifacts.
 - A CI-hardening review touches `actions/cache` blocks and you need to decide whether the combined action's unconditional post-job save is acceptable.
-- Deciding WHICH cache blocks are worth splitting: high-risk build-output caches (written late, after the build that can fail) vs low-risk caches written early before any fallible step.
+- A "fix every X occurrence" issue: you must enumerate ALL combined blocks from a grep, write a per-file/per-job accounting line that provably sums to the issue's stated total, and re-grep right before implementing because counts and line numbers drift.
 - A restore step already carries an `if:` skip guard and you need to AND the `success()` gate with it on the save side.
+- You are about to ship a design linchpin (e.g. "the save reuses `steps.<id>.outputs.cache-primary-key`") and must decide whether to verify it against the action's docs/`action.yml` or push it to the implementer as an assumption.
 - Doing a bulk edit across many workflow files and needing a discipline that avoids the prior KB failure mode (parallel Edit calls / unquoted `rm` lost or garbled edits).
 
 ## Proposed Workflow
@@ -84,7 +89,7 @@ tags:
   uses: actions/cache/save@v4          # SAME major version as the restore
   with:
     path: build/_deps                  # MUST exactly match the restore path
-    key: ${{ steps.cache-build-deps.outputs.cache-primary-key }}  # reuse restore's key — no drift
+    key: ${{ steps.cache-build-deps.outputs.cache-primary-key }}  # reuse restore's key — populated on hit AND miss
 ```
 
 ```yaml
@@ -135,6 +140,22 @@ print("OK: all cache/save steps gated on success(); no combined actions/cache@ f
 ```
 
 ```bash
+# COMPLETENESS + SELF-CONSISTENT VERIFICATION — derive N from grep, then assert the arithmetic.
+# 1. Count every combined block the issue says to fix (this is the authoritative N):
+N=$(grep -rnE "uses:\s*actions/cache@v[0-9]" .github/workflows/ | wc -l)
+echo "combined blocks to split: $N"
+# 2. Per-file accounting (must sum to N) — write this line in the plan, do not eyeball:
+grep -rcE "uses:\s*actions/cache@v[0-9]" .github/workflows/ | grep -v ':0$'
+# 3. AFTER the edit, the acceptance commands must pass AGAINST THE PLANNED END-STATE.
+#    Zero combined blocks remain:
+grep -rnE "uses:\s*actions/cache@v[0-9]" .github/workflows/ && echo FAIL || echo "OK: 0 combined"
+#    Count-assertions keep the arithmetic internally consistent (expect N each):
+R=$(grep -rcE "uses:\s*actions/cache/restore@" .github/workflows/ | awk -F: '{s+=$2} END{print s}')
+S=$(grep -rcE "uses:\s*actions/cache/save@"    .github/workflows/ | awk -F: '{s+=$2} END{print s}')
+K=$(grep -rcE "outputs\.cache-primary-key"     .github/workflows/ | awk -F: '{s+=$2} END{print s}')
+echo "restore=$R save=$S key-reuses=$K (expect each == $N)"
+test "$R" = "$N" && test "$S" = "$N" && test "$K" = "$N" && echo "OK: arithmetic consistent" || echo "FAIL"
+
 # BULK EDIT DISCIPLINE — do the conversion in a SINGLE Python pass, never parallel Edit calls
 # or unquoted rm (a prior KB lesson: those lost/garbled edits). Then validate:
 actionlint .github/workflows/*.yml
@@ -144,78 +165,125 @@ python3 scripts/check_cache_save_gating.py
 
 ### Detailed Steps
 
-1. **Convert the restore side first, preserving the original block verbatim.** Keep the
-   step's `name:` and entire `with:` (path + key + any restore-keys) unchanged. Add a unique
-   `id:` (the save will reference `steps.<id>.outputs.cache-primary-key`). Switch only
+1. **Derive N from a grep and write a sum-checked accounting BEFORE planning the edits.** On a
+   "fix every combined block" issue, do NOT assert "all N covered" from memory or a partial scan.
+   Grep for `actions/cache@v[0-9]` across the workflow files, record the per-file (and where it
+   matters, per-job) counts, and write an explicit accounting line that PROVABLY sums to the
+   issue's stated total. The first-pass plan claimed "all 26 blocks / 6 files" but its per-file
+   breakdown only summed to 21 — it silently dropped 5 blocks (`_required.yml:517` and `:526`, a
+   high-risk `build/**/_deps` release block, plus all 3 `python-client.yml` blocks). Re-grep
+   immediately before implementing because line numbers and counts drift.
+
+2. **Make the plan's own verification section pass against the artifact the plan produces.**
+   The first-pass acceptance check was `grep -rnE "actions/cache@..." && echo FAIL`, but because
+   5 combined blocks were silently dropped, those blocks would still match and the plan FAILED ITS
+   OWN GATE. Mentally (or actually) run each acceptance command against the planned end-state. A
+   self-contradicting verification section is independently disqualifying. Add count-assertions
+   (expect N restore + N save + N key-reuses) so the arithmetic is internally consistent.
+
+3. **Verify a design linchpin against the action's docs/`action.yml` before trusting it.** The
+   save side reuses `steps.<id>.outputs.cache-primary-key` — that output's behaviour is the
+   linchpin of the whole pattern. The first pass flagged it "unverified — is it populated on a
+   cache miss?" and shipped it anyway. The re-plan fetched the `actions/cache/restore` docs:
+   `cache-primary-key` = "Cache primary key passed in the input to use in subsequent steps of the
+   workflow," set whenever the action runs (NOT conditional on hit/miss). So reusing it as the
+   save `key:` is safe on both hit and miss. Do not push a flagged linchpin to the implementer —
+   verify it.
+
+4. **State scope decisions with rationale, not options.** The first pass left "should we split
+   the low-risk Conan cache?" as an open option and drew a reviewer MINOR. Decide and justify:
+   split ALL combined blocks, because (a) leaving any combined `actions/cache@` block fails the
+   grep-zero acceptance check, and (b) there is a real poisoning window if a job fails after
+   `conan install` partially populates `~/.conan2`. Plans state decisions; they do not defer
+   judgment calls to the reader.
+
+5. **Convert the restore side first, preserving the original block verbatim.** Keep the step's
+   `name:` and entire `with:` (path + key + any restore-keys) unchanged. Add a unique `id:` (the
+   save will reference `steps.<id>.outputs.cache-primary-key`). Switch only
    `uses: actions/cache@vN` → `uses: actions/cache/restore@vN`. The restore stays early and
    unconditional (or keeps its existing skip guard).
 
-2. **Append the save step at the END of the job, after build/test, gated on `if: success()`.**
+6. **Append the save step at the END of the job, after build/test, gated on `if: success()`.**
    Use `uses: actions/cache/save@vN` with the SAME major version as the restore. The `path:`
    MUST exactly match the restore's path. Set `key: ${{ steps.<id>.outputs.cache-primary-key }}`
    so the save reuses the restore's resolved key — never re-type the `hashFiles()` expression
    independently (that drifts when only one side is later edited).
 
-3. **Match the `actions/cache` major version per-block to what the repo already pins.** Do NOT
+7. **Match the `actions/cache` major version per-block to what the repo already pins.** Do NOT
    bulk-bump every block to one version. If the repo mixes `@v4` and one SHA-pinned `@v5`, the
    v5 block splits to `restore@v5` / `save@v5` and the v4 blocks split to `restore@v4` / `save@v4`.
 
-4. **Handle compound conditions.** When a restore step already carries an `if:` (e.g. a skip
+8. **Handle compound conditions.** When a restore step already carries an `if:` (e.g. a skip
    guard `steps.detect.outputs.skip == 'false'`), the save must AND it with `success()`:
    `if: success() && steps.detect.outputs.skip == 'false'`. A bare `if: success()` would run the
    save on jobs the restore deliberately skipped.
 
-5. **Do all YAML edits in a SINGLE Python pass.** Never use parallel Edit calls or unquoted `rm`
+9. **Do all YAML edits in a SINGLE Python pass.** Never use parallel Edit calls or unquoted `rm`
    for the bulk conversion — a prior KB failure mode lost/garbled edits. Drive the conversion from
    one script that reads, transforms, and writes each file once.
 
-6. **Validate before commit.** Run `actionlint` and `check-jsonschema` (GitHub workflow schema)
-   over every edited workflow, plus the regression guard below.
+10. **Validate before commit.** Run `actionlint` and `check-jsonschema` (GitHub workflow schema)
+    over every edited workflow, plus the regression guard, plus the count-assertions from step 2.
 
-7. **Add a regression guard script (PyYAML).** `scripts/check_cache_save_gating.py` fails CI if
-   any `actions/cache/save@` step lacks `success()` in its `if:`, or if a combined
-   `actions/cache@` block reappears. Wire it into CI / pre-commit so the split cannot regress.
-
-8. **Decide scope deliberately.** High-risk caches (build output written LATE, after a fallible
-   build — FetchContent / `build/_deps`) are the ones that benefit most from the gate. Low-risk
-   caches written EARLY (e.g. a Conan download cache populated before any build step) may not be
-   worth the churn. This is a judgment call the reviewer should weigh, not an automatic "split all".
+11. **Add a regression guard script (PyYAML).** `scripts/check_cache_save_gating.py` fails CI if
+    any `actions/cache/save@` step lacks `success()` in its `if:`, or if a combined
+    `actions/cache@` block reappears. Wire it into CI / pre-commit so the split cannot regress.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | ------- | -------------- | ------------- | -------------- |
+| Claimed "all 26 blocks / 6 files covered" but the per-file breakdown summed to 21 | First-pass plan asserted full coverage from a partial scan | Silently dropped 5 blocks (`_required.yml:517`/`:526` — a high-risk `build/**/_deps` release block — and all 3 `python-client.yml` blocks); scope drop earned a NOGO | On "fix every X", derive N from a grep, write an explicit per-file accounting that PROVABLY sums to N, and re-grep right before implementing — never assert "all N covered" without the enumeration |
+| Acceptance grep would still match the dropped blocks | First-pass acceptance was `grep -rnE "actions/cache@..." && echo FAIL` | The 5 un-split blocks still matched, so the plan FAILED ITS OWN GATE — a self-contradicting verification section | Dry-run each acceptance command against the planned end-state; add count-assertions (expect N restore + N save + N key-reuses) so the arithmetic is internally consistent |
+| Flagged `cache-primary-key` as unverified and shipped it anyway | Marked the save-key linchpin "is it populated on a cache miss?" and pushed it to the implementer | A design linchpin left unverified means the whole pattern rests on an unconfirmed assumption | Fetch the action's docs/`action.yml` outputs and VERIFY: `cache-primary-key` is set whenever the action runs (hit AND miss), so it is safe as the save `key:` |
+| Left the Conan-cache split as an open option | First-pass plan offered "split the low-risk Conan cache?" as a judgment call for the reader | Reviewer MINOR; an undecided option is not a plan, and leaving any combined block fails the grep-zero acceptance check | State decisions with rationale: split ALL blocks — leaving any fails the gate, and a failed `conan install` can partially poison `~/.conan2` |
 | Relying on the combined action's built-in post-job save | Left `actions/cache@vN` as a single block | The built-in save fires UNCONDITIONALLY in the post-job phase, even after a failed build — it can cache corrupt/partial build state (e.g. half-written `build/_deps`) that poisons later green runs | Split into `restore@vN` (early, unconditional) + `save@vN` gated on `if: success()` so only a successful build writes the cache |
 | Bumping every cache block to one major version | Bulk-rewrote all blocks to a single `actions/cache@vN` major during the split | Diverges from the repo's mixed pinning convention (e.g. `@v4` everywhere plus one SHA-pinned `@v5`); a bulk bump is an unrelated, unreviewed change | Match the major version PER-BLOCK to what the repo already pins — split each block to the same `restore@vN` / `save@vN` it used before |
 | Hardcoding the save `key:` independently of the restore | Re-typed the `hashFiles(...)` expression on the save step | Key drift: when someone later edits only one side's `hashFiles()`, restore and save compute different keys and the cache silently never hits | Reuse the restore's resolved key via `key: ${{ steps.<id>.outputs.cache-primary-key }}` |
 | Putting a bare `if: success()` on saves whose restore had a skip guard | Save used `if: success()` while the restore used `if: ...skip == 'false'` | The save then runs on jobs the restore deliberately skipped, attempting to save a cache that was never restored / built for | AND the `success()` gate with the original condition: `if: success() && steps.detect.outputs.skip == 'false'` |
-| Bulk-editing workflow YAML via parallel Edit calls / unquoted rm | Applied many concurrent Edit operations (and an unquoted `rm`) across the 6 workflow files | Prior KB lesson: parallel edits and unquoted `rm` lost or garbled edits, leaving workflows in an inconsistent half-converted state | Do the entire conversion in a SINGLE Python pass (read → transform → write once per file), then validate with `actionlint` + `check-jsonschema` |
+| Bulk-editing workflow YAML via parallel Edit calls / unquoted rm | Applied many concurrent Edit operations (and an unquoted `rm`) across the workflow files | Prior KB lesson: parallel edits and unquoted `rm` lost or garbled edits, leaving workflows in an inconsistent half-converted state | Do the entire conversion in a SINGLE Python pass (read → transform → write once per file), then validate with `actionlint` + `check-jsonschema` |
 
 ## Results & Parameters
 
+- **Completeness / sum-check:** derive N from `grep -rnE "actions/cache@v[0-9]" .github/workflows/`, write a per-file accounting that sums to N, and re-grep right before implementing. The first pass's "26 / 6" summed to only 21 (5 dropped).
+- **Self-consistent verification:** every acceptance command must pass against the PLANNED end-state. Add count-assertions: expect **N** restore steps, **N** save steps, and **N** `cache-primary-key` reuses (the bash block in Quick Reference does this with `awk` sums).
+- **`cache-primary-key` — VERIFIED (was uncertain in v1.0.0):** per the `actions/cache/restore` action docs, `cache-primary-key` = "Cache primary key passed in the input to use in subsequent steps of the workflow." It is set whenever the restore action runs, NOT conditional on a cache hit/miss — so reusing it as the save `key:` is safe on both hit and miss (first-run cache miss included).
 - **Pattern (restore + save):**
   - RESTORE: keep `name:` + `with:` verbatim, add a unique `id:`, switch `uses:` → `actions/cache/restore@vN`; stays early and unconditional (or keeps its existing skip guard).
   - SAVE: appended at the END of the job (after build/test), `if: success()`, `uses: actions/cache/save@vN` (SAME major as restore), `path:` exactly matching restore, `key: ${{ steps.<id>.outputs.cache-primary-key }}`.
 - **Per-block version matching:** never bulk-bump; a `@v4` block → `restore@v4`/`save@v4`, a SHA-pinned `@v5` block → `restore@v5`/`save@v5`.
-- **Compound condition:** `if: success() && steps.detect.outputs.skip == 'false'` when the restore already had a skip guard.
+- **Compound condition (pixi-check variant):** `if: success() && steps.detect.outputs.skip == 'false'` when the restore already had a skip guard.
+- **Scope decision:** split ALL combined blocks (including the low-risk Conan cache) — rationale: any remaining combined `actions/cache@` fails the grep-zero acceptance check, and a failed `conan install` can partially poison `~/.conan2`.
 - **Bulk edit:** single Python pass, never parallel Edit calls or unquoted `rm`. Validate with `actionlint` + `check-jsonschema`.
 - **Regression guard:** `scripts/check_cache_save_gating.py` (PyYAML) fails CI if any `cache/save@` lacks `success()` in `if:`, or if a combined `actions/cache@` reappears (snippet in Quick Reference).
-- **Scope judgment:** high-risk build-output caches (FetchContent / `build/_deps`, written after a fallible build) benefit most; low-risk early-written Conan caches may not be worth the churn.
-- **Inventory (point-in-time, DRIFTS):** issue #244 cited 26 cache blocks across 6 workflow files. Re-grep before implementing — counts and per-block line numbers change as workflows change.
+- **Inventory (point-in-time, DRIFTS):** issue #244 cited combined cache blocks across the workflow files. Re-grep before implementing — counts and per-block line numbers change as workflows change.
 
 ### Risks & Uncertain Assumptions
 
-These are the durable PLANNING learnings — each is an open reviewer task, none was verified during planning:
+These are the durable PLANNING learnings — each remaining item is an open reviewer task:
 
-1. **`cache-primary-key` output name — UNVERIFIED.** It is believed to be the documented output of `actions/cache/restore`, but this was NOT verified against the action's docs/source during planning. A reviewer MUST confirm the exact output name AND that it is populated on a cache MISS (otherwise the save `key:` would be empty on the first run).
-2. **Glob path resolution timing — UNVERIFIED.** For path GLOBS like `build/**/_deps`, `actions/cache/save` resolves the glob at SAVE time against the post-build tree. Restore-vs-save glob-resolution timing was ASSUMED equivalent, not verified — a glob that matched at restore may match a different (or empty) set at save.
-3. **"26 blocks / 6 files" + line numbers DRIFT.** This inventory came from grep at a point in time. Workflows change; re-grep immediately before implementing rather than trusting the plan's counts/offsets.
-4. **`if: success()` does not catch exit-0 partial artifacts — NARROW.** `success()` gates on prior STEPS in the job succeeding (exit 0). Cache poisoning can STILL occur if a build step exits 0 while producing a partial/corrupt artifact — `success()` will not catch that. The gate reduces, not eliminates, poisoning risk.
-5. **Conan-cache split is a judgment call.** Whether splitting the low-risk Conan cache (written early, before fallible steps) is worth the churn vs splitting ONLY the high-risk FetchContent / build-output caches is a scope decision the reviewer should weigh.
-6. **Scope boundary (out of scope) — confirm with reviewer.** The plan intentionally leaves `setup-pixi cache: true` and composite-action extraction OUT of scope. Confirm the reviewer agrees this boundary is correct before implementing.
+1. **Previously uncertain, NOW VERIFIED — `cache-primary-key`.** In v1.0.0 this was flagged
+   unverified ("is it populated on a cache miss?"). The re-plan fetched the `actions/cache/restore`
+   docs: the output is "Cache primary key passed in the input to use in subsequent steps of the
+   workflow," set whenever the action runs (NOT conditional on hit/miss). Reusing it as the save
+   `key:` is safe on both hit and miss. No longer an open risk.
+2. **Glob path resolution timing — UNVERIFIED.** For path GLOBS like `build/**/_deps`,
+   `actions/cache/save` resolves the glob at SAVE time against the post-build tree. Restore-vs-save
+   glob-resolution timing was ASSUMED equivalent, not verified — a glob that matched at restore may
+   match a different (or empty) set at save.
+3. **Inventory + line numbers DRIFT.** The block-count inventory came from grep at a point in time.
+   Workflows change; re-grep immediately before implementing rather than trusting the plan's
+   counts/offsets. (This is exactly what caused the first-pass scope drop.)
+4. **`if: success()` does not catch exit-0 partial artifacts — NARROW.** `success()` gates on
+   prior STEPS in the job succeeding (exit 0). Cache poisoning can STILL occur if a build step
+   exits 0 while producing a partial/corrupt artifact — `success()` will not catch that. The gate
+   reduces, not eliminates, poisoning risk.
+5. **Scope boundary (out of scope) — confirm with reviewer.** The plan intentionally leaves
+   `setup-pixi cache: true` and composite-action extraction OUT of scope. Confirm the reviewer
+   agrees this boundary is correct before implementing.
 
 ## Verified On
 
 | Project | Context | Details |
 | ------- | ------- | ------- |
-| HomericIntelligence/ProjectAgamemnon | Issue #244 — split 26 combined `actions/cache@v4` blocks across 6 workflow files into restore + save gated on `if: success()` | unverified — PLAN only; CI never ran; `actionlint` / `check-jsonschema` not executed; `cache-primary-key` output name and glob timing not verified against action source. Treat all assumptions as open reviewer tasks. |
+| HomericIntelligence/ProjectAgamemnon | Issue #244 — split every combined `actions/cache@vN` block across the workflow files into restore + save gated on `if: success()` (re-plan after a first-pass NOGO) | unverified — PLAN only; CI never ran; `actionlint` / `check-jsonschema` not executed. The `cache-primary-key` linchpin WAS verified against the `actions/cache/restore` docs. Treat the remaining assumptions as open reviewer tasks. |


### PR DESCRIPTION
## Summary

Second `/learn` pass for ProjectAgamemnon issue #244 (split combined `actions/cache@vN` into `actions/cache/restore@vN` + `actions/cache/save@vN` gated on `if: success()`). The first plan (skill v1.0.0, PR #2643) drew a NOGO in review; the re-plan fixed it. This amends the existing skill to **v1.1.0** with the durable PLANNING-process learnings the re-plan produced.

## Verification Level

**unverified** — still a PLAN; no CI run was observed; `actionlint`/`check-jsonschema` were not executed. The `cache-primary-key` linchpin WAS verified against the `actions/cache/restore` action docs. Repo `scripts/validate_plugins.py` CI pending.

## Key Findings (the new learnings)

1. **Completeness / sum-check** on "fix all N occurrences" issues — derive N from a grep, write a per-file accounting that PROVABLY sums to N, and re-grep before implementing. The first plan claimed "all 26 blocks / 6 files" but its per-file breakdown summed to only 21, silently dropping 5 blocks (`_required.yml:517`/`:526` and all 3 `python-client.yml` blocks).
2. **A plan's verification gate must pass against the artifact the plan produces** — the first plan's grep-zero acceptance check would still match the 5 dropped blocks, so it failed its own gate. Dry-run each acceptance command against the planned end-state; add count-assertions (expect N restore + N save + N key-reuses).
3. **`cache-primary-key` verified, not assumed** — `actions/cache/restore` docs confirm it is "Cache primary key passed in the input to use in subsequent steps of the workflow," set whenever the action runs (hit AND miss), so reusing it as the save `key:` is safe.
4. **State decisions with rationale, not options** — split ALL combined blocks (incl. the low-risk Conan cache): any remaining combined block fails the grep-zero gate, and a failed `conan install` can partially poison `~/.conan2`.
5. **Compound `if:`** for saves inheriting a skip guard (carried forward, reinforced).

Adds 4 new Failed Attempts rows, a history v1.1.0 entry with a full v1.0.0 snapshot, and a `history:` frontmatter field.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` → 437/437 valid
- [x] pre-commit hooks pass on push
- [ ] repo CI green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)