### PR TITLE
skill(config-governance): amend with verify-issue-premise-against-HEAD planning learning

### DIFF
--- a/skills/config-governance-fix-scope-all-variant-files.history
+++ b/skills/config-governance-fix-scope-all-variant-files.history
@@ -1,0 +1,51 @@
+<!-- markdownlint-disable MD024 -->
+# History: config-governance-fix-scope-all-variant-files
+
+This file preserves prior versions of the
+`config-governance-fix-scope-all-variant-files` skill.
+
+## v1.1.0 (2026-06-20)
+
+**What changed:** Added a PLANNING-PHASE premise-verification finding from a
+session that planned a CI guard for issue #309 ("ruleset configs must stay
+enforcement=active"). The issue's embedded fix sketch asserted PR #177 flipped
+the two BASE files (`repo-ruleset.json:4`, `org-ruleset.json:4`) from
+`evaluate` to `active` and prescribed a guard looping ALL FOUR ruleset files
+asserting `enforcement=="active"`. Running `jq -r .enforcement` on all four
+files showed the actual on-disk state is `evaluate, active, evaluate, active` —
+the base files are intentionally `evaluate` and only the `*-active.json`
+variants are `active` (a two-form split documented in
+`configs/github/canonical-checks.md:58-62`). The issue sketch's guard would
+have been red-on-day-one against a correct repo. Added: a new Failed Attempts
+row (adopt-the-blanket-guard), a `### Verify the issue premise before planning
+to it` subsection under the workflow with a Quick Reference, a per-file
+expected-enforcement map guard (catches drift in BOTH directions), new
+unverified-reliance caveats, and cross-references to
+`architecture-executable-convention-guard-pattern` and
+`ci-hygiene-and-validation-gates` Pattern 2. Bumped `version` 1.0.0 → 1.1.0
+(MINOR — additive findings/triggers), `date` → 2026-06-20.
+
+**Why:** An issue that prescribes a literal assertion over named files can carry
+a factually wrong premise; only an on-disk `jq`/grep check against current HEAD
+reveals it. The premise-verification technique here is **verified-local** (the
+`jq` premise check WAS run during planning and confirmed
+`evaluate,active,evaluate,active`); the proposed guard/CI wiring is
+**unverified** (planning only). Searchers for "verify issue premise",
+"enforcement drift guard", "ruleset evaluate vs active" should land here.
+
+### Snapshot of v1.0.0 (superseded 2026-06-20)
+
+The full v1.0.0 markdown body (frontmatter + the original When to Use, Verified
+Workflow, six Failed Attempts rows, and Results & Parameters) is preserved in
+git history at the commit immediately preceding the v1.1.0 amendment. The
+v1.0.0 frontmatter was:
+
+```yaml
+name: config-governance-fix-scope-all-variant-files
+category: ci-cd
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: []
+```

--- a/skills/config-governance-fix-scope-all-variant-files.md
+++ b/skills/config-governance-fix-scope-all-variant-files.md
@@ -1,12 +1,21 @@
 ---
 name: config-governance-fix-scope-all-variant-files
