### PR TITLE
feat: amend tracking-doc-checkbox-sync-regression-guard skill (v2.0.0)

### DIFF
--- a/skills/tracking-doc-checkbox-sync-regression-guard.history
+++ b/skills/tracking-doc-checkbox-sync-regression-guard.history
@@ -1,0 +1,98 @@
+# tracking-doc-checkbox-sync-regression-guard — History
+
+## v2.0.0 (2026-06-20)
+
+**Changed by:** ProjectProteus issue #183, R1 (re-plan) iteration. The R0 plan
+(captured as v1.0.0 in PR #2673) received a NOGO because its committed regression
+guard had two fatal flaws it flagged but left UNSOLVED. R1 solved them by changing
+the guard's design.
+**Verification:** verified-local — the embedded EXPECT-table test logic was executed
+this session against a passing fixture (PASS, exit 0) and three negative fixtures
+(checkbox drift, new-untracked-line, deleted-line) which each FAILed as designed. No
+network/`gh`/auth involved, so the run is deterministic. CI on the consuming repo
+(ProjectProteus) was NOT run, hence `verified-local` not `verified-ci`.
+
+### What changed
+
+- **CORE REDESIGN (major):** Replaced the recommended workflow. The live-API guard
+  (query `gh issue view <n>` at test time, SKIP when `gh` is unauthenticated) is
+  DEMOTED to a Failed Attempt. The new primary workflow is a **committed-fixture
+  invariant table**: embed an explicit `declare -A EXPECT=([key]=state ...)` inside
+  the test, parse the tracked file, and diff each line's actual checkbox char against
+  the expected char. No network, no auth, no SKIP path — deterministic in every
+  environment (including the required-CI runner that has no issue-read token, exactly
+  where the live-`gh` guard provided ZERO protection).
+- **Key by the line's STABLE PRIMARY TOKEN, not by scanning every `#NNN` on the line.**
+  The R0 design's "any CLOSED `#NNN` on an unchecked line" false-FAILed on bundle lines
+  (a PR row legitimately stays `[ ]` while some of its child issues are already CLOSED).
+  The fix derives ONE key per line (leading `#NNN`, or `PR-X`, or a phrase) and looks it
+  up in the table. A closed child inside an open bundle can never trip the guard because
+  the bundle is keyed once, as `[ ]`-expected.
+- **Added bidirectional coverage cross-checks** via a `SEEN` set: (a) fail with a
+  `__MISSING__` sentinel if a tracked-looking line's key is absent from `EXPECT` (new
+  lines can't silently escape coverage); (b) after parsing, fail if any `EXPECT` key was
+  never `SEEN` (catches a deleted/renamed line).
+- **New Failed Attempts rows:** scan-every-issue-on-the-line bundle mis-fire (now solved
+  by single-key derivation); and the honest caveat that the hand-maintained EXPECT table
+  enforces internal (file-vs-table) consistency, NOT freshness against live GitHub state.
+- Verification level raised from `unverified` (v1.0.0) to `verified-local` because the
+  test logic was actually run this session.
+- Retained the cross-links to `code-quality-enforcement-gates` §5 ("assert the property
+  via static analysis, NOT a live runtime check") and §10 (verify findings vs ground
+  truth), and to `planning-roadmap-tracking-issue-reconciliation`.
+
+### Why
+
+The R0 (v1.0.0) plan got a NOGO because the committed artifact failed the test it
+shipped, and because the live-`gh` guard's offline-SKIP meant it provided zero protection
+in the exact CI environment it was meant to guard (a required runner with no issue-read
+token). The invariant-table design is a direct application of
+`code-quality-enforcement-gates` §5: assert the property via static analysis (a committed
+table diffed offline), not a live runtime check. Because the table is authored to match
+the committed checkbox state, the self-contained file PASSES its own test deterministically
+— removing the R0 disqualifier. The trade-off, recorded honestly: the table is
+hand-maintained and detects file-vs-table divergence, NOT divergence from live issue
+state; freshness against GitHub is sacrificed for determinism. A future, non-required,
+tokened nightly drift job is the belt-and-suspenders complement.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: tracking-doc-checkbox-sync-regression-guard
+description: "When a tracking DOCUMENT (remediation plan, roadmap, status table, audit-checklist markdown FILE) encodes issue/PR state as `- [ ]` / `- [x]` checkboxes, that state silently rots out of sync with live GitHub OPEN/CLOSED state. Fix in two parts: (1) verify EVERY referenced `#NNN` against `gh issue view <n> --json state` ground truth BEFORE editing — do NOT trust the triggering issue body's own wave/group/CLOSED claims (they drift and mis-bucket children); (2) add a REGRESSION GUARD that asserts the INVARIANT as a property ('no CLOSED issue sits on an unchecked `- [ ]` line'), not a snapshot of which boxes are ticked, and that SKIPS gracefully (exit 0 + notice) when `gh` is unavailable/unauthenticated so it never breaks offline/sandboxed CI; wire it into the repo's aggregate task (e.g. justfile `check`). Use when: (1) editing a markdown tracking/remediation/roadmap doc whose checkboxes claim issue state, (2) an issue body groups children under waves/sections you are tempted to trust, (3) a single doc line bundles multiple `#NNN`, (4) adding a guard against checkbox drift. This is doc-FILE sync; for reconciling a GitHub ISSUE BODY checklist see planning-roadmap-tracking-issue-reconciliation; for the general 'verify audit findings vs ground truth' principle see code-quality-enforcement-gates §10."
+category: documentation
+date: 2026-06-20
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [tracking-doc, remediation-plan, roadmap, checkbox, doc-sync, regression-guard, verify-ground-truth, gh-issue-state, offline-skip, false-confidence, audit, property-not-snapshot, planning, unverified]
+---
+
+# Tracking-Doc Checkbox Sync + Regression Guard
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-20 |
+| **Objective** | Correct stale `- [ ]` / `- [x]` checkbox state in a tracking markdown FILE (`docs/audit-2026-04-28/remediation-plan.md`) so it matches live GitHub issue OPEN/CLOSED state, and add a regression guard that survives future legitimate edits |
+| **Outcome** | PLAN produced for ProjectProteus issue #183. Per-issue `gh issue view` verification was done and caught a mis-grouping (the #183 body bucketed #112 under the wrong wave; #112 is in fact CLOSED). The doc edit and the guard were NOT executed end-to-end and no CI ran |
+| **Verification** | unverified — this is a plan, not executed code. See warning in Proposed Workflow |
+
+(The full v1.0.0 body recommended a live-`gh issue view` guard with an offline SKIP and a
+single-issue-line restriction. v2.0.0 replaces that primary workflow with a committed
+invariant table and demotes the live-`gh` approach to a Failed Attempt. See the v2.0.0
+"What changed" / "Why" above and the current skill file for the superseding design.)
+```
+
+---
+
+## v1.0.0 (2026-06-20)
+
+**Initial version** (PR #2673, MERGED). Captured the R0 plan for ProjectProteus issue
+#183: ground-truth every `#NNN` via `gh issue view` before editing, then add a
+live-API regression guard that asserts the property "no CLOSED issue on an unchecked
+line" and SKIPs when `gh` is unavailable. Verification: `unverified` (plan only). The
+plan received a NOGO; the offline-SKIP and bundle-line flaws were flagged but left
+unsolved — solved in v2.0.0.

--- a/skills/tracking-doc-checkbox-sync-regression-guard.md
+++ b/skills/tracking-doc-checkbox-sync-regression-guard.md
@@ -1,12 +1,13 @@
 ---
 name: tracking-doc-checkbox-sync-regression-guard
-description: "When a tracking DOCUMENT (remediation plan, roadmap, status table, audit-checklist markdown FILE) encodes issue/PR state as `- [ ]` / `- [x]` checkboxes, that state silently rots out of sync with live GitHub OPEN/CLOSED state. Fix in two parts: (1) verify EVERY referenced `#NNN` against `gh issue view <n> --json state` ground truth BEFORE editing — do NOT trust the triggering issue body's own wave/group/CLOSED claims (they drift and mis-bucket children); (2) add a REGRESSION GUARD that asserts the INVARIANT as a property ('no CLOSED issue sits on an unchecked `- [ ]` line'), not a snapshot of which boxes are ticked, and that SKIPS gracefully (exit 0 + notice) when `gh` is unavailable/unauthenticated so it never breaks offline/sandboxed CI; wire it into the repo's aggregate task (e.g. justfile `check`). Use when: (1) editing a markdown tracking/remediation/roadmap doc whose checkboxes claim issue state, (2) an issue body groups children under waves/sections you are tempted to trust, (3) a single doc line bundles multiple `#NNN`, (4) adding a guard against checkbox drift. This is doc-FILE sync; for reconciling a GitHub ISSUE BODY checklist see planning-roadmap-tracking-issue-reconciliation; for the general 'verify audit findings vs ground truth' principle see code-quality-enforcement-gates §10."
+description: "When a tracking DOCUMENT (remediation plan, roadmap, status table, audit-checklist markdown FILE) encodes issue/PR state as `- [ ]` / `- [x]` checkboxes, that state silently rots. The PREFERRED guard is a self-contained COMMITTED-FIXTURE INVARIANT TABLE: embed an explicit `declare -A EXPECT=([key]=state ...)` in the test, derive ONE stable key per line (leading `#NNN`, else `PR-X`, else a phrase), and diff each line's actual checkbox char against the expected char — no network, no `gh`, no auth, no SKIP path, deterministic everywhere (including required-CI runners with no issue-read token). Add bidirectional coverage cross-checks via a SEEN set: fail `__MISSING__` if a tracked line's key is absent from EXPECT, and fail if any EXPECT key was never SEEN (deleted/renamed line). Key by the line's STABLE PRIMARY TOKEN, not by scanning every `#NNN`, so an open bundle line with a closed child never false-FAILs. Do NOT use a live `gh issue view` guard: it SKIPs to a no-op when unauthenticated — exactly the required-CI state — giving ZERO protection, and it is non-deterministic. Use when: (1) editing a markdown tracking/remediation/roadmap doc whose checkboxes claim issue state, (2) adding a guard against checkbox drift, (3) a doc line bundles multiple `#NNN`, (4) you need a guard that the committed file itself passes deterministically in offline/sandboxed CI. This applies code-quality-enforcement-gates §5 ('assert the property via static analysis, NOT a live runtime check'); for ISSUE-BODY checklists see planning-roadmap-tracking-issue-reconciliation; for verify-findings-vs-ground-truth see code-quality-enforcement-gates §10."
 category: documentation
 date: 2026-06-20
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
-verification: unverified
-tags: [tracking-doc, remediation-plan, roadmap, checkbox, doc-sync, regression-guard, verify-ground-truth, gh-issue-state, offline-skip, false-confidence, audit, property-not-snapshot, planning, unverified]
+verification: verified-local
+history: tracking-doc-checkbox-sync-regression-guard.history
+tags: [tracking-doc, remediation-plan, roadmap, checkbox, doc-sync, regression-guard, invariant-table, committed-fixture, static-analysis-not-runtime, deterministic, offline-ci, no-network, bidirectional-coverage, seen-set, missing-sentinel, stable-key, bundle-line, verify-ground-truth, audit, property-not-snapshot, planning, verified-local]
 ---
 
 # Tracking-Doc Checkbox Sync + Regression Guard
@@ -16,125 +17,182 @@ tags: [tracking-doc, remediation-plan, roadmap, checkbox, doc-sync, regression-g
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-20 |
-| **Objective** | Correct stale `- [ ]` / `- [x]` checkbox state in a tracking markdown FILE (`docs/audit-2026-04-28/remediation-plan.md`) so it matches live GitHub issue OPEN/CLOSED state, and add a regression guard that survives future legitimate edits |
-| **Outcome** | PLAN produced for ProjectProteus issue #183. Per-issue `gh issue view` verification was done and caught a mis-grouping (the #183 body bucketed #112 under the wrong wave; #112 is in fact CLOSED). The doc edit and the guard were NOT executed end-to-end and no CI ran |
-| **Verification** | unverified — this is a plan, not executed code. See warning in Proposed Workflow |
-| **Related** | `planning-roadmap-tracking-issue-reconciliation` (issue-BODY checklists), `code-quality-enforcement-gates` §10 (verify audit findings vs ground truth), `automation-moot-issue-regression-guard-pattern` (property-as-test) |
+| **Objective** | Keep `- [ ]` / `- [x]` checkbox state in a tracking markdown FILE (`docs/audit-2026-04-28/remediation-plan.md`) honest, and add a regression guard that (a) the committed file itself passes, and (b) actually protects in a required-CI runner that has NO issue-read token |
+| **Outcome** | R1 (re-plan) of ProjectProteus issue #183. The R0 live-`gh` guard got a NOGO (offline-SKIP = zero CI protection; committed artifact failed its own test). R1 replaces it with a committed-fixture INVARIANT TABLE that runs with no network and PASSES deterministically. The embedded test logic was executed this session: PASS on a matching fixture, FAIL on each of 3 negative fixtures (drift / new line / deleted line) as designed |
+| **Verification** | verified-local — the EXPECT-table test logic was run this session and behaved as specified; the consuming repo's CI was not run |
+| **History** | [changelog](./tracking-doc-checkbox-sync-regression-guard.history) |
+| **Related** | `code-quality-enforcement-gates` §5 (assert the property via static analysis, NOT a live runtime check) and §10 (verify findings vs ground truth); `planning-roadmap-tracking-issue-reconciliation` (issue-BODY checklists); `automation-moot-issue-regression-guard-pattern` (property-as-test) |
 
 ## When to Use
 
 - You are editing a markdown tracking document — remediation plan, roadmap, status table, audit checklist — whose `- [ ]` / `- [x]` checkboxes assert the OPEN/CLOSED state of GitHub issues or PRs.
-- The triggering issue (or the doc itself) groups child issues under "waves", "phases", or sections, and you are tempted to trust that grouping or its CLOSED/OPEN annotations.
-- A single doc line bundles MORE THAN ONE `#NNN` (e.g. a Wave-3 line that ships several issues together).
-- You want to add a guard that prevents checkbox state from silently rotting again — without pinning to a brittle snapshot of which specific boxes are ticked today.
-- You are about to wire a state-drift check into the repo's aggregate task (e.g. justfile `check`) and need it to behave in offline/sandboxed CI.
-
-## Proposed Workflow
-
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
->
-> **Heading note:** The repository validator (`scripts/validate_plugins.py`) hard-requires the literal section string `## Verified Workflow`, so the canonical steps below are emitted under that heading to keep validation green. This skill was captured at `unverified` level — the per-issue ground-truth checks were performed this session, but the doc edit, the guard, and CI were NOT executed. Read the steps as **proposed**, per the warning above.
+- You want a guard against checkbox drift that the committed file itself PASSES, and that protects in a required-CI runner with **no** issue-read token (i.e. where a live-`gh` guard would SKIP to a no-op).
+- A single doc line bundles MORE THAN ONE `#NNN` (e.g. a Wave-3 PR row that ships several issues together) and you must not false-FAIL when one bundled child closes while the row stays `[ ]`.
+- You are tempted to query `gh issue view` at test time — read the Failed Attempts first; that design is demoted here.
+- You are wiring a state-drift check into the repo's aggregate task (e.g. justfile `check`) and need it deterministic offline.
 
 ## Verified Workflow
 
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+> Verified locally this session: the embedded EXPECT-table test logic was executed against a
+> matching fixture (PASS, exit 0) and three negative fixtures — checkbox drift, a new untracked
+> line, and a deleted line — which each FAILed exactly as designed. The run uses no network, no
+> `gh`, and no auth, so it is deterministic in any environment. CI on the consuming repo
+> (ProjectProteus) has not been run, hence `verified-local` rather than `verified-ci`.
 
 ### Quick Reference
 
 ```bash
-# 1. Ground-truth EVERY referenced issue BEFORE editing any checkbox.
-#    Do NOT trust the triggering issue body's wave/group/CLOSED claims.
-for n in $(grep -oE '#[0-9]+' docs/audit-2026-04-28/remediation-plan.md | tr -d '#' | sort -un); do
-  state=$(gh issue view "$n" --repo OWNER/REPO --json state --jq .state 2>/dev/null || echo "UNKNOWN")
-  echo "#$n -> $state"
-done
+# The guard is a self-contained bash test with an embedded EXPECTED-STATE table.
+# No `gh`, no network, no auth, no SKIP path -> deterministic in required CI.
 
-# 2. A CLOSED issue must NOT sit on an unchecked '- [ ]' line; OPEN must NOT sit on '- [x]'.
-#    Edit the doc to match ground truth (flip boxes), one issue at a time.
-
-# 3. Add a regression guard that asserts the PROPERTY and SKIPS when gh is unusable.
-#    (see Detailed Steps for the full script + the single-issue-line refinement)
+declare -A EXPECT=(
+  [#1]=' '            # OPEN  -> expect unchecked
+  [#84]='x'           # CLOSED-> expect checked
+  [PR-C]=' '          # bundle line: stays [ ] even if a child issue is CLOSED
+  ["wave-3 docs sweep"]=' '   # phrase-keyed line (no leading #NNN)
+)
+# 1. derive ONE stable key per line (leading #NNN, else PR-X, else phrase)
+# 2. diff actual checkbox char vs EXPECT[key]
+# 3. SEEN-set cross-checks: __MISSING__ if a tracked line's key is not in EXPECT;
+#    and fail if any EXPECT key was never SEEN (deleted/renamed line).
+# See Detailed Steps for the full, runnable script.
 ```
 
 ### Detailed Steps
 
-1. **Enumerate every `#NNN` in the tracking doc and query live state.** Parse the markdown for issue
-   references and call `gh issue view <n> --json state` for each. The triggering issue body for #183
-   grouped #112 under the wrong wave; per-issue verification caught it (#112 is CLOSED). This is a
-   direct application of "verify audit/reviewer findings against ground truth" — the issue body is a
-   self-report, not a fact source.
+1. **Author an explicit EXPECTED-STATE table inside the test.** A bash
+   `declare -A EXPECT=([key]=state ...)` maps each tracked line's stable key to its expected
+   checkbox char (`' '` for OPEN/unchecked, `'x'` for CLOSED/checked). This is a committed fixture —
+   a static-analysis assertion, not a live runtime query. (Direct application of
+   `code-quality-enforcement-gates` §5: "assert the property via static analysis, NOT a live runtime
+   check.") Because the table is authored to match the committed checkbox state, the file PASSES its
+   own test deterministically — which removes the R0 disqualifier (the R0 committed artifact failed
+   the test it shipped).
 
-2. **Flip checkboxes to match ground truth, one issue at a time.** The invariant: a CLOSED issue
-   belongs on a `- [x]` line; an OPEN issue belongs on a `- [ ]` line. Do NOT bulk-trust the doc's
-   existing groupings — re-derive each box from `gh` output.
+2. **Key each line by its STABLE PRIMARY TOKEN, not by scanning every `#NNN` on the line.** Derive
+   exactly ONE key per line: the leading `#NNN` if present, else a `PR-X` token, else a short phrase.
+   Look that single key up in `EXPECT`. A closed child inside an OPEN bundle line can never trip the
+   guard, because the bundle line is keyed once (e.g. `PR-C`) and expected `[ ]`. This is the fix for
+   the R0 bundle-line false-FAIL.
 
-3. **Add a regression guard that encodes the INVARIANT as a property, not a snapshot.** Assert "no
-   CLOSED issue sits on an unchecked `- [ ]` line", NOT "boxes 3, 7, 9 are ticked". A snapshot test
-   breaks on the next legitimate edit; a property test survives it. (Same principle as
-   `code-quality-enforcement-gates` §5 and `automation-moot-issue-regression-guard-pattern`.)
+3. **Diff actual vs expected and collect violations.** For every line matching the checkbox regex,
+   compare its actual char to `EXPECT[key]`; emit `::error::` and increment a counter on mismatch.
 
-4. **Make the guard SKIP gracefully when `gh` is unavailable or unauthenticated.** Exit 0 with a
-   `::notice::` (or plain skip line) so the check never breaks offline or sandboxed CI runners. SEE
-   THE CAVEAT BELOW — this graceful skip is also the guard's biggest weakness.
+4. **Add bidirectional coverage cross-checks with a `SEEN` set.** (a) If a tracked-looking line's key
+   is absent from `EXPECT`, fail with a `__MISSING__` sentinel — new lines cannot silently escape
+   coverage. (b) After parsing, fail if any `EXPECT` key was never `SEEN` — catches a deleted or
+   renamed line.
 
-5. **Refine the property so bundled lines do not false-FAIL.** A Wave-3 line that bundles multiple
-   `#NNN` legitimately stays `- [ ]` while ONE of its children is already CLOSED. Asserting on every
-   `#NNN` of an unchecked line mis-fires. Restrict the assertion to lines carrying a SINGLE issue
-   number, or parse a per-issue ✅ annotation, before treating "unchecked line + CLOSED issue" as a
-   violation.
+5. **Constrain the checkbox regex deliberately.** `^-\ \[([\ x])\]\ (.*)$` matches only `[ ]` / `[x]`
+   (lowercase `x`, single space). A `[X]` or `[~]` is silently skipped as a non-checkbox — acceptable
+   for a tracked file that uses the canonical form, but a sharp edge to record.
 
 6. **Wire the guard into the repo's existing aggregate task** (e.g. justfile `check: lint validate`).
-   Cite the target by its recipe NAME, not a line number — `justfile` line numbers (e.g. `:73`/`:76`)
-   are read live but drift; grep for the recipe name instead.
+   Cite the target by its recipe NAME and grep for it — never hard-code a `justfile` line number, which
+   drifts on any edit above it.
+
+7. **(Future enhancement, NOT part of this guard) Add a SEPARATE non-required tokened nightly job** that
+   diffs the EXPECT table against live `gh` issue state and opens an issue on drift. This is the
+   belt-and-suspenders complement that restores freshness-detection without sacrificing the determinism
+   of the required guard.
 
 ```bash
-# scripts/check-remediation-checkboxes.sh — property guard with offline skip
+#!/usr/bin/env bash
+# tests/check-remediation-checkboxes.sh — committed-fixture invariant table.
+# Parses the tracking doc and diffs each line's checkbox char against EXPECT.
+# No network, no gh, no auth, no SKIP path -> deterministic in every environment.
 set -euo pipefail
-DOC="docs/audit-2026-04-28/remediation-plan.md"
-REPO="OWNER/REPO"
 
-# OFFLINE SKIP: never break sandboxed/offline CI (but see CAVEAT — zero protection here).
-if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
-  echo "::notice::gh unavailable/unauthenticated — skipping checkbox-state guard"
-  exit 0
-fi
+DOC="${1:-docs/audit-2026-04-28/remediation-plan.md}"
 
+# EXPECTED state table. Key -> expected checkbox char (' ' or 'x').
+# HAND-MAINTAINED: when an issue closes, flip BOTH the doc checkbox AND its entry here.
+declare -A EXPECT=(
+  [#1]=' '       # OPEN
+  [#84]='x'      # CLOSED
+  [#85]='x'      # CLOSED
+  [#112]='x'     # CLOSED (mis-grouped child; actually closed)
+  [#183]=' '     # OPEN  (the tracking-doc fix itself)
+  [PR-C]=' '     # bundle row: stays [ ] even though a child is CLOSED
+  ["wave-3 docs sweep"]=' '
+)
+
+# Derive ONE stable key per line: leading #NNN, else PR-X, else a phrase.
+key_for() {
+  local text="$1"
+  if [[ "$text" =~ ^(#[0-9]+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  elif [[ "$text" =~ (PR-[A-Z]) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  else
+    printf '%s' "$(printf '%s' "$text" | tr '[:upper:]' '[:lower:]' | awk '{print $1, $2, $3}')"
+  fi
+}
+
+declare -A SEEN=()
 violations=0
-# Only assert on lines carrying a SINGLE issue number (avoids bundled-line false FAILs).
+
 while IFS= read -r line; do
-  ids=$(grep -oE '#[0-9]+' <<<"$line" | tr -d '#')
-  [ "$(wc -w <<<"$ids")" -eq 1 ] || continue          # skip bundled / zero-issue lines
-  n="$ids"
-  state=$(gh issue view "$n" --repo "$REPO" --json state --jq .state 2>/dev/null || echo UNKNOWN)
-  if grep -qE '^\s*- \[ \]' <<<"$line" && [ "$state" = "CLOSED" ]; then
-    echo "::error::#$n is CLOSED but sits on an unchecked line: $line"
+  # Match ONLY '- [ ]' / '- [x]' (lowercase x, single space). [X]/[~] are skipped.
+  [[ "$line" =~ ^-\ \[([\ x])\]\ (.*)$ ]] || continue
+  actual="${BASH_REMATCH[1]}"
+  rest="${BASH_REMATCH[2]}"
+  key="$(key_for "$rest")"
+  SEEN["$key"]=1
+  if [[ -z "${EXPECT[$key]+set}" ]]; then
+    echo "::error::tracked line key '$key' is __MISSING__ from EXPECT table: $line"
+    violations=$((violations + 1)); continue
+  fi
+  exp="${EXPECT[$key]}"
+  if [[ "$actual" != "$exp" ]]; then
+    echo "::error::key '$key' expected [${exp}] but doc has [${actual}]: $line"
     violations=$((violations + 1))
   fi
-done < <(grep -nE '^\s*- \[[ x]\].*#[0-9]+' "$DOC")
+done < "$DOC"
 
-[ "$violations" -eq 0 ] || { echo "::error::$violations checkbox(es) out of sync with issue state"; exit 1; }
-echo "remediation-plan checkboxes consistent with live issue state"
+# Bidirectional: every EXPECT key must have been SEEN (catches deleted/renamed line).
+for k in "${!EXPECT[@]}"; do
+  if [[ -z "${SEEN[$k]+set}" ]]; then
+    echo "::error::EXPECT key '$k' was never SEEN in $DOC (deleted/renamed line?)"
+    violations=$((violations + 1))
+  fi
+done
+
+[[ "$violations" -eq 0 ]] || { echo "FAIL: $violations checkbox invariant violation(s)"; exit 1; }
+echo "PASS: all tracked lines match the invariant table"
 ```
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Trust the triggering issue body's wave grouping | Read #183's body, accepted its wave-to-issue buckets as authoritative | The body grouped #112 under the wrong wave; #112 was already CLOSED | Verify EVERY `#NNN` with `gh issue view <n> --json state`; the issue body is a self-report, not ground truth |
-| Trust the issue body's OPEN/CLOSED claims | Took the body's own CLOSED/OPEN annotations at face value | Body annotations drift the same way the doc checkboxes do | Re-derive each box from live `gh` output, not from any prose claim |
-| Snapshot which specific boxes are ticked | Test asserted literal `- [x]` positions / a fixed list of ticked items | Breaks on the next legitimate doc edit — false regression noise | Assert the PROPERTY ("no CLOSED issue on a `- [ ]` line"), not a snapshot |
-| Offline-skip guard treated as real protection | Guard exits 0 + notice when `gh` is unavailable/unauth | Sandboxed CI runners have no `gh` auth — so the guard SKIPS in exactly the environment CI runs in, giving ZERO protection and FALSE confidence | An offline-skipping guard is near-worthless in default CI. Prefer a committed fixture file diffed offline, OR run the check only in a job that has a token. Document the gap honestly |
-| Assert on every `#NNN` of an unchecked line | Treated each issue number on a `- [ ]` line as "claimed open" | Wave-3 lines bundle multiple issues; a line legitimately stays `[ ]` while one child is CLOSED — mis-fires (e.g. on PR-C / PR-E batches) | Restrict the property to lines with a SINGLE issue number, or parse a per-issue ✅ annotation; do not assert on bundled lines |
-| Cite the justfile wire-in point by line number | Referenced `justfile:73` / `:76` and the `check: lint validate` recipe by line | Line numbers were read live but are brittle and drift on any edit above them | Cite the recipe NAME (`check`) and grep for it; never hard-code a line number |
+| Live-`gh` regression guard (R0 primary; now DEMOTED) | Guard queried `gh issue view <n> --json state` at test time and SKIPed (exit 0 + `::notice::`) when `gh` was unavailable/unauthenticated | The required-CI runner has no issue-read token, so the guard SKIPs to a no-op in EXACTLY the environment CI runs in — ZERO protection and false confidence. It is also non-deterministic / network-dependent | Do not assert via a live runtime API call. Apply `code-quality-enforcement-gates` §5: assert the property via STATIC analysis (a committed EXPECT table diffed offline). No network, no auth, no SKIP path |
+| Scan every `#NNN` on an unchecked line (R0 refinement) | Treated each issue number on a `- [ ]` line as "claimed open"; flagged any CLOSED `#NNN` on an unchecked line | Bundle lines (one PR row shipping several issues) legitimately stay `[ ]` while a child is already CLOSED — mis-fired on PR-C / PR-E batches | Derive ONE stable key per line (leading `#NNN`, else `PR-X`, else phrase) and look up that single key. A closed child inside an open bundle is never tested because the bundle is keyed once, as `[ ]`-expected |
+| Snapshot which specific boxes are ticked | Test asserted literal `- [x]` positions / a fixed list of ticked items | Breaks on the next legitimate doc edit — false regression noise | Assert the invariant via the EXPECT table (key -> expected char), not a positional snapshot |
+| Trust the triggering issue body's wave grouping / OPEN-CLOSED claims | Accepted #183's body buckets and CLOSED/OPEN annotations as authoritative | The body grouped #112 under the wrong wave; #112 was already CLOSED. Body annotations drift like the doc itself | Re-derive each box from ground truth; the issue body is a self-report. (`code-quality-enforcement-gates` §10) |
+| Treat the invariant table as freshness against GitHub | Assumed a passing EXPECT-table test means the doc matches live issue state | The table is HAND-MAINTAINED: it enforces file-vs-table consistency, NOT file-vs-live-GitHub. If a human flips neither the checkbox nor the table entry when an issue closes, the test passes but the doc is stale | Be honest: this guard trades freshness-detection for determinism. Add a SEPARATE non-required tokened nightly job to diff the table against live `gh` and open an issue on drift (future enhancement, not part of this required guard) |
+| Assume keys are always unique | Keyed each line by its leading token without checking for collisions | If two lines share a leading token (two `PR-C` rows, or one `#NNN` leading two lines) the SEEN/table mapping collapses — last write wins, coverage is lost silently | Verify keys are distinct for the target file (25 distinct keys here). It is a structural assumption; a duplicate-key pre-check would harden it |
+| Cite the justfile wire-in point by line number | Referenced `justfile:73` / `:76` for the `check` recipe | Line numbers are read live but drift on any edit above them | Cite the recipe NAME (`check`) and grep for it; never hard-code a line number |
 
 ## Results & Parameters
 
-**Ground-truth facts captured this session (ProjectProteus):**
+**Local test execution this session (the basis for `verified-local`):**
 
-| Issue | Live state (`gh issue view`) | Note |
-|-------|------------------------------|------|
+| Fixture | Scenario | Result |
+|---------|----------|--------|
+| matching | every line's char matches EXPECT (incl. open `PR-C` bundle with a closed child) | PASS, exit 0 |
+| drift | `#84` is CLOSED (expect `[x]`) but doc has `[ ]` | FAIL — `key '#84' expected [x] but doc has [ ]` |
+| new line | a `#999` line not present in EXPECT | FAIL — `__MISSING__` sentinel |
+| deleted line | `#112` line removed from the doc | FAIL — EXPECT key `#112` never SEEN |
+
+**Ground-truth facts captured (ProjectProteus):**
+
+| Issue | Live state | Note |
+|-------|------------|------|
 | #183 | OPEN | The triggering follow-up issue (the tracking-doc fix) |
 | #112 | CLOSED | Mis-grouped under the wrong wave by #183's body; caught by per-issue verification |
+| #84  | CLOSED | dispatch host contract fixed |
+| #85  | CLOSED | Trivy gate restored |
 
 **Target doc:** `docs/audit-2026-04-28/remediation-plan.md` (ProjectProteus).
 **Aggregate task to wire into:** justfile `check` recipe (cite by name, not line).
@@ -142,20 +200,17 @@ echo "remediation-plan checkboxes consistent with live issue state"
 **The invariant the guard enforces (state it explicitly in the script header):**
 
 ```text
-For every tracking-doc line carrying exactly one issue reference #N:
-  state(#N) == CLOSED  =>  the line is checked   ( - [x] )
-  state(#N) == OPEN    =>  the line is unchecked  ( - [ ] )
-Lines bundling >1 issue are EXEMPT from the simple property (refine before asserting).
+For every tracked line, derive ONE stable key K (leading #NNN, else PR-X, else phrase):
+  EXPECT[K] must exist (else __MISSING__ violation), and
+  actual_checkbox_char(line) == EXPECT[K]            (else drift violation)
+And every K in EXPECT must be SEEN at least once     (else deleted/renamed violation)
+This is file-vs-TABLE consistency, enforced statically and offline.
+It is NOT freshness against live GitHub state (see Failed Attempts — add a separate
+non-required tokened nightly drift job for that).
 ```
-
-**Stronger alternative a reviewer should weigh (the offline-skip gap is real):** instead of (or in
-addition to) the live-API guard, snapshot the expected per-issue states into a COMMITTED fixture file
-and diff against it offline — this provides protection in sandboxed CI where `gh` auth is absent. Or
-gate the live check to a CI job that is granted a token. Do not present the offline-skipping guard as
-full protection.
 
 ## Verified On
 
 | Project | Context |
 |---------|---------|
-| ProjectProteus | issue #183 remediation-plan checkbox sync (PLAN ONLY — unverified). Per-issue `gh` verification caught #112 mis-grouped under the wrong wave (#112 CLOSED, #183 OPEN). Doc edit + guard + CI not executed |
+| ProjectProteus | issue #183 remediation-plan checkbox guard, R1 re-plan. Replaced the R0 live-`gh` guard (NOGO: offline-SKIP gave zero CI protection; committed artifact failed its own test) with a committed-fixture invariant table. Embedded test logic executed locally: PASS on a matching fixture, FAIL on drift / new-line / deleted-line fixtures as designed. Consuming-repo CI not run — `verified-local` |


### PR DESCRIPTION
## Summary

Amends `tracking-doc-checkbox-sync-regression-guard` from v1.0.0 to **v2.0.0** (major — the recommended design flips). R1 (re-plan) of ProjectProteus issue #183; the R0 plan (v1.0.0, PR #2673, merged) got a NOGO. R1 solves the two flaws R0 flagged but left unsolved.

- **Replaces the live-`gh` regression guard with a committed-fixture INVARIANT TABLE.** An embedded `declare -A EXPECT=([key]=state ...)` is diffed against each line's checkbox char — no network, no `gh`, no auth, no SKIP path, deterministic everywhere (including required-CI runners with no issue-read token).
- **Keys each line by its STABLE PRIMARY TOKEN** (leading `#NNN` / `PR-X` / phrase), not by scanning every `#NNN`, so an open bundle line with a closed child never false-FAILs.
- **Bidirectional coverage cross-checks** via a SEEN set: `__MISSING__` sentinel for new untracked lines; never-SEEN failure for deleted/renamed lines.
- Direct application of `code-quality-enforcement-gates` §5 (assert the property via static analysis, NOT a live runtime check) and §10 (verify findings vs ground truth) — cross-links retained.
- Previous v1.0.0 archived in `tracking-doc-checkbox-sync-regression-guard.history`.

## Verification Level

**verified-local** — the embedded EXPECT-table test logic was executed this session: PASS (exit 0) on a fixture matching the table (including an open `PR-C` bundle line with a closed child), and FAIL — as designed — on three negative fixtures (checkbox drift, a new untracked line via `__MISSING__`, a deleted line via never-SEEN). No network/`gh`/auth involved, so the run is deterministic. The consuming repo's (ProjectProteus) CI was not run, hence `verified-local` not `verified-ci`.

## Key Findings

**What Worked**:
- Committed invariant table that PASSES its own test deterministically — removes the R0 disqualifier (R0's committed artifact failed the test it shipped).
- Single-key-per-line derivation eliminates the bundle-line false-FAIL.

**What Failed (demoted to Failed Attempts)**:
- Live `gh issue view` guard → SKIPs to a no-op in unauthenticated required CI (zero protection) and is non-deterministic.
- Scanning every `#NNN` on a line → false-FAILs on bundle rows with a closed child.

**Honest caveat recorded**: the hand-maintained table enforces file-vs-table consistency, NOT freshness against live GitHub. A separate non-required tokened nightly drift job is suggested as a future complement.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (454/454 valid)
- [x] Execute embedded EXPECT-table logic against pass + 3 negative fixtures
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>