### PR TITLE
feat: amend planning-container-image-build-publish-meta-repo skill (v1.1.0)

### DIFF
--- a/skills/planning-container-image-build-publish-meta-repo.history
+++ b/skills/planning-container-image-build-publish-meta-repo.history
@@ -1,12 +1,37 @@
+# planning-container-image-build-publish-meta-repo — History
+
+## v1.1.0 (2026-06-20)
+
+**Changed by:** Round R1 of planning Odysseus issue #201 ("No container image build or publish workflow", MINOR/DRY). R0's plan got a NOGO (Grade C; 3 Major + 2 minor findings). R1 revised the plan and RESOLVED every finding, each now backed by DIRECT Odysseus repo inspection.
+**Verification:** unverified (the plan was still NEVER executed end-to-end — no image built/pushed, no CI run; only the individual findings are now repo-verified by inspection)
+
+### What changed
+- Bumped version 1.0.0 -> 1.1.0 (MINOR: new repo-verified findings + resolution patterns; no rewrite of the core thesis).
+- Added the `history:` frontmatter field pointing at this changelog.
+- Upgraded each R0 "uncertain assumption" into a "verified finding + resolution pattern", now anchored to concrete Odysseus evidence:
+  - **Required-check enforcement (the central NOGO).** Verified `configs/github/canonical-checks.md` defines a FIXED fleet-wide set of EXACTLY 8 required contexts (`lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync`) that all 15 repos must emit, and `configs/github/repo-ruleset.json` pins exactly those 8 bare contexts with `"integration_id": 15368`. RESOLUTION PATTERN: do NOT add a new "required" job for a repo-local policy check — fold the new validation as a STEP into the already-required `schema-validation` job (which already validates `.github/workflows/*.yml` + the ruleset JSON). Genuine per-PR enforcement, ZERO ruleset-JSON edits, fleet uniformity preserved.
+  - **Multi-arch audit.** Verified `e2e/single-container/Dockerfile:43` hardcodes `nats-server-v2.10.24-linux-amd64.tar.gz` (no TARGETARCH) -> arm64 leg provably fails. The other two owned Dockerfiles (`e2e/nats-loki-bridge/Dockerfile`, `e2e/Dockerfile.argus-exporter`) are `FROM python:3.11-slim` (multi-arch-capable). RESOLUTION: set `platforms` PER-IMAGE in the build matrix (pure-Python -> multi-arch; the amd64-binary image -> `linux/amd64` only) + a policy-test assertion the amd64-only image is never advertised arm64.
+  - **Third-party action SHAs.** RESOLUTION made concrete: resolve each via `gh api repos/docker/<action>/git/ref/tags/<tag> --jq '.object.sha'` (follow `.object.type==tag` -> `git/tags/<sha>` for annotated tags) IN-SESSION; add a policy test asserting every `uses:` is a 40-hex SHA (reject `@vX` and short SHAs).
+  - **ADR status.** Verified `docs/adr/template.md:3` and `docs/adr/008-nats-tls-encryption.md:3` both use `**Status:** Proposed`; CLAUDE.md mandates Proposed-until-merged. RESOLUTION: ship new ADRs Status: Proposed + a policy test asserting it.
+  - **Scope ambiguity.** RESOLUTION: surface the meta-repo-altitude scope as an explicit OPEN DECISION (options A/B) recorded as a *Proposed* ADR for the issue author to ratify at merge — do NOT silently narrow scope.
+  - **GHCR lowercase (confirmed from R0).** Assert `ghcr.io/homericintelligence` lowercase; reject the mixed-case org name in a policy test.
+- Added the META-lesson for re-planning: a NOGO of the form "the artifact you added doesn't actually achieve the stated effect (e.g. 'enforced')" is best closed by ATTACHING the new behavior to an EXISTING mechanism already known to have that effect (here: the already-required `schema-validation` job) rather than creating a parallel mechanism — plus a verification command that proves the attachment (the step lives inside the already-required job AND `configs/github/` is unchanged).
+- Added Failed Attempts rows for the R1 re-plan path and recast the resolutions as repo-verified.
+
+### Why
+R0 captured the six risks as OPEN/UNVERIFIED assumptions. R1 investigated each against the live Odysseus repo and resolved them, so the skill is amended (not duplicated) to upgrade every "uncertain assumption" into a "verified finding + resolution pattern". The overall plan OUTCOME remains unverified (never executed end-to-end), so `verification` stays `unverified`; the precision is: findings are repo-verified by inspection, the plan is not.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
 ---
 name: planning-container-image-build-publish-meta-repo
 description: "Planning-phase risk checklist for designing a container-image BUILD + PUBLISH workflow (ghcr.io, docker/build-push-action, multi-arch) in a git-SUBMODULE META-REPO that owns only a handful of Dockerfiles while delegating app images to submodule repos. This is the DIFFERENT search surface a plan REVIEWER reaches for — 'are this image-publish plan's assumptions verified?' — distinct from the release-workflow planning skill (tags/CHANGELOG/semver) and from the image-DIGEST-PINNING skill (consuming :latest in compose). Core thesis: an image-publish plan is full of assertions that look like decisions but are unverified guesses — the docker/* action SHAs, the ghcr.io namespace casing, multi-arch buildability of every Dockerfile, and whether a new required-check job is ACTUALLY enforced. Use when: (1) reviewing or writing a plan that adds a `.github/workflows/image-publish.yml` building owned Dockerfiles and pushing to ghcr.io, (2) a plan hard-codes docker/setup-qemu-action / setup-buildx-action / login-action / metadata-action / build-push-action SHAs with version comments WITHOUT a fresh `gh api` lookup, (3) a plan writes `ghcr.io/<org>` namespace casing without confirming GHCR's lowercase requirement against a real published package, (4) a plan promises `platforms: linux/amd64,linux/arm64` but a target Dockerfile hard-codes an amd64-only vendor download URL (e.g. `*-linux-amd64.tar.gz`), (5) a plan adds a job to a canonical `_required.yml` but does NOT also update the branch-protection ruleset JSON, (6) a plan sets a new ADR Status to 'Accepted' when the repo's CLAUDE.md says new ADRs start 'Proposed', (7) a plan decides to build ONLY meta-repo-owned images vs ALL fleet/submodule images and that altitude call is asserted, not justified."
 category: ci-cd
 date: 2026-06-20
