### PR TITLE
feat: amend planning-validator-ci-gate-tasks skill (v1.1.0)

### DIFF
--- a/skills/planning-validator-ci-gate-tasks.history
+++ b/skills/planning-validator-ci-gate-tasks.history
@@ -1,0 +1,122 @@
+# planning-validator-ci-gate-tasks — History
+
+## v1.1.0 (2026-06-20)
+
+**Changed by:** Re-plan of Odysseus issue #198 ("No unit or integration tests for justfile recipes or configs"). The FIRST plan (which produced v1.0.0, PR #2701) was NOGO'd; this revision fixed every finding AND, critically, RAN the candidate validators locally during planning, converting the v1.0.0 "uncertain assumptions" into empirically verified facts.
+**Verification:** verified-local (the empirical claims below were verified by local execution; the full plan/CI was NOT yet run end-to-end)
+
+### What changed
+
+The core upgrade is epistemic: v1.0.0 flagged a set of UNVERIFIED tool-flag/coverage
+assumptions and told the implementer to confirm them in step 1. This round actually ran
+them, so they graduate from "open assumption" to "confirmed fact," and the recommended
+design changed as a result.
+
+1. **CONFIRMED: an authoritative validator CLI fails on VALID input.** v1.0.0 only
+   SUSPECTED `nats-server -t` semantics were unreliable. Running it confirmed:
+   `nats-server -c configs/nats/server.conf -t` exits **1 on a perfectly valid config**
+   because it eagerly opens TLS cert files (`/etc/nats/certs/server-cert.pem`) absent in
+   CI/dev. The "authoritative" syntax checker conflates syntax errors with runtime
+   resource errors and is USELESS as a CI gate. New rule: two-sided check at PLAN time
+   (good->0 AND bad->nonzero), not just bad->nonzero.
+
+2. **NEW recommended design: binary-free pure-Python validators are the robust default.**
+   Because nats-server/podman/nomad are not installed on the GitHub runners (and `-t` is
+   unreliable even when present), the winning design is stdlib + PyYAML validators: a
+   HOCON brace/string-balance checker for NATS `.conf`, and `yaml.safe_load` + structural
+   assertions for docker-compose. Runs on any runner with python3 — the required gate is
+   never vacuous. Directly defeats the dead-gate/vacuous-pass failure mode
+   (cross-link ci-hygiene-and-validation-gates Pattern 4).
+
+3. **NEW lesson: naive brace-balance is wrong without comment+string handling, and the
+   validator itself needs a negative test.** First brace counter gave a false PASS on
+   broken input because `#` comments containing apostrophes ("server's") flipped the
+   string state machine and `{{` was miscounted. Fix: line-by-line, break at first
+   UNQUOTED `#`, track quote state with escape handling — and run it against an
+   injected-broken fixture, confirming non-zero, or it ships broken.
+
+4. **CONFIRMED symbol name:** v1.0.0's invented `exit_with_status` does not exist; the real
+   helper is `exit_code()` at `e2e/lib/common.sh:41` (verified by reading the file).
+
+5. **NEW lesson: CI tooling presence is part of the gate's correctness.** The revision had
+   to add `setup-just` and `pip install pyyaml` to the `integration-tests` job (which had
+   neither). The `build` job already had yamllint (PyYAML) so `validate-configs` gains
+   coverage free. For every new CI step, enumerate its binaries/modules and confirm the
+   target job installs them.
+
+6. **NEW lesson: commit negative tests as permanent TDD assets, not inline cp/restore.**
+   Reviewer dinged the first plan's inline `cp server.conf /tmp; printf broken; restore`
+   snippet. Fix: a committed `tests/test-config-validators.sh` with positive + negative
+   cases importing the validators' `check()` functions.
+
+- Added 4 new Failed Attempts rows (trusted `nats-server -t` as a syntax gate; naive brace
+  counter false PASS; invented `exit_with_status`; added validator steps to a job lacking
+  the tool).
+- Re-titled the canonical steps as a genuine "Verified Workflow" for the VALIDATOR BEHAVIOR
+  (locally verified), while keeping the broader PLAN steps marked proposed — the Overview
+  states this distinction explicitly.
+- Bumped frontmatter `verification: unverified -> verified-local`; version 1.0.0 -> 1.1.0;
+  added `history:` field; date 2026-06-20.
+
+### Why
+
+The first #198 plan was NOGO'd. The durable, reusable value of the revision is that the
+previously-uncertain "trust the vendor CLI's check flag" assumption was empirically
+DISPROVEN (it fails on valid input due to cert loading), which flips the recommended design
+to binary-free Python structural validators. Recording the confirmed behavior (with the
+exact exit code, the cert path, and the comment-apostrophe brace-counter bug) prevents the
+whole class of "I'll just wire `<tool> --check` into a required gate" mistakes.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: planning-validator-ci-gate-tasks
+description: "Planning-phase risk assessment for 'add a build-free validator' tasks in a submodule meta-repo, where the validator shells out to an external CLI (nats-server, podman/docker compose, nomad) and gets wired into a pinned required CI gate. Captures the recurring uncertain assumptions a reviewer must check: (1) TOOL-FLAG SEMANTICS are the #1 risk — you cannot trust that `nats-server -c <f> -t` means 'test config and exit' or that `podman compose config -q` parses without a running daemon/images; either verify the exact flag at plan time (`<tool> --help | grep`) or label it an explicit unverified assumption the implementer confirms in step 1; (2) GRACEFUL-SKIP-WHEN-TOOL-ABSENT is mandatory to mirror existing conventions (the `nomad`-absent skip) BUT it creates a VACUOUS/DEAD-GATE hazard — a validator that skips when the binary is missing gives ZERO coverage if the enforcing CI runner lacks that binary, so for EACH skip branch the planner must answer 'does the required CI environment actually have this tool installed?'; (3) a repo-wide FORBID-SUPPRESSIONS gate (pre-commit `forbid-or-true` + `_required.yml` forbid-suppressions) rejects `|| true`, `continue-on-error: true`, and `::warning::` — draft every validator error branch with explicit `if`-guards from the start, never silence failures; (4) PINNED required-check contexts (`_required.yml` job `name:` values referenced in the org/repo ruleset JSON) must be STRENGTHENED IN PLACE, never renamed or split into a new job — grep the ruleset for pinned contexts and reuse an existing job; (5) editing `.github/workflows/*` may be blocked by a security hook — plan a Python read->replace->write fallback; (6) UNVERIFIED SYMBOLS in a sourced shared lib (e.g. an `exit_with_status`/`exit_with_failure_count` function in `e2e/lib/common.sh` whose tail was never read) must be confirmed on disk in step 1. Use when: planning to add a config-syntax or compose-validity validator, a justfile-recipe integrity test, strengthening `just validate-configs`, or wiring any new build-free check into a canonical `_required.yml` gate in a meta-repo. Cross-link: ci-hygiene-and-validation-gates (implementation: dead-gate detection + build-free check mechanics, esp. Pattern 4), justfile-and-local-build-verification (implementation: recipe authoring + local verify loop), planning-verify-issue-claims-and-required-check-gating (runs-vs-gates + grep-the-claim), planning-verify-assumptions-before-enforcement-gate (verify infra assumptions + git-ls-files scan scope)."
+category: ci-cd
+date: 2026-06-20
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [planning, planning-methodology, validator, ci-gate, config-validation, meta-repo, tool-availability, flag-semantics, graceful-skip, vacuous-pass, dead-gate, forbid-suppressions, no-op-suppression, pinned-context, required-status-check, strengthen-in-place, workflow-edit-hook, unverified-symbol, nats-server, compose-config, build-free, unverified-assumptions]
+---
+
+# Planning: Risk Assessment for "Add a Build-Free Validator + CI Gate" Tasks
+
+Verification level: unverified — planning learning only. The plan was NOT executed, the
+validators were NOT run, CI did NOT run. Every "ASSUMPTION" was an open reviewer/implementer
+task to confirm in step 1, not a verified fact. Key unverified items at v1.0.0:
+- `nats-server -c <f> -t` ASSUMED to mean "test config and exit" (NOT run).
+- `podman/docker compose config -q` ASSUMED parse-only without daemon/images (NOT run).
+- Whether `nats-server` is installed in the `_required.yml` integration-tests runner (NOT confirmed).
+- The failure-count->exit-code helper in `e2e/lib/common.sh` plan-named `exit_with_status`
+  (only lines 13-40 read; tail UNread; name/signature UNVERIFIED).
+
+Seven proposed-workflow disciplines: (1) verify tool-flag semantics or mark unverified;
+(2) for every graceful-skip branch confirm the enforcing CI runner has the tool, else
+dead/vacuous gate; (3) draft error branches with explicit if-guards, never `|| true`/
+`continue-on-error`/`::warning::` (forbid-suppressions gate); (4) strengthen pinned
+required-check contexts IN PLACE, never rename/split (grep `gh api .../rulesets`); (5) plan
+a Python pathlib read->replace->write fallback for hook-blocked `.github/workflows/*` edits;
+(6) confirm every symbol sourced from a shared lib exists on disk; (7) honesty gate — a
+planning-only learning is `unverified`, "## Verified Workflow" heading kept only to satisfy
+the validator.
+
+Six v1.0.0 Failed Attempts: drafted `nats-server -t` from memory; drafted `|| true` error
+branch; assumed graceful-skip == coverage; considered a new dedicated CI job (would not be a
+pinned context); planned a direct workflow edit with no fallback; referenced
+`exit_with_status` sight-unread.
+
+Verified On: HomericIntelligence/Odysseus issue #198 planning — unverified, planning session
+only; validators not run, CI not run.
+```
+
+---
+
+## v1.0.0 (2026-06-20)
+
+**Initial version.** Planning-phase risk assessment for "add a build-free validator + CI
+gate" tasks in the Odysseus submodule meta-repo (issue #198), captured at `unverified`
+level: tool-flag semantics, vacuous/dead-gate hazard, forbid-suppressions gate, pinned
+required-check contexts, workflow-edit hook fallback, and unverified sourced-lib symbols —
+all as open implementer assumptions. Created via PR #2701.

--- a/skills/planning-validator-ci-gate-tasks.md
+++ b/skills/planning-validator-ci-gate-tasks.md
@@ -1,11 +1,12 @@
 ---
 name: planning-validator-ci-gate-tasks
-description: "Planning-phase risk assessment for 'add a build-free validator' tasks in a submodule meta-repo, where the validator shells out to an external CLI (nats-server, podman/docker compose, nomad) and gets wired into a pinned required CI gate. Captures the recurring uncertain assumptions a reviewer must check: (1) TOOL-FLAG SEMANTICS are the #1 risk — you cannot trust that `nats-server -c <f> -t` means 'test config and exit' or that `podman compose config -q` parses without a running daemon/images; either verify the exact flag at plan time (`<tool> --help | grep`) or label it an explicit unverified assumption the implementer confirms in step 1; (2) GRACEFUL-SKIP-WHEN-TOOL-ABSENT is mandatory to mirror existing conventions (the `nomad`-absent skip) BUT it creates a VACUOUS/DEAD-GATE hazard — a validator that skips when the binary is missing gives ZERO coverage if the enforcing CI runner lacks that binary, so for EACH skip branch the planner must answer 'does the required CI environment actually have this tool installed?'; (3) a repo-wide FORBID-SUPPRESSIONS gate (pre-commit `forbid-or-true` + `_required.yml` forbid-suppressions) rejects `|| true`, `continue-on-error: true`, and `::warning::` — draft every validator error branch with explicit `if`-guards from the start, never silence failures; (4) PINNED required-check contexts (`_required.yml` job `name:` values referenced in the org/repo ruleset JSON) must be STRENGTHENED IN PLACE, never renamed or split into a new job — grep the ruleset for pinned contexts and reuse an existing job; (5) editing `.github/workflows/*` may be blocked by a security hook — plan a Python read→replace→write fallback; (6) UNVERIFIED SYMBOLS in a sourced shared lib (e.g. an `exit_with_status`/`exit_with_failure_count` function in `e2e/lib/common.sh` whose tail was never read) must be confirmed on disk in step 1. Use when: planning to add a config-syntax or compose-validity validator, a justfile-recipe integrity test, strengthening `just validate-configs`, or wiring any new build-free check into a canonical `_required.yml` gate in a meta-repo. Cross-link: ci-hygiene-and-validation-gates (implementation: dead-gate detection + build-free check mechanics, esp. Pattern 4), justfile-and-local-build-verification (implementation: recipe authoring + local verify loop), planning-verify-issue-claims-and-required-check-gating (runs-vs-gates + grep-the-claim), planning-verify-assumptions-before-enforcement-gate (verify infra assumptions + git-ls-files scan scope)."
+description: "Planning-phase risk assessment for 'add a build-free validator + required CI gate' tasks in a submodule meta-repo, NOW WITH LOCALLY-VERIFIED findings that overturn the naive design. The headline (EMPIRICALLY CONFIRMED this round): an authoritative-looking validator CLI can FAIL ON VALID INPUT — `nats-server -c <f> -t` exits 1 on a perfectly valid config because it eagerly loads TLS cert files (`/etc/nats/certs/server-cert.pem`) that do not exist in CI/dev, conflating syntax errors with runtime resource errors; before adopting `<tool> --check`/`-t` as a gate, run it TWO-SIDED at plan time (known-good -> 0 AND known-bad -> nonzero), not just bad->nonzero. Because nats-server/podman/nomad are not installed on the GitHub runners (and `-t` is unreliable even when present), the WINNING DESIGN is binary-free pure-Python validators (stdlib + PyYAML): a HOCON brace/string-balance checker for NATS `.conf` and `yaml.safe_load` + structural assertions for docker-compose — these run on any runner with python3 so the required gate is never vacuous (defeats the dead-gate failure mode). Also captured: naive brace-balance gives FALSE PASS without comment+string handling (a `#` comment with an apostrophe flips the quote state machine; `{{` is miscounted) so process line-by-line, break at first UNQUOTED `#`, track quote/escape state, AND give the validator its own committed negative test; the real failure-count->exit-code helper in `e2e/lib/common.sh:41` is `exit_code()` (NOT the invented `exit_with_status` — read the sourced lib for the exact name); CI tooling presence is part of the gate's correctness (the integration-tests job needed `setup-just` + `pip install pyyaml` added or the new steps are a dead gate); commit negative tests as permanent TDD assets (`tests/test-config-validators.sh`), not inline cp/restore. Still applies: forbid-suppressions gate (no `|| true`/`continue-on-error`/`::warning::`), strengthen pinned `_required.yml` contexts IN PLACE never rename/split, Python read->replace->write fallback for hook-blocked workflow edits. Use when: planning to add a config-syntax/compose-validity validator, a justfile-recipe integrity test, strengthening `just validate-configs`, or wiring any new build-free check into a canonical `_required.yml` gate in a meta-repo — especially when tempted to shell out to a vendor CLI's `--check`/`-t` flag. Cross-link: ci-hygiene-and-validation-gates (dead-gate detection + build-free mechanics, esp. Pattern 4), justfile-and-local-build-verification (recipe authoring + local verify loop), planning-verify-issue-claims-and-required-check-gating (runs-vs-gates + grep-the-claim), planning-verify-assumptions-before-enforcement-gate (verify infra assumptions + git-ls-files scan scope)."
 category: ci-cd
 date: 2026-06-20
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
-verification: unverified
+verification: verified-local
+history: planning-validator-ci-gate-tasks.history
 tags:
   - planning
   - planning-methodology
@@ -28,7 +29,12 @@ tags:
   - nats-server
   - compose-config
   - build-free
-  - unverified-assumptions
+  - python-validator
+  - pyyaml
+  - hocon-brace-balance
+  - two-sided-validation
+  - tdd-negative-test
+  - tool-install-in-job
 ---
 
 # Planning: Risk Assessment for "Add a Build-Free Validator + CI Gate" Tasks
@@ -38,179 +44,222 @@ tags:
 | Field | Value |
 | ------- | ------- |
 | **Date** | 2026-06-20 |
-| **Objective** | Capture the PLANNING-PHASE risk profile for "add a build-free validator" work in a submodule meta-repo (HomericIntelligence/Odysseus), where the validator shells out to an external CLI and is wired into a pinned, canonical `_required.yml` CI gate. This is a planning-quality skill: it enumerates the recurring UNCERTAIN ASSUMPTIONS a plan of this shape repeatedly gets wrong, and the discipline that resolves each one. |
-| **Outcome** | A PLAN (not executed code) for Odysseus issue #198 ("No unit or integration tests for justfile recipes or configs"): add a NATS config-syntax validator (`nats-server -c <f> -t`), a docker-compose validity validator (`podman/docker compose -f <f> config -q`), a justfile-recipe integrity test sourcing `e2e/lib/common.sh`, strengthen `just validate-configs`, and wire the checks into the canonical `_required.yml` gate by STRENGTHENING the existing weak NATS step inside the already-pinned `integration-tests` job (not adding a new job). |
-| **Verification** | **unverified** — this is a PLANNING learning. The plan was NOT executed, the validators were NOT run, and CI did NOT run. Every "ASSUMPTION" below is an open reviewer/implementer task to confirm in step 1, not a verified fact. |
+| **Objective** | Capture the PLANNING-PHASE risk profile for "add a build-free validator + required CI gate" work in a submodule meta-repo (HomericIntelligence/Odysseus, issue #198), AND — new this round — record the findings that were EMPIRICALLY VERIFIED by running the candidate validators locally during planning. v1.0.0 listed uncertain assumptions; v1.1.0 upgrades the load-bearing ones into confirmed facts and changes the recommended design accordingly. |
+| **Outcome** | RE-PLAN (the first plan was NOGO'd) for issue #198 ("No unit or integration tests for justfile recipes or configs"). The verified winning design: BINARY-FREE pure-Python validators (HOCON brace/string-balance for NATS `.conf`; `yaml.safe_load` + structural assertions for docker-compose), committed `tests/test-config-validators.sh` (positive + negative), strengthen `just validate-configs`, strengthen the existing NATS step IN PLACE inside the pinned `integration-tests` job, and ADD `setup-just` + `pip install pyyaml` to that job so the steps actually run. |
+| **Verification** | **verified-local** — the VALIDATOR BEHAVIOR claims were confirmed by local execution during planning: good configs pass, injected-broken fixtures fail, and the `nats-server -c configs/nats/server.conf -t` exit-1-on-valid-config misbehavior was reproduced. The FULL PLAN and CI were NOT executed end-to-end; the broader plan/CI-wiring steps remain proposed. |
 | **Category** | ci-cd / planning |
-| **History** | none (initial version) |
+| **History** | [changelog](./planning-validator-ci-gate-tasks.history) |
 
-> **Verification note:** Nothing in this skill was executed end-to-end. In particular, the tool-flag semantics (`nats-server -t`, `compose config -q`), the presence of `nats-server` in the `_required.yml` integration-tests runner, and the exact name of the "return exit code from failure count" function in `e2e/lib/common.sh` were NOT confirmed by execution at plan time. Treat each as an explicit unverified assumption.
+> **Verified vs proposed — read this distinction.** What is `verified-local` is the
+> **validator behavior**: the pure-Python brace/YAML validators were run (known-good
+> configs -> pass; injected-broken fixtures -> non-zero), and the failure of
+> `nats-server -t` on a VALID config (exit 1 due to missing TLS certs) was reproduced
+> firsthand. What remains **proposed** is the full implementation plan and its CI run —
+> the `_required.yml` wiring has not been executed in CI. The "Verified Workflow" section
+> below describes the locally-verified validator-design facts; treat the broader
+> plan-execution steps as proposed until CI confirms.
 
 ## When to Use
 
-- Planning to add a **build-free validator** (config-syntax check, compose-validity check, recipe-integrity test) that shells out to an external CLI such as `nats-server`, `podman`/`docker compose`, or `nomad`.
-- Planning to **strengthen an existing `just validate-configs`-style recipe** or add a new lint/validate recipe.
-- Planning to wire any new check into a **canonical / pinned `_required.yml` CI gate** in a meta-repo.
-- The plan **sources a shared shell lib** (e.g. `e2e/lib/common.sh`) and depends on a helper function whose definition you have not fully read.
-- The repo has a **silent-failure-forbidding gate** (`forbid-suppressions` / `forbid-or-true`) and you are about to draft validator error branches.
-- You are about to add or rename a **CI job `name:`** that may be pinned as a required status-check context in the org/repo ruleset.
-
-## Proposed Workflow
-
-> **Warning:** This workflow has NOT been validated end-to-end. It is a PLANNING methodology captured at `unverified` level — the plan was never executed and CI never ran. Treat every step as a hypothesis and every "ASSUMPTION" as an open task to confirm before relying on it.
-
-> **Heading note:** The repository validator (`scripts/validate_plugins.py`) hard-requires the literal section string `## Verified Workflow`, so the canonical steps are emitted under that heading to keep validation green. Read the steps as **proposed**, per the warning above.
+- Planning to add a **build-free validator** (config-syntax check, compose-validity check,
+  recipe-integrity test) — ESPECIALLY when tempted to shell out to a vendor CLI's
+  `--check`/`-t`/`config -q` flag as the gate.
+- Planning to **strengthen an existing `just validate-configs`-style recipe** or add a new
+  lint/validate recipe.
+- Planning to wire any new check into a **canonical / pinned `_required.yml` CI gate** in a
+  meta-repo where the validating binaries (nats-server, podman, nomad) are NOT installed on
+  the runner.
+- You are about to trust `<tool> --check` / `<tool> -t` as a CI gate and have not run it
+  against a KNOWN-GOOD input.
+- You are writing a **structural validator** (brace balance, YAML shape) and need to know it
+  requires comment/string handling and its own negative test.
+- The plan **sources a shared shell lib** (e.g. `e2e/lib/common.sh`) and depends on a helper
+  function whose exact name you have not confirmed on disk.
 
 ## Verified Workflow
 
-> **Warning:** This workflow has NOT been validated end-to-end. Treat as a hypothesis until CI confirms. The "Verified Workflow" heading exists only to satisfy the marketplace validator; the actual verification level is `unverified` (see frontmatter and the warning banner above).
+> **Verified-local scope:** the validator-design facts below (two-sided check outcome,
+> `nats-server -t` failing on valid input, the brace-counter false-PASS, the `exit_code()`
+> symbol name) were confirmed by local execution. The CI-wiring steps that depend on a full
+> CI run remain proposed until CI confirms.
 
 ### Quick Reference
 
 ```bash
-# 1. TOOL-FLAG SEMANTICS — the #1 risk for "add a validator". Verify the exact flag at plan time,
-#    OR mark it an explicit unverified assumption the implementer confirms in step 1.
-#    Do NOT assume `-t` means "test config and exit" or `config -q` parses without a daemon.
-nats-server --help 2>&1 | grep -iE -- '-t|--test|config'        # confirm the "check & exit" flag
-podman compose --help 2>&1 | grep -iE -- 'config'               # confirm `config -q` is parse-only
-docker compose config --help 2>&1 | grep -iE -- 'quiet|-q'      # version-dependent; pin it
+# 0. TWO-SIDED CHECK before trusting any vendor "test config" flag as a gate.
+#    VERIFIED THIS ROUND: nats-server -t exits 1 on a PERFECTLY VALID config because it
+#    eagerly opens TLS cert files that don't exist in CI/dev. It is USELESS as a syntax gate.
+nats-server -c configs/nats/server.conf -t; echo "exit=$?"   # -> exit=1 on a VALID config!
+#    (fails loading /etc/nats/certs/server-cert.pem — a RUNTIME resource error, not a syntax error)
+#    RULE: a check flag is trustworthy only if known-good -> 0 AND known-bad -> nonzero.
+#    Many "config test" flags also OPEN referenced resources (certs, sockets, remote URLs).
 
-# 2. VACUOUS-PASS / DEAD-GATE check — graceful-skip is mandatory BUT must not be a dead gate.
-#    For EACH skip branch, answer: does the ENFORCING CI runner actually have this binary?
-command -v nats-server >/dev/null || { echo "skip: nats-server absent"; }   # mirrors existing nomad skip
-#    THEN grep the workflow that defines the required job to confirm the tool is installed there:
-grep -nE 'nats-server|apt-get install|setup-.*nats|container:' .github/workflows/_required.yml
-#    If the runner lacks the binary, the new required check is a DEAD GATE (zero coverage).
+# 1. WINNING DESIGN — binary-free pure-Python validators (stdlib + PyYAML). Run on ANY
+#    runner with python3, so the required gate is never vacuous (defeats the dead-gate mode).
+#    NATS .conf: HOCON brace/string balance, comment- and quote-aware (see step 3 below).
+#    compose:   yaml.safe_load + assert services is a non-empty mapping; each service a mapping.
+python3 -c "import yaml,sys; d=yaml.safe_load(open('e2e/compose.yml')); \
+  s=d.get('services'); assert isinstance(s,dict) and s, 'services must be non-empty mapping'; \
+  assert all(isinstance(v,dict) for v in s.values()), 'each service must be a mapping'"
 
-# 3. FORBID-SUPPRESSIONS — never emit `|| true`, `continue-on-error: true`, or `::warning::`.
-#    Read the gate's regex BEFORE drafting; write explicit if-guards from the start.
+# 2. CI TOOLING PRESENCE is part of the gate's correctness. The integration-tests job had
+#    NEITHER just NOR pyyaml — add both or the new steps are a dead gate.
+#      - uses: extractions/setup-just@<pin>
+#      - run: pip install pyyaml
+#    (the build job already had yamllint -> PyYAML, so validate-configs gets coverage free)
+
+# 3. STRUCTURAL VALIDATOR NEEDS comment+string handling AND its own negative test.
+#    A naive brace counter gave a FALSE PASS: a `#` comment containing an apostrophe
+#    ("server's") flipped the string state machine, and `{{` was miscounted.
+#    Fix: line-by-line, break at the FIRST UNQUOTED `#`, track quote state with escape handling.
+bash tests/test-config-validators.sh   # positive (real configs) + negative (unbalanced brace,
+                                        # non-mapping services) -> MUST exit non-zero on broken
+
+# 4. CONFIRM the exact sourced-lib symbol. The real helper is exit_code(), NOT exit_with_status.
+grep -nE '^[a-z_]+\(\)' e2e/lib/common.sh   # -> exit_code() at line 41 (read the WHOLE file)
+
+# 5. FORBID-SUPPRESSIONS still applies — explicit if-guards, never `|| true`/continue-on-error.
 grep -nE 'forbid|or-true|continue-on-error|suppress' .pre-commit-config.yaml .github/workflows/_required.yml
-#    BAD : nats-server -c "$f" -t || true
-#    GOOD: if ! nats-server -c "$f" -t; then echo "FAIL: $f"; rc=1; fi
 
-# 4. PINNED CONTEXTS — strengthen in place, never rename/split. Grep the ruleset for pinned names.
-gh api repos/<org>/<repo>/rulesets --jq '.[].id' | while read id; do
+# 6. PINNED CONTEXTS — strengthen in place; never rename/split (grep the ruleset first).
+gh api repos/<org>/<repo>/rulesets --jq '.[].id' | while read id; do \
   gh api repos/<org>/<repo>/rulesets/$id \
-    --jq '.rules[]?|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'
-done
-#    Reuse an EXISTING pinned job (e.g. integration-tests); renaming/splitting bricks the merge queue.
+    --jq '.rules[]?|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'; done
 
-# 5. WORKFLOW-EDIT may be hook-blocked — plan a Python read->replace->write fallback up front.
+# 7. WORKFLOW-EDIT may be hook-blocked — Python read->replace->write fallback.
 python3 - <<'PY'
 import pathlib; p=pathlib.Path(".github/workflows/_required.yml")
 s=p.read_text(); s=s.replace("<old weak step>","<strengthened step>"); p.write_text(s)
 PY
-
-# 6. UNVERIFIED SYMBOLS in a sourced lib — confirm the helper exists and its name/signature.
-grep -nE 'exit_with_status|exit_with_failure_count|^[a-z_]+\(\)' e2e/lib/common.sh   # read the WHOLE file
 ```
 
 ### Detailed Steps — the discipline a plan of this shape needs
 
-1. **Verify tool-flag semantics, or flag them as unverified — this is the #1 planning risk.**
-   When a validator shells out to an external CLI, the exact "check config and exit" flag and
-   its no-daemon behavior are version-dependent and NOT trustworthy from memory. The plan assumed
-   `nats-server -c <f> -t` is the correct "test config and exit" invocation and that
-   `podman compose config -q` parses without a running daemon or pulled images — NEITHER was
-   verified by execution. EITHER run `<tool> --help | grep` during planning to confirm the flag,
-   OR write the assumption into the plan explicitly as "implementer must confirm in step 1." Both
-   `nats-server -t` and `compose config -q` are plausible but pinned-version-dependent.
+1. **Two-sided-verify any vendor "test config" flag before trusting it as a gate
+   (VERIFIED).** v1.0.0 only SUSPECTED `nats-server -t` semantics. This round CONFIRMED by
+   running it: `nats-server -c configs/nats/server.conf -t` exits **1 on a perfectly valid
+   config** because it eagerly loads TLS cert files (`/etc/nats/certs/server-cert.pem`) that
+   do not exist in CI/dev. The "authoritative" syntax checker conflates syntax errors with
+   runtime RESOURCE errors and is useless as a CI gate. Before adopting any
+   `<tool> --check`/`-t`/`config -q` as a validation gate, run it against a KNOWN-GOOD input
+   and confirm exit 0 — many "config test" flags also OPEN referenced resources (certs,
+   sockets, remote URLs) and fail in sandboxed CI. Two-sided at PLAN time: good -> 0,
+   bad -> nonzero.
 
-2. **For every graceful-skip branch, answer "does the enforcing CI runner have this tool?"**
-   Mirroring the existing `nomad`-absent skip is the right convention for local dev. BUT a
-   validator that skips when the binary is absent provides ZERO coverage in a CI image that lacks
-   the binary — a "vacuous pass" / dead gate. The plan did NOT confirm whether `nats-server` is
-   installed in the `_required.yml` integration-tests runner; that is a real gap. For each skip
-   branch, grep the workflow that defines the required job and confirm the tool is installed
-   (`apt-get install`, a setup action, or a `container:` image that bundles it). A required check
-   that always skips on CI enforces nothing (ties to `ci-hygiene-and-validation-gates` Pattern 4:
-   a named required check that asserts nothing).
+2. **Default to binary-free Python validators for meta-repo config gates (VERIFIED design
+   choice).** Because nats-server/podman/nomad are NOT installed on the GitHub runners (and
+   `-t` is unreliable per step 1), the winning design is pure-Python validators using only
+   stdlib + PyYAML: a HOCON brace/string-balance checker for NATS `.conf`, and
+   `yaml.safe_load` + structural assertions (`services` is a non-empty mapping; each service
+   is a mapping) for docker-compose. These run on ANY runner with python3, so the required
+   gate is never vacuous. Prefer a small pure-language structural validator over shelling out
+   when (a) the CLI may be absent on the runner, or (b) the CLI's check mode touches external
+   resources. This directly DEFEATS the dead-gate/vacuous-pass mode (cross-link
+   `ci-hygiene-and-validation-gates` Pattern 4).
 
-3. **Draft error branches with explicit `if`-guards; never use `|| true` / `continue-on-error`.**
-   Repos with a silent-failure-forbidding gate (`forbid-suppressions` in `_required.yml` plus a
-   `forbid-or-true` pre-commit hook) reject `|| true`, `continue-on-error: true`, and `::warning::`.
-   The plan had to iterate its own snippets to remove `|| true`. Read the gate's literal regex
-   first, then author every validator failure path as an explicit `if ! cmd; then ...; rc=1; fi`
-   from the start — do not draft a suppression and "fix it later."
+3. **A structural validator needs comment+string handling AND its own negative test
+   (VERIFIED).** The first brace counter gave a false PASS on broken input because a `#`
+   comment containing an apostrophe ("server's") flipped the string state machine and `{{`
+   was miscounted. Fix: process line-by-line, break at the first UNQUOTED `#`, track quote
+   state with escape handling. A config-structure validator is itself code that needs a
+   negative test — the planning step must run it against an injected-broken fixture and
+   confirm non-zero, or it ships broken.
 
-4. **Strengthen pinned required-check contexts IN PLACE — never rename or split.** `_required.yml`
-   job `name:` values are pinned in the org/repo ruleset JSON; renaming a job (or moving a step
-   into a brand-new job) removes the pinned context and bricks the merge queue. The plan correctly
-   strengthened the weak NATS step INSIDE the existing `integration-tests` job rather than adding a
-   new job. Before touching CI, grep the ruleset JSON (`gh api .../rulesets`) for the pinned
-   contexts and reuse an existing required job (cross-link
-   `planning-verify-issue-claims-and-required-check-gating`: runs-vs-gates).
+4. **Confirm the exact symbol in a sourced lib before calling it (VERIFIED).** v1.0.0
+   invented `exit_with_status`; the real function is `exit_code()` at `e2e/lib/common.sh:41`
+   (verified by reading the file). When a test sources a shared bash lib, grep/read the lib
+   for the EXACT name (`summary`, `exit_code`, `pass`, `fail`) — never assume a plausible one.
 
-5. **Plan a Python read→replace→write fallback for `.github/workflows/*` edits.** Editing workflow
-   files may be blocked by a security hook. Decide up front that if a direct edit is refused, you
-   will apply the change via a small stdlib `pathlib` read/replace/write script, and write that
-   into the plan so the implementer is not stuck mid-execution.
+5. **CI tooling presence is part of the gate's correctness, not an afterthought.** The
+   revision had to add `setup-just` and `pip install pyyaml` to the `integration-tests` job
+   (which had neither) so the new steps actually run. The `build` job already had yamllint
+   (-> PyYAML), so `validate-configs` gains coverage free. For every new CI validation step,
+   enumerate the binaries/modules it needs and confirm the target job installs them — a step
+   in a job missing its tool is a dead gate.
 
-6. **Confirm every symbol you source from a shared lib exists on disk.** The plan sources
-   `e2e/lib/common.sh` and calls a "return exit code based on failure count" helper it named
-   `exit_with_status`, but only lines 13–40 were read — the tail was NOT read, so the name and
-   signature are UNVERIFIED. List it as an open step-1 confirmation. Read the WHOLE sourced file
-   before depending on a function from it.
+6. **Commit negative tests as permanent TDD assets, not ad-hoc cp/restore.** The reviewer
+   dinged the first plan for an inline `cp server.conf /tmp; printf broken; restore` snippet
+   in the verification section. Fix: a committed `tests/test-config-validators.sh` with
+   positive (real configs accepted) and negative (unbalanced brace, non-mapping `services`)
+   cases that import the validators' `check()` functions.
 
-7. **Honesty gate: a planning-only learning is `unverified`.** Because the plan was never executed
-   and CI never ran, the verification level is `unverified`: title the workflow section "Proposed
-   Workflow" with the warning banner (the literal "## Verified Workflow" heading is kept only to
-   satisfy the validator), and set frontmatter `verification: unverified`.
+7. **Still applies — forbid-suppressions, pinned-context, workflow-edit fallback.** Repos
+   with a `forbid-suppressions` gate (`_required.yml`) plus a `forbid-or-true` pre-commit
+   hook reject `|| true`, `continue-on-error: true`, and `::warning::`; author every failure
+   path as an explicit `if ! cmd; then echo FAIL; rc=1; fi`. `_required.yml` job `name:`
+   values are pinned in the org/repo ruleset JSON — strengthen the weak step IN PLACE inside
+   the pinned `integration-tests` job; never rename/split (it bricks the merge queue). And
+   plan a stdlib `pathlib` read->replace->write fallback in case a security hook blocks
+   editing `.github/workflows/*`.
+
+8. **Honesty gate: validator behavior is `verified-local`; the full plan/CI is not.** The
+   validators were RUN locally (good pass, broken fail, `nats-server -t` misbehavior
+   reproduced), so frontmatter is `verification: verified-local` and the workflow section is
+   genuinely "Verified Workflow" for the validator-design facts. The broader plan steps and
+   the `_required.yml` CI wiring were NOT executed in CI and remain proposed — the Overview
+   states this distinction.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | ------- | -------------- | ------------- | -------------- |
-| Drafted validator with `nats-server -c <f> -t` from memory | Assumed `-t` is the "test config and exit" flag and `podman compose config -q` parses without a daemon/images | Neither flag's semantics was verified by execution; both are version-dependent and may differ on the pinned toolchain | Verify the exact flag with `<tool> --help \| grep` at plan time, OR write it into the plan as an explicit unverified assumption the implementer confirms in step 1 |
-| Drafted validator error branch with `\|\| true` | Wrote `nats-server -c "$f" -t \|\| true` to keep the step "non-fatal" | The repo's `forbid-suppressions` (`_required.yml`) + `forbid-or-true` pre-commit hook reject `\|\| true`, `continue-on-error: true`, and `::warning::` | Read the suppression gate's regex first; author every failure path as an explicit `if ! cmd; then echo FAIL; rc=1; fi` from the start — never draft a suppression |
-| Assumed graceful-skip-when-tool-absent was sufficient coverage | Mirrored the existing `nomad`-absent skip for the new `nats-server` check | A skip-when-absent validator gives ZERO coverage if the ENFORCING CI runner lacks the binary — a vacuous/dead required gate; the plan never confirmed `nats-server` is installed in the `_required.yml` integration-tests runner | For each skip branch, grep the workflow defining the required job and confirm the tool is installed there; a required check that always skips on CI enforces nothing |
-| Considered adding a new dedicated CI job for the validators | Thought a clean separate job would be tidier than touching the existing step | `_required.yml` job `name:` values are pinned in the org/repo ruleset; a new job is not a required context (runs but does not gate) and renaming an existing one bricks the merge queue | Strengthen the weak step IN PLACE inside the already-pinned `integration-tests` job; grep `gh api .../rulesets` for pinned contexts before changing any CI job name |
-| Planned a direct edit to `.github/workflows/_required.yml` with no fallback | Assumed the workflow file could be edited directly | Editing `.github/workflows/*` may be blocked by a security hook, leaving the implementer stuck mid-execution | Plan a stdlib `pathlib` read→replace→write fallback up front and write it into the plan |
-| Referenced `exit_with_status` from `e2e/lib/common.sh` sight-unread | Named the "return exit code from failure count" helper and built the recipe-integrity test on it after reading only lines 13–40 | The function's existence, exact name, and signature were never confirmed — the file tail was not read | Read the WHOLE sourced lib before depending on a function; list the symbol as an explicit step-1 confirmation in the plan |
+| Trusted `nats-server -c <f> -t` as the syntax gate | Wired `nats-server -t` into the required check, assuming `-t` means "validate config syntax and exit 0 on valid input" | RAN it: it exits **1 on a perfectly VALID config** because it eagerly loads TLS cert files (`/etc/nats/certs/server-cert.pem`) absent in CI/dev — conflating syntax errors with runtime resource errors | Two-sided-verify any `<tool> --check`/`-t` at plan time (known-good -> 0 AND known-bad -> nonzero); many "config test" flags also OPEN referenced certs/sockets/URLs and fail in sandboxed CI |
+| Wrote a naive brace-balance counter for NATS `.conf` | Counted `{`/`}` across the whole file to decide HOCON balance | FALSE PASS on broken input: a `#` comment containing an apostrophe ("server's") flipped the string state machine, and `{{` was miscounted | Process line-by-line, break at the FIRST UNQUOTED `#`, track quote state with escape handling — and run the validator against an injected-broken fixture (must exit non-zero) before trusting it |
+| Referenced `exit_with_status` from `e2e/lib/common.sh` | Built the recipe-integrity test on a plausibly-named "return exit code from failure count" helper | The function does not exist — the real helper is `exit_code()` at `e2e/lib/common.sh:41` | grep/read the sourced lib for the EXACT symbol name; never assume a plausible function name |
+| Added validator steps to the integration-tests job as-is | Put the new `just`/PyYAML validator steps into the `integration-tests` job | That job had NEITHER `just` NOR PyYAML installed, so the steps would error or no-op — a dead gate | For every new CI step, enumerate its binaries/modules and confirm the target job installs them (add `setup-just` + `pip install pyyaml`); the `build` job already had yamllint -> PyYAML so it got coverage free |
+| Verified configs via inline `cp`/`printf broken`/restore | Demonstrated the validator catching a break with an ad-hoc `cp server.conf /tmp; printf broken; restore` snippet in the verification section | Reviewer rejected it as non-durable, mutating-a-tracked-file scaffolding | Commit a permanent `tests/test-config-validators.sh` with positive + negative cases importing the validators' `check()` functions (TDD asset, not throwaway) |
+| Drafted validator error branch with `\|\| true` | Wrote `<check> \|\| true` to keep the step "non-fatal" | The repo's `forbid-suppressions` (`_required.yml`) + `forbid-or-true` pre-commit hook reject `\|\| true`, `continue-on-error: true`, and `::warning::` | Author every failure path as an explicit `if ! cmd; then echo FAIL; rc=1; fi` from the start |
+| Considered adding a new dedicated CI job for the validators | Thought a clean separate job was tidier than touching the existing step | `_required.yml` job `name:` values are pinned in the org/repo ruleset; a new job is not a required context and renaming an existing one bricks the merge queue | Strengthen the weak step IN PLACE inside the already-pinned `integration-tests` job; grep `gh api .../rulesets` for pinned contexts first |
+| Planned a direct edit to `.github/workflows/_required.yml` with no fallback | Assumed the workflow file could be edited directly | Editing `.github/workflows/*` may be blocked by a security hook, leaving the implementer stuck | Plan a stdlib `pathlib` read->replace->write fallback up front |
 
 ## Results & Parameters
 
 - **Task shape:** add build-free validators + wire into a pinned `_required.yml` gate, in a
-  ~14-submodule meta-repo (HomericIntelligence/Odysseus, issue #198).
-- **Validators planned (all unverified flag semantics):**
-  - NATS config syntax: `nats-server -c <f> -t` (ASSUMED "test config and exit"; confirm flag).
-  - Compose validity: `podman compose -f <f> config -q` / `docker compose -f <f> config -q`
-    (ASSUMED parse-only, no daemon/images required; confirm `-q` exists on the pinned version).
-  - Justfile-recipe integrity test sourcing `e2e/lib/common.sh` (depends on an UNVERIFIED helper,
-    plan-named `exit_with_status`; confirm on disk in step 1).
+  ~14-submodule meta-repo (HomericIntelligence/Odysseus, issue #198). RE-PLAN — first plan
+  NOGO'd; this revision fixed every finding and locally RAN the candidate validators.
+- **VERIFIED facts (run locally during planning):**
+  - `nats-server -c configs/nats/server.conf -t` exits **1 on a VALID config** (loads
+    missing `/etc/nats/certs/server-cert.pem`) -> useless as a syntax gate.
+  - Pure-Python validators PASS the real configs and FAIL injected-broken fixtures.
+  - Naive brace counter false-PASSes on a `#`-comment apostrophe + `{{`; fixed with
+    comment/quote/escape handling.
+  - Real sourced-lib helper is `exit_code()` at `e2e/lib/common.sh:41` (not `exit_with_status`).
+- **Validators (binary-free, the verified winning design):**
+  - NATS `.conf`: HOCON brace/string-balance checker (stdlib only) — line-by-line, break at
+    first UNQUOTED `#`, quote+escape state machine.
+  - docker-compose: `yaml.safe_load` (PyYAML) + structural assertions (`services` non-empty
+    mapping; each service a mapping).
+  - Justfile-recipe integrity test sourcing `e2e/lib/common.sh`, using `exit_code()`.
+  - `tests/test-config-validators.sh`: committed positive + negative cases importing
+    `check()`.
   - Strengthen `just validate-configs` to invoke the above.
-- **CI wiring:** strengthen the existing weak NATS step INSIDE the already-pinned
-  `integration-tests` job in `_required.yml` — do NOT add a new job (a new job is not a required
-  context; renaming an existing one removes the pinned context and bricks the merge queue).
+- **CI wiring (proposed, not yet CI-run):** strengthen the existing weak NATS step IN PLACE
+  inside the already-pinned `integration-tests` job; ADD `setup-just` + `pip install pyyaml`
+  to that job so the steps run; the `build` job already has yamllint (PyYAML) so
+  `validate-configs` gains coverage free. Do NOT add a new job / rename the pinned one.
 - **Forbid-suppressions constraint:** `_required.yml` forbid-suppressions + pre-commit
-  `forbid-or-true` reject `|| true`, `continue-on-error: true`, `::warning::`. All validator error
+  `forbid-or-true` reject `|| true`, `continue-on-error: true`, `::warning::`. All error
   branches must be explicit `if`-guards.
-- **Graceful-skip convention:** mirror the existing `nomad`-absent skip — but EACH skip branch is a
-  potential vacuous/dead gate; the plan must confirm the enforcing CI runner has the tool installed.
-- **Workflow-edit fallback:** plan a Python `pathlib` read→replace→write in case a security hook
+- **Workflow-edit fallback:** Python `pathlib` read->replace->write in case a security hook
   blocks editing `.github/workflows/*`.
-- **Open reviewer/implementer tasks (step 1 of execution):** (a) exact `nats-server` "check & exit"
-  flag; (b) whether `compose config -q` parses without a daemon on the pinned version; (c) whether
-  `nats-server` is installed in the `_required.yml` integration-tests runner; (d) the real name of
-  the failure-count→exit-code helper in `e2e/lib/common.sh`.
-- **Verification level:** `unverified` — plan only; nothing executed, no CI run. Workflow section is
-  titled "Proposed Workflow" with a warning banner; the "## Verified Workflow" heading is retained
-  solely to satisfy `scripts/validate_plugins.py`.
+- **Verification level:** `verified-local` — validator behavior locally verified; full plan
+  and CI not yet executed end-to-end (the `_required.yml` wiring remains proposed).
 
 ### Related skills
 
-- `ci-hygiene-and-validation-gates` — IMPLEMENTATION patterns for build-free CI/pre-commit gates and
-  detecting/repairing a dead required gate (Pattern 4). THIS skill is the upstream PLANNING-phase
-  risk assessment; it does not duplicate that skill's implementation mechanics.
-- `justfile-and-local-build-verification` — IMPLEMENTATION patterns for justfile recipe authoring
-  and the local verify→fix→commit→PR loop. THIS skill plans the validator/recipe before it is built.
-- `planning-verify-issue-claims-and-required-check-gating` — runs-vs-gates distinction and the
+- `ci-hygiene-and-validation-gates` — IMPLEMENTATION patterns for build-free CI/pre-commit
+  gates and detecting/repairing a dead required gate (Pattern 4). THIS skill is the upstream
+  PLANNING-phase risk assessment; the binary-free Python validator finding here directly
+  feeds that skill's dead-gate avoidance.
+- `justfile-and-local-build-verification` — IMPLEMENTATION patterns for justfile recipe
+  authoring and the local verify->fix->commit->PR loop.
+- `planning-verify-issue-claims-and-required-check-gating` — runs-vs-gates distinction and
   grep-the-claim discipline for required status checks (the rulesets-API gating-reality check).
-- `planning-verify-assumptions-before-enforcement-gate` — verify infrastructure assumptions before
-  building a gate, and scope file scans with `git ls-files` (the index) so submodules drop out.
+- `planning-verify-assumptions-before-enforcement-gate` — verify infrastructure assumptions
+  before building a gate, and scope file scans with `git ls-files` so submodules drop out.
 
 ## Verified On
 
 | Project | Context | Details |
 | ------- | ------- | ------- |
-| HomericIntelligence/Odysseus | Issue #198 planning ("No unit or integration tests for justfile recipes or configs") | unverified — planning session only; validators not run, CI not run. All tool-flag semantics, CI-runner tool presence, and the `e2e/lib/common.sh` helper name are open step-1 confirmations, not verified facts. |
+| HomericIntelligence/Odysseus | Issue #198 RE-PLAN ("No unit or integration tests for justfile recipes or configs") | verified-local — validators RUN locally during planning: good configs pass, injected-broken fixtures fail, and `nats-server -c configs/nats/server.conf -t` reproduced exiting 1 on a valid config (missing TLS certs). Full plan and `_required.yml` CI wiring NOT yet executed in CI (proposed). Confirmed `e2e/lib/common.sh:41` is `exit_code()`. |


### PR DESCRIPTION
## Summary

Amends the existing `planning-validator-ci-gate-tasks` skill from **v1.0.0 -> v1.1.0**, upgrading its previously-uncertain planning assumptions into LOCALLY-VERIFIED facts after a re-plan of Odysseus issue #198 (the first plan was NOGO'd; this revision fixed every finding and ran the candidate validators locally).

- An authoritative-looking validator CLI can fail on VALID input: `nats-server -c configs/nats/server.conf -t` exits **1 on a perfectly valid config** because it eagerly loads TLS cert files (`/etc/nats/certs/server-cert.pem`) absent in CI/dev. Two-sided-verify any check flag (good->0 AND bad->nonzero).
- Winning design: binary-free pure-Python validators (stdlib + PyYAML) — HOCON brace/string-balance for NATS `.conf`, `yaml.safe_load` + structural assertions for compose. Runs on any python3 runner so the required gate is never vacuous.
- Naive brace-balance gives a false PASS without comment+string handling (a `#` comment with an apostrophe flips the quote state machine; `{{` miscounted) and needs its own committed negative test.
- Real sourced-lib helper is `exit_code()` at `e2e/lib/common.sh:41` (not the invented `exit_with_status`).
- CI tooling presence is part of the gate's correctness (`integration-tests` job needed `setup-just` + `pip install pyyaml`).
- Commit negative tests as permanent TDD assets, not inline cp/restore.

Prior v1.0.0 archived in `planning-validator-ci-gate-tasks.history` (full snapshot + changelog).

## Verification Level

**verified-local** — the validator BEHAVIOR was confirmed by local execution during planning (good configs pass, injected-broken fixtures fail, the `nats-server -t` exit-1-on-valid-config misbehavior reproduced). The full plan and `_required.yml` CI wiring were NOT executed end-to-end and remain proposed.

## Key Findings

**What Worked**:
- Binary-free pure-Python (stdlib + PyYAML) structural validators
- Comment/quote/escape-aware HOCON brace balance + a committed negative test
- Strengthening the pinned `integration-tests` job IN PLACE and installing its tools

**What Failed**:
- Trusting `nats-server -t` as a syntax gate -> exits 1 on valid config (missing certs)
- Naive brace counter -> false PASS from a comment apostrophe
- Inventing `exit_with_status` -> real name is `exit_code()`
- Adding validator steps to a job lacking `just`/PyYAML -> dead gate

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (472/472 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>