### PR TITLE
feat: amend planning-check-already-shipped-before-planning skill (v1.5.0)

### DIFF
--- a/skills/planning-check-already-shipped-before-planning.history
+++ b/skills/planning-check-already-shipped-before-planning.history
@@ -1,5 +1,84 @@
 # planning-check-already-shipped-before-planning — History
 
+## v1.5.0 (2026-06-19)
+
+**Changed by:** ProjectAgamemnon extraction-epic #1 RE-PLAN session — after the v1.4.0
+verification-and-closeout reframe, the re-plan was NOGO'd by the plan-loop reviewer NOT for its
+conclusion but for a FALSE evidentiary premise underneath it. The re-plan claimed 3 failing `ctest`
+cases came from "an untracked file from a different branch's WIP"; the reviewer disproved the
+premise by checking git provenance precisely. The correction is the durable learning.
+**Verification:** verified-local — the corrected git-provenance commands (`git cat-file -e HEAD:`,
+`git status --short`, `git show HEAD:… | grep`) and the ctest label runs were executed this session
+and confirmed the findings; the downstream plan was NOT executed end-to-end in CI. Keystone CI
+remains unobserved (the local sibling `../ProjectKeystone` is on main HEAD e28b649); the pagination
+bug root cause is asserted from test behavior, not yet confirmed by reading the brief→store path.
+
+### What changed
+
+- Added the PRIMARY new lesson (Verified-Workflow step 14): when dismissing a failing test as "out
+  of scope," verify the test artifact's git PROVENANCE precisely before writing it off. The test
+  `.cpp` was `??` (untracked) BUT its wiring into `test/CMakeLists.txt` was an uncommitted `M` edit
+  in the CURRENT tree — so the failures were real-and-local, not foreign. The out-of-scope
+  conclusion was right, but reached via a false premise = verification defect = NOGO. Correct
+  technique: `git cat-file -e HEAD:<path>` (in HEAD?), `git status --short <path>` (?? vs M),
+  `git show HEAD:<wiring> | grep <entry>` (build wiring committed?). Untracked file + uncommitted
+  wiring = THIS tree's local WIP, not in HEAD, not on any branch.
+- Added the RED-CI-DISPOSITION lesson (step 15): a closeout/docs PR must ship green — explicitly do
+  NOT stage failing WIP, cut from `main`, run only the deliverable's labels (`ctest --preset debug
+  -L agents`), and route the underlying bug to its own issue ("Never merge with red CI").
+- Added the CROSS-REPO-EDIT lesson (step 16): a fix touching a sibling repo (`../OtherRepo/...`)
+  needs its OWN PR there; "OtherRepo CI passes" is `gh pr checks` in THAT repo, never a local
+  `cmake` build (smoke test, not the criterion).
+- Added the INTERNAL-CONSISTENCY lesson (step 17): reconcile every count across every section —
+  run the count once, reuse one number; reconcile the issue's LOC estimate against landed LOC.
+- Added 4 When-to-Use triggers; sharpened the existing "dismiss failing tests" Failed Attempts row
+  (the real defect was the false provenance premise, not the scope conclusion) and added 3 new
+  Failed Attempts rows (bundle-WIP-into-green-PR; bundle-sibling-repo-edit; inconsistent-counts).
+- Added a Results & Parameters worked example (Agamemnon epic #1 RE-PLAN NOGO) with the exact
+  provenance commands and corrected disposition; corrected the third honest caveat in the prior
+  Agamemnon example to reflect the false-premise diagnosis.
+- Extended the planner decision tree: the SOME-FAIL branch now runs provenance checks before
+  dismissing failures, and a new "cross-cutting plan-hygiene gates" block covers sibling-repo split
+  and count reconciliation. Added a Verified On row for the RE-PLAN NOGO.
+- Frontmatter: bumped `version` 1.4.0 → 1.5.0 (MINOR, additive), kept `date` 2026-06-19, broadened
+  `description` (provenance/red-CI/cross-repo/consistency clauses + trigger 7), added tags
+  (`git-provenance`, `false-premise-nogo`, `red-ci-disposition`, `cross-repo-pr-split`,
+  `internal-consistency`, `replan`), kept `verification: verified-local`.
+
+### Why
+
+v1.4.0 taught the verification-and-closeout reframe for already-delivered extraction epics. The
+RE-PLAN of that same epic then failed for a DIFFERENT reason: a confident-but-false evidentiary
+claim about where a failing test came from. The lesson is that provenance ("whose tree is this
+artifact from?") is a distinct question from scope ("is it part of my issue?") — `??` does not mean
+"foreign branch," because an uncommitted `M` wiring edit makes an untracked file fail the LOCAL
+build. A right conclusion via a false premise is still a NOGO. The amendment also captures the
+correct dispositions that resolve such a NOGO: don't stage failing WIP, split sibling-repo edits
+into their own PRs, and reconcile counts across the plan.
+
+### Previous version (v1.4.0) snapshot
+
+```markdown
+---
+name: planning-check-already-shipped-before-planning
+description: "Before writing an implementation plan, verify the ACTUAL on-disk state — grep/wc/test the real source — instead of trusting the issue body's stated starting condition (LOC counts, method counts, \"needs to be done\"). The fix may already be merged, OR already landed uncommitted in a sibling worktree that git log will NOT show. This applies HARDEST to a large extraction/migration/\"do X\" EPIC filed months earlier: the work is often ALREADY DELIVERED under a different ADR/PR, so the correct plan is verification-and-closeout, NOT re-implementation — run cheap existence checks first (find target/src, ls source/src/<moved-dir> expecting ABSENT, grep -rl MovedSymbol source-repo), map every acceptance criterion to a runnable command, and build+run the actual suite to prove \"CI passes with the new code\" is ALREADY true. And even when the work IS already on disk, the plan-loop still demands a FORWARD-LOOKING plan — a retrospective status note gets NOGO'd, gates you defer to the reviewer are stage-handoff failures, and an EMPTY/placeholder artifact (output withheld while a background job runs) is an automatic Grade F. Use when: (1) planning a follow-up, consolidation, or EXTRACTION/MIGRATION epic, (2) issue body cites specific file paths or LOC/method counts, (3) git status shows an untracked sibling worktree directory, (4) the plan-loop reviewer NOGO'd your plan as a 'status note' / retrospective, (5) you're tempted to wait on a background job / Monitor / long test run before producing a due plan or review artifact, (6) an epic's premise asserts work must move from repo A to repo B and you have not confirmed it didn't already happen."
+category: architecture
+date: 2026-06-19
+version: "1.4.0"
+user-invocable: false
+verification: verified-local
+history: planning-check-already-shipped-before-planning.history
+tags: [planning, already-shipped, stale-issue-premise, extraction-epic, migration, verification-and-closeout, reframe, cross-repo, adr-attribution, acceptance-criteria-mapping, ifdef-guarded-untested, residuals, ctest, cpp]
+---
+```
+
+(The v1.5.0 edits are purely additive — 4 triggers, Verified-Workflow steps 14–17, 3 new Failed
+Attempts rows plus a sharpened existing row, a Results subsection, two decision-tree additions, and
+a Verified On row; the full v1.4.0 body is reconstructable from this changelog plus the v1.4.0
+entry below.)
+
+---
+
 ## v1.4.0 (2026-06-19)
 
 **Changed by:** ProjectAgamemnon extraction-epic #1 planning session — a months-old epic asked to

--- a/skills/planning-check-already-shipped-before-planning.md
+++ b/skills/planning-check-already-shipped-before-planning.md
@@ -1,13 +1,13 @@
 ---
 name: planning-check-already-shipped-before-planning
-description: "Before writing an implementation plan, verify the ACTUAL on-disk state — grep/wc/test the real source — instead of trusting the issue body's stated starting condition (LOC counts, method counts, \"needs to be done\"). The fix may already be merged, OR already landed uncommitted in a sibling worktree that git log will NOT show. This applies HARDEST to a large extraction/migration/\"do X\" EPIC filed months earlier: the work is often ALREADY DELIVERED under a different ADR/PR, so the correct plan is verification-and-closeout, NOT re-implementation — run cheap existence checks first (find target/src, ls source/src/<moved-dir> expecting ABSENT, grep -rl MovedSymbol source-repo), map every acceptance criterion to a runnable command, and build+run the actual suite to prove \"CI passes with the new code\" is ALREADY true. And even when the work IS already on disk, the plan-loop still demands a FORWARD-LOOKING plan — a retrospective status note gets NOGO'd, gates you defer to the reviewer are stage-handoff failures, and an EMPTY/placeholder artifact (output withheld while a background job runs) is an automatic Grade F. Use when: (1) planning a follow-up, consolidation, or EXTRACTION/MIGRATION epic, (2) issue body cites specific file paths or LOC/method counts, (3) git status shows an untracked sibling worktree directory, (4) the plan-loop reviewer NOGO'd your plan as a 'status note' / retrospective, (5) you're tempted to wait on a background job / Monitor / long test run before producing a due plan or review artifact, (6) an epic's premise asserts work must move from repo A to repo B and you have not confirmed it didn't already happen."
+description: "Before writing an implementation plan, verify the ACTUAL on-disk state — grep/wc/test the real source — instead of trusting the issue body's stated starting condition (LOC counts, method counts, \"needs to be done\"). The fix may already be merged, OR already landed uncommitted in a sibling worktree that git log will NOT show. This applies HARDEST to a large extraction/migration/\"do X\" EPIC filed months earlier: the work is often ALREADY DELIVERED under a different ADR/PR, so the correct plan is verification-and-closeout, NOT re-implementation — run cheap existence checks first (find target/src, ls source/src/<moved-dir> expecting ABSENT, grep -rl MovedSymbol source-repo), map every acceptance criterion to a runnable command, and build+run the actual suite to prove \"CI passes with the new code\" is ALREADY true. And even when the work IS already on disk, the plan-loop still demands a FORWARD-LOOKING plan — a retrospective status note gets NOGO'd, gates you defer to the reviewer are stage-handoff failures, and an EMPTY/placeholder artifact (output withheld while a background job runs) is an automatic Grade F. When you dismiss a failing test as \"out of scope,\" verify the test artifact's git PROVENANCE precisely (`git cat-file -e HEAD:<path>`, `git status --short <path>` for ?? vs M, `git show HEAD:<wiring> | grep <entry>`) — an untracked `.cpp` whose CMakeLists wiring is an uncommitted `M` edit is THIS tree's local WIP that fails the real build, NOT a foreign branch's; a right conclusion reached via a false premise is still a verification defect = NOGO. A closeout/docs PR must ship green: don't stage failing WIP, run only the labels covering the deliverable, and route the bug to its own issue. A fix touching a sibling repo (../OtherRepo/...) needs its OWN PR there — \"OtherRepo CI passes\" is `gh pr checks` in that repo, never a local cmake build. Reconcile counts across every plan section (run the count once; reconcile the issue's LOC estimate against landed LOC). Use when: (1) planning a follow-up, consolidation, or EXTRACTION/MIGRATION epic, (2) issue body cites specific file paths or LOC/method counts, (3) git status shows an untracked sibling worktree directory, (4) the plan-loop reviewer NOGO'd your plan as a 'status note' / retrospective OR for a false evidentiary premise, (5) you're tempted to wait on a background job / Monitor / long test run before producing a due plan or review artifact, (6) an epic's premise asserts work must move from repo A to repo B and you have not confirmed it didn't already happen, (7) you're about to dismiss failing tests as out-of-scope WIP, or your plan touches a sibling repo, or your sections quote different counts for the same thing."
 category: architecture
 date: 2026-06-19
-version: "1.4.0"
+version: "1.5.0"
 user-invocable: false
 verification: verified-local
 history: planning-check-already-shipped-before-planning.history
-tags: [planning, already-shipped, stale-issue-premise, extraction-epic, migration, verification-and-closeout, reframe, cross-repo, adr-attribution, acceptance-criteria-mapping, ifdef-guarded-untested, residuals, ctest, cpp]
+tags: [planning, already-shipped, stale-issue-premise, extraction-epic, migration, verification-and-closeout, reframe, cross-repo, adr-attribution, acceptance-criteria-mapping, ifdef-guarded-untested, residuals, ctest, cpp, git-provenance, false-premise-nogo, red-ci-disposition, cross-repo-pr-split, internal-consistency, replan]
 ---
 
 # Planning: Check If Already Shipped Before Writing a Plan
@@ -18,8 +18,8 @@ tags: [planning, already-shipped, stale-issue-premise, extraction-epic, migratio
 |-------|-------|
 | **Date** | 2026-06-19 |
 | **Objective** | Detect whether a GitHub issue's fix is already done before writing an implementation plan — covering merged fixes, uncommitted-worktree work, AND large EXTRACTION/MIGRATION epics already delivered under a different ADR/PR — and, even when it IS done, still emit a FORWARD-LOOKING plan (not a retrospective status note) and run every gate yourself instead of deferring to the plan reviewer |
-| **Outcome** | Successful — caught a shipped fix (PR #1308, merged), a fix that had already landed uncommitted in an untracked `1-fix` worktree (issue #1357), and a months-old ProjectAgamemnon extraction epic whose move was ALREADY delivered under a different ADR (586/589 tests pass, agents+integration labels 100% green) so the plan reframed to verification-and-closeout; also diagnosed why a "status note" plan for landed work was NOGO'd (Grade D), and why a SUBSEQUENT plan that withheld its content while a background `pytest` ran was NOGO'd even harder (Grade F, empty placeholder), and what resolves each |
-| **Verification** | verified-local — the extraction-epic INVESTIGATION procedure (find/ls/grep + `cmake --build --preset debug` + `ctest --preset debug -L`) was actually run this session and confirmed the move complete, but the downstream PLAN was NOT executed end-to-end in CI; cross-repo Keystone build, ADR-015 attribution, the 3 failing tests, the `#ifdef ENABLE_GRPC` path, and the 3,393-line figure all remain inferred/unreconciled. The earlier uncommitted-worktree finding ran a SUBSET of tests; the boundary/mypy/ruff gates ran GREEN; the original merged-fix example remains verified-ci |
+| **Outcome** | Successful — caught a shipped fix (PR #1308, merged), a fix that had already landed uncommitted in an untracked `1-fix` worktree (issue #1357), and a months-old ProjectAgamemnon extraction epic whose move was ALREADY delivered under a different ADR (586/589 tests pass, agents+integration labels 100% green) so the plan reframed to verification-and-closeout; also diagnosed why a "status note" plan for landed work was NOGO'd (Grade D), why a SUBSEQUENT plan that withheld its content while a background `pytest` ran was NOGO'd even harder (Grade F, empty placeholder), and — NEW in v1.5.0 — why a RE-PLAN of the Agamemnon epic was NOGO'd for a FALSE evidentiary premise: it dismissed 3 failing ctest cases as "a different branch's WIP," but the test `.cpp` was `??` (untracked) while its `test/CMakeLists.txt` wiring was an uncommitted `M` edit in the CURRENT tree — so the failures were real-and-local, not foreign; right conclusion (out of scope) via a false premise = verification defect = NOGO |
+| **Verification** | verified-local — the corrected git-provenance commands (`git cat-file -e HEAD:`, `git status --short`, `git show HEAD:… | grep`) and the ctest label runs were executed this session and confirmed the findings; the extraction-epic INVESTIGATION procedure (find/ls/grep + `cmake --build --preset debug` + `ctest --preset debug -L`) was run and confirmed the move complete, but the downstream PLAN was NOT executed end-to-end in CI; cross-repo Keystone claims rest on the local sibling tree (`../ProjectKeystone` main HEAD e28b649), not Keystone's CI; ADR-015 attribution, the 3 failing tests' downstream routing, the `#ifdef ENABLE_GRPC` path, and the 3,393-line figure (vs landed 1,732 src + 4,349 hdr) all remain inferred/unreconciled. The earlier uncommitted-worktree finding ran a SUBSET of tests; the boundary/mypy/ruff gates ran GREEN; the original merged-fix example remains verified-ci |
 | **History** | [changelog](./planning-check-already-shipped-before-planning.history) |
 
 ## When to Use
@@ -33,6 +33,10 @@ tags: [planning, already-shipped, stale-issue-premise, extraction-epic, migratio
 - The issue describes a refactor/decomposition as FUTURE work but a parallel branch/worktree may have already completed it
 - **The plan-loop reviewer NOGO'd your plan as a "status note" / retrospective** — discovering the work is already on disk does NOT exempt you from writing a forward-looking implementation plan; describing what shipped (bullets + caveats) fails the rubric even when the code is correct
 - **You're tempted to wait on a background job / Monitor / long test run before producing a due plan or review artifact** — a deliverable with a hard turn-boundary (a plan-loop artifact, a review verdict, any "your output IS the posted artifact" contract) must be emitted NOW from evidence in hand; blocking the emission on a pending background task produces an empty/placeholder artifact that is an automatic Grade F
+- **You're about to dismiss a failing test as "out of scope" / "another branch's WIP"** — verify the test artifact's git PROVENANCE precisely BEFORE writing it off: a `.cpp` shown as `??` (untracked) may still be wired into the build by an uncommitted `M` edit in the CURRENT tree, which means the failures are real in the local build, not foreign. A correct out-of-scope CONCLUSION reached through a FALSE "it's on a different branch" premise is still a verification defect → NOGO.
+- **You're cutting a closeout/docs/epic PR that must ship green** — uncommitted WIP that fails tests must be explicitly NOT staged, only the labels covering the actual deliverable run, and the underlying bug routed to its own issue (project rule: "Never merge with red CI"). Don't bundle unrelated red into the epic.
+- **Your fix touches a sibling repo (`../OtherRepo/...`)** — that edit cannot land on the current repo's branch; it needs its own PR in that repo, and "OtherRepo CI passes" is verified by `gh pr checks` in THAT repo, never by a local `cmake` build.
+- **Your plan quotes a count more than once** (a `find` result, a file count, a LOC figure) — reconcile counts across every section; run the count ONCE and use the same number everywhere, and reconcile the issue's original LOC estimate against the actual landed LOC rather than treating the estimate as a checklist.
 - Before any implementation plan step — running this check costs seconds and avoids wasted (and worse, duplicate/conflicting) work
 
 ## Verified Workflow
@@ -106,6 +110,20 @@ ctest --preset debug -L <label>                       # e.g. -L agents -L integr
 
 13. **Distinguish residuals that MATTER from harmless ones — do not over-scope the closeout** — After concluding "already moved," a `grep` for the moved symbol in the source repo may still return hits. Triage them before deciding the move is incomplete: a hit inside ACTIVELY-COMPILED code (a moved type still referenced from a `.cpp` that the default build compiles) is a real residual the closeout must address; a hit inside a `#ifdef`-guarded include that the current build config never compiles, or inside a Doxygen `@code`/comment example, is harmless and must NOT inflate the closeout scope. **Caveat the build-config gap explicitly:** an `#ifdef ENABLE_GRPC`-guarded path (e.g. a coordinator-submission branch) never compiles in the default preset, so "extraction complete" covers only the non-guarded surface — the guarded path is UNTESTED in this build and must be flagged as an open risk, not silently claimed done.
 
+14. **VERIFY THE GIT PROVENANCE of a failing-test artifact before dismissing it as "out of scope" — `??` (untracked) does NOT mean "foreign branch's WIP"** — This is the PRIMARY v1.5.0 lesson, and the one that NOGO'd a re-plan. The re-plan asserted that 3 failing `ctest` cases came from "an untracked file from a different branch's WIP." The reviewer caught the defect: the test `.cpp` was indeed `??` (untracked), BUT its wiring into `test/CMakeLists.txt` was an uncommitted `M` edit in the CURRENT working tree — so the failures were REAL in the local build and originated in THIS tree, not a foreign branch. The CONCLUSION (out-of-scope for the issue) happened to be right, but it was reached via a FALSE premise, and a right conclusion through a false premise is a verification defect → NOGO. Correct technique, run all three before asserting provenance:
+    ```bash
+    git cat-file -e HEAD:<path>           # exit 0 = the file IS in HEAD; nonzero = it is NOT committed
+    git status --short <path>             # "?? " = untracked; " M"/"M " = tracked-but-modified-uncommitted
+    git show HEAD:<wiring-file> | grep <entry>   # is the BUILD WIRING (CMakeLists entry) committed, or only local?
+    ```
+    Decision: an **untracked file + uncommitted wiring** = THIS tree's local WIP — not in HEAD, not on any branch. It fails the local build for real (so "foreign branch" is false), but it is genuinely not part of the committed deliverable (so "out of scope" can still be the right disposition — see step 15 for what to DO with it). Never conflate the two: provenance ("whose tree is this?") is a separate question from scope ("is it part of my issue?").
+
+15. **RED-CI DISPOSITION: a closeout/docs PR must ship green — explicitly do NOT stage failing WIP, and route the underlying bug to its own issue** — Once step 14 has established that the failing tests are local-uncommitted WIP outside the deliverable: (a) cut the closeout branch from `main`, (b) do NOT `git add` the failing WIP (`.cpp` + the `M` CMakeLists edit), (c) run ONLY the labels covering the actual deliverable (e.g. `ctest --preset debug -L agents`) so the PR's evidence is green for what it ships, and (d) file the underlying bug as its OWN issue. The project rule is "Never merge with red CI"; bundling unrelated red into the epic violates it. The disposition is "not staged + bug routed," not "ignored."
+
+16. **CROSS-REPO EDIT: a sibling-repo fix needs its OWN PR in that repo — never bundle it into the current branch, and verify its CI THERE** — A fix that touches `../OtherRepo/...` cannot land on the current repo's branch (the current PR's diff and CI only cover the current repo). Split it into a second PR in the sibling repo. And "OtherRepo CI passes" is an observation made with `gh pr checks` against THAT repo's PR — never inferred from a local `cmake`/`ctest` build of a sibling working tree (that clone can be stale/dirty and is not the repo's CI on main). Label any local sibling-tree build a SMOKE TEST, not the acceptance criterion.
+
+17. **INTERNAL CONSISTENCY: reconcile every count across every section of the plan** — A plan that says "7 files" in one section and "8" in another for the SAME `find` is internally contradictory and gets flagged. Run the count ONCE and reuse the single number everywhere. Separately, reconcile the issue's original LOC ESTIMATE against the actual LANDED LOC instead of treating the estimate as a manifest/checklist — they routinely diverge (e.g. an issue's 3,393-line estimate vs a delivered 1,732 src + 4,349 hdr, where the header tree vendored transitive deps). State the reconciliation explicitly rather than letting two numbers sit unexplained.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -125,7 +143,10 @@ ctest --preset debug -L <label>                       # e.g. -L agents -L integr
 | Assume an extraction epic = unstarted work | Treated an "extract agents from repo A into repo B" epic (filed months earlier) as future work to plan top-to-bottom | The extraction was ALREADY delivered under a different ADR/PR that never back-referenced the epic; `find <target>/src`, `ls <source>/src/agents` (absent), and a `grep` for the moved symbol proved the move was complete and the suite (586/589) already green | A large move filed long ago is the highest-risk class for "already done" — run cheap existence checks FIRST and reframe to verification-and-closeout, never re-implement |
 | Trust a sibling working tree for a cross-repo "still builds" claim | Asserted "ProjectKeystone CI still passes" (an epic acceptance step) from a local `cmake` build in the sibling `../ProjectKeystone` working tree | The local clone could be stale/dirty; a local build is NOT the repo's CI on its main branch — the claim was inferred, not observed | Cross-repo "downstream still builds/CI passes" claims must be confirmed against that repo's actual CI/main, not a local sibling tree; label sibling-tree builds as "inferred, local only" |
 | Attribute provenance from an in-repo comment | Concluded the work was "delivered under ADR-015 / Odysseus#143" because `CMakeLists.txt` comments said so | The ADR doc itself was never opened; an in-repo comment is hearsay, not the ADR | Verify "delivered under ADR-N" against the ADR document, not a code comment that cites it |
