### PR TITLE
feat(skill): amend automation-loop-log-driven-layered-debug v1.1.0

### DIFF
--- a/skills/automation-loop-log-driven-layered-debug.history
+++ b/skills/automation-loop-log-driven-layered-debug.history
@@ -1,10 +1,73 @@
+# automation-loop-log-driven-layered-debug -- History
+
+## v1.1.0 (2026-06-20)
+
+**Changed by:** ProjectHephaestus single-issue end-to-end verify session (issue #1517 → PR #1538)
+**Verification:** verified-ci AND verified live end-to-end on a real loop run
+
+### What changed
+- Added a NEW verification technique — "single-issue end-to-end drive" — that strengthens the
+  existing step-5 "validate with a scoped re-run" into driving ONE real issue all the way to a
+  MERGED PR + CLOSED issue. Key principle reinforced: "no errors in the log" is NOT a pass; a real
+  ARTIFACT CHAIN is.
+- Added a new Verified Workflow subsection (#6) "Verifying a fix: single-issue end-to-end drive"
+  with:
+  - The scoped plan/implement commands (`--issues <N> --phases plan` then `--phases implement
+    --allow-unsafe-phase-order`, with `--loops 1 --max-workers 1 -v` and `tee build/verify-<N>.log`),
+    and a note on what `--allow-unsafe-phase-order` silences.
+  - Scope notes: the loop runs only the current repo by default (no `--org`), operates on the
+    `--projects-dir` clone (default `/home/mvillmow/Projects/<repo>`) NOT necessarily CWD, and
+    reports `trunk=<sha>` to confirm against your merged fixes.
+  - The artifact-chain success signals: `Created PR #N` → `Analysis complete ... found 0 inline
+    comment(s)` → `Verdict=GO` → `Enabled auto-merge` → `Follow-up complete` → `Removed worktree`
+    → `phase implement done (rc=0)`, then auto-MERGE + auto-CLOSE via `Closes #N`.
+  - The whole-log zero-error health-check grep (`429|session limit|usage cap|waiting for
+    reset|Traceback|[ERROR]|- ERROR -|Failed to remove worktree|No JSON object found` → expect 0).
+  - The live GitHub cross-check (`gh pr view --json state,mergedAt`, `gh issue view --json state`).
+  - The "what is NORMAL and must NOT be mistaken for failure" notes (internal `/learn` step,
+    10-15 min implementer self-validation, once-per-phase marketplace-path WARNING).
+- Extended the Quick Reference step-2 grep alternation with the new verify-run signals:
+  `Created PR #[0-9]+|Analysis complete for PR|Verdict=GO|Enabled auto-merge|Follow-up
+  complete|Removed worktree|Failed to remove worktree|phase (plan|implement) done|implemented=|No
+  JSON object found`.
+- Added 4 new Failed Attempts rows: (1) `pgrep` poll races on completion detection, (2) mistaking
+  the loop's internal `/learn` step for one's own or a hang, (3) assuming a long implementer step
+  is stuck when it is running the worktree pytest suite, (4) flagging the benign marketplace-path
+  WARNING as a failure.
+- Results & Parameters: added the new grep tokens (Created PR, Analysis complete, Verdict=GO,
+  Enabled auto-merge, Follow-up complete, Removed worktree, phase done, No JSON object found), the
+  verify-run zero-error health-check grep, the single-issue verify command block (plan/implement +
+  gh cross-checks), a "Single-issue verify scope" parameter, and an "End-to-end verify result" row
+  recording issue #1517 → PR #1538 (commit 6c8fbed) with the verified fixes #1530/#1531/#1533/
+  #1535/#1537.
+- Extended the "Verified On" row to record the single-issue end-to-end verify drive (issue #1517 →
+  merged PR #1538 + closed issue).
+- Frontmatter: bumped version 1.0.0 -> 1.1.0; set date to 2026-06-20; added `history:` field;
+  extended `description` with trigger (6) for verifying fixes via single-issue end-to-end drive;
+  added 4 new tags (single-issue-end-to-end-verify, artifact-chain-signals, merged-pr-closed-issue,
+  zero-error-health-check).
+- When to Use: added trigger (6) for the single-issue end-to-end verify drive.
+
+### Why
+After fixing 5 root-cause bugs found in an automation-loop `output.log` (429 session-limit
+handling, worktree cleanup, follow-up JSON parse, central is_error envelope guard, plus a prereq
+mypy-gate fix), the fixes were VERIFIED end-to-end by re-running the loop on a SINGLE live GitHub
+issue and driving it all the way to a merged PR + closed issue. This produced durable, reusable
+verification material — how to scope the loop to one issue, the exact artifact chain a clean PASS
+must produce (not just "no errors"), the zero-error health check that the original broken log would
+fail, and the gotchas that look like failures but are not (internal `/learn` step, long implementer
+self-validation, `pgrep` races, marketplace-path WARNING). These extend the same META/methodology
+skill rather than forming a new one, so they are folded in as a MINOR amendment.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
 ---
 name: automation-loop-log-driven-layered-debug
-description: "Use when: (1) debugging hephaestus-automation-loop / a multi-stage plan→implement→drive-green pipeline from its output.log, (2) a single symptom ('PR not reviewed/implemented') turns out to be a stack of layered bugs revealed one at a time as each prior blocker is removed, (3) a fix 'didn't work' because the loop runs editable working-tree code and the fix wasn't dev-installed, (4) --issues was given PR numbers instead of issue numbers, (5) validating an automation-loop fix with a scoped re-run, (6) verifying automation-loop fixes by driving a single issue end-to-end to a merged PR + closed issue (scoped plan→implement re-run, artifact-chain success signals, zero-error health-check grep, live GitHub cross-check)."
+description: "Use when: (1) debugging hephaestus-automation-loop / a multi-stage plan→implement→drive-green pipeline from its output.log, (2) a single symptom ('PR not reviewed/implemented') turns out to be a stack of layered bugs revealed one at a time as each prior blocker is removed, (3) a fix 'didn't work' because the loop runs editable working-tree code and the fix wasn't dev-installed, (4) --issues was given PR numbers instead of issue numbers, (5) validating an automation-loop fix with a scoped re-run."
 category: debugging
-date: 2026-06-20
-version: "1.1.0"
-history: automation-loop-log-driven-layered-debug.history
+date: 2026-06-09
+version: "1.0.0"
 verification: verified-ci
 user-invocable: false
 tags:
@@ -20,10 +83,6 @@ tags:
   - plan-implement-drive-green
   - pr-review-loop
   - methodology
-  - single-issue-end-to-end-verify
-  - artifact-chain-signals
-  - merged-pr-closed-issue
-  - zero-error-health-check
 ---
 
 # Automation-Loop Log-Driven Layered Debugging
@@ -50,7 +109,6 @@ Trigger phrases / situations that should route to this skill:
 3. A fix "didn't work" — but the loop runs the EDITABLE working-tree code and the fix was never dev-installed.
 4. `--issues` was given PR numbers instead of ISSUE numbers (planner "Could not resolve to an Issue").
 5. Validating an automation-loop fix with a scoped re-run before declaring victory.
-6. Verifying automation-loop fixes by driving ONE real issue end-to-end — scoped `plan`→`implement` re-run that must produce a real artifact chain (`Created PR #N` → in-loop review `Verdict=GO` → `Enabled auto-merge` → `Removed worktree` → `phase implement done (rc=0)`), then the PR auto-MERGES and the issue auto-CLOSES — confirmed against live GitHub, not just a clean log.
 
 ## Verified Workflow
 
@@ -61,7 +119,7 @@ Trigger phrases / situations that should route to this skill:
 pixi run hephaestus-automation-loop --issues 725,711 2>&1 | tee output.log
 
 # 2. Grep the decisive per-issue lines from the log
-grep -nE 'Issue #[0-9]+: .*(implementation-review (GO|NO-GO))|re-running implement|head branch is|already checked out .* reusing|Verdict=.*Grade=.*threads=|Successful:|Skipped:|Failed:|Repo not done|Could not resolve to an Issue|Created PR #[0-9]+|Analysis complete for PR|Verdict=GO|Enabled auto-merge|Follow-up complete|Removed worktree|Failed to remove worktree|phase (plan|implement) done|implemented=|No JSON object found' output.log
+grep -nE 'Issue #[0-9]+: .*(implementation-review (GO|NO-GO))|re-running implement|head branch is|already checked out .* reusing|Verdict=.*Grade=.*threads=|Successful:|Skipped:|Failed:|Repo not done|Could not resolve to an Issue' output.log
 
 # 3. CRITICAL: verify the fix is actually LIVE before re-running (loop runs editable code)
 git checkout main && git pull && pixi run dev-install
@@ -147,83 +205,6 @@ emits a real `Verdict:` line (not AMBIGUOUS). Then cross-check live GitHub state
 (Cross-ref `multi-repo-pr-automation-loop-orchestration`'s report-vs-live-state
 rule.)
 
-#### 6. Verifying a fix: single-issue end-to-end drive
-
-The strongest form of step-5 validation is to drive ONE real issue all the way
-through the loop to a MERGED PR + CLOSED issue. "No errors in the log" is NOT a
-pass; a real artifact chain is. Pick one small, real, ready issue — e.g. an
-audit-finding `severity:minor` already at `state:plan-go`, or a fresh
-`state:needs-plan` one — and scope the loop tightly:
-
-```bash
-# Plan only (one issue, one loop, one worker) — capture per-issue
-pixi run hephaestus-automation-loop --issues <N> --phases plan \
-  --loops 1 --max-workers 1 -v 2>&1 | tee build/verify-<N>.log
-
-# Implement (after the issue reaches plan-go). --allow-unsafe-phase-order
-# silences the "plan without implement predecessor" warning when running
-# implement standalone.
-pixi run hephaestus-automation-loop --issues <N> --phases implement \
-  --allow-unsafe-phase-order --loops 1 --max-workers 1 -v \
-  2>&1 | tee -a build/verify-<N>.log
-```
-
-Scope notes:
-
-- The loop runs ONLY the current repo by default (no `--org`) — exactly what you
-  want for a single-repo verify.
-- It operates on the clone under `--projects-dir` (default
-  `/home/mvillmow/Projects/<repo>`), NOT necessarily your CWD, and reports
-  `trunk=<sha>` — CONFIRM that sha contains your merged fixes before trusting the
-  run (same liveness discipline as step 3, but for the projects-dir clone).
-
-A clean PASS produces a real ARTIFACT CHAIN, not just "no errors":
-
-```text
-Created PR #N
-... Analysis complete for PR ... found 0 inline comment(s)   # in-loop review
-... Verdict=GO
-Enabled auto-merge for implementation-GO PR #N
-... Follow-up complete ... filed=none accepted=0 rejected=K
-Removed worktree for issue #N
-... phase implement done ... (rc=0)
-```
-
-Because auto-merge was armed, the PR then MERGES and the issue auto-CLOSES via its
-`Closes #N`. The log is an OBSERVATION REPORT, not ground truth — always
-cross-check live GitHub:
-
-```bash
-gh pr view <PR> --json state,mergedAt    # expect MERGED + a mergedAt timestamp
-gh issue view <N> --json state           # expect CLOSED
-```
-
-Zero-error health check — across the WHOLE verify log, every one of these must be
-absent (the ORIGINAL broken `output.log` was full of them; a clean verify run has
-NONE):
-
-```bash
-grep -ciE "429|session limit|usage cap|waiting for reset|Traceback|\[ERROR\]|- ERROR -|Failed to remove worktree|No JSON object found" build/verify-<N>.log
-#   -> expect 0
-```
-
-What is NORMAL in a verify log and must NOT be mistaken for failure:
-
-- The implement phase runs the loop's OWN internal `/learn` step
-  (`claude --resume ... /learn EXECUTE the /learn skill-creation workflow ...
-  --model claude-haiku-4-5`) near the end — that is normal post-implementation
-  behavior, not your own `/learn` and not a hang. After it, the follow-up +
-  worktree-cleanup steps run, THEN the phase reports done.
-- The implementer step can legitimately take 10–15 min for one issue: it edits
-  files and runs the FULL `pytest` suite IN THE WORKTREE to self-validate before
-  committing. A log "stalled" at `agent=implementer ... mode=create` is usually
-  the implementer working — confirm via the nested `claude` child process
-  consuming CPU and edits in `build/.worktrees/issue-<N>/`
-  (`git -C <worktree> status --short`), not stuck.
-- The `prompts: Path '...marketplace.json' is not under repo_root ...; injecting
-  absolute path` WARNING appears once per phase and is working-as-designed — do
-  NOT treat it as a failure.
-
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -232,10 +213,6 @@ What is NORMAL in a verify log and must NOT be mistaken for failure:
 | Re-ran the loop expecting a branch/merged-PR fix to apply | Re-ran `pixi run hephaestus-automation-loop` after the fix merged | The loop runs the editable working-tree code; the fix was never installed, so behavior was unchanged | `git checkout main && git pull && pixi run dev-install`, then verify with `inspect.getsource` before re-running |
 | Passed PR numbers to `--issues` | Invoked the loop with PR numbers in `--issues` | The planner could not resolve them as issues, failed open, and posted planner comments onto the PR | `--issues` takes comma-delimited ISSUE numbers, not PR numbers, not space-delimited |
 | Trusted a clean log as proof the fix worked | Read `output.log`, saw expected lines, declared done | The log is an observation report, not ground truth — live GitHub state can differ | Cross-check PR labels/comments on GitHub after a scoped validation re-run |
-| Polled `pgrep` to decide if the verify loop was still running | `pgrep -f "hephaestus-automation-loop --issues <N>"` to detect completion | It RACES: briefly shows RUNNING just after exit, and can miss the process under the pixi/python wrapper — one stale reading is not proof | Prefer the loop's OWN completion signal (backgrounded exit / `phase ... done (rc=0)`); if you must poll, re-check with `ps -eo pid,etime,args \| grep automation-loop` before concluding |
-| Mistook the loop's internal `/learn` step for my own `/learn` or a hang | Saw `claude --resume ... /learn ... --model claude-haiku-4-5` late in the implement phase and assumed something went wrong | That step is NORMAL post-implementation behavior baked into the loop; follow-up + worktree-cleanup run after it, then the phase reports done | Recognize the internal `/learn` line as expected; wait for `Removed worktree` + `phase implement done (rc=0)` before judging |
-| Assumed a long implementer step was stuck | Saw the log "stalled" at `agent=implementer ... mode=create` and thought it hung | The implementer legitimately takes 10–15 min: it edits files and runs the FULL `pytest` suite in the worktree to self-validate before committing | Confirm progress via the nested `claude` child CPU usage and edits in `build/.worktrees/issue-<N>/` (`git -C <wt> status --short`) before declaring a hang |
-| Flagged the marketplace-path WARNING as a verify failure | Treated `prompts: Path '...marketplace.json' is not under repo_root ...; injecting absolute path` as an error | It is a once-per-phase working-as-designed WARNING, not a failure | Exclude it from the zero-error health check; only `429`/`Traceback`/`[ERROR]`/`- ERROR -`/`Failed to remove worktree`/`No JSON object found` count as failures |
 
 ## Results & Parameters
 
@@ -250,21 +227,6 @@ What is NORMAL in a verify log and must NOT be mistaken for failure:
 | `Successful:` / `Skipped:` / `Failed:` | Per-loop implementer summary — fastest "did real work happen?" signal |
 | `Repo not done` | Loop has more work to do |
 | `Could not resolve to an Issue with the number of N` | `--issues` was likely given a PR number |
-| `Created PR #N` | Implement phase opened the PR (verify-run artifact-chain start) |
-| `Analysis complete for PR ... found 0 inline comment(s)` | In-loop review ran clean |
-| `Verdict=GO` | In-loop review approved (verify pass requires this) |
-| `Enabled auto-merge for implementation-GO PR #N` | Auto-merge armed → PR will merge when checks pass |
-| `Follow-up complete ... filed=none accepted=0 rejected=K` | Follow-up step finished (rejected=K is fine) |
-| `Removed worktree for issue #N` | Worktree cleaned up (vs `Failed to remove worktree` = bug) |
-| `phase (plan\|implement) done ... (rc=0)` | Phase finished successfully |
-| `No JSON object found` | Follow-up/plan JSON parse failure — must be ABSENT in a clean verify |
-
-**Verify-run zero-error health check** (across the whole `build/verify-<N>.log`):
-
-```bash
-grep -ciE "429|session limit|usage cap|waiting for reset|Traceback|\[ERROR\]|- ERROR -|Failed to remove worktree|No JSON object found" build/verify-<N>.log
-#   -> expect 0
-```
 
 **Commands:**
 
@@ -277,15 +239,6 @@ pixi run python -c "import inspect, hephaestus.automation.<module> as m; print('
 
 # Scoped validation re-run
 pixi run hephaestus-automation-loop --issues <a,few,real,issues> 2>&1 | tee output.log
-
-# Single-issue end-to-end VERIFY drive (plan, then implement after plan-go)
-pixi run hephaestus-automation-loop --issues <N> --phases plan \
-  --loops 1 --max-workers 1 -v 2>&1 | tee build/verify-<N>.log
-pixi run hephaestus-automation-loop --issues <N> --phases implement \
-  --allow-unsafe-phase-order --loops 1 --max-workers 1 -v \
-  2>&1 | tee -a build/verify-<N>.log
-gh pr view <PR> --json state,mergedAt   # expect MERGED
-gh issue view <N> --json state          # expect CLOSED
 ```
 
 | Parameter | Value |
@@ -294,9 +247,7 @@ gh issue view <N> --json state          # expect CLOSED
 | Diagnostic instrument | `output.log` via `2>&1 \| tee output.log` |
 | Layered bugs peeled in one session | 6 (#1104, #1106, #1108, #1110, #1112, #1114) |
 | Re-run scope | `--issues <comma-delimited ISSUE numbers>` |
-| Single-issue verify scope | `--issues <N> --phases plan` then `--phases implement --allow-unsafe-phase-order` (`--loops 1 --max-workers 1 -v`) |
-| End-to-end verify result | ProjectHephaestus issue #1517 (audit finding) driven plan→implement → PR #1538 (`fix(security): include NOTICE in license-scan path filter`), in-loop `Verdict=GO`, follow-up `rejected=2`, worktree removed cleanly, ZERO error/429/Traceback lines → PR #1538 auto-merged to main (commit `6c8fbed`), issue #1517 auto-closed. Verified fixes: PRs #1530 / #1531 / #1533 / #1535 / #1537. |
-| **Verified On** | ProjectHephaestus PRs #1104 / #1106 / #1108 / #1110 / #1112 / #1114 (all merged to main, green CI); single-issue end-to-end verify drive of issue #1517 → merged PR #1538 + closed issue (verified-ci + verified live) |
+| **Verified On** | ProjectHephaestus PRs #1104 / #1106 / #1108 / #1110 / #1112 / #1114 (all merged to main, green CI) |
 
 ## Related Skills
 
@@ -307,3 +258,8 @@ Jump to these per-bug skills for the specific fix behind each layered blocker:
 - `automation-reuse-repo-clone-with-worktree-per-pr` — real `headRefName` sync, worktree reuse on branch collision (#1106, #1110).
 - `cli-flag-validation-prevent-silent-noop` — issue-vs-PR `--issues` validation.
 - `pixi-runtime-env-gotchas` — editable working-tree code / dev-install gotcha.
+```
+
+## v1.0.0 (2026-06-09)
+
+Initial version.


### PR DESCRIPTION
Amends the `automation-loop-log-driven-layered-debug` methodology skill (MINOR bump 1.0.0 → 1.1.0, first amendment) to add a new verification technique discovered this session.

## What changed
- **New verification technique — single-issue end-to-end drive**: scoped `plan`→`implement` re-run on ONE real issue that must produce a real ARTIFACT CHAIN (`Created PR #N` → in-loop `Verdict=GO` → `Enabled auto-merge` → `Removed worktree` → `phase implement done (rc=0)`) and then auto-MERGE + auto-CLOSE — not merely "no errors". Includes the `--allow-unsafe-phase-order` note, `--projects-dir`/`trunk=<sha>` scope caveats, a whole-log zero-error health-check grep, and the live GitHub cross-check (`gh pr view`/`gh issue view`).
- Extended the Quick Reference grep alternation with the new verify-run signals.
- Added 4 new Failed Attempts rows (pgrep completion race; internal `/learn` step mistaken for a hang; long implementer self-validation mistaken for stuck; benign marketplace-path WARNING).
- Results & Parameters + Verified On: recorded ProjectHephaestus issue #1517 → merged PR #1538 (commit 6c8fbed) as the end-to-end verify result (verified fixes #1530/#1531/#1533/#1535/#1537).
- Frontmatter: version 1.1.0, date 2026-06-20, added `history:` field, extended description + tags, added When-to-Use trigger (6).
- Added `.history` (first amendment) with the v1.1.0 entry and a full v1.0.0 snapshot.

## Verification
- `python3 scripts/validate_plugins.py` → Valid: 451/451.
- Skill content itself is verified-ci AND verified live end-to-end (issue #1517 → PR #1538 auto-merged + issue auto-closed).