### PR TITLE
skill(meta-repo-build-root-pattern): amend with Atlas #154 planning reviewer-risk catalogue (v1.2.0)

### DIFF
--- a/skills/meta-repo-build-root-pattern.history
+++ b/skills/meta-repo-build-root-pattern.history
@@ -1,5 +1,24 @@
 # meta-repo-build-root-pattern — History
 
+## v1.2.0 (2026-06-20)
+
+**Changed by:** Planning session for Odysseus issue #154 (Atlas dashboard Compose registration + justfile targets). Plan only — NOT executed.
+**Verification:** unverified (plan only, no code run, no CI)
+
+### What changed
+- Added 3 Failed Attempts rows capturing planning lessons:
+  1. Re-adding `atlas-review-dispatch`/`atlas-review-aggregate` recipes verbatim from the issue #154 snippet — they already existed at justfile:704-709, causing a hard `just` duplicate-recipe parse error. An issue's fenced code block is a desired END STATE, not a literal diff.
+  2. Assuming the `dashboard/` build context exists — it is delivered by the still-OPEN dependency issue #153, so verification must be scoped to structure-only.
+  3. Re-declaring `NATS_URL`/`AGAMEMNON_URL` in `.env.example` with different (compose-service-name) values — dotenv last-wins silently overrides the earlier cross-host Tailscale values.
+- Added a "Reviewer-risk / planning learnings (unverified)" subsection cataloguing the 6 most-uncertain assumptions in the #154 plan (env-key collision, #153 dependency contract, line-number drift, distroless wget/healthcheck risk, `depends_on` condition support, 15-vs-19 env-count mismatch).
+- Added project-agnostic meta planning lessons (issue snippet = end state; distroless makes shell/wget healthchecks suspect; sibling-issue claims are UNVERIFIED).
+- Bumped minor version 1.1.0 -> 1.2.0. Existing verified-local content kept intact.
+
+### Why
+The #154 plan was written but never executed. The durable value is the reviewer-risk catalogue plus the concrete planning lesson that an issue body's snippet can instruct you to ADD recipes/env keys that already exist, producing duplicate-definition errors. This skill already owns Odysseus root/submodule justfile orchestration, so it is the correct home.
+
+---
+
 ## v1.1.0 (2026-03-29)
 
 **Changed by:** Odysseus full e2e build session — all 5 targets passing

--- a/skills/meta-repo-build-root-pattern.md
+++ b/skills/meta-repo-build-root-pattern.md
@@ -3,11 +3,11 @@ name: meta-repo-build-root-pattern
 description: "Orchestrate out-of-tree CMake builds in a meta-repo justfile without importing build tool dependencies into the root pixi.toml. Use when: (1) adding a just build recipe to a meta-repo that coordinates multiple C++/CMake submodules, (2) redirecting all build artifacts into a single root build/ directory, (3) the meta-repo should stay lean — each submodule manages its own pixi environment."
 category: architecture
 date: 2026-03-29
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 verification: verified-local
 history: meta-repo-build-root-pattern.history
-tags: [cmake, justfile, meta-repo, build-root, out-of-tree, pixi, submodule, mojo]
+tags: [cmake, justfile, meta-repo, build-root, out-of-tree, pixi, submodule, mojo, compose, dashboard, planning, reviewer-risk]
 ---
 
 # Meta-Repo BUILD_ROOT Pattern for CMake Submodules
@@ -77,6 +77,28 @@ clean:
 | Add cmake/ninja to root pixi.toml | Added `cmake`, `ninja`, `cxx-compiler` as root-level pixi dependencies | Violates meta-repo principle: Odysseus should not own build tool deps — each submodule manages its own pixi env | Root `pixi.toml` is for meta-repo tooling only (just, gh, etc.). Submodule build tools stay in each submodule's `pixi.toml`. |
 | Override CMake binaryDir in CMakePresets.json | Set `binaryDir` in submodule's CMakePresets.json to `${sourceDir}/../../build/${sourceDirName}` | CMake presets `binaryDir` is relative to sourceDir; path traversal with `../..` is unreliable and not portable | Use `cmake -S <srcdir> -B <external_builddir>` at the call site. The `-B` CLI flag always overrides presets. |
 | Pass BUILD_ROOT through just -d delegation | Called `just -d <submodule_path> build BUILD_ROOT=<root>/build/<Name>` hoping sub-repo justfile would use it | Sub-repo justfiles don't declare a BUILD_ROOT variable; the override is silently ignored | Call cmake directly from the meta-repo justfile rather than delegating through the submodule's own build recipe. |