-| Dismiss failing tests as out-of-scope WIP | Wrote off 3 failing tests as another branch's work-in-progress because `git status` showed the file as untracked (`??`) | If that file is actually within the epic's intended scope, dismissing it is wrong — untracked ≠ unrelated | Before dismissing failures as out-of-scope, confirm the file is NOT part of the issue's acceptance scope; untracked status alone does not prove irrelevance |
+| Dismiss failing tests via a FALSE provenance premise ("a different branch's WIP") | Wrote off 3 failing `ctest` cases as "an untracked file from a different branch's WIP" because `git status` showed the test `.cpp` as `??` | The `.cpp` was untracked, BUT its wiring into `test/CMakeLists.txt` was an uncommitted `M` edit in the CURRENT tree — so the failures were real in THIS local build, not foreign. The out-of-scope conclusion was right, but reached via a false premise = verification defect → NOGO | Verify provenance with `git cat-file -e HEAD:<path>` + `git status --short <path>` (?? vs M) + `git show HEAD:<wiring> \| grep <entry>`; untracked file + uncommitted wiring = THIS tree's local WIP (real local failures), NOT a foreign branch. Keep provenance ("whose tree?") separate from scope ("part of my issue?") |
+| Plan to bundle failing local WIP into a green closeout PR | Considered letting the 3 failing tests ride along in the epic closeout branch | Project rule "Never merge with red CI"; uncommitted WIP that fails tests must not be staged into a docs/closeout PR | Cut the closeout from `main`, do NOT stage the failing WIP, run only the deliverable's labels (`ctest --preset debug -L agents`), and route the underlying bug to its own issue |
+| Bundle a sibling-repo (Keystone) edit into the current repo's commit | Tried to fold a `../ProjectKeystone` doc edit into the ProjectAgamemnon #1 commit | A sibling-repo edit cannot land on the current repo's branch — the PR diff/CI only cover the current repo | Split into two PRs (one per repo); verify the sibling's "CI passes" with `gh pr checks` in THAT repo, never from a local `cmake` smoke build of its working tree |
+| Quote inconsistent counts across plan sections | Said "7 files" in one section and "8" in another for the SAME `find`, and treated the issue's LOC estimate as a manifest | Reviewer flagged the contradiction; the estimate (3,393) never reconciled to landed LOC (1,732 src + 4,349 hdr, header tree vendored transitive deps) | Run the count ONCE and reuse one number everywhere; explicitly reconcile the issue's LOC estimate against actual landed LOC instead of treating the estimate as a checklist |
 | Claim "extraction complete" while a path is `#ifdef`-guarded out | Declared the move done after a green build/suite, when the gRPC/coordinator-submission path sat behind `#ifdef ENABLE_GRPC` and never compiled in the default preset | "Complete" covered only the non-guarded surface; the guarded coordinator path in `chief_architect_agent.cpp` was UNTESTED in this config | A guarded path that the current build never compiles is an open risk, not a verified surface — flag it explicitly; don't claim coverage you didn't compile |
 | Treat the move as byte-for-byte complete from the epic's LOC figure | Implicitly trusted the epic's "3,393 lines" scope estimate as the size of the moved code | Actual counts (1,732 src + 4,349 hdr) did not reconcile to 3,393 — the original estimate and the delivered code differ | An epic's LOC estimate is a forecast, not a manifest; don't assume the move is byte-for-byte complete because a count "roughly matches" — they often don't |
 
