### PR TITLE
skill(adr-authoring): amend with cross-repo citation discipline (v1.2.0)

### DIFF
--- a/skills/adr-authoring-indexing-and-maintenance.md
+++ b/skills/adr-authoring-indexing-and-maintenance.md
@@ -1,9 +1,9 @@
 ---
 name: adr-authoring-indexing-and-maintenance
-description: "Use when: (1) generating a new Architecture Decision Record (ADR) to document a significant architectural decision; (2) an ADR file exists but is not listed in the index table (docs/adr/README.md); (3) updating ADR status to Accepted (Deferred) when implementation is bypassed pending platform support; (4) two or more functions have nearly identical limitation comments and need consolidating into a single ADR with cross-references replacing duplicates; (5) updating ADR directory tree listings to reflect actual filesystem contents after file deletions or additions; (6) writing an ADR on an epic branch where some child PRs have not yet merged to main — use pending-tense language for open PRs, past-tense only for work already on main."
+description: "Use when: (1) generating a new Architecture Decision Record (ADR) to document a significant architectural decision; (2) an ADR file exists but is not listed in the index table (docs/adr/README.md); (3) updating ADR status to Accepted (Deferred) when implementation is bypassed pending platform support; (4) two or more functions have nearly identical limitation comments and need consolidating into a single ADR with cross-references replacing duplicates; (5) updating ADR directory tree listings to reflect actual filesystem contents after file deletions or additions; (6) writing an ADR on an epic branch where some child PRs have not yet merged to main — use pending-tense language for open PRs, past-tense only for work already on main; (7) writing an ADR that references decisions from other repos or external docs — verify every ADR number on disk before asserting it exists, use commit SHAs for cross-repo work, cite file:line for cross-repo CLAUDE.md claims."
 category: documentation
 date: 2026-06-20
-version: "1.1.0"
+version: "1.2.0"
 user-invocable: false
 history: adr-authoring-indexing-and-maintenance.history
 tags:
@@ -17,6 +17,10 @@ tags:
   - pending-pr
   - epic-branch
   - in-flight-work
+  - cross-repo
+  - citation-discipline
+  - provenance
+  - append-only
 ---
 # ADR Authoring, Indexing, and Maintenance
 
@@ -43,6 +47,7 @@ directory-tree listings accurate against the real filesystem.
 - **Status lifecycle**: An ADR has `**Status**: Accepted` but the implementation explicitly bypasses the architecture (e.g., `# Temporary: Direct malloc`); a bypass comment references a known platform gap (e.g., Mojo global variable support); the underlying design decision is still valid but the active status is wrong.
 - **Consolidation**: A GitHub issue says "consider a single shared ADR instead of cross-referencing between two function docstrings"; two or more functions contain nearly identical `# NOTE:`/`Note:` blocks describing the same limitation; an audit finds that updating a limitation note requires editing multiple files.
 - **Directory-tree accuracy**: A file is deleted/added in a PR but the ADR directory tree was not updated; a follow-up issue asks to verify a helpers/tests directory is accurately documented; `grep` finds an ADR tree listing fewer files than `ls` shows on disk.
+- **Cross-repo citation discipline**: Writing an ADR in a meta-repo (e.g., Odysseus) that references decisions from submodule repos or external docs; the ADR text asserts an ADR number from another repo; the ADR claims a CLAUDE.md or internal doc says something — all such claims must be verified on disk before the ADR is written since ADRs are append-only once Accepted.
 
 ## Verified Workflow
 
@@ -56,6 +61,7 @@ directory-tree listings accurate against the real filesystem.
 | Consolidate dupes | Create ADR, replace each verbose block with 2–3 line `See docs/adr/ADR-NNN-<name>.md` cross-ref |
 | Fix dir tree | Compare ADR ASCII tree vs `ls`; Edit to match real files using `├──`/`└──` connectors |
 | Lint | `pixi run pre-commit run markdownlint-cli2 --files docs/adr/<file>.md` (NOT `npx`/`just`) |