-version: "1.1.0"
+version: "1.0.0"
 user-invocable: false
 verification: unverified
-history: planning-container-image-build-publish-meta-repo.history
 tags:
   - planning
   - planning-methodology
@@ -33,14 +58,6 @@ tags:
   - unverified-assumptions
   - ghcr-lowercase-namespace
   - dockerfile-arch-audit
-  - re-planning
-  - nogo-finding-resolution
-  - attach-to-existing-mechanism
-  - fixed-required-check-set
-  - per-image-platforms-matrix
-  - policy-test-assertions
-  - open-decision-not-silent-narrowing
-  - repo-verified-findings
 ---
 
 # Container Image Build/Publish Planning: Assumptions & Risks (Submodule Meta-Repo)
@@ -50,9 +67,8 @@ tags:
 | Field | Value |
 | ------- | ------- |
 | **Date** | 2026-06-20 |
-| **Objective** | Capture the durable PLANNING-PHASE risks surfaced while writing an implementation plan for Odysseus issue #201 ("No container image build or publish workflow") — a MINOR/DRY finding in a git-submodule meta-repo. The plan proposed an ADR (ghcr.io registry + tag scheme + promotion policy), a `.github/workflows/image-publish.yml` that builds ONLY the 3 e2e/test Dockerfiles Odysseus physically owns (delegating submodule app images to their own repos), a bash policy regression test, a `just` recipe, and per-PR enforcement. **R0** of the plan made several assertions that LOOKED like decisions but were unverified guesses. **R1** (this version) investigated each against the live Odysseus repo and RESOLVED them. |
-| **R0 → R1** | R0 got a NOGO (Grade C; 3 Major + 2 minor). R1 closed every finding, each now backed by DIRECT repo inspection: (1) the central NOGO — "a new `_required.yml` job is not actually enforced" — was closed by folding the new validation as a STEP into the already-required `schema-validation` job (8 fixed fleet-wide contexts pinned with `integration_id: 15368`; ZERO ruleset-JSON edits); (2) multi-arch promised but `e2e/single-container/Dockerfile:43` hardcodes `nats-server-...-linux-amd64.tar.gz` → per-image `platforms` matrix; (3) action SHAs resolved in-session via `gh api`; (4) ADR ships `Status: Proposed` per `docs/adr/template.md:3`; (5) scope ambiguity surfaced as an explicit OPEN DECISION (Proposed ADR), not silently narrowed; (6) GHCR lowercase asserted via policy test. |
-| **Outcome** | Findings are now REPO-VERIFIED by direct inspection — but the overall plan was STILL never executed end-to-end (no image built or pushed, no CI run). Be precise about the distinction: each *finding* is verified; the *plan outcome* is not. Verification therefore stays `unverified`. This skill is a reviewer/author checklist plus a plan-time verification cheat-sheet, not a verified procedure. |
+| **Objective** | Capture the durable PLANNING-PHASE risks surfaced while writing an implementation plan for Odysseus issue #201 ("No container image build or publish workflow") — a MINOR/DRY finding in a git-submodule meta-repo. The plan proposed ADR-009 (ghcr.io registry + tag scheme + promotion policy), a `.github/workflows/image-publish.yml` that builds ONLY the 3 e2e/test Dockerfiles Odysseus physically owns (delegating submodule app images to their own repos), a bash policy regression test, a `just` recipe, and a new required-checks job. The plan made several assertions that LOOK like decisions but are unverified guesses: hard-coded docker/* action SHAs (verification only DEFERRED to implementation), `ghcr.io/homericintelligence` lowercase casing (asserted, not checked against a published package), multi-arch buildability of a single-container Dockerfile that hard-codes an amd64 NATS tarball (a real arm64 BREAK), a new `_required.yml` job whose enforcement was only FLAGGED (ruleset JSON edits omitted), an ADR Status of "Accepted" against a CLAUDE.md "Proposed-until-merged" convention, and the whole meta-repo-altitude scoping (3 owned images vs all fleet images). |
+| **Outcome** | Hypothesis only — no CI run built or pushed any image, so verification stays `unverified`. The single-container amd64-tarball arm64 break was found by READING the Dockerfile, not by running a build. This skill is a reviewer/author checklist plus a plan-time verification cheat-sheet, not a verified procedure. |
 | **Verification** | unverified |
 
 > **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
@@ -83,15 +99,15 @@ Reach for this when REVIEWING or WRITING an image-build/publish plan for a submo
 
 Run these checks at PLAN time (or demand them as implementation acceptance criteria) before treating any of these assertions as a decision:
 