@@ -296,15 +317,60 @@ session, but the downstream plan was NOT executed end-to-end in CI):
   be stale or dirty; treat this as inferred, not observed.
 - **The "delivered under ADR-015 / Odysseus#143" attribution came from `CMakeLists.txt` comments,
   not from reading the ADR doc itself** — provenance rests on an in-repo comment.
-- **The 3 failing tests (of 589) were dismissed as out-of-scope WIP from another branch** based
-  only on `git status` showing the file as untracked (`??`); if that file is actually within the
-  epic's intended scope, dismissing it is wrong.
+- **The 3 failing tests (of 589) were dismissed as "another branch's WIP" on a FALSE premise** —
+  `git status` showed the test `.cpp` as untracked (`??`), but its `test/CMakeLists.txt` wiring was
+  an uncommitted `M` edit in THIS tree, so the failures were real-and-local, not foreign (see the
+  re-plan NOGO example below). The out-of-scope conclusion was still right, but reached by a false
+  premise; the corrected disposition is "not staged + bug routed to its own issue."
 - **The gRPC/coordinator path is behind `#ifdef ENABLE_GRPC` and never compiles in this preset** —
   `chief_architect_agent.cpp`'s coordinator-submission branch is UNTESTED here, so "extraction
   complete" covers only the non-gRPC surface.
 - **Line counts do not reconcile to the epic's 3,393-line figure** (found 1,732 src + 4,349 hdr) —
   the original scope estimate and the actual moved code differ; do not treat the move as
   byte-for-byte complete.