+| Cross-repo ADR ref | `ls docs/adr/` to verify number exists; cite commit SHA for cross-repo work; cite `<file>:<line>` for CLAUDE.md claims |
 | Land | conventional commit `docs(adr): ...`, push, `gh pr create --label documentation`, `gh pr merge --auto --rebase` |
 
 ### Detailed Steps
@@ -252,6 +258,70 @@ done
 Reviewers will flag any past-tense claim on an epic branch if the underlying PR is still open
 (the file on the branch will contradict the claim). Fix before requesting re-review.
 
+#### H. Cross-repo citation discipline in append-only ADRs
+
+ADRs are frozen once Accepted. Any unverifiable claim baked into an Accepted ADR is permanent.
+Apply these rules **before drafting** any ADR that references work in other repos or external docs.
+
+**Rule 1 — Verify ADR numbers on disk before asserting they exist.**
+
+```bash
+ls docs/adr/
+# Only assert "ADR-NNN" if docs/adr/ADR-NNN-*.md appears in this listing.
+# If the number came from an implementation plan or external source, treat it as unverified.
+```
+
+**Rule 2 — Use commit SHAs for cross-repo work, not asserted ADR numbers.**
+
+When documenting that another repo made a decision, prefer:
+
+```markdown
+# GOOD: verifiable evidence
+The C++ HMAS hierarchy extraction is verifiable via commits 473da6a/341ae56 in ProjectAgamemnon.
+
+# BAD: unverifiable assertion
+ADR-015 subsequently extracted the C++ HMAS hierarchy.
+```
+
+If the external ADR number cannot be verified on disk, fall back to "external docs cite ADR-NNN"
+framing, paired with the commit SHA or file:line citation that proves the work happened.
+
+**Rule 3 — Cite `<file>:<line>` for CLAUDE.md or internal-doc claims.**
+
+Never write "Keystone's internal documentation refers to this decision as 'ADR-016'" without citing
+the exact file and line. Use:
+
+```bash
+grep -n 'ADR-016' submodule/CLAUDE.md
+# → CLAUDE.md:144, CLAUDE.md:156 — cite these line numbers in the ADR
+```
+
+Template for a cross-repo label claim:
+
+```markdown
+ProjectKeystone's `CLAUDE.md` (lines 144, 156) labels the Python orchestration layer as ADR-016.
+```
+
+**Rule 4 — Frame unverifiable external ADR numbers as "external docs cite X".**
+
+| Situation | Safe framing | Unsafe framing |
+| --------- | ------------ | -------------- |
+| External plan says "ADR-015 did X" but no file exists locally | "External docs cite ADR-015; this is not present in `docs/adr/` (001–009 confirmed on disk)." | "ADR-015 subsequently extracted …" |
+| Cross-repo CLAUDE.md mentions a number | "ProjectKeystone `CLAUDE.md:156` labels this layer as ADR-016." | "Keystone's internal documentation refers to this decision as 'ADR-016'." |
+| Cross-repo work verified by commit | "The extraction is verifiable via commits 473da6a/341ae56 in ProjectAgamemnon." | "ADR-015 extracted the C++ hierarchy." |
+
+**Verification checklist before finalising a cross-repo ADR**:
+
+```bash
+# 1. Confirm every ADR number cited exists on disk
+ls docs/adr/   # shows 001-009 → only assert numbers in this range
+
+# 2. Find commit SHAs for cross-repo work
+git -C <submodule-path> log --oneline | grep -i '<keyword>'
+
+# 3. Verify CLAUDE.md line numbers
+grep -n 'ADR-[0-9]\+\|<keyword>' <submodule-path>/CLAUDE.md
+```
 
 ## Failed Attempts
 
@@ -266,6 +336,9 @@ Reviewers will flag any past-tense claim on an epic branch if the underlying PR 
 | Past-tense claim for open child PR | ADR said "#5182: Split of `any_tensor.mojo` is now ≤3,000 lines" | On the epic branch `any_tensor.mojo` was still 4,106 lines because PR #5503 had not merged; reviewer flagged two threads (line 24 and line 55) — factually false | Use pending tense for open PRs: "Pending split … (PR #XXXX — pending merge to main)"; past tense only for work already on main |
 | "is now" in Consequences for pending PR | Consequences said "`any_tensor.mojo` is now ≤3,000 lines" when PR #5503 was unmerged | False on the branch; same code review thread flagged it as a second major finding | Write "will reach ≤3,000 lines once PR #XXXX merges" for pending outcomes; "is now" only after the PR lands |
 | Assuming the deletion was pending | Searched for an allegedly-stale deleted-file reference | No matches — the file was already removed by a prior PR | Always check both the filesystem AND the ADR independently before editing |