-description: "Planning discipline for scoping a security/governance config fix: when a finding cites one or two specific config files, grep the WHOLE config directory for the same field before scoping the change — duplicate/variant files (e.g. an enforcing `*-active.json` vs a baseline `*-evaluate`) often hold the same defective value, and the variant actually deployed may not be the one the issue names. Fixing only the cited files leaves the gap live under the enforcing path. Use when: (1) planning a fix for a security/governance finding (branch protection, rulesets, IAM, OPA) that names specific config files, (2) a repo keeps active/baseline or per-env variants of the same JSON/YAML config and an apply script selects which one is deployed, (3) the only existing test surface is JSON/YAML syntax validation and a defective value could silently regress, (4) a fix adds a review/approval requirement and you must check existing bypass_actors before adding a redundant one, (5) you are relying on governance-API numeric IDs or bypass semantics taken from existing JSON or a KB note without live-API confirmation."
+description: "Planning discipline for scoping a security/governance config fix: when a finding cites one or two specific config files, grep the WHOLE config directory for the same field before scoping the change — duplicate/variant files (e.g. an enforcing `*-active.json` vs a baseline `*-evaluate`) often hold the same defective value, and the variant actually deployed may not be the one the issue names. Fixing only the cited files leaves the gap live under the enforcing path. SEPARATELY: when an issue prescribes a LITERAL assertion over named files (e.g. 'guard that all four ruleset files are enforcement==active'), run that assertion against current HEAD with jq/grep BEFORE adopting it — the issue's premise may be factually wrong and ship a guard that is red-on-day-one or asserts the wrong invariant. Use when: (1) planning a fix for a security/governance finding (branch protection, rulesets, IAM, OPA) that names specific config files, (2) a repo keeps active/baseline or per-env variants of the same JSON/YAML config and an apply script selects which one is deployed, (3) the only existing test surface is JSON/YAML syntax validation and a defective value could silently regress, (4) a fix adds a review/approval requirement and you must check existing bypass_actors before adding a redundant one, (5) you are relying on governance-API numeric IDs or bypass semantics taken from existing JSON or a KB note without live-API confirmation, (6) an issue body or embedded fix sketch prescribes a blanket equality assertion over a set of named config files and you are about to encode it as a CI guard."
 category: ci-cd
-date: 2026-06-19
-version: "1.0.0"
+date: 2026-06-20
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
-tags: []
+history: config-governance-fix-scope-all-variant-files.history
+tags:
+  - config-governance
+  - ruleset
+  - enforcement-drift
+  - verify-issue-premise
+  - evaluate-vs-active
+  - per-file-expected-value
+  - ci-regression-guard
+  - planning-discipline
 ---
 
 # Config Governance Fix: Scope Across All Variant Files
@@ -15,11 +24,11 @@ tags: []
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-19 |
-| **Objective** | Capture the planning discipline for correctly scoping a security/governance config-defect fix when a finding names only one or two config files but variant copies of the same config exist |
-| **Outcome** | Plan corrected to fix ALL variant files (including the enforcing `-active.json` the issue never named) plus a CI regression guard; planning-time risks recorded honestly |
-| **Verification** | verified-local — jq/grep verification commands run locally; GitHub-API IDs and bypass semantics NOT confirmed against live `gh api`; the skill PR's own CI gate not yet observed green |
-| **History** | n/a (initial version) |
+| **Date** | 2026-06-20 (v1.1.0) · 2026-06-19 (v1.0.0) |
+| **Objective** | Capture the planning discipline for (a) correctly scoping a security/governance config-defect fix across variant files, and (b) verifying an issue's literal-assertion PREMISE against current HEAD before encoding it as a CI guard |
+| **Outcome** | v1.0.0: plan corrected to fix ALL variant files plus a CI guard. v1.1.0: a `jq` premise check showed an issue's prescribed `enforcement==active`-over-all-4-files guard was factually wrong (on-disk state is `evaluate,active,evaluate,active` by design) and would have been red-on-day-one; corrected to a per-file expected-value map |
+| **Verification** | verified-local for the premise-check technique (the `jq` premise verification WAS run during planning and confirmed `evaluate,active,evaluate,active`). The proposed enforcement-drift guard / CI wiring is **unverified** (planning only — not implemented or CI-run). GitHub-API IDs and bypass semantics from v1.0.0 also NOT confirmed against live `gh api` |
+| **History** | `config-governance-fix-scope-all-variant-files.history` (v1.0.0 → v1.1.0) |
 
 ## When to Use
 
@@ -28,6 +37,8 @@ tags: []
 - The only existing "test surface" for a config is syntax validation (JSON parse, YAML lint), so a defective value can silently regress with no functional test catching it.
 - A fix adds a review/approval requirement and you need to decide whether an existing `bypass_actors` entry already mitigates a solo-author self-approval deadlock.
 - You are about to rely on governance-API numeric IDs (actor IDs, integration IDs) or bypass semantics pulled from existing JSON or a KB note, without confirming them against the live API.
