### PR TITLE
feat: add planning-verify-issue-premises-against-main skill

### DIFF
--- a/skills/planning-verify-issue-premises-against-main.md
+++ b/skills/planning-verify-issue-premises-against-main.md
@@ -1,0 +1,220 @@
+---
+name: planning-verify-issue-premises-against-main
+description: "Consolidated / auto-generated follow-up issue bodies often describe a PLANNED or PARALLEL-BRANCH state, not the state of `main`. Before planning, verify EVERY premise against `main`: the issue's OPEN/CLOSED state, whether the PR it claims 'already did X' is actually merged, whether referenced files/recipes/commands exist on `main`, and whether a parallel in-flight PR already does this work. Prove commits are/aren't on main with `git merge-base --is-ancestor`, read the on-main file with `git show HEAD:<path>`, list on-main tests with `git ls-files`, check issue state with `gh issue view N --json state`, and surface overlapping PRs with `gh pr list`. Make the plan SELF-CONTAINED against main, not dependent on unmerged PRs; never copy an issue's prescribed 'mark X resolved' wording while the underlying issue is still OPEN; and never wire a CI gate to a recipe/target that does not yet exist on main (it hard-fails on day one). Use when: (1) planning a consolidated / auto-generated / follow-up issue that asserts 'PR #N did X' or 'issue #M is resolved', (2) the issue prescribes editing CLAUDE.md / docs to mark a defect resolved, (3) the issue tells you to wire a hook/gate to a named command (e.g. `just test-all`), (4) the issue overlaps work that may be in flight on a parallel branch / PR, (5) any premise depends on commits that may live on `*-auto-impl` or other unmerged branches."
+category: documentation
+date: 2026-06-20
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - planning
+  - verify-before-planning
+  - issue-premise
+  - against-main
+  - unmerged-pr
+  - parallel-branch
+  - follow-up-issue
+  - consolidated-issue
+  - auto-generated-issue
+  - git-merge-base
+  - git-show-head
+  - gh-issue-state
+  - parallel-pr-overlap
+  - pre-commit
+  - justfile-recipe
+  - self-contained-plan
+  - stale-issue
+---
+
+# Verify Every Issue Premise Against `main` Before Planning
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-20 |
+| **Objective** | Capture a durable planning-discipline lesson: a consolidated / auto-generated / follow-up issue body narrates a PLANNED or PARALLEL-BRANCH state, NOT the state of `main`. Before planning, verify every premise (issue state, PR merge status, referenced files, referenced recipes/commands) against `main`, and make the plan self-contained against `main` rather than dependent on unmerged PRs |
+| **Outcome** | Plan written for ProjectProteus issue #185. The issue asserted "PR #173 replaces stubs with real tests" and prescribed a pre-push hook running `just test-all`. Premise checks against `main` showed: issue #5 still OPEN, PR #173 still OPEN/unmerged, the #5 real-test commits NOT ancestors of main (they live on `*-auto-impl` branches), NO `test-all` recipe exists on main, the only on-main test is `tests/dispatch-apply.test.sh`, and a separate open PR #187 already did essentially the same work. The plan was reframed to be self-contained against `main`. The PLAN itself was NOT executed (no code committed, CI not run); the PREMISE-VERIFICATION commands WERE run and confirmed via git/gh |
+| **Verification** | **verified-local** — the `gh issue view` / `gh pr list` / `git merge-base --is-ancestor` / `git show HEAD:justfile` / `git ls-files` premise checks were executed locally this session and produced the cited outputs. The resulting plan is **unexecuted** (no commit, no CI). Treat the plan's prescriptions as a hypothesis; treat the premise findings as confirmed |
+
+This is a planning-DISCIPLINE learning. It is the **temporal / branch** complement to the
+spatial-disambiguation skill `verify-issue-premise-against-code-before-planning` (which greps the
+premise tokens to find WHICH same-repo file matches). Here the question is not *which file* but
+*which timeline*: the issue describes a future/parallel-branch state that is not yet on `main`.
+
+> **Warning:** The resulting implementation plan was produced in a planning session and NOT
+> executed end-to-end (no commit, no CI). The verification COMMANDS below were genuinely run
+> against the live repo (`verified-local`); the plan they fed is a hypothesis until CI confirms.
+
+## When to Use
+
+- Planning a **consolidated / auto-generated / follow-up** issue whose body asserts "PR #N already
+  did X" or "issue #M is resolved" — these bodies are snapshots of a PLANNED end-state, not `main`.
+- The issue tells you to **edit CLAUDE.md / docs to mark a defect resolved**. Never copy the
+  issue's prescribed "resolved" wording while the underlying issue is still OPEN.
+- The issue tells you to **wire a hook / CI gate to a named command** (e.g. `just test-all`).
+  Confirm that recipe/target actually exists on `main` before wiring a gate to it.
+- The issue **overlaps work that may be in flight** on a parallel branch or another open PR.
+- Any premise depends on commits that may live on `*-auto-impl` (or other) unmerged branches
+  rather than on `main`.
+
+## Verified Workflow
+
+> **Warning:** The numbered discipline below is the workflow that worked at planning time; its
+> verification commands were run live (`verified-local`). The downstream plan was NOT executed.
+> The heading is "Verified Workflow" to satisfy the marketplace validator (it requires that exact
+> heading) — but the PLAN it produced is unexecuted.
+
+### Quick Reference
+
+```bash
+ORG=HomericIntelligence
+REPO=ProjectProteus
+
+# 1. Is the issue the body claims is "resolved" actually CLOSED?
+gh issue view 5 --repo "$ORG/$REPO" --json state --jq .state
+#   -> OPEN  (so do NOT copy the issue's "mark #5 resolved" wording)
+
+# 2. Is the PR the body says "already did X" actually MERGED?
+gh pr view 173 --repo "$ORG/$REPO" --json state,mergedAt --jq '{state,mergedAt}'
+#   -> {"state":"OPEN","mergedAt":null}  (unmerged — its changes are NOT on main)
+
+# 3. Prove the claimed commits are / are NOT on main (the key technique).
+git fetch origin
+#    Find the branch the work really lives on (often *-auto-impl):
+git branch -r --contains <commit-sha>
+#    Then prove it is NOT an ancestor of main:
+git merge-base --is-ancestor <commit-sha> origin/main && echo "ON MAIN" || echo "NOT ON MAIN"
+#   -> NOT ON MAIN  (the real-test commits live on 27-auto-impl / 182-auto-impl)
+
+# 4. Does the recipe/command the issue tells you to gate on EXIST on main?
+git show HEAD:justfile | grep -nE '^[a-z0-9_-]+( [A-Z]|:)'   # list recipes ON MAIN
+just --list                                                   # what `just` actually offers
+#   -> only `test NAME` (a Dagger wrapper) and `validate`; NO `test-all`.
+#      A pre-push hook running `just test-all` would crash on every push:
+#      "Justfile does not contain recipe `test-all`".
+
+# 5. What test files actually exist ON MAIN (not on a branch)?
+git ls-files tests/
+#   -> tests/dispatch-apply.test.sh   (the ONLY test file on main)
+git show HEAD:dagger/package.json | grep -E '"test"|jest'   # -> no test/jest script
+
+# 6. Is a PARALLEL PR already doing this work?
+gh pr list --repo "$ORG/$REPO" --state open \
+  --json number,title,headRefName --jq '.[]|"\(.number) \(.headRefName) — \(.title)"'
+#   -> #187 add pre-push hook and mark #5 resolved (branch 182-auto-impl) — OVERLAP
+```
+
+### Detailed Steps
+
+1. **Treat the consolidated/auto-generated issue body as a description of a PLANNED end-state, not
+   `main`.** Auto-generated follow-up issues are often written assuming a set of sibling PRs will
+   have merged. They describe the intended steady state, which is frequently a parallel-branch or
+   not-yet-merged reality. Every "PR #N did X" / "#M is resolved" assertion is a CLAIM to verify.
+
+2. **Verify referenced issue states with `gh issue view N --json state`.** If the body says
+   "issue #5 is resolved," confirm it. In #185, `gh issue view 5 --json state` returned `OPEN` —
+   so any doc edit marking #5 resolved would have stated a falsehood on `main`.
+
+3. **Verify referenced PRs are actually MERGED, not just open.** `gh pr view N --json state,mergedAt`.
+   In #185 the body said "PR #173 replaces stubs with real tests," but #173 was `OPEN` / `mergedAt:
+   null` — its changes are not on `main`, so the plan cannot assume real tests exist there.
+
+4. **Prove commits are / are not on `main` with `git merge-base --is-ancestor`.** This is the load-
+   bearing technique: `git merge-base --is-ancestor <sha> origin/main` exits 0 iff `<sha>` is on
+   main. `git branch -r --contains <sha>` shows which branch *does* hold it — here the #5 real-test
+   commits lived on `27-auto-impl` / `182-auto-impl`, not main. Read the *content* of `main`, never
+   the working tree (which may be checked out to a feature branch).
+
+5. **Confirm any recipe / command the issue tells you to gate on EXISTS on `main`.** Read the on-
+   main file with `git show HEAD:justfile` and cross-check with `just --list`. In #185 there was NO
+   `test-all` recipe on main — only `test NAME` (a Dagger wrapper) and `validate`. A pre-push hook
+   wired to `just test-all` would hard-fail on EVERY push with "Justfile does not contain recipe
+   `test-all`." Wiring a gate to a non-existent target is a day-one breakage, not a future-proofing.
+
+6. **List the tests that actually exist on `main` with `git ls-files`.** In #185 the only on-main
+   test was `tests/dispatch-apply.test.sh`; `git show HEAD:dagger/package.json` had no `test`/Jest
+   script. So CLAUDE.md wording like "unit-tests runs Jest / integration-tests runs bats / #5
+   resolved" would have been FALSE against main. Defect docs must stay truthful to `main`.
+
+7. **Surface overlapping in-flight PRs with `gh pr list`.** A consolidated issue often overlaps a
+   sibling PR already in flight. In #185, open PR #187 ("add pre-push hook and mark #5 resolved",
+   branch `182-auto-impl`) already did essentially the same work. Cross-link it in the plan instead
+   of duplicating it.
+
+8. **Make the plan SELF-CONTAINED against `main`.** Once the premises are checked, write the plan
+   so it stands on the actual state of `main` — do not write "assuming PR #173 lands, then…" forks.
+   If the prerequisite work is not on main, either (a) scope the plan to what main can support now,
+   or (b) explicitly mark the dependency and cross-link the in-flight PR. Keep defect docs (CLAUDE.md)
+   reflecting main's real state; cross-link the open PRs rather than copying their "resolved" wording.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust "PR #173 replaces stubs with real tests" from the issue body | Planned as if real tests already existed on main | `gh pr view 173` showed `state:OPEN, mergedAt:null`; `git merge-base --is-ancestor` proved the #5 real-test commits were NOT on main (they live on `27-auto-impl`/`182-auto-impl`) | Verify a referenced PR is actually MERGED and its commits are ancestors of `origin/main` before assuming its output exists on main |
+| Wire a pre-push hook to `just test-all` (as the issue prescribed) | Planned a hook with `entry`/command running `just test-all` | NO `test-all` recipe exists on `main` (`git show HEAD:justfile` + `just --list` show only `test NAME` and `validate`); the hook would crash every push with "Justfile does not contain recipe `test-all`" | Confirm a referenced recipe/command/target exists on `main` before wiring any gate to it; otherwise the gate hard-fails on day one |
+| `entry: bash -c just test-all` in the pre-commit hook | Used `bash -c just test-all` to "run the recipe" | `bash -c` takes its FIRST word as the command and the rest as `$0`/positional args, so this runs command `just` with `$0=test-all` — the recipe is never invoked as intended | Use `entry: just test-all` (with `language: system`), or quote it: `bash -c "just test-all"` if a shell wrapper is truly needed |
+| Copy the issue's "mark #5 resolved" / "unit-tests runs Jest, integration-tests runs bats" wording into CLAUDE.md | Transcribed the issue's prescribed "resolved" documentation edits | Issue #5 was still OPEN (`gh issue view 5 --json state` → OPEN); the only on-main test is `tests/dispatch-apply.test.sh` and `dagger/package.json` has no Jest script — so the wording was FALSE on main | Never copy an issue's prescribed "resolved" wording while the underlying issue is still OPEN; reconcile doc edits against the real state of `main` and cross-link the in-flight PRs |
+| Plan without checking for parallel in-flight PRs | Treated #185 as standalone net-new work | A separate open PR #187 ("add pre-push hook and mark #5 resolved", branch `182-auto-impl`) already did essentially the same work — `gh pr list` surfaced it | `gh pr list` before planning a consolidated issue; cross-link overlapping in-flight PRs instead of duplicating their work |
+| Read the working tree to learn "what's on main" | Inspected the checked-out files | The working tree may be on a feature branch; on-disk content is not evidence of `main` | Read on-main content explicitly: `git show HEAD:<path>` / `git ls-files` against `origin/main`, and prove ancestry with `git merge-base --is-ancestor` |
+
+## Results & Parameters
+
+### The premise-verification command set that worked (the core of this skill)
+
+```bash
+ORG=HomericIntelligence; REPO=ProjectProteus
+gh issue view 5  --repo "$ORG/$REPO" --json state --jq .state                 # OPEN
+gh pr view  173  --repo "$ORG/$REPO" --json state,mergedAt                    # OPEN / null
+git merge-base --is-ancestor <real-test-sha> origin/main || echo "NOT ON MAIN"
+git branch -r --contains <real-test-sha>                                      # *-auto-impl
+git show HEAD:justfile | grep -nE 'test-all'                                  # (no output)
+just --list                                                                   # test NAME, validate
+git ls-files tests/                                                           # tests/dispatch-apply.test.sh
+git show HEAD:dagger/package.json | grep -E '"test"|jest'                     # (no output)
+gh pr list --repo "$ORG/$REPO" --state open --json number,title,headRefName   # surfaces #187
+```
+
+### Verified findings for ProjectProteus #185 (live, 2026-06-20)
+
+- Issue #5: `state == OPEN` (not resolved, despite the body's prescribed "mark resolved" edit).
+- PR #173: `state == OPEN`, `mergedAt == null` — unmerged; its "real tests" are NOT on main.
+- The #5 real-test commits are NOT ancestors of `origin/main` (`git merge-base --is-ancestor`
+  failed); they live on `27-auto-impl` / `182-auto-impl` branches.
+- No `test-all` recipe on main — only `test NAME` (a Dagger wrapper) and `validate`.
+- Only on-main test file: `tests/dispatch-apply.test.sh`; `dagger/package.json` has no test/Jest
+  script.
+- Open PR #187 (branch `182-auto-impl`) already does essentially the same work → cross-link, don't
+  duplicate.
+
+### The pre-commit `bash -c` parsing gotcha (copy-paste correct forms)
+
+```yaml
+# WRONG — `just` runs with $0=test-all; the recipe is never invoked as intended:
+entry: bash -c just test-all
+# CORRECT — run the command directly:
+entry: just test-all
+language: system
+# CORRECT alternative — if a shell wrapper is genuinely needed, QUOTE it:
+entry: bash -c "just test-all"
+```
+
+### Related skills
+
+- `verify-issue-premise-against-code-before-planning` — the SPATIAL complement: grep the premise's
+  distinctive tokens to disambiguate WHICH same-repo file/job matches. THIS skill is the TEMPORAL/
+  branch complement: the premise describes a not-yet-on-main (planned/parallel-branch) state.
+- `planning-verify-live-state-before-assuming-work-remains` — verify live external state (default
+  branch, applied ruleset) may already be done OR the opposite. THIS skill focuses on commits/PRs
+  that look merged in the narrative but live on unmerged branches.
+- `planning-dependent-issue-unverified-upstream` — when the dependency IS already merged, read it
+  and eliminate forks. THIS skill handles the case where the dependency is NOT merged (still open),
+  so the plan must be made self-contained against main instead.
+- `git-unmerged-branch-file-access` — reading files from branches that are not on main.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectProteus | Issue #185 planning (consolidated / auto-generated follow-up) | verified-local — premise checks run live: `gh issue view 5` → OPEN; `gh pr view 173` → OPEN/unmerged; `git merge-base --is-ancestor` proved #5 real-test commits not on main (on `*-auto-impl`); `git show HEAD:justfile` + `just --list` showed no `test-all`; `git ls-files tests/` → only `dispatch-apply.test.sh`; `gh pr list` surfaced overlapping open PR #187. The resulting plan is unexecuted (no commit, no CI). |


### PR DESCRIPTION
## Summary

New skill (planning-discipline / documentation). Documents that consolidated, auto-generated, or follow-up issue bodies often describe a PLANNED or PARALLEL-BRANCH state, NOT the state of `main`. Before planning, verify EVERY premise against `main` — issue OPEN/CLOSED state, PR merge status, referenced files, referenced recipes/commands — and make the plan self-contained against `main` rather than dependent on unmerged PRs.

- Prove commits are/aren't on main with `git merge-base --is-ancestor` (the PR you think merged may still be OPEN, with its work on a `*-auto-impl` branch).
- Confirm a referenced recipe/command exists on main (`git show HEAD:justfile` + `just --list`) before wiring a CI gate to it; a gate on a non-existent recipe hard-fails on day one.
- Never copy an issue's prescribed 'mark X resolved' wording while the underlying issue is still OPEN; surface overlapping in-flight PRs with `gh pr list` and cross-link instead of duplicating.

## Verification Level

**verified-local** — the premise-verification commands (`gh issue view`, `gh pr view`, `gh pr list`, `git merge-base --is-ancestor`, `git show HEAD:justfile`, `git ls-files`) were executed live against HomericIntelligence/ProjectProteus while planning issue #185 and produced the cited outputs. The resulting implementation PLAN was NOT executed (no commit, no CI). So: premise findings = verified-local; plan = unexecuted hypothesis.

## Key Findings

**What Worked**:
- `git merge-base --is-ancestor <sha> origin/main` cleanly proved the #5 real-test commits were NOT on main (they live on `27-auto-impl`/`182-auto-impl`), despite the issue claiming PR #173 'replaces stubs with real tests'.
- `git show HEAD:justfile` + `just --list` showed no `test-all` recipe on main — the issue's prescribed pre-push hook would crash every push.
- `gh pr list` surfaced parallel open PR #187 already doing essentially the same work.

**What Failed (captured as Failed Attempts)**:
- Trusting 'PR #173 replaces stubs with real tests' → PR #173 still OPEN/unmerged.
- `entry: bash -c just test-all` → `just` runs with \$0=test-all; recipe never invoked. Use `entry: just test-all` or quoted `bash -c "just test-all"`.
- Copying the issue's 'mark #5 resolved' wording → #5 still OPEN; wording false on main.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (477/477 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>