+
+### Concrete example (ProjectAgamemnon epic #1 RE-PLAN — NOGO'd for a FALSE evidentiary premise, v1.5.0)
+
+After the verification-and-closeout reframe above, the RE-PLAN of the same epic was NOGO'd by the
+reviewer — not for its conclusion, but for a FALSE evidentiary premise underneath it. The re-plan
+claimed the 3 failing `ctest` cases came from "an untracked file from a different branch's WIP."
+
+The reviewer ran the provenance precisely and disproved the premise. The test `.cpp`
+(`test/src/test_routes_pagination_http.cpp`) was indeed untracked (`??`), BUT its wiring into
+`test/CMakeLists.txt` was an uncommitted `M` edit in the CURRENT working tree — so the failures
+were REAL in the local build and originated in THIS tree, not a foreign branch:
+
+```bash
+git cat-file -e HEAD:test/src/test_routes_pagination_http.cpp   # nonzero → NOT in HEAD (untracked)
+git status --short test/src/test_routes_pagination_http.cpp     # "?? " → untracked
+git status --short test/CMakeLists.txt                          # " M " → tracked, modified, UNCOMMITTED
+git show HEAD:test/CMakeLists.txt | grep test_routes_pagination_http   # → no match: wiring is LOCAL only
+```
+
+Diagnosis: **untracked file + uncommitted wiring = THIS tree's local WIP** — not in HEAD, not on
+any branch. It fails the local build for real (so "a different branch's WIP" is FALSE), yet it is
+genuinely outside the epic's committed deliverable (so "out of scope" can still be the right
+DISPOSITION). The re-plan's conclusion was right; its premise was wrong; a right conclusion via a
+false premise is a verification defect → NOGO.
+
+The corrected disposition that resolves the NOGO:
+
+- **Git provenance, stated precisely** — not "foreign branch," but "uncommitted local WIP in this
+  tree (untracked `.cpp` + `M` CMakeLists edit), absent from HEAD and from every branch."
+- **Red-CI disposition** — cut the closeout from `main`, do NOT stage the failing WIP, run only the
+  deliverable's labels (`ctest --preset debug -L agents`), and route the pagination bug to its own
+  issue (project rule: "Never merge with red CI").
+- **Cross-repo split** — the Keystone doc edit the re-plan tried to bundle into the Agamemnon #1
+  commit cannot land on the Agamemnon branch; it needs its own Keystone PR, and "Keystone CI passes"
+  is `gh pr checks` on THAT PR, never the local `../ProjectKeystone` (main HEAD e28b649) cmake build
+  (a smoke test, not the criterion).
+- **Internal consistency** — the re-plan said "7 files" in one section and "8" in another for the
+  same `find`; run the count once, use one number, and reconcile the issue's 3,393-line estimate
+  against landed LOC (1,732 src + 4,349 hdr; the header tree vendored transitive deps).
+
+The pagination bug root cause (`POST /v1/briefs` not persisting the tasks that `GET /v1/tasks`
+reads) is asserted from test BEHAVIOR, not yet confirmed by reading the brief→store code path —
+flagged as an open risk, not a verified diagnosis.
 
 ### Decision tree for planners
 
