### PR TITLE
feat: amend stdlib-json-decoder-raw-decode-string-extraction skill (v1.1.0)

### DIFF
--- a/skills/stdlib-json-decoder-raw-decode-string-extraction.history
+++ b/skills/stdlib-json-decoder-raw-decode-string-extraction.history
@@ -1,13 +1,56 @@
+<!-- markdownlint-disable MD024 MD025 MD040 -->
+# stdlib-json-decoder-raw-decode-string-extraction — History
+
+## v1.1.0 (2026-06-20)
+
+**Changed by:** ProjectHephaestus advise selector-JSON fix, PR #1557 (Closes #1556)
+**Verification:** verified-ci
+
+**What changed:**
+
+- Added the **parse-then-repair technique** complementing `raw_decode` extraction: a
+  best-effort `_repair_json_text` pass that (a) flips single quotes to double **only when
+  the text contains no double quotes at all** (`'"' not in text` guard) and (b) strips
+  trailing commas via `re.sub(r",(\s*[\]}])", r"\1", text)`, wrapped in a strict-first
+  layered `_extract_json_object` (strict `json.loads` → brace-slice → repair the slice).
+- Documented the **char-1 error signature**: `Expecting property name enclosed in double
+  quotes: line 1 column 2 (char 1)` is the tell-tale of single-quoted keys; trailing
+  commas yield `Illegal trailing comma`.
+- Stated the **single-quote-guard safety rule** explicitly (an unguarded flip would
+  corrupt `{"reason": "it's fine"}`) and the **strict-first ordering rule** (never repair
+  before strict parse succeeds, so valid input is never mangled).
+- Added **3 Failed Attempts** (single-quoted dict → char-1 error and raw_decode also
+  fails; unconditional quote-flip corrupts apostrophe strings; hand-trimming trailing
+  commas is brittle vs the regex).
+- Added a **new verified data point**: ProjectHephaestus PR #1557 (merged, commit
+  5798d5a), `hephaestus/automation/advise_runner.py`, TDD tests in
+  `tests/unit/automation/test_advise_runner.py::TestExtractJsonObject` (10 cases).
+- **Upgraded verification** verified-local → verified-ci (the fix shipped in merged
+  PR #1557 with full CI green).
+
+**Why:** `raw_decode` extracts a valid JSON object from mixed text but cannot parse
+text that is structurally near-JSON-but-invalid — single-quoted Python dicts and
+trailing commas that real LLM selectors emit. These are a distinct failure mode
+(malformed, not merely mixed) and need a complementary repair pass.
+
+## v1.0.0 (2026-06-04)
+
+Initial version.
+
+### Previous version (v1.0.0) snapshot
+
+The full v1.0.0 skill `.md` content as it stood before this amendment:
+
+````markdown
 ---
 name: stdlib-json-decoder-raw-decode-string-extraction
-description: "Use json.JSONDecoder.raw_decode() to extract the first JSON object from mixed text (with preamble, trailing text, whitespace, or nested objects), and a complementary parse-then-repair pass for structurally near-JSON the decoder cannot parse. Canonical stdlib pattern replacing custom balanced-brace parsers. Use when: (1) extracting JSON from LLM responses with preamble/postamble text, (2) parsing JSON from markdown code blocks with surrounding text, (3) handling edge cases like nested JSON objects, leading whitespace, or multiple trailing comment lines, (4) avoiding reinvention of the balanced-brace parser wheel, (5) json.loads fails with 'Expecting property name enclosed in double quotes ... char 1' on LLM output, (6) an LLM returned a Python-style single-quoted dict instead of JSON, (7) trailing commas appear in model-emitted JSON, (8) you need a best-effort repair pass after strict JSON fails."
+description: "Use json.JSONDecoder.raw_decode() to extract the first JSON object from mixed text (with preamble, trailing text, whitespace, or nested objects). Canonical stdlib pattern replacing custom balanced-brace parsers. Use when: (1) extracting JSON from LLM responses with preamble/postamble text, (2) parsing JSON from markdown code blocks with surrounding text, (3) handling edge cases like nested JSON objects, leading whitespace, or multiple trailing comment lines, (4) avoiding reinvention of the balanced-brace parser wheel."
 category: architecture
-date: 2026-06-20
-version: "1.1.0"
+date: 2026-06-04
+version: "1.0.0"
 user-invocable: false
-verification: verified-ci
-history: stdlib-json-decoder-raw-decode-string-extraction.history
-tags: [json, stdlib, parsing, jsondecoderraw_decode, robustness, edge-cases, refactoring, json-repair, single-quote-guard, llm-output, trailing-comma]
+verification: verified-local
+tags: [json, stdlib, parsing, jsondecoderraw_decode, robustness, edge-cases, refactoring]
 ---
 
 # stdlib: json.JSONDecoder.raw_decode() for String Extraction
@@ -16,12 +59,12 @@ tags: [json, stdlib, parsing, jsondecoderraw_decode, robustness, edge-cases, ref
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-20 |
-| **Objective** | Document canonical stdlib approach (json.JSONDecoder.raw_decode) for robust JSON extraction from mixed text, replacing custom 35-line balanced-brace parsers; plus a complementary parse-then-repair pass for structurally near-JSON (single-quoted dicts, trailing commas) the decoder cannot parse |
-| **Outcome** | ✅ SUCCESS - Refactor eliminated duplicated logic while maintaining 100% behavioral compatibility. Parse-then-repair shipped in merged PR #1557 with full CI green |
-| **Verification** | verified-ci — this session's parsing fix shipped in merged PR #1557 (ProjectHephaestus, commit 5798d5a) with all CI checks green |
-| **Related Issue** | #736, #1556 (ProjectHephaestus) |
-| **Related PR** | #924, #1557 (ProjectHephaestus) |
+| **Date** | 2026-06-04 |
+| **Objective** | Document canonical stdlib approach (json.JSONDecoder.raw_decode) for robust JSON extraction from mixed text, replacing custom 35-line balanced-brace parsers |
+| **Outcome** | ✅ SUCCESS - Refactor eliminated duplicated logic while maintaining 100% behavioral compatibility. 31 tests pass locally (28 existing + 3 new regression tests), 90.03% module coverage |
+| **Verification** | verified-local (CI validation pending) |
+| **Related Issue** | #736 (ProjectHephaestus) |
+| **Related PR** | #924 (ProjectHephaestus) |
 
 ## When to Use
 
@@ -35,15 +78,6 @@ Apply this pattern when:
    - Trailing text/comments after the closing brace
    - Multiple JSON objects (need the first one)
 4. **Replacing custom balanced-brace parsers** that are error-prone, hard to test, and duplicate across modules
-5. **Repairing structurally near-JSON that strict parsing rejects** — specifically when:
-   - `json.loads` fails with `Expecting property name enclosed in double quotes: line 1 column 2 (char 1)` on LLM output (the char-1 / column-2 position right after the opening brace is the tell-tale signature of single-quoted keys)
-   - an LLM returned a Python-style single-quoted dict instead of JSON (e.g. `{'skills': [{'name': 'x', 'reason': 'y'}]}`)
-   - the model emitted trailing commas (`[{"a": 1},]` or `{...,}`) → `Illegal trailing comma ...`
-   - you need a best-effort repair pass to run *after* strict JSON (and raw_decode extraction) fails
-
-`raw_decode` solves EXTRACTION (a valid JSON object embedded in mixed text). The
-parse-then-repair pass below solves MALFORMED-but-near-JSON (single quotes, trailing
-commas) — a different failure mode. A robust parser for real LLM output may need both.
 
 ## Verified Workflow
 
@@ -280,74 +314,6 @@ def extract_json_from_markdown_or_text(text: str) -> dict[str, Any] | None:
 
 **Key**: The regex uses non-greedy `.*?` to stop at the first closing brace, which correctly handles nested objects because the regex engine expands the match until BOTH the closing brace AND the fence match.
 
-### Malformed near-JSON: parse-then-repair
-
-`raw_decode` extracts a valid JSON object embedded in mixed text, but it cannot parse
-text that is *structurally near-JSON but not valid JSON* — the two dominant cases from
-real LLM "selector" outputs are:
-
-- **Python-style single-quoted dicts**: `{'skills': [{'name': 'x', 'reason': 'y'}]}`.
-  `json.loads` / `raw_decode` both fail with the signature error
-  `Expecting property name enclosed in double quotes: line 1 column 2 (char 1)`. The
-  `char 1` / `column 2` position (immediately after the opening brace) is the tell-tale
-  of single-quoted keys.
-- **Trailing commas**: `[{"a": 1},]` or `{"a": 1,}` → `Illegal trailing comma ...`.
-
-Use a **layered parse-then-repair** strategy. Always try STRICT json first; only on
-failure attempt a best-effort repair, then re-parse. **Order matters: strict-first
-never corrupts already-valid input.**
-
-```python
-import json
-import re
-from typing import Any
-
-
-def _repair_json_text(text: str) -> str:
-    """Best-effort repair of structurally near-JSON LLM output.
-
-    Last resort only — call after strict json.loads (and brace-slicing) fail.
-    """
-    repaired = text
-    # Flip single quotes to double ONLY when there are no double quotes at all,
-    # so a valid JSON string containing an apostrophe is never corrupted.
-    if "'" in repaired and '"' not in repaired:
-        repaired = repaired.replace("'", '"')
-    # Drop trailing commas before ] or } (optionally separated by whitespace).
-    repaired = re.sub(r",(\s*[\]}])", r"\1", repaired)
-    return repaired
-
-
-def _extract_json_object(stripped: str) -> dict[str, Any]:
-    """Strict first, then brace-slice, then repair the slice as a last resort."""
-    try:
-        return json.loads(stripped)
-    except json.JSONDecodeError:
-        # Markdown ```json fences and prose prefixes are handled here: slice from
-        # the first '{' to the last '}'. Repair is only the final fallback.
-        start, end = stripped.find("{"), stripped.rfind("}")
-        candidate = stripped[start : end + 1]
-        try:
-            return json.loads(candidate)
-        except json.JSONDecodeError:
-            return json.loads(_repair_json_text(candidate))  # last resort
-```
-
-**KEY SAFETY RULE — guard the single-quote flip with `'"' not in text`.** Without the
-guard, a legitimately double-quoted JSON string containing an apostrophe (e.g.
-`{"reason": "it's fine"}`) would be corrupted into invalid JSON. The flip must run only
-when the text contains single quotes AND no double quotes at all. This is the subtle
-correctness point of the whole repair pass.
-
-**Strict-first ordering rule.** Never repair before attempting strict `json.loads`.
-Repair is heuristic and can in theory mangle exotic-but-valid input; running it only on
-already-failed parses guarantees valid input is passed through untouched.
-
-**Composes with raw_decode / brace-slicing.** Markdown ```json fences and prose
-prefixes are handled by the brace-slice (first `{` / last `}`), so `_repair_json_text`
-is genuinely the last resort — invoked only when the sliced candidate is still
-malformed (single quotes / trailing commas).
-
 ## Failed Attempts & Lessons Learned
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -358,9 +324,6 @@ malformed (single quotes / trailing commas).
 | Fenced regex with greedy `.*` | `r'```(.*)\s*```'` for markdown code blocks | Greedy `.*` matches too much; stops at LAST `}` in nested objects (`` `{"a": {"b": 1}} more text}` `` matches past the real closing) | Use non-greedy `.*?` anchored by trailing literal (``` backticks); engine expands until both patterns match |
 | Stripping leading/trailing whitespace before json.loads() | `text.strip()` before json.loads() | Strips valid leading whitespace that's separate from JSON; raw_decode handles whitespace correctly | raw_decode skips leading whitespace per JSON spec; no manual strip needed |
 | Not testing nested objects during refactoring | Assumed refactored code handles nested dicts same as custom parser | Later found test failure in dict-containing-dict case (regression test caught it) | Always write regression tests for edge cases BEFORE refactoring, not after |
-| Passing a single-quoted dict from the model straight to the decoder | `json.loads("{'skills': [...]}")` (and `raw_decode`) | Fails with `Expecting property name enclosed in double quotes: line 1 column 2 (char 1)` — it's MALFORMED, not just mixed text, so `raw_decode` extraction cannot help either | `raw_decode` handles mixed/embedded valid JSON; structurally-malformed near-JSON needs a separate repair pass |
-| Flipping ALL single quotes to double unconditionally | `text.replace("'", '"')` with no guard | Would corrupt valid JSON strings containing apostrophes, e.g. `{"reason": "it's fine"}` → broken | Guard the flip with `'"' not in text` — only flip when there are single quotes AND zero double quotes |
-| Hand-trimming trailing commas with string slicing | Manually locating and slicing out `,` before `]`/`}` | Brittle and position-dependent; misses whitespace cases and multiple occurrences | A single regex `re.sub(r",(\s*[\]}])", r"\1", text)` is the clean, whitespace-tolerant fix |
 
 ## Results & Parameters
 
@@ -442,7 +405,6 @@ def extract_json_from_follow_up(text: str) -> dict[str, Any] | None:
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectHephaestus | Issue #736 follow-up JSON extraction refactor | [PR #924](https://github.com/HomericIntelligence/ProjectHephaestus/pull/924) — signed commit 02fc191, 31 tests pass locally, 90.03% coverage |
-| ProjectHephaestus | Issue #1556 advise selector parse-then-repair (single-quoted dict / trailing comma) | [PR #1557](https://github.com/HomericIntelligence/ProjectHephaestus/pull/1557) — merged, commit 5798d5a; `hephaestus/automation/advise_runner.py` (`_repair_json_text` + `_extract_json_object`); TDD tests in `tests/unit/automation/test_advise_runner.py::TestExtractJsonObject` (10 cases incl. single-quote / trailing-comma / fenced); full CI green (verified-ci) |
 
 ## Related Skills
 
@@ -456,5 +418,4 @@ def extract_json_from_follow_up(text: str) -> dict[str, Any] | None:
 - Issue #736: https://github.com/HomericIntelligence/ProjectHephaestus/issues/736
 - PR #924: https://github.com/HomericIntelligence/ProjectHephaestus/pull/924
 - Commit: 02fc191 — "refactor(automation): use json.JSONDecoder.raw_decode for follow_up JSON extraction"
-- Issue #1556: https://github.com/HomericIntelligence/ProjectHephaestus/issues/1556
-- PR #1557: https://github.com/HomericIntelligence/ProjectHephaestus/pull/1557 — advise selector parse-then-repair (single-quote flip with guard + trailing-comma strip), commit 5798d5a
+````


### PR DESCRIPTION
## Summary

Amends the `stdlib-json-decoder-raw-decode-string-extraction` skill (v1.0.0 -> **v1.1.0**, MINOR) to add a **complementary parse-then-repair technique** for structurally near-JSON that `raw_decode` cannot parse.

`raw_decode` solves EXTRACTION (a valid JSON object embedded in mixed text). This amendment documents the MALFORMED-but-near-JSON failure mode — single-quoted Python-style dicts and trailing commas that real LLM "selectors" emit — which is distinct and needs a repair pass.

### Additions
- **New When-to-Use triggers**: char-1 `Expecting property name enclosed in double quotes` error, single-quoted dict from a model, trailing commas, needing a best-effort repair after strict JSON fails.
- **New "Malformed near-JSON: parse-then-repair" subsection**: layered `_extract_json_object` (strict `json.loads` -> brace-slice -> repair) + `_repair_json_text`, with the **single-quote-guard safety rule** (`'"' not in text`) and the **strict-first ordering rule** stated explicitly.
- **3 new Failed Attempts**: single-quoted dict (raw_decode also fails); unconditional quote-flip corrupting apostrophe strings; hand-trimming trailing commas vs the clean regex.
- **New verified-ci data point**: ProjectHephaestus PR #1557 (merged, commit 5798d5a, Closes #1556), `hephaestus/automation/advise_runner.py`, 10 TDD cases in `test_advise_runner.py::TestExtractJsonObject`.
- **Verification upgraded** verified-local -> **verified-ci**.
- **First `.history` file created** (v1.1.0 entry + full v1.0.0 snapshot).

### Validation
`python3 scripts/validate_plugins.py` -> 476/476 valid.