+| Re-adding recipes verbatim from the issue snippet (#154 planning, unverified) | The issue #154 body listed `atlas-review-dispatch`/`atlas-review-aggregate` in the justfile snippet to show the full target set | Those recipes ALREADY existed at justfile:704-709 — adding them again is a hard `just` duplicate-recipe parse error | An issue's code snippet is a desired END STATE, not a literal diff. grep each recipe/env key for prior existence before adding; treat the snippet as illustrative. |
+| Assuming `dashboard/` build context exists (#154 planning, unverified) | Plan references `build: ./dashboard`, volume `../../shared/ProjectMnemosyne/skills`, and `scripts/atlas-review-*.sh` | The `dashboard/` dir does NOT exist yet — it is created by the dependency issue #153 (still OPEN) | `docker compose config` validates structure but cannot build until the dependency merges; scope verification to structure-only and state the dependency explicitly. |
+| Re-declaring `NATS_URL`/`AGAMEMNON_URL` in `.env.example` (#154 planning, unverified) | Added the issue's 15-entry Atlas block which re-lists keys already present (lines 21,25) with different (cross-host Tailscale) values | Not a build failure, but a SILENT-OVERRIDE risk: dotenv last-assignment-wins means the later Atlas block (service-name defaults) overrides the earlier cross-host values for any consumer that loads the whole file | When an env block duplicates existing keys with different values, call out the override explicitly; don't assume "harmless". |
+
+## Reviewer-risk / planning learnings (unverified)
+
+> **Proposed planning catalogue — verification level: `unverified`.** Captured while writing an implementation plan for Odysseus issue #154 (Atlas dashboard Compose registration + justfile targets). The plan was NOT executed: no code run, no `just`/`docker compose` parse, no CI. The verified-local workflow above is unaffected; the items below are uncertain assumptions a reviewer must confirm before this plan is trusted.
+
+When wiring a new Compose service + justfile targets into the Odysseus meta-repo from an issue snippet, catalogue these most-uncertain assumptions:
+
+1. **`.env.example` key collision.** A new env block re-declaring `NATS_URL`/`AGAMEMNON_URL` with compose-service-name values overrides the existing cross-host Tailscale values via dotenv last-wins. Confirm no consumer (e.g. `e2e/start-crosshost.sh`) sources the whole file and breaks.
+2. **Sibling-issue dependency contract.** Build context `./dashboard`, volume source `../../shared/ProjectMnemosyne/skills`, the `tests/e2e` Go layout, `templ`/`golangci-lint` tooling, and `scripts/atlas-review-*.sh` are ALL assumed delivered by the OPEN dependency #153 — none verified to exist. If #153's actual layout differs, the compose block, `dashboard-test`, `dashboard-gen`, and the existing `atlas-review-*` recipes break.
+3. **Line-number drift.** Cited line numbers (justfile:289-290 argus-start, :704-709 atlas-review, docker-compose.yml:179, argus justfile:80, .env.example:48) were read once and may drift — re-grep before editing.
+4. **Distroless + wget healthcheck.** A healthcheck array form like `["CMD","wget","-qO-",...]` is structurally safe (single binary, matches existing services), but a **distroless** runtime image (per the #153 "distroless runtime" title) may LACK `wget`, making the healthcheck always fail. Confirm `wget`/busybox exists in the runtime image — a REAL unverified risk.
+5. **`depends_on: { condition: service_healthy }`.** Requires the dependency services to define healthchecks (verified for prometheus/argus-exporter) AND the compose runtime to support condition syntax — podman-compose support is version-dependent.
+6. **Env-count mismatch in acceptance criterion.** The criterion counts "15 entries" but the compose service references ~19 env vars (LISTEN_ADDR, NESTOR_URL, HERMES_URL, EXPORTER_URL, WORKER_HOST_IP, CONTROL_HOST_IP not all in the .env block) — confirm "15" matches the documented set, not the full compose env surface.
+
+### Meta planning lessons (project-agnostic)
+
+- An issue body's fenced code block is a target END STATE, not an apply-this-diff. Grep for prior existence of every recipe name and env key before adding; verbatim addition risks duplicate-definition errors (a hard `just` parse failure for recipes).
+- A "distroless runtime" dependency makes shell/wget-based healthchecks suspect — flag the busybox/wget availability assumption whenever the image is distroless.
+- When a plan depends on an unmerged sibling issue, every path/layout/tooling claim sourced from that sibling is an assumption to label UNVERIFIED, not a fact.
 
 ## Results & Parameters
 


### PR DESCRIPTION
## Summary

Amends the existing `meta-repo-build-root-pattern` skill (v1.1.0 -> v1.2.0) with planning learnings from writing the implementation plan for Odysseus issue #154 (Atlas dashboard Compose registration + justfile targets). The plan was **NOT executed** — verification level is `unverified`.

This skill already owns Odysseus root/submodule justfile orchestration, so it is the correct home (no new skill created).

## What changed

- **3 Failed Attempts rows** (planning lessons):
  - Re-adding `atlas-review-dispatch`/`atlas-review-aggregate` verbatim from the issue snippet — they already existed at justfile:704-709, a hard `just` duplicate-recipe parse error. An issue snippet is a desired END STATE, not a diff.
  - Assuming the `dashboard/` build context exists — it is delivered by the still-OPEN dependency #153.
  - Re-declaring `NATS_URL`/`AGAMEMNON_URL` in `.env.example` with different values — dotenv last-wins silent override.
- **New "Reviewer-risk / planning learnings (unverified)" subsection** cataloguing the 6 most-uncertain assumptions (env-key collision, #153 contract, line-number drift, distroless wget/healthcheck risk, `depends_on` condition support, 15-vs-19 env-count mismatch).
- **Project-agnostic meta lessons** (issue snippet = end state; distroless makes shell/wget healthchecks suspect; sibling-issue claims are UNVERIFIED).

## Honesty

Verification: `unverified` (plan only, no code run, no CI). Existing verified-local content kept intact. Prior version snapshotted in `.history`.

## Validation

`python3 scripts/validate_plugins.py` -> 464/464 valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)