@@ -345,7 +411,21 @@ Before writing any implementation plan:
     ├─ SUBSET green → verified-local only (coverage gate fails on subsets — a gate artifact;
     │                 run subsets with --no-cov; run `pixi run mypy` bare, no paths)
     ├─ FULL suite + mypy + ruff + boundary green → verified-ci, safe to report done
-    └─ SOME FAIL → issue is genuinely open; proceed with planning
+    └─ SOME FAIL → before dismissing as "out of scope / another branch's WIP", VERIFY PROVENANCE:
+        git cat-file -e HEAD:<test.cpp>        (in HEAD? nonzero = no)
+        git status --short <test.cpp>          (?? untracked vs M modified)
+        git show HEAD:<wiring> | grep <entry>  (is the build wiring committed, or local-only?)
+        ├─ untracked file + uncommitted wiring → THIS tree's LOCAL WIP (real local failures,
+        │   NOT foreign). Disposition: don't stage it, run only the deliverable's labels
+        │   (ctest -L <label>), route the bug to its OWN issue. Closeout ships GREEN.
+        └─ in HEAD / part of the issue's scope → issue is genuinely open; plan the fix
+
+Cross-cutting plan-hygiene gates (apply to EVERY plan):
+│
+├─ Touches a sibling repo (../OtherRepo/...)? → SPLIT into its own PR in that repo;
+│   "OtherRepo CI passes" = `gh pr checks` THERE, never a local cmake smoke build
+└─ Quotes any count more than once (find/file/LOC)? → run it ONCE, reuse one number everywhere;
+    reconcile the issue's LOC estimate against ACTUAL landed LOC (estimate ≠ manifest)
 
 When the artifact is DUE this turn (plan-loop / review verdict):
 │