+| Asserting cross-repo ADR number without on-disk verification | ADR-009 draft said "ADR-015 subsequently extracted the C++ HMAS hierarchy" | `ls docs/adr/` shows only 001–009; ADR-015 does not exist in Odysseus; reviewer caught permanently-baked false claim in an append-only document | Run `ls docs/adr/` before asserting any ADR number; if the file isn't listed, reframe as "external docs cite ADR-NNN" + commit SHA evidence |
+| Asserting CLAUDE.md content without file:line citation | ADR-009 draft said "Keystone's internal documentation refers to this decision as 'ADR-016'" | No file:line was cited; reviewer blocked as unverifiable in a frozen document | Run `grep -n 'ADR-016' submodule/CLAUDE.md` first; cite the exact lines (e.g., `CLAUDE.md:144,156`) in the ADR |
+| Trusting implementation plan ADR numbers | Used ADR numbers from a planning doc without verifying on disk | Planning docs can reference ADRs from other repos or future ADRs not yet merged | Always independently verify every ADR number reference with `ls docs/adr/` in the target repo |
 
 ## Results & Parameters
 
@@ -324,3 +397,4 @@ pixi run pre-commit run markdownlint-cli2 --files docs/adr/<file>.md
 | ProjectOdyssey | Issue #3291, PR #3886 — consolidate FP16 SIMD limitation into ADR-010 | [history](adr-authoring-indexing-and-maintenance.history) |
 | ProjectOdyssey | Issue #3252, PR #3820 — ADR-004 helpers directory tree accuracy | [history](adr-authoring-indexing-and-maintenance.history) |
 | ProjectOdyssey | Issue #5191, PR #5504 — ADR-014 pending-PR accuracy: corrected past-tense claim for open child PR #5503 (commit 20b0d7c7) | [history](adr-authoring-indexing-and-maintenance.history) |
+| Odysseus | Issue #143, branch 143-auto-impl — ADR-009 cross-repo citation discipline: removed unverifiable ADR-015/016 claims; replaced with `ls docs/adr/` verification, commit SHA citations, and `CLAUDE.md:line` references | [history](adr-authoring-indexing-and-maintenance.history) |


### PR DESCRIPTION
## Summary

- Amends `skills/adr-authoring-indexing-and-maintenance.md` from v1.1.0 → v1.2.0
- Adds **Section H — Cross-repo citation discipline in append-only ADRs** with four
  rules and a verification checklist for writing ADRs that reference work in other repos
- Adds three new **Failed Attempts** rows documenting the specific failure patterns that
  triggered this amendment (unverifiable ADR-015/016 assertions in Odysseus ADR-009)
- Adds new `cross-repo`, `citation-discipline`, `provenance`, `append-only` tags
- Adds Odysseus issue #143 to the **Verified On** table

## What failed that prompted this

When authoring Odysseus ADR-009 (Python orchestration extraction), the initial draft
asserted "ADR-015 subsequently extracted the C++ HMAS hierarchy" and "Keystone's
internal documentation refers to this decision as 'ADR-016'" — both without on-disk
verification. A reviewer caught these as unverifiable claims that would be permanently
baked into a frozen append-only document. The fix: `ls docs/adr/` confirmed only
ADR-001–009 exist in Odysseus; commit SHAs in ProjectAgamemnon verified the C++
extraction; `grep -n 'ADR-016' ProjectKeystone/CLAUDE.md` produced the exact lines to cite.

## Test plan

- [x] `python scripts/validate_plugins.py` — 476/476 valid
- [x] Pre-commit hooks passed on commit (trim whitespace, end-of-file, large files)
- [x] Push signed with GPG (required-context hook passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)