-| # | Risky assertion in the plan | Verify-instead command / action | Fail signal | R1 RESOLUTION (repo-verified) |
-| - | --------------------------- | -------------------------------- | ----------- | ----------------------------- |
-| 1 | Hard-coded docker/* action SHAs with `# vX.Y.Z` comments | `gh api repos/docker/build-push-action/git/ref/tags/v6 --jq '.object.sha'` (and setup-qemu / setup-buildx / login / metadata) — resolve the tag to its current commit SHA AT PLAN TIME | The pinned SHA does not match the live tag's commit, or the tag does not exist → stale/yanked pin | Resolve each in-session (deref annotated tags via `.object.type==tag` → `git/tags/<sha>`); add a policy test that every `uses:` is a 40-hex SHA (reject `@vX` and short SHAs) |
-| 2 | `ghcr.io/<org>` lowercase namespace | `git remote get-url origin` (real org casing) + confirm GHCR lowercases (docs) OR `gh api /orgs/<org>/packages?package_type=container` to see an existing published package's path | Plan asserts casing without any source; or an existing package uses a different path form | Assert `ghcr.io/homericintelligence` (lowercase) and reject the mixed-case org name in a policy test |
-| 3 | `platforms: linux/amd64,linux/arm64` for every owned Dockerfile | `grep -nE 'amd64|x86_64|aarch64|arm64|TARGETARCH|uname -m' <Dockerfile>` for EACH built Dockerfile | Any hard-coded `*-linux-amd64.*` download with no `TARGETARCH` mapping → arm64 build fails | VERIFIED: `e2e/single-container/Dockerfile:43` hardcodes `nats-server-v2.10.24-linux-amd64.tar.gz`. Set `platforms` PER-IMAGE in the matrix (the two `python:3.11-slim` images → multi-arch; the amd64-binary image → `linux/amd64` only) + a policy test that the amd64-only image is never advertised arm64 |
-| 4 | New required-check job added to `_required.yml` | `grep -n '<new-job-name>' configs/github/*ruleset*.json configs/github/canonical-checks.md` | Job `name:` absent from the ruleset JSON → check is silently non-blocking | VERIFIED: `canonical-checks.md` defines a FIXED fleet-wide set of EXACTLY 8 contexts; `repo-ruleset.json` pins those bare contexts with `integration_id: 15368`. Do NOT add a new "required" job — fold the validation as a STEP into the already-required `schema-validation` job (already validates `.github/workflows/*.yml` + ruleset JSON). ZERO ruleset edits; fleet uniformity preserved |
-| 5 | New ADR Status = "Accepted" | `grep -niE 'Status.*Proposed|until merged|new ADR' CLAUDE.md docs/adr/template.md` | CLAUDE.md/template says "Proposed until merged" → "Accepted" violates convention | VERIFIED: `docs/adr/template.md:3` and `008-nats-tls-encryption.md:3` both use `**Status:** Proposed`. Ship new ADRs `Status: Proposed`; add a policy test asserting it |
-| 6 | "Build only meta-repo-owned images" altitude call | `git submodule status` + read each owned Dockerfile's `COPY`/context; confirm submodule repos already build their own images | Submodule images already published elsewhere → building them here = dual source of truth (DRY) | Surface the altitude as an explicit OPEN DECISION (options A/B) recorded as a *Proposed* ADR for the issue author to ratify at merge — do NOT silently narrow scope |
-| 7 | `context: .` + `submodules: recursive` for a Dockerfile that COPYs submodule paths | Read the Dockerfile's `COPY`/`ADD` sources; confirm checkout step uses `submodules: recursive` | Dockerfile COPYs a submodule path but checkout omits `submodules: recursive` → build can't find the path | Confirm `context: .` + `submodules: recursive` for the COPY-from-submodule Dockerfile; pair with the per-image multi-arch audit (row 3) |
+| # | Risky assertion in the plan | Verify-instead command / action | Fail signal |
+| - | --------------------------- | -------------------------------- | ----------- |
+| 1 | Hard-coded docker/* action SHAs with `# vX.Y.Z` comments | `gh api repos/docker/build-push-action/git/ref/tags/v6` (and for setup-qemu / setup-buildx / login / metadata) — resolve the tag to its current commit SHA AT PLAN TIME | The pinned SHA does not match the live tag's commit, or the tag does not exist → stale/yanked pin |
+| 2 | `ghcr.io/<org>` lowercase namespace | `git remote get-url origin` (real org casing) + confirm GHCR lowercases (docs) OR `gh api /orgs/<org>/packages?package_type=container` to see an existing published package's path | Plan asserts casing without any source; or an existing package uses a different path form |
+| 3 | `platforms: linux/amd64,linux/arm64` for every owned Dockerfile | `grep -nE 'amd64|x86_64|aarch64|arm64|TARGETARCH|uname -m' <Dockerfile>` for EACH built Dockerfile | Any hard-coded `*-linux-amd64.*` download with no `TARGETARCH` mapping → arm64 build fails |
+| 4 | New required-check job added to `_required.yml` | `grep -n '<new-job-name>' configs/github/*ruleset*.json configs/github/canonical-checks.md` | Job `name:` absent from the ruleset JSON → check is silently non-blocking |
+| 5 | New ADR Status = "Accepted" | `grep -niE 'Status.*Proposed|until merged|new ADR' CLAUDE.md docs/adr/template.md` | CLAUDE.md/template says "Proposed until merged" → "Accepted" violates convention |
+| 6 | "Build only meta-repo-owned images" altitude call | `git submodule status` + read each owned Dockerfile's `COPY`/context; confirm submodule repos already build their own images | Submodule images already published elsewhere → building them here = dual source of truth (DRY) |
+| 7 | `context: .` + `submodules: recursive` for a Dockerfile that COPYs submodule paths | Read the Dockerfile's `COPY`/`ADD` sources; confirm checkout step uses `submodules: recursive` | Dockerfile COPYs a submodule path but checkout omits `submodules: recursive` → build can't find the path |
 
 **Plan-time verification command sequence** — run this exact block (or demand it as acceptance criteria) BEFORE pinning any SHA, promising multi-arch, or wiring a required check:
 
@@ -143,25 +159,6 @@ Two cross-cutting source-trust rules:
 - **Re-verify third-party action SHAs at plan time, do not defer.** A plan that writes `docker/build-push-action@<sha> # v6` without having run `gh api repos/docker/build-push-action/git/ref/tags/v6` is presenting a guess as a pin. "Verify at implementation time" is a deferral, not a verification — the reviewer cannot tell a fresh SHA from a stale one, so the burden is on the plan to show the lookup.
 - **Distinguish meta-repo-OWNED images from submodule-OWNED images.** Building a submodule's app image in the meta-repo creates a second source of truth for that image (the submodule's own CI builds it too) — a DRY violation. The meta-repo should build ONLY the Dockerfiles it physically owns (e2e/test harnesses) and delegate app images to the submodule repos that own them. State this altitude decision and its DRY justification explicitly; do not let it be an unspoken assumption.
 
-### META-lesson: how a re-plan correctly closes a NOGO finding
-
-A NOGO finding of the form **"the artifact you added doesn't actually achieve the stated effect"** (e.g. you added a job and called it "required", but it does not actually block merges) is best closed by **ATTACHING the new behavior to an EXISTING mechanism already known to have that effect** — NOT by building a parallel mechanism and asserting it works.
-
-In Odysseus #201 the central R0 NOGO was exactly this: a new `image-validate` job in `_required.yml` is NOT actually required, because the branch-protection ruleset pins a FIXED fleet-wide set of EXACTLY 8 contexts (`configs/github/canonical-checks.md`) and `configs/github/repo-ruleset.json` pins precisely those 8 bare contexts with `"integration_id": 15368`. The required-set is a cross-repo CONTRACT, not a per-repo knob — every one of the 15 repos must emit the same 8. So the R1 resolution does NOT add a 9th "required" job; it folds the new validation as a STEP inside the already-required `schema-validation` job (which already runs `check-jsonschema` over `.github/workflows/*.yml` and `jq`-validates the ruleset JSON). This buys genuine per-PR enforcement with ZERO ruleset-JSON edits and preserves fleet uniformity.
-
-The general rule has two halves:
-
-1. **Before adding a "required" check, read the ruleset JSON + the canonical-checks doc** to learn whether the required-set is a fixed cross-repo contract. If it is, you cannot make something "required" by naming a new job — you must attach to a context that is already pinned.
-2. **Add a verification command that PROVES the attachment.** It is not enough to claim the step is enforced; assert (a) the step lives INSIDE the already-required job, and (b) `configs/github/` is unchanged:
-
-   ```bash
-   # (a) the new validation runs inside the already-required `schema-validation` job:
-   awk '/name: schema-validation/,/^  [a-z]/' .github/workflows/_required.yml | grep -n '<new-step-name>'
-   # (b) prove no ruleset edits were needed (fleet contract untouched):
-   git diff --quiet -- configs/github/ && echo "configs/github unchanged -> fleet contract preserved" \
-     || echo "ERROR: ruleset/canonical-checks touched -> you broke fleet uniformity"
-   ```
-
 ### Detailed Steps
 
 **1. Re-resolve every docker/* action SHA at plan time — never defer, never copy from memory.**
@@ -176,28 +173,20 @@ Annotated tags require a second deref (`git/tags/<sha>` → `.object.sha`). A `#
 **2. Treat GHCR namespace casing as a verification task.**
 GHCR requires lowercase owner+image segments: `ghcr.io/<lowercased-org>/<image>`. The org `HomericIntelligence` lowercases to `homericintelligence`. Lowercasing IS correct — but cite the rule (GHCR docs) or an existing `ghcr.io/<org>/<pkg>` package, rather than asserting it. The trap is a plan that silently lowercases and a reviewer who cannot tell whether the author knew GHCR lowercases or just got lucky.
 
-**3. Audit EVERY owned Dockerfile for arch-specific downloads, then set `platforms` PER-IMAGE.**
-`platforms: linux/amd64,linux/arm64` only works if every layer is arch-portable. A Dockerfile that does `wget ... nats-server-vX-linux-amd64.tar.gz` downloads an amd64 binary unconditionally; under QEMU on the arm64 leg the resulting image contains an amd64 binary that won't execute (or the download 404s for a non-existent arm64 asset). Grep each built Dockerfile for `amd64|x86_64|aarch64|arm64|TARGETARCH|uname -m`. **VERIFIED in Odysseus:** of the three owned Dockerfiles, `e2e/nats-loki-bridge/Dockerfile` and `e2e/Dockerfile.argus-exporter` are pure-Python (`FROM python:3.11-slim`, multi-arch-capable), while `e2e/single-container/Dockerfile:43` hardcodes `nats-server-v2.10.24-linux-amd64.tar.gz` with no `TARGETARCH` mapping → its arm64 leg PROVABLY fails. RESOLUTION: do NOT promise one blanket `platforms` for all images — set `platforms` PER-IMAGE in the build matrix (pure-Python images → `linux/amd64,linux/arm64`; the amd64-binary image → `linux/amd64` only) and add a policy-test assertion that the amd64-only image is never advertised arm64. (Alternative for a portable image: a `TARGETARCH`→asset-name mapping — see `[[ci-cd-opencode-asset-arch-naming]]` and `[[ci-cd-achaean-fleet-ci-cascade-patterns]]` Levels 7/8 — but only if the upstream actually publishes a linux-arm64 asset.)
+**3. Audit EVERY owned Dockerfile for arch-specific downloads before promising multi-arch.**
+`platforms: linux/amd64,linux/arm64` only works if every layer is arch-portable. A Dockerfile that does `curl ... nats-server-vX-linux-amd64.tar.gz` downloads an amd64 binary unconditionally; under QEMU on the arm64 leg the resulting image contains an amd64 binary that won't execute (or the download 404s for a non-existent arm64 asset). Grep each built Dockerfile for `amd64|x86_64|aarch64|arm64|TARGETARCH|uname -m`. The fix is a `TARGETARCH`→asset-name mapping (`case "$TARGETARCH" in amd64) ...;; arm64) ...;; esac`) — see `[[ci-cd-opencode-asset-arch-naming]]`. If a Dockerfile cannot be made portable, either drop arm64 for that image or document the single-arch exception in the plan; do NOT silently promise multi-arch.
 
-**4. Attach the new validation to an ALREADY-required job; do not add a new "required" job.**
-**VERIFIED in Odysseus:** `configs/github/canonical-checks.md` defines a FIXED fleet-wide set of EXACTLY 8 required check contexts (`lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync`) that all 15 fleet repos must emit, and `configs/github/repo-ruleset.json` pins exactly those 8 BARE contexts with `"integration_id": 15368` (the `org-ruleset*.json` variants pin `"Required Checks / <name>"`). The required-set is a cross-repo CONTRACT, so a new `_required.yml` job whose `name:` is not in that fixed set runs but NEVER blocks a merge — and editing the ruleset to add a 9th context would break fleet uniformity. RESOLUTION: do NOT add a new "required" job for a repo-local policy check — fold the new image-publish validation as a STEP into the already-required `schema-validation` job (it already runs `check-jsonschema` over `.github/workflows/*.yml` and `jq`-validates the ruleset JSON, so an image-publish policy test is a natural fit). This gives genuine per-PR enforcement with ZERO ruleset-JSON edits. Prove it with `awk '/name: schema-validation/,/^  [a-z]/' .github/workflows/_required.yml | grep '<new-step>'` AND `git diff --quiet -- configs/github/`.
+**4. Wire a new gate INTO the enforced contexts, not merely into `_required.yml`.**
+In Odysseus the branch-protection rulesets (`configs/github/org-ruleset*.json`, `repo-ruleset*.json`, documented in `configs/github/canonical-checks.md`) pin specific status-check contexts. Adding a job to `_required.yml` whose `name:` is NOT in those rulesets makes the check run but never block a merge. A plan that *flags* "the ruleset JSON and canonical-checks.md must be updated" but does NOT include those edits ships a non-enforced gate. The plan must EITHER include the ruleset edits OR attach the new step to an already-pinned job. Verify with `grep -n '<job-name>' configs/github/*ruleset*.json`.
 
 **5. Respect the ADR status convention from the repo's CLAUDE.md.**
-Odysseus `CLAUDE.md` says new ADRs use Status "Proposed" until merged (superseding decisions get a new ADR; ADRs are append-only). **VERIFIED:** `docs/adr/template.md:3` and the latest real ADR `docs/adr/008-nats-tls-encryption.md:3` both literally read `**Status:** Proposed`. A plan that stamps a new ADR "Accepted" before merge violates the convention — a merge-blocking nit. RESOLUTION: ship the new ADR with `Status: Proposed`, and add a policy test asserting any ADR added by this change carries `**Status:** Proposed`.
+Odysseus `CLAUDE.md` says new ADRs use Status "Proposed" until merged (superseding decisions get a new ADR; ADRs are append-only). A plan that stamps ADR-009 "Accepted" before merge violates the convention. Read `CLAUDE.md` and `docs/adr/template.md` and set the status the convention prescribes.
 
-**6. Resolve scope ambiguity as an explicit OPEN DECISION, not by silently narrowing.**
-Issue #201's "build images for submodule components" phrasing is ambiguous: build only the 3 meta-repo-owned Dockerfiles, or build all fleet/submodule app images here too? Meta-repo altitude (build only owned images, DRY-delegate the rest) is defensible — building a submodule's image here duplicates the submodule's own CI build = a second source of truth — but it is a JUDGMENT call the issue author may read differently. RESOLUTION: do NOT present a unilateral reinterpretation as settled. Lay out options A (owned only) / B (all fleet images) in the plan and record the chosen option as a *Proposed* ADR decision for the issue author to ratify at merge. Surfacing the ambiguity beats silently narrowing scope.
+**6. Justify the build-altitude decision with a DRY argument, don't assume it.**
+Issue #201's "submodule components" phrasing is ambiguous: build only the 3 meta-repo-owned Dockerfiles, or build all fleet/submodule app images here too? The DRY-correct answer is to build only owned Dockerfiles and delegate submodule app images to the submodule repos (each submodule already has its own CI). State this explicitly: building a submodule image in the meta-repo duplicates the submodule's own build = a second source of truth. The altitude call is a judgment a reviewer may dispute, so make the reasoning visible.
 
 **7. Confirm build context + `submodules: recursive` for any Dockerfile that COPYs submodule paths.**
-The single-container e2e Dockerfile COPYs from submodule paths, so its build context must be the repo root and the checkout step must use `submodules: recursive` (and `build-push-action` `context: .`). This was VERIFIED by reading the Dockerfile — but reading proves the COPY paths, not that the build succeeds. Pair the context check with the per-image multi-arch audit (step 3): a correct context does not save the amd64-only NATS download on the arm64 leg.
-
-**8. Encode every finding as a fast, deterministic policy test wired into `schema-validation`.**
-Because the enforcement mechanism is the already-required `schema-validation` job (step 4), each repo-verified finding should become an assertion the policy test runs on every PR — no network, no actual build needed:
-- every `uses:` in `image-publish.yml` is a 40-hex commit SHA (reject `@vX` and short SHAs);
-- the registry namespace is the lowercase `ghcr.io/homericintelligence` (reject the mixed-case org slug);
-- the amd64-only image (`single-container`) is never listed with `linux/arm64` in the `platforms` matrix;
-- any newly added ADR carries `**Status:** Proposed`.
-These assertions are what convert the R1 *findings* into *enforced invariants* — but note this is still plan-stage: the workflow has not been run, so verification stays `unverified`.
+The single-container e2e Dockerfile COPYs from submodule paths, so its build context must be the repo root and the checkout step must use `submodules: recursive` (and `build-push-action` `context: .`). This was VERIFIED by reading the Dockerfile — but reading proves the COPY paths, not that the build succeeds. Pair the context check with the multi-arch audit (step 3): a correct context does not save an amd64-only download on the arm64 leg.
 
 ## Failed Attempts
 
@@ -208,53 +197,11 @@ These assertions are what convert the R1 *findings* into *enforced invariants* �
 | Promise linux/arm64 for a Dockerfile that hard-codes an amd64 tarball | The plan set `platforms: linux/amd64,linux/arm64` for all 3 owned images, including the single-container e2e Dockerfile, having only READ the Dockerfile (confirming its COPY paths) — the build was never run | The single-container Dockerfile hard-codes `nats-server-*-linux-amd64.tar.gz` with no `TARGETARCH` mapping; the arm64 leg downloads a non-portable/absent binary and the build BREAKS. Reading proves COPY paths, not arm64 buildability | RESOLUTION: grep EVERY built Dockerfile for `amd64\|x86_64\|aarch64\|arm64\|TARGETARCH\|uname -m`. Any unconditional `*-linux-amd64.*` download is a multi-arch landmine — fix with a `TARGETARCH`→asset mapping (`[[ci-cd-opencode-asset-arch-naming]]`) or drop arm64 for that image and document the single-arch exception. Cross-ref `[[ci-cd-achaean-fleet-ci-cascade-patterns]]` Level 6/8 |
 | Add an `image-publish` job to `_required.yml` and only FLAG the ruleset edit | The plan added a new required-checks job to the canonical `_required.yml` and noted that the branch-protection ruleset JSON + `canonical-checks.md` "must be updated" — but did NOT include those edits | A job in `_required.yml` whose `name:` is absent from the rulesets' pinned status-check contexts runs but never blocks a merge — the gate is SILENTLY non-blocking. Flagging an edit is not making it | RESOLUTION: the plan must EITHER include the `configs/github/*ruleset*.json` + `canonical-checks.md` edits OR attach the new step to an already-pinned job. Verify with `grep -n '<job-name>' configs/github/*ruleset*.json`. Required-check status is conferred by the ruleset pin, not by the job existing in `_required.yml` |
 | Set ADR-009 Status to "Accepted" pre-merge | The plan stamped the new ADR Status as "Accepted" immediately | The repo's `CLAUDE.md` says new ADRs are "Proposed" until merged (ADRs are append-only; superseding decisions get a new ADR). "Accepted" pre-merge violates the documented convention — a merge-blocking nit | RESOLUTION: read `CLAUDE.md` + `docs/adr/template.md` and set Status to "Proposed" until the ADR is merged. Respect the repo's ADR-status convention |
-| Assume meta-repo-altitude scoping (3 owned images only) without justification | The whole plan rested on "fix #201 at the meta-repo altitude — build only the 3 owned Dockerfiles, delegate submodule app images" without making the DRY reasoning explicit | The issue's "submodule components" phrasing is ambiguous; a reviewer could read it as wanting submodule app images built in the meta-repo too. An unjustified altitude call is a judgment a reviewer may simply reject | RESOLUTION (R1): do NOT silently narrow scope. Surface the ambiguity as an explicit OPEN DECISION (options A: owned-only / B: all fleet images) and record the chosen option as a *Proposed* ADR for the issue author to ratify at merge. State the DRY justification (building a submodule's image here = a second source of truth) so the reviewer can agree or dispute it on the merits |
-| R1: close the "not actually required" NOGO by adding a 2nd "required" job | In R0 the plan added a NEW `image-validate` job to `_required.yml` and called the gate "required"; the obvious R1 reflex is to also pin a 9th context in the ruleset JSON | VERIFIED: `configs/github/canonical-checks.md` defines a FIXED fleet-wide set of EXACTLY 8 required contexts and `repo-ruleset.json` pins exactly those 8 bare contexts with `integration_id: 15368`. The required-set is a cross-repo CONTRACT — adding a 9th context breaks fleet uniformity across all 15 repos, and a job not in the set never blocks merges | RESOLUTION (R1 + META-lesson): when a NOGO says "the artifact you added doesn't achieve the stated effect (enforced)", ATTACH the new behavior to an EXISTING mechanism already known to have that effect rather than building a parallel one. Fold the image-publish validation as a STEP into the already-required `schema-validation` job (it already validates workflow YAML + ruleset JSON). Genuine per-PR enforcement, ZERO ruleset edits, fleet contract preserved |
-| R1: claim "multi-arch works now" with one blanket `platforms` for all images | R1 reflex after the R0 arm64 break: set `platforms: linux/amd64,linux/arm64` once for the whole build | Two of the three owned images (`python:3.11-slim`) ARE multi-arch-capable, but `e2e/single-container/Dockerfile:43` hardcodes `nats-server-...-linux-amd64.tar.gz` (no `TARGETARCH`) and still breaks on arm64. A single blanket `platforms` re-introduces the same break for one image | RESOLUTION (R1): set `platforms` PER-IMAGE in the build matrix (pure-Python → multi-arch; the amd64-binary image → `linux/amd64` only) and add a policy test asserting the amd64-only image is never advertised arm64. Audit EVERY Dockerfile's download URLs, not just the base image |
-| R1: treat the now-verified findings as if the PLAN is verified | After resolving all 6 findings by direct repo inspection, the temptation is to upgrade `verification` to verified-local/verified-ci | The findings are repo-verified by inspection, but the PLAN was still never executed end-to-end — no image was built or pushed and no CI run exercised the workflow. Verified findings ≠ verified plan | RESOLUTION (honesty gate): keep `verification: unverified`. Be precise in the Overview/notes: each FINDING is repo-verified; the plan OUTCOME is not. Only a green CI run that builds+pushes the images would justify upgrading the level |
+| Assume meta-repo-altitude scoping (3 owned images only) without justification | The whole plan rested on "fix #201 at the meta-repo altitude — build only the 3 owned Dockerfiles, delegate submodule app images" without making the DRY reasoning explicit | The issue's "submodule components" phrasing is ambiguous; a reviewer could read it as wanting submodule app images built in the meta-repo too. An unjustified altitude call is a judgment a reviewer may simply reject | RESOLUTION: state the altitude decision AND its DRY justification — building a submodule's image in the meta-repo duplicates the submodule's own CI build = a second source of truth. Build only owned Dockerfiles; delegate app images to the repos that own them. Make the reasoning visible so the reviewer can agree or dispute it on the merits |
 
 ## Results & Parameters
 
-This skill produced no execution results (it is `unverified` — no image was built or pushed). What it produces is a plan-time verification cheat-sheet for an image-build/publish workflow in a submodule meta-repo, plus the reusable snippets that resolve each risk. In R1 each finding was VERIFIED by direct Odysseus inspection (the PLAN remains unverified — never run end-to-end).
-
-**R1 repo-verified evidence (Odysseus @ main):**
-
-| Finding | Evidence (file:line / command output) |
-| ------- | ------------------------------------- |
-| Fixed 8-context required-set is a fleet contract | `configs/github/canonical-checks.md` "Required checks" table lists exactly 8: `lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync` |
-| Ruleset pins exactly those 8 bare contexts | `configs/github/repo-ruleset.json` lines 29–36: each is `{ "context": "<name>", "integration_id": 15368 }`; `org-ruleset*.json` use `"Required Checks / <name>"` |
-| `schema-validation` is the natural attach point | `.github/workflows/_required.yml` job `name: schema-validation` already runs `check-jsonschema` over `find .github/workflows -name "*.yml"` AND `jq`-validates the four `configs/github/*ruleset*.json` files |
-| amd64-only image break | `e2e/single-container/Dockerfile:43` → `nats-server-v2.10.24-linux-amd64.tar.gz` (no `TARGETARCH`); base `FROM ubuntu:24.04` |
-| Multi-arch-capable images | `e2e/nats-loki-bridge/Dockerfile:1` and `e2e/Dockerfile.argus-exporter:1` both `FROM python:3.11-slim` |
-| ADR status convention | `docs/adr/template.md:3` and `docs/adr/008-nats-tls-encryption.md:3` both `**Status:** Proposed`; `CLAUDE.md` mandates Proposed-until-merged |
-
-**Per-image `platforms` matrix (do NOT use one blanket `platforms`):**
-
-```yaml
-strategy:
-  matrix:
-    include:
-      - image: nats-loki-bridge
-        dockerfile: e2e/nats-loki-bridge/Dockerfile      # FROM python:3.11-slim -> portable
-        platforms: linux/amd64,linux/arm64
-      - image: argus-exporter
-        dockerfile: e2e/Dockerfile.argus-exporter        # FROM python:3.11-slim -> portable
-        platforms: linux/amd64,linux/arm64
-      - image: single-container
-        dockerfile: e2e/single-container/Dockerfile       # hardcodes linux-amd64 NATS tarball
-        platforms: linux/amd64                            # amd64 ONLY — never advertise arm64
-```
-
-**Proof-of-attachment commands (the META-lesson verification — run at plan/PR time):**
-
-```bash
-# The new validation MUST live inside the already-required schema-validation job:
-awk '/name: schema-validation/,/^  [a-z]/' .github/workflows/_required.yml | grep -n 'image-publish'
-# And NO ruleset/canonical-checks edits were needed (fleet contract preserved):
-git diff --quiet -- configs/github/ \
-  && echo "configs/github unchanged -> fleet contract preserved" \
-  || echo "ERROR: ruleset touched -> fleet uniformity broken"
-```
+This skill produced no execution results (it is `unverified` — no image was built or pushed). What it produces is a plan-time verification cheat-sheet for an image-build/publish workflow in a submodule meta-repo, plus the reusable snippets that resolve each risk.
 
 **Plan-time action-SHA resolution (run for ALL five docker actions; never defer):**
 
@@ -345,3 +292,12 @@ steps:
 - `[[ci-cd-opencode-asset-arch-naming]]` — the `TARGETARCH`→asset-name mapping fix for arch-specific vendor downloads.
 - `[[planning-container-image-digest-pinning]]` — the CONSUMING side: pinning floating image tags in compose/e2e to immutable digests (distinct from building/publishing images).
 - `[[planning-verify-issue-claims-and-required-check-gating]]` — adjacent planning skill on required-check gating and verifying issue claims.
+
+```
+
+
+---
+
+## v1.0.0 (2026-06-20)
+
+**Initial version.** Created in R0 of planning Odysseus issue #201 via PR https://github.com/HomericIntelligence/ProjectMnemosyne/pull/2706. Captured the SIX image-publish planning risks as open/unverified assumptions (docker/* action SHAs, ghcr.io namespace casing, multi-arch Dockerfile buildability, required-check wiring, ADR status convention, meta-repo build altitude). Verification: unverified.


### PR DESCRIPTION
## Summary

Amends the existing skill `planning-container-image-build-publish-meta-repo` from **v1.0.0 → v1.1.0** (MINOR). This is round **R1** of planning Odysseus issue #201 ("No container image build or publish workflow", MINOR/DRY). R0's plan got a **NOGO (Grade C; 3 Major + 2 minor)** and created the skill capturing six risks as open/unverified assumptions (PR #2706). R1 revised the plan and **resolved every finding**, each now backed by **direct Odysseus repo inspection** — so the skill is amended (not duplicated) to upgrade each "uncertain assumption" into a "verified finding + resolution pattern".

- Adds `history:` frontmatter field; archives the full v1.0.0 snapshot to `skills/planning-container-image-build-publish-meta-repo.history` (append-only, newest-first).
- Converts the R0 Quick-Reference / Detailed-Steps / Failed-Attempts rows into repo-verified findings with resolution patterns.
- Adds a META-lesson for re-planning and an evidence table.

## Verification Level

**unverified**

The individual FINDINGS are now repo-verified by direct inspection, but the overall PLAN was **still never executed end-to-end** — no image was built or pushed, and no CI run exercised the workflow. Verified findings ≠ verified plan, so the level stays `unverified` and the workflow section keeps its "Proposed Workflow" framing + warning blockquote (a literal `## Verified Workflow` heading is retained only because the validator requires it).

## Key Findings (the 6 R1 resolutions)

1. **A new job in `_required.yml` is NOT actually required unless the ruleset also pins its context.** Verified: `configs/github/canonical-checks.md` defines a FIXED fleet-wide set of EXACTLY 8 required contexts; `repo-ruleset.json` pins those bare contexts with `integration_id: 15368`. RESOLUTION: fold the new validation as a STEP into the already-required `schema-validation` job → genuine per-PR enforcement, ZERO ruleset-JSON edits, fleet uniformity preserved.
2. **Multi-arch claims must be audited per Dockerfile.** Verified: `e2e/single-container/Dockerfile:43` hardcodes `nats-server-v2.10.24-linux-amd64.tar.gz` (no TARGETARCH) → arm64 fails. RESOLUTION: per-image `platforms` matrix (the two `python:3.11-slim` images → multi-arch; the amd64-binary image → `linux/amd64` only) + a policy test the amd64-only image is never advertised arm64.
3. **Resolve third-party action SHAs in-session.** `gh api repos/docker/<action>/git/ref/tags/<tag> --jq '.object.sha'` (deref annotated tags); policy test that every `uses:` is a 40-hex SHA.
4. **Respect the ADR status convention.** Verified: `docs/adr/template.md:3` and `008-nats-tls-encryption.md:3` both `**Status:** Proposed`. RESOLUTION: new ADRs ship `Status: Proposed` + a policy test.
5. **Surface scope ambiguity as an explicit OPEN DECISION, not silent narrowing.** Options A/B recorded as a *Proposed* ADR for the issue author to ratify at merge.
6. **GHCR namespaces are lowercase.** Assert `ghcr.io/homericintelligence`; reject the mixed-case org name in a policy test.

**META-lesson:** a NOGO of the form "the artifact you added doesn't actually achieve the stated effect (enforced)" is best closed by ATTACHING the new behavior to an EXISTING mechanism already known to have that effect — plus a command that PROVES the attachment (step lives inside the already-required job AND `configs/github/` is unchanged).

Cross-refs `[[ci-cd-achaean-fleet-ci-cascade-patterns]]` (Levels 7/8) and `[[gha-release-package-workflow-patterns]]`.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (474/474 valid; target skill ✓)
- [ ] Verify amended skill appears in marketplace
- [ ] Test skill discovery with relevant keywords (container image publish, ghcr, multi-arch, required-check, ruleset)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>