@@ -366,3 +446,4 @@ When the artifact is DUE this turn (plan-loop / review verdict):
 | ProjectHephaestus | Issue #1357 — plan-loop NOGO (Grade D) on a retrospective "status note" for the landed work | Reshaped into a forward plan + ran the deferred gates: boundary tests 2 passed, `pixi run mypy` clean (402 files), ruff clean, 25 delegation stubs; full automation suite count unconfirmed (verified-local) |
 | ProjectHephaestus | Issue #1357 — SECOND plan-loop NOGO (Grade F) on an EMPTY placeholder artifact (output withheld while a background `pytest`/Monitor ran) | Fix verified: emit the complete plan from evidence in hand and flag the still-running gate as an open risk — the very next iteration got a complete, gradeable plan (verified-local) |
 | ProjectAgamemnon | Epic #1 — "extract the agent layer into Agamemnon" was already delivered under a different ADR/PR | Existence checks (`find <agamemnon>/src`, `ls <source>/src/agents` absent, `grep -rl <MovedSymbol>`) + `cmake --build --preset debug` + `ctest --preset debug -L agents -L integration` confirmed the move complete: 586/589 tests pass, agents+integration labels 100% green → plan = verification-and-closeout (verified-local; investigation run this session, downstream plan NOT executed in CI; cross-repo Keystone build, ADR-015 attribution, the 3 failing tests, the `#ifdef ENABLE_GRPC` path, and the 3,393-line figure all remain inferred/unreconciled) |
