### PR TITLE
feat: add atlas dockerfile/embed + dependent-issue planning skills

### DIFF
--- a/skills/atlas-dashboard-dockerfile-embed-distroless.md
+++ b/skills/atlas-dashboard-dockerfile-embed-distroless.md
@@ -1,0 +1,94 @@
+---
+name: atlas-dashboard-dockerfile-embed-distroless
+description: "Package a Go HTTP service into a tiny distroless image with assets baked in via //go:embed. Use when: (1) writing a Dockerfile/.dockerignore/Makefile for a Go service that must ship static web assets inside the binary, (2) targeting gcr.io/distroless/static:nonroot (no shell, nonroot UID, non-privileged port) with a ≤30MB image budget, (3) injecting a build-time version string when .dockerignore excludes .git so `git describe` cannot run inside the build."
+category: ci-cd
+date: 2026-06-20
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags:
+  - atlas
+  - dashboard
+  - go
+  - docker
+  - dockerfile
+  - go-embed
+  - embed-fs
+  - distroless
+  - dockerignore
+  - ldflags
+  - git-describe
+  - build-arg
+  - multi-stage
+  - nonroot
+---
+
+# Atlas Dashboard: Dockerfile + embed.FS + distroless Packaging (M1)
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-20 |
+| **Objective** | Plan ProjectArgus issue #153 "[atlas][M1] Dockerfile + embed.FS + distroless runtime" — add Dockerfile/.dockerignore/Makefile and `//go:embed` wiring on top of the #152 chi-server skeleton |
+| **Outcome** | PLAN ONLY — never executed; no `docker build` run, no CI green. Captured for the next implementer. |
+| **Verification** | unverified (plan only — never built or run in CI) |
+
+## When to Use
+
+- Writing a `Dockerfile` for a Go HTTP service whose static web assets must live **inside** the binary (no `COPY web/` at runtime).
+- Targeting `gcr.io/distroless/static:nonroot` and you need to satisfy: no shell, nonroot UID, non-privileged port, static-binary-only copy.
+- The issue spec asks for a `git describe`-derived version but a correct `.dockerignore` excludes `.git`.
+- You hit a build where a `Dockerfile` `ARG` is unexpectedly empty in a later `FROM` stage.
+- You need to keep a Go container image small (≤30MB) and are deciding between `embed.FS` vs. copying an assets directory.
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```bash
+# 1. embed: web/ MUST be a sibling of the .go file holding the directive
+#    cmd/argus-dashboard/main.go  +  cmd/argus-dashboard/web/...
+#    //go:embed web         <- legal
+#    //go:embed ../web      <- ILLEGAL (no parent refs)
+fs.Sub(assets, "web/static")   # serve /static/ from embedded web/static/
+
+# 2. Compute version on the HOST (Makefile), NOT inside the Dockerfile,
+#    because .dockerignore excludes .git -> `git describe` cannot run in-build.
+VERSION := $(shell git describe --tags --always 2>/dev/null || echo dev)
+docker build --build-arg VERSION=$(VERSION) -t argus-dashboard .
+
+# 3. Re-declare ARG in EVERY stage that consumes it (ARG does not cross FROM).
+# 4. distroless:nonroot -> bind a non-privileged port (3002 OK), no shell-form healthcheck.
+```
+
+### Detailed Steps
+
+1. **Embed lives next to the directive file; no parent references.** `//go:embed web` only works when `web/` is a sibling of the `.go` file that contains the directive. Place embedded assets at `cmd/argus-dashboard/web/...` next to `main.go`. `//go:embed ../web` is a compile error — embed patterns cannot escape the directive file's directory. Serve the static route by sub-rooting the FS: `sub, _ := fs.Sub(assets, "web/static"); mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(sub))))`.
+2. **Multi-stage Dockerfile, version via `--build-arg`, `git describe` on the host.** A correct `.dockerignore` excludes `.git`, so any `RUN git describe` inside the build context fails (no `.git`). Resolve the issue spec's `-X version.Version=$(git describe ...)` contradiction by: (a) computing `git describe --tags --always` in the **Makefile** on the host, (b) passing it as `ARG VERSION` (default `dev`), (c) consuming it in `-ldflags "-X .../version.Version=$VERSION"`.
+3. **Re-declare `ARG VERSION` in each `FROM` stage that uses it.** A `Dockerfile` `ARG` declared before the first `FROM` (or in the builder stage) is **not** visible in a later stage; an undeclared `ARG` expands to empty silently — the version becomes blank with no error. Add `ARG VERSION` immediately after each `FROM ... AS <stage>` that references `$VERSION`.
+4. **Respect the distroless:nonroot runtime constraints.** `gcr.io/distroless/static:nonroot` has no shell (no shell-form `HEALTHCHECK`, no entrypoint scripts — use exec-form or an in-binary `/healthz` handler), runs as a nonroot UID (bind a non-privileged port like 3002, never <1024), and contains only what you `COPY` — so you copy a single static binary. This is exactly **why** `embed.FS` is required: there is no place to `COPY web/` and have it served, and the embedded assets are what keep the image ≤30MB.
+5. **Drop `-ldflags -X` if no version package exists in the upstream skeleton.** If #152 did not create a `version` package, `-X version.Version=...` references a non-existent symbol. Fall back to building without the `-X` flag (or add a minimal `internal/version` package) rather than failing the build.
+
+## Verified Workflow
+
+_Not applicable._ This skill was captured from a planning session and is `unverified`: the Dockerfile/embed plan was never built and no CI ran, so there is no verified workflow. The actionable, hypothesis-level mechanics live under **Proposed Workflow** above and must be treated as unvalidated until CI confirms them. (This placeholder section exists only because `scripts/validate_plugins.py` requires the literal `## Verified Workflow` heading; it intentionally makes no verification claim.)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| 1 | Followed the issue spec literally: `RUN ... -X version.Version=$(git describe --tags --always)` inside the Dockerfile build. | A correct `.dockerignore` excludes `.git`, so `git describe` has no repo to read inside the build context — the spec is self-contradictory. | Compute `git describe` on the HOST in the Makefile and pass it via `--build-arg VERSION=` (default `dev`); never run `git describe` inside the build. |
+| 2 | Placed embedded assets at repo-root `web/` and wrote `//go:embed ../web` in `cmd/argus-dashboard/main.go`. | `//go:embed` patterns are relative to the directive file's directory and cannot reference parent directories — compile error. | Put `web/` as a sibling of the `.go` file holding the directive (`cmd/argus-dashboard/web/`); serve via `fs.Sub(assets, "web/static")`. |
+| 3 | Declared `ARG VERSION` once before the first `FROM` and used `$VERSION` in the final runtime stage. | `ARG` does not cross `FROM` boundaries; an undeclared `ARG` in a later stage expands to empty with no error — version silently blank. | Re-declare `ARG VERSION` immediately after each `FROM ... AS <stage>` that consumes it. |
+| 4 | Planned a shell-form `HEALTHCHECK CMD curl ...` and copied `web/` into the final image. | `distroless:nonroot` has no shell and copies only the static binary — shell healthcheck cannot run and `COPY web/` assets would not be served from the binary. | Use an in-binary `/healthz` handler (exec-form check), bind a non-privileged port (3002), and rely on `embed.FS` instead of `COPY web/` to stay ≤30MB. |
+
+## Results & Parameters
+
+- **Status:** Implementation plan for ProjectArgus issue #153; not executed. No image was built, no size measured, no CI confirmed.
+- **Target image:** `gcr.io/distroless/static:nonroot`, size budget ≤30MB, runtime port 3002 (non-privileged).
+- **Key paths (hypothesis, pending #152 verification):** `cmd/argus-dashboard/main.go`, `cmd/argus-dashboard/web/static/...`, `Dockerfile`, `.dockerignore`, `Makefile`.
+- **Build invocation:** `docker build --build-arg VERSION=$(git describe --tags --always 2>/dev/null || echo dev) -t argus-dashboard .`
+- **Unverified assumptions (must check before building):** module path in `go.mod`, existence of a `version` package, location of the `web/` directory, whether `atlas.css`/`/healthz` already exist from #152. See the companion skill `planning-dependent-issue-unverified-upstream` for the verification methodology.

--- a/skills/planning-dependent-issue-unverified-upstream.md
+++ b/skills/planning-dependent-issue-unverified-upstream.md
@@ -1,0 +1,85 @@
+---
+name: planning-dependent-issue-unverified-upstream
+description: "Plan an issue whose dependency has not yet shipped, so the upstream's real interface is unknown. Use when: (1) writing an implementation plan for issue B that builds on a not-yet-merged issue A (e.g. B adds a Dockerfile on top of A's server skeleton), (2) you are tempted to hardcode the upstream's module path / function signature / directory layout into your plan, (3) the repo on disk does not yet contain the dependency's output and you must avoid baking unverified assumptions into 'Files to Modify'."
+category: architecture
+date: 2026-06-20
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags:
+  - planning
+  - dependent-issue
+  - unverified-dependency
+  - upstream-interface
+  - verify-before-planning
+  - fallbacks
+  - assumptions
+  - milestone
+---
+
+# Planning a Dependent Issue When the Upstream Output Is Unverified
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-20 |
+| **Objective** | Plan ProjectArgus issue #153 (atlas M1 Dockerfile/embed) which DEPENDS on #152 (creates the Go module + chi server skeleton) — but #152's actual output was not yet on disk at plan time |
+| **Outcome** | PLAN ONLY — never executed. The methodology (front-load dependency verification + inline fallbacks) is the durable learning. |
+| **Verification** | unverified (plan only — never executed or CI-confirmed) |
+
+## When to Use
+
+- You are writing an implementation plan for an issue that explicitly depends on another, not-yet-merged issue.
+- The dependency's concrete output (module path, exported function signatures, directory layout, helper packages) is described in prose but not yet present on disk.
+- You catch yourself about to write the upstream's interface (e.g. `server.New(...)`, a module path, a `web/` location) into your plan as fact.
+- The repo today is a different shape than your plan assumes (e.g. config-only, no `go.mod`, `find . -name '*.go'` is empty).
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```bash
+# STEP 1 of the implementation order is ALWAYS "verify the dependency's real output":
+head -1 dashboard/go.mod                 # actual module path (don't hardcode it)
+find dashboard -type d -name web         # where the embed source actually lives
+ls dashboard/internal/version 2>&1       # does a version package exist?
+grep -rn 'func New' dashboard/...        # real server.New signature, if any
+ls dashboard/.../atlas.css 2>&1          # does the asset the issue assumes exist?
+
+# Then state a FALLBACK inline next to every assumption:
+#   - no version package -> drop `-ldflags -X version.Version=...`
+#   - no atlas.css       -> create a minimal one
+#   - no /healthz        -> add the handler in this issue
+```
+
+### Detailed Steps
+
+1. **Make Step 1 of the implementation order "verify the dependency's actual output."** Do not begin with your own changes. Front-load concrete verification commands that read the upstream's real interface from disk: `head -1 <module>/go.mod` for the module path, `find <dir> -type d -name web` for the embed source location, `ls`/`grep` for any package or asset the issue assumes. At plan time for #153 the repo was config-only — `find . -name '*.go'` was empty and there was no `go.mod` — so EVERY interface detail was a hypothesis, not a fact.
+2. **Never hardcode the upstream's interface into the plan.** Treat `server.New(...)`'s signature, the module path, and the `web/` directory location as values to be discovered, not constants to be typed. Write the plan so the implementer fills them in from Step 1's output, e.g. "use the module path from `head -1 go.mod`" rather than "the module is `github.com/.../argus`".
+3. **State a conditional fallback inline next to every assumption.** For each thing the upstream might not have produced, write the if/then directly in the step: if no `version` package, drop the `-ldflags -X version.Version=...` flag; if `atlas.css` is missing, add a minimal one in this issue; if `/healthz` was not wired by the dependency, add the handler here. This keeps the plan executable even when the dependency's output differs from prose.
+4. **Label the plan's verification level honestly as `unverified`.** Because the dependency was never confirmed and nothing was built, the plan is a hypothesis. Mark it `unverified` and use a "Proposed Workflow" framing — do not claim a verified workflow for a plan that could not even compile against a non-existent upstream.
+5. **Separate the dependency-verification risk as the top stated risk.** The single largest risk in a dependent-issue plan is that the upstream shipped a different interface than assumed. Call this out explicitly as the #1 risk so reviewers and implementers re-check it first.
+
+## Verified Workflow
+
+_Not applicable._ This skill was captured from a planning session and is `unverified`: the dependent-issue plan was never executed and the upstream dependency (#152) was never confirmed, so there is no verified workflow. The actionable, hypothesis-level methodology lives under **Proposed Workflow** above and must be treated as unvalidated until CI confirms it. (This placeholder section exists only because `scripts/validate_plugins.py` requires the literal `## Verified Workflow` heading; it intentionally makes no verification claim.)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| 1 | Wrote the upstream #152's `server.New(...)` signature directly into the #153 plan's "Files to Modify". | #152 was not merged and its real signature was unknown; the repo on disk had no `go.mod` and no `.go` files, so the hardcoded interface was a guess. | Never hardcode an unverified upstream interface; make "discover it from disk" Step 1 and reference the discovered value. |
+| 2 | Assumed the embed source `web/` already existed at a known path from #152. | The directory layout #152 would produce was unconfirmed, and `//go:embed` is path-sensitive — a wrong assumed path makes the plan uncompilable. | Add `find <dir> -type d -name web` as a verification step before writing the embed path into the plan. |
+| 3 | Assumed `atlas.css` and a `version` package existed because the issue mentioned them. | The issue described intended end-state, not guaranteed upstream output; either could be absent, breaking the `-ldflags -X` build or the static route. | State inline fallbacks: drop `-X version.Version` if no version package; create a minimal `atlas.css`/`/healthz` if absent. |
+| 4 | Labeled the plan as a confident, ready-to-execute workflow. | Nothing was built and the dependency was unverified — the plan could not compile against a non-existent upstream. | Mark dependent-issue plans `unverified` and frame them as a "Proposed Workflow" hypothesis until CI confirms the dependency's real shape. |
+
+## Results & Parameters
+
+- **Status:** Methodology distilled from the implementation plan for ProjectArgus issue #153 (depends on #152); plan never executed.
+- **Repo state at plan time:** config-only — `find . -name '*.go'` empty, no `go.mod`; every upstream interface detail was a hypothesis.
+- **Verification-first commands:** `head -1 <module>/go.mod`, `find <dir> -type d -name web`, `ls internal/version`, `grep -rn 'func New'`, `ls .../atlas.css`.
+- **Top stated risk:** the dependency (#152) ships a different interface than assumed — re-verify before implementing.
+- **Companion skill:** `atlas-dashboard-dockerfile-embed-distroless` covers the concrete Dockerfile/embed/distroless mechanics of the same issue.


### PR DESCRIPTION
## Summary
New skills capturing planning learnings from issue #153 (atlas M1: Dockerfile + embed.FS + distroless).

## Verification Level
**unverified** — these are PLANNING learnings; the plan was never executed end-to-end and no CI confirmed it.

## Key Findings
- go:embed path is relative to the .go file dir; parent refs illegal
- git describe in ldflags conflicts with .dockerignore excluding .git → use --build-arg
- ARG does not cross FROM; re-declare per stage
- Planning a dependent issue: front-load dependency verification + inline fallbacks; never hardcode upstream interface

## Test Plan
- [ ] Validate with `python3 scripts/validate_plugins.py`
- [ ] Verify skills appear in marketplace

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>