+- **(v1.1.0)** An issue body or its embedded fix sketch prescribes a *literal* blanket assertion over a set of named config files (e.g. "guard that all four ruleset files have `enforcement == "active"`") and you are about to encode it as a CI guard — run the assertion against current HEAD first; the premise may be wrong.
+- **(v1.1.0)** A repo deliberately keeps a two-form split of the same config (a base/`evaluate` form and an `*-active.json`/enforcing form) with different per-file intended values, so a single blanket equality check is the wrong invariant and a per-file expected-value map is required.
 
 ## Verified Workflow
 
@@ -75,6 +86,71 @@ jq '.bypass_actors' configs/github/org-ruleset-active.json
 7. **Record planning-time assumptions you could not verify as explicit risks** (see Failed
    Attempts) rather than presenting them as facts.
 
+### Verify the issue premise before planning to it (v1.1.0)
+
+> **Warning — partially unverified.** The *premise-verification technique* below is
+> **verified-local**: the `jq` premise check WAS actually run during this planning session and
+> confirmed the on-disk state `evaluate,active,evaluate,active`. The *proposed enforcement-drift
+> guard and its CI wiring are UNVERIFIED* — they were designed at planning time only, never
+> implemented, never run in CI. Treat the guard snippet as a proposal, not a tested artifact.
+
+When an issue (or its embedded fix sketch) prescribes a **literal assertion over named files** —
+here, issue #309 asserted PR #177 flipped the two BASE files (`repo-ruleset.json:4`,
+`org-ruleset.json:4`) from `evaluate` to `active` and prescribed a guard looping **all four**
+ruleset files asserting `enforcement == "active"` — do **not** adopt it on faith.
+
+1. **Run the literal assertion against current HEAD with a cheap `jq`/grep one-liner.**
+   ```bash
+   for f in repo-ruleset repo-ruleset-active org-ruleset org-ruleset-active; do
+     printf '%s: %s\n' "$f" "$(jq -r .enforcement "configs/github/$f.json")"
+   done
+   # Actual on-disk state -> evaluate, active, evaluate, active
+   ```
+2. **Compare to the premise.** The issue claimed all four should be `active`. On disk the two
+   BASE files (`*-ruleset.json`) are intentionally `"evaluate"` and only the `*-active.json`
+   variants are `"active"`. The prescribed blanket guard would have **failed on day one against a
+   correct repo** (red CI, no actual defect).
+3. **Confirm the split is intentional, not drift.** `configs/github/canonical-checks.md:58-62`
+   documents the two-form split as design (base/evaluate form vs active/enforcing form, with
+   different required-check context strings). A blanket `== "active"` check encodes the wrong
+   invariant.
+4. **Encode the CORRECT invariant: a per-file expected-enforcement map** (catches drift in BOTH
+   directions — an active config silently downgraded to evaluate, AND a base config silently
+   upgraded to active). This is strictly stronger than the issue's blanket check. *(Proposed —
+   unverified.)*
+5. **Wire it per `ci-hygiene-and-validation-gates` Pattern 2**: add the value-assertion to an
+   EXISTING static-check job (not a new workflow), keep echoes ASCII-only, and put the logic in a
+   reusable `just` recipe that CI calls so it lives in one place. Follow
+   `architecture-executable-convention-guard-pattern` for the prose-invariant → tested-blocking-
+   check shape: loud collision-free failure, and two-sided verification (clean PASS on a correct
+   tree + synthetic FAIL on a deliberately corrupted copy).
+
+### Quick Reference
+
+```bash
+# STEP 0 (CHEAP, ALWAYS DO THIS): verify the issue's literal premise against HEAD.
+for f in repo-ruleset repo-ruleset-active org-ruleset org-ruleset-active; do
+  printf '%s: %s\n' "$f" "$(jq -r .enforcement "configs/github/$f.json")"
+done
+# Expected/intended -> evaluate, active, evaluate, active  (NOT all "active")
+
+# PROPOSED guard (UNVERIFIED): assert each file against its INTENDED per-file value.
+# Two-sided drift detection: base must stay evaluate, active must stay active.
+declare -A want=(
+  [repo-ruleset]=evaluate  [repo-ruleset-active]=active
+  [org-ruleset]=evaluate   [org-ruleset-active]=active
+)
+fail=0
+for f in "${!want[@]}"; do
+  got=$(jq -r .enforcement "configs/github/$f.json")
+  if [ "$got" != "${want[$f]}" ]; then
+    echo "DRIFT: configs/github/$f.json enforcement=$got expected=${want[$f]}"
+    fail=1
+  fi
+done
+[ "$fail" -eq 0 ] || exit 1
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -85,6 +161,7 @@ jq '.bypass_actors' configs/github/org-ruleset-active.json
 | Trust governance-API IDs from existing JSON / KB | Took `actor_id: 1` (OrganizationAdmin), `5` (RepositoryRole admin), `49699333` (Integration), `integration_id: 15368` (GitHub Actions app) at face value | Never confirmed against live `gh api`; numeric IDs and app IDs can differ per org/install | Verify governance-API IDs against the live API before relying on them in a security fix |
 | Assume bypass-actor merge semantics | Assumed a `pull_request`-mode bypass lets an admin author merge a self-PR the review requirement would block | Never empirically tested against GitHub's live behavior — it is the deadlock-mitigation claim and remains unverified | Empirically verify bypass behavior against live GitHub before relying on it to resolve a deadlock |
 | Cite exact line numbers in the plan | Referenced `org:21`, `repo:17` from the current checkout | Line numbers drift as files change; they are checkout-relative | Reference the field name and file, not just line numbers; re-grep at apply time |
+| Adopt issue sketch's blanket `enforcement==active` guard over all 4 files (v1.1.0) | Issue #309 prescribed a guard looping all four ruleset files asserting `enforcement == "active"`, claiming PR #177 flipped the two base files | A `jq -r .enforcement` over all four files showed the on-disk state is `evaluate, active, evaluate, active`; the two base files are `evaluate` by design (`canonical-checks.md:58-62`), so the guard would be red on day one against a correct repo | Run the literal assertion against HEAD before adopting it; encode a per-file expected-value map (catches drift both directions), not a blanket equality check |
 
 ## Results & Parameters
 
@@ -122,6 +199,45 @@ done
 - Line numbers (`org:21`, `repo:17`) are checkout-relative and can drift.
 - `just ruleset-validate` requires `gh` auth + network; not runnable in a plan-time sandbox.
 
-**Related skills (apply/debug rulesets — distinct from this planning-scope discipline):**
+**Concrete evidence from the v1.1.0 session (issue #309 — "ruleset configs must stay enforcement=active"):**
+
+```text
+Issue premise:  PR #177 flipped repo-ruleset.json:4 and org-ruleset.json:4 from
+                "evaluate" to "active"; prescribed guard loops ALL FOUR files
+                asserting enforcement == "active".
+Premise check:  jq -r .enforcement over all four files (RUN during planning) ->
+                repo-ruleset.json         = evaluate   (base form, by design)
+                repo-ruleset-active.json  = active
+                org-ruleset.json          = evaluate   (base form, by design)
+                org-ruleset-active.json   = active
+Verdict:        Premise WRONG. Blanket enforcement=="active" guard would be
+                red-on-day-one against a correct repo.
+Design source:  configs/github/canonical-checks.md:58-62 documents the two-form
+                split (base/evaluate vs active/enforcing, different required-check
+                context strings) as intentional.
+Corrected plan: per-file expected-enforcement map (evaluate for base, active for
+                *-active) -> catches drift in BOTH directions, strictly stronger
+                than the issue's blanket check. (PROPOSED — not implemented/CI-run.)
+Verification:   premise-verification technique = verified-local (jq WAS run);
+                proposed guard + CI wiring = UNVERIFIED (planning only).
+```
+
+**v1.1.0 unverified assumptions / unverified reliances recorded as risks:**
+
+- Assumed `jq` is preinstalled on GitHub `ubuntu-latest` runners — relied on without a CI run in
+  THIS repo's image confirming it (it is standard on `ubuntu-latest` but not asserted here).
+- Line numbers cited at planning time (`justfile:679/693/695`, `ci.yml:10/21-25/44-48`,
+  `canonical-checks.md:58-62`) were read at planning time and can drift before implementation —
+  re-read / re-grep at apply time.
+- The proposed per-file enforcement-drift guard and its `just`+CI wiring are **unverified**: never
+  implemented, never run in CI, no clean-PASS / synthetic-FAIL two-sided check executed. Only the
+  on-disk `jq` premise verification was actually run (and confirmed
+  `evaluate,active,evaluate,active`).
+
+**Related skills (apply/debug rulesets + the guard/CI patterns this plan leans on):**
 `github-branch-protection-org-standardize`, `ci-cd-ruleset-bootstrap-deadlock`,
-`github-ruleset-pr-blocked-diagnose-missing-check-requirements`.
+`github-ruleset-pr-blocked-diagnose-missing-check-requirements`,
+`architecture-executable-convention-guard-pattern` (prose invariant → tested blocking check; loud
+collision-free failure; two-sided clean-PASS + synthetic-FAIL verification),
+`ci-hygiene-and-validation-gates` (Pattern 2: value-assertion step in an EXISTING static-check job,
+ASCII-only echoes, reusable `just` recipe called by CI).


### PR DESCRIPTION
## What

Amends the `config-governance-fix-scope-all-variant-files` skill **1.0.0 → 1.1.0** (MINOR, additive) with a planning-phase learning captured while planning a CI guard for issue #309 ("ruleset configs must stay enforcement=active").

## The durable learning: verify the issue's premise before planning to it

Issue #309's embedded fix sketch asserted that PR #177 flipped the two **base** files (`repo-ruleset.json:4`, `org-ruleset.json:4`) from `evaluate` to `active`, and prescribed a guard looping **all four** ruleset files asserting `enforcement == "active"`.

Running `jq -r .enforcement` over all four files showed the actual on-disk state is `evaluate, active, evaluate, active` — the two **base** files (`*-ruleset.json`) are intentionally `"evaluate"` and only the `*-active.json` variants are `"active"`. The two-form split (base/evaluate vs active/enforcing) is documented as intentional design in `configs/github/canonical-checks.md:58-62`. **The prescribed blanket guard would have been red-on-day-one against a correct repo.**

**Lesson:** when an issue prescribes a literal assertion over named files, run that assertion against current HEAD first. The correct guard asserts each file against its **intended per-file value** (a map), catching drift in BOTH directions (active→evaluate downgrade AND base→active silent upgrade) — strictly stronger than the issue's blanket check.

## Verification honesty

- **verified-local**: the premise-verification technique — the `jq` premise check WAS run during planning and confirmed `evaluate,active,evaluate,active`.
- **unverified**: the proposed enforcement-drift guard and its CI wiring (planning only — never implemented or CI-run). A warning banner marks the proposed-workflow section.

## Changes

- Frontmatter: `version` 1.0.0 → 1.1.0, `date` → 2026-06-20, added `history` ref + 8 tags.
- New When-to-Use triggers (6).
- New "Verify the issue premise before planning to it" workflow subsection with its own `### Quick Reference` and an unverified warning banner.
- New Failed Attempts row (adopt-the-blanket-guard).
- v1.1.0 Results & Parameters evidence + unverified-reliance caveats.
- Cross-refs to `architecture-executable-convention-guard-pattern` and `ci-hygiene-and-validation-gates` Pattern 2.
- Archived v1.0.0 into the new `.history` file.

## Validation

`python3 scripts/validate_plugins.py` → **Valid: 476/476**.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)