+| ProjectAgamemnon | Epic #1 RE-PLAN — plan-loop NOGO for a FALSE evidentiary premise (3 failing `ctest` cases dismissed as "a different branch's WIP") | Provenance verified this session: `test/src/test_routes_pagination_http.cpp` is `??` (untracked, not in HEAD) but its `test/CMakeLists.txt` wiring is an uncommitted `M` edit in THIS tree (`git show HEAD:test/CMakeLists.txt \| grep` finds no match) → real-and-local WIP, NOT foreign. Right out-of-scope conclusion, false premise = NOGO. Corrected disposition: don't stage the WIP, run `ctest --preset debug -L agents`, route the pagination bug to its own issue, split the Keystone edit into its own PR, reconcile the 7-vs-8 file count and the 3,393 vs 1,732+4,349 LOC figures (verified-local — provenance commands + ctest labels run this session; downstream plan NOT run in CI; Keystone CI unobserved (`../ProjectKeystone` main HEAD e28b649); pagination root cause asserted from test behavior, not the brief→store code path) |


### PR DESCRIPTION
## Summary

Amends the existing `planning-check-already-shipped-before-planning` skill **v1.4.0 → v1.5.0** (MINOR, additive). This is a RE-PLAN learning from the ProjectAgamemnon extraction-epic #1 session: the re-plan was NOGO'd not for its conclusion but for a FALSE evidentiary premise underneath it.

**Primary lesson:** the re-plan dismissed 3 failing `ctest` cases as "an untracked file from a different branch's WIP." The reviewer disproved the premise — the test `.cpp` was `??` (untracked) BUT its wiring into `test/CMakeLists.txt` was an uncommitted `M` edit in the CURRENT tree, so the failures were real-and-local, not foreign. A right conclusion (out of scope) reached via a false premise is still a verification defect = NOGO.

## What changed (additive)

- **Step 14 (PRIMARY):** verify the git PROVENANCE of a failing-test artifact before dismissing it — `git cat-file -e HEAD:<path>`, `git status --short <path>` (?? vs M), `git show HEAD:<wiring> | grep <entry>`. Untracked file + uncommitted wiring = THIS tree's local WIP, not foreign.
- **Step 15:** red-CI disposition — a closeout/docs PR ships green; don't stage failing WIP, run only the deliverable's labels (`ctest --preset debug -L agents`), route the bug to its own issue.
- **Step 16:** cross-repo edit (`../OtherRepo/...`) needs its own PR; "OtherRepo CI passes" = `gh pr checks` there, never a local `cmake` build.
- **Step 17:** reconcile counts across every plan section (run once, reuse; estimate ≠ manifest).
- 4 new When-to-Use triggers, sharpened + 3 new Failed Attempts rows, a worked RE-PLAN example, two decision-tree additions, a Verified On row, broadened description + tags.
- v1.4.0 frontmatter snapshot archived in the history file (newest-first).

## Verification

`verified-local` — the corrected git-provenance commands and the ctest label runs were executed this session and confirmed the findings; the downstream plan was NOT executed end-to-end in CI. `python3 scripts/validate_plugins.py` passes (437/437, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)