### PR TITLE
feat: amend testing-verification-gate-zero-test-false-pass skill (v1.1.0)

### DIFF
--- a/skills/testing-verification-gate-zero-test-false-pass.history
+++ b/skills/testing-verification-gate-zero-test-false-pass.history
@@ -1,0 +1,106 @@
+# testing-verification-gate-zero-test-false-pass — History
+
+## v1.1.0 (2026-06-20)
+
+**Changed by:** ProjectAgamemnon issue #279 R1 re-planning (plan NOGO'd, revised). A second, C++/CMake manifestation of the same "name-filtered gate selects zero tests → false pass" lesson.
+**Verification:** unverified (plan-only) — the revised plan was never executed (no build, no `ctest`, no Docker run); all facts from static source reading + the plan reviewer's own verification.
+
+### What changed
+- Generalized the skill from a pytest-only finding to the broader class of NAME-FILTERED acceptance gates (`pytest -k`, `ctest -R`, `go test -run`).
+- Added the C++/CMake-specific manifestation: an ORPHANED test source (`test/src/test_healthcheck.cpp` listed in NO `test/CMakeLists.txt` target) makes `ctest -R Healthcheck` match zero tests and exit 0 — a silent false-positive acceptance gate.
+- Added the planning-review angle: when a PLAN cites a name-filtered runner as an acceptance gate, first prove the gate is non-empty (filter matches ≥1 test AND the source is wired into a build target).
+- Added the fix mechanics: wire the orphaned test into its own executable; inject the binary-under-test path via CMake `$<TARGET_FILE:...>` generator expression (+ `add_dependencies`) rather than a hard-coded literal/relative path.
+- Added an empty-match guard pattern: `ctest -R X --show-only | grep -qE 'Test #' || exit 1`.
+- Added a `### Detailed Steps` generalizable workflow (classify gate → prove wiring → guard empty match → inject target-file path).
+- Added 3 Failed Attempts rows (#4–#6, all marked plan-only).
+- Updated frontmatter: description (now mentions ctest/orphaned-target + 5th trigger), tags (+ctest, cmake, gtest, show-only, orphaned-test, target-file, plan-review), version 1.0.0 → 1.1.0, added `history` field.
+- Added the ProjectAgamemnon #279 row to "Verified On"; reframed the table around pytest case (#143) vs ctest case (#279).
+- Added documented open reviewer risks for the ctest case (unbuilt target / gtest discovery, unconfirmed suite name, shell-quoting of `$<TARGET_FILE>` into `system()`, sanitizer/port-binding flakiness) and externally-cited-but-unverified sources.
+
+### Why
+v1.0.0 captured the pytest variant (`pytest -k config` matched 0 tests, exited 0) from ProjectAgamemnon #143. A second R1 re-plan (ProjectAgamemnon #279) hit the IDENTICAL failure class in C++: a plan cited `ctest -R Healthcheck` as an acceptance gate, but the test source was compiled into no CMake target, so the regex matched zero tests and the gate proved nothing. Same search surface (someone debugging a name-filtered test false-positive), same category (testing), same verification level (unverified/plan-only) — so the learning belongs in this skill rather than a new file. The genuinely new content is the orphaned-build-target detection and the planning rule that a cited gate must be proven non-empty before it can be trusted.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: testing-verification-gate-zero-test-false-pass
+description: "A verification gate that selects ZERO tests still exits 0 (green) and silently gates nothing — a FALSE PASS. Happens when a plan says 'wrap existing test X in pytest.warns' but X never existed, or uses `pytest -k <expr>` that matches no tests. Net-new code (e.g. a deprecation shim) then ships untested. Use when: (1) a plan modifies/wraps an 'existing' test, (2) a verification step relies on `pytest -k`/selection, (3) you add net-new code and want a real gate, (4) you must enforce a DeprecationWarning rather than just allow it."
+category: testing
+date: 2026-06-20
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [testing, pytest, verification-gate, false-pass, deprecation-warning, test-count, collect-only, planning]
+---
+
+# Verification Gate: Zero-Test False Pass
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-06-20 |
+| Objective | Validate the test gate in the R1 plan that "verifies" a new deprecation shim added while moving code ProjectKeystone → ProjectAgamemnon |
+| Outcome | Planning-only (R1 re-plan after NOGO). Found the planned gate was a false pass: it wrapped phantom tests and used `pytest -k config` which matched 0 tests yet exited 0. Replaced with grep-confirmed test existence, a net-new test for net-new code, an asserted pass COUNT, and `-W error::DeprecationWarning` enforcement |
+| Verification | unverified — gate not executed; no CI ran |
+
+## When to Use
+
+- A plan or issue says "wrap the existing `LegacyClass(...)` test in `pytest.warns`" or "modify test X" — before trusting it, confirm X actually exists.
+- A verification step relies on `pytest -k <expr>` or any test SELECTION to gate a change.
+- You are adding **net-new** code (a deprecation shim, a new module) and want a gate that actually exercises it.
+- You need a DeprecationWarning to be **enforced** (failing the build if it regresses), not merely permitted.
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+The trap: `pytest -k config` (or `pytest.warns` wrapped around a non-existent call) returns exit code 0 when it collects **zero** matching tests. Green build, nothing tested. The fix is to (a) prove the tests you intend to modify exist, (b) give net-new code a net-new test, (c) assert an explicit pass COUNT and collection parity so a missing test can't hide, and (d) promote the warning to an error so it's enforced.
+
+1. **Before writing "wrap/modify existing test X":** grep-confirm X exists. If the grep returns nothing, the assertions you planned to wrap are phantom.
+2. **Net-new code gets a NET-NEW test** — not a wrapper around a phantom assertion. A deprecation shim that ships without its own test is untested code.
+3. **Never let a selection gate pass on zero tests.** Assert the expected pass count (e.g. `... | grep -q "4 passed"`), so a zero-match run (which prints `no tests ran` / `0 selected`) fails the gate.
+4. **Enforce the warning** with `-W error::DeprecationWarning` so the deprecation path is actually triggered and a regression fails the build.
+5. **Check collection parity:** `pytest --collect-only -q | tail -1` must equal `baseline + N-new`, so a net-new test cannot be silently absent.
+
+### Quick Reference
+
+(See v1.1.0 file for the pytest commands — unchanged in substance: phantom-detection grep, `pytest -k config` false pass, real gate with `-W error::DeprecationWarning` + `grep -q "4 passed"`, collection parity.)
+
+## Verified Workflow
+
+_Not applicable_ — unverified; no workflow was executed. Captured during an R1 re-planning session; the gate above is a hypothesis to be confirmed by CI/execution.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| 1 | Plan: "wrap each legacy-var assertion in `pytest.warns`" to verify the new deprecation shim | grep returned nothing and no `test_config.py` existed — the assertions to wrap were phantom | Before writing "wrap/modify existing test X", grep-confirm X exists; net-new code needs a NET-NEW test, not a wrapped phantom |
+| 2 | `pytest -k config` as the verification gate for the change | It matched 0 tests, exited 0 (green), and gated nothing — a FALSE PASS; net-new shim shipped untested | A `pytest -k` gate matching zero tests is a false pass; assert the expected pass COUNT so a zero-match run fails |
+| 3 | Allowed the DeprecationWarning to merely fire (default filter) | A merely-allowed warning never fails the build, so a regression on the deprecation path would pass silently | Run with `-W error::DeprecationWarning` to enforce the warning, and use `--collect-only` count parity so a missing test can't hide |
+
+## Results & Parameters
+
+- **False-pass command:** `pytest -k config` → "no tests ran", exit 0.
+- **Phantom-detection grep:** `grep -rnE 'setenv|os\.environ|KEYSTONE_|monkeypatch' tests/*.py` (empty result ⇒ no test to wrap).
+- **Real gate:** `pytest <net-new-test> -W error::DeprecationWarning -q` AND `grep -q "<N> passed"` on the output.
+- **Collection parity:** `pytest --collect-only -q | tail -1` == baseline + N-new.
+- **Rules:** (1) grep-confirm a test exists before "wrapping" it; (2) net-new code → net-new test; (3) assert pass count, not just exit code; (4) enforce warnings as errors.
+- **Status:** unverified (planning-only); gate not executed, no CI run.
+
+## Verified On
+
+| Item | Value |
+|------|-------|
+| Migration | ProjectKeystone → ProjectAgamemnon |
+| Meta-repo | Odysseus |
+| Issue | #143 (R1 planning) |
+| Verification | unverified — not executed |
+```
+
+---
+
+## v1.0.0 (2026-06-20)
+
+**Initial version.** Captured the pytest-only manifestation from ProjectAgamemnon #143 (R1 plan after NOGO): `pytest -k config` selected zero tests, exited 0, and gated a net-new deprecation shim that shipped untested.

--- a/skills/testing-verification-gate-zero-test-false-pass.md
+++ b/skills/testing-verification-gate-zero-test-false-pass.md
@@ -1,12 +1,12 @@
 ---
 name: testing-verification-gate-zero-test-false-pass
-description: "A verification gate that selects ZERO tests still exits 0 (green) and silently gates nothing — a FALSE PASS. Happens when a plan says 'wrap existing test X in pytest.warns' but X never existed, or uses `pytest -k <expr>` that matches no tests. Net-new code (e.g. a deprecation shim) then ships untested. Use when: (1) a plan modifies/wraps an 'existing' test, (2) a verification step relies on `pytest -k`/selection, (3) you add net-new code and want a real gate, (4) you must enforce a DeprecationWarning rather than just allow it."
+description: "A name-filtered verification gate that selects ZERO tests still exits 0 (green) and silently gates nothing — a FALSE PASS. Happens with `pytest -k <expr>`, `ctest -R <regex>`, `go test -run <regex>` etc. when the filter matches nothing OR the test source is compiled into NO build target (orphaned file). The change then ships untested. Use when: (1) a plan modifies/wraps an 'existing' test, (2) a verification step relies on a NAME-FILTERED selection (`pytest -k`, `ctest -R`, `go test -run`), (3) you add net-new code and want a real gate, (4) you must enforce a DeprecationWarning rather than just allow it, (5) a plan cites `ctest -R <name>` as an acceptance gate — first prove the test source is wired into a CMake target."
 category: testing
 date: 2026-06-20
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
-verification: unverified
-tags: [testing, pytest, verification-gate, false-pass, deprecation-warning, test-count, collect-only, planning]
+history: testing-verification-gate-zero-test-false-pass.history
+tags: [testing, pytest, ctest, cmake, gtest, verification-gate, false-pass, deprecation-warning, test-count, collect-only, show-only, orphaned-test, target-file, planning, plan-review]
 ---
 
 # Verification Gate: Zero-Test False Pass
@@ -16,52 +16,78 @@ tags: [testing, pytest, verification-gate, false-pass, deprecation-warning, test
 | Field | Value |
 |-------|-------|
 | Date | 2026-06-20 |
-| Objective | Validate the test gate in the R1 plan that "verifies" a new deprecation shim added while moving code ProjectKeystone → ProjectAgamemnon |
-| Outcome | Planning-only (R1 re-plan after NOGO). Found the planned gate was a false pass: it wrapped phantom tests and used `pytest -k config` which matched 0 tests yet exited 0. Replaced with grep-confirmed test existence, a net-new test for net-new code, an asserted pass COUNT, and `-W error::DeprecationWarning` enforcement |
-| Verification | unverified — gate not executed; no CI ran |
+| Objective | Validate the test gates in R1 re-plans (after NOGO) on ProjectAgamemnon — both a pytest deprecation-shim gate (#143) and a C++/ctest healthcheck gate (#279) |
+| Outcome | Planning-only (R1 re-plans after NOGO). Both plans cited a NAME-FILTERED gate that selected ZERO tests yet exited 0 — a false pass. pytest case: `pytest -k config` matched nothing; ctest case: `ctest -R Healthcheck` matched nothing because `test/src/test_healthcheck.cpp` was compiled into NO CMake target (orphaned). Fixes: prove the gate is non-empty before trusting it, wire the orphaned test into its own target, inject the binary-under-test path via `$<TARGET_FILE:...>` |
+| Verification | unverified — gates not executed; no CI ran; facts from static source reading + plan-reviewer verification |
+| History | [changelog](./testing-verification-gate-zero-test-false-pass.history) |
 
 ## When to Use
 
 - A plan or issue says "wrap the existing `LegacyClass(...)` test in `pytest.warns`" or "modify test X" — before trusting it, confirm X actually exists.
-- A verification step relies on `pytest -k <expr>` or any test SELECTION to gate a change.
-- You are adding **net-new** code (a deprecation shim, a new module) and want a gate that actually exercises it.
+- A verification step relies on a **name-filtered selection** (`pytest -k <expr>`, `ctest -R <regex>`, `go test -run <regex>`) to gate a change.
+- **A plan cites `ctest -R <name>` (or any name-filtered runner) as an ACCEPTANCE GATE** — first prove the filter matches ≥1 registered test AND the test source is wired into a real build target. An orphaned test file (in no CMake target) makes the gate a silent no-op.
+- You are adding **net-new** code (a deprecation shim, a new module, a new test file) and want a gate that actually exercises it.
 - You need a DeprecationWarning to be **enforced** (failing the build if it regresses), not merely permitted.
+- You are wiring an orphaned test that shells out to a built binary and need a robust, CWD-independent way to find that binary.
 
-## Proposed Workflow
+## Verified Workflow
 
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+> **Warning:** This workflow has not been validated end-to-end. Both gates were captured during R1 re-planning (after NOGO); neither was executed (no build, no `ctest`, no `pytest` run, no CI). Treat as a hypothesis until CI confirms. The ctest/CMake rows added in v1.1.0 are `unverified (plan-only)`.
 
-The trap: `pytest -k config` (or `pytest.warns` wrapped around a non-existent call) returns exit code 0 when it collects **zero** matching tests. Green build, nothing tested. The fix is to (a) prove the tests you intend to modify exist, (b) give net-new code a net-new test, (c) assert an explicit pass COUNT and collection parity so a missing test can't hide, and (d) promote the warning to an error so it's enforced.
+The trap: a name-filtered runner returns exit code 0 when it collects **zero** matching tests. Green build, nothing tested. Two ways to get zero matches:
 
-1. **Before writing "wrap/modify existing test X":** grep-confirm X exists. If the grep returns nothing, the assertions you planned to wrap are phantom.
-2. **Net-new code gets a NET-NEW test** — not a wrapper around a phantom assertion. A deprecation shim that ships without its own test is untested code.
-3. **Never let a selection gate pass on zero tests.** Assert the expected pass count (e.g. `... | grep -q "4 passed"`), so a zero-match run (which prints `no tests ran` / `0 selected`) fails the gate.
-4. **Enforce the warning** with `-W error::DeprecationWarning` so the deprecation path is actually triggered and a regression fails the build.
-5. **Check collection parity:** `pytest --collect-only -q | tail -1` must equal `baseline + N-new`, so a net-new test cannot be silently absent.
+1. The filter expression simply doesn't match any registered test name (`pytest -k config`, a wrong `ctest -R` regex), or you wrapped `pytest.warns` around a call that never existed.
+2. **The test source is compiled into no build target.** `test/src/test_healthcheck.cpp` not listed in `test/CMakeLists.txt` → no executable is built → `ctest -R Healthcheck` matches nothing and exits 0, *appearing* to pass while proving nothing. This is the C++/CMake-specific manifestation and is especially insidious because the file exists on disk and reads like a real test.
+
+A verification step is only as real as the target it runs. The fix is to (a) prove the gate is non-empty before trusting it, (b) for C++ specifically, grep the build config to prove the test source is wired into a target, (c) add an explicit empty-match guard so a zero-match run FAILS, and (d) for orphaned-test wiring, inject the binary-under-test path via the build system's target-location primitive, never a hard-coded relative path.
 
 ### Quick Reference
 
 ```bash
-# 1. BEFORE planning "wrap existing test X": confirm the assertions/tests exist.
-grep -rnE 'setenv|os\.environ|KEYSTONE_|monkeypatch' tests/*.py
-# If this prints NOTHING and tests/test_config.py does not exist, the "existing test
-# to wrap" is PHANTOM. Net-new code needs a NET-NEW test, not a wrapped phantom.
-
-# 2. FALSE PASS to avoid — selects 0 tests, exits 0, gates nothing:
+# === pytest variant ===
+# FALSE PASS to avoid — selects 0 tests, exits 0, gates nothing:
 pytest -k config            # "no tests ran" but exit code 0  → green, untested
 
-# 3. REAL gate — assert the expected COUNT and enforce the warning:
-pytest tests/test_config_deprecation.py -W error::DeprecationWarning -q \
-  | tee /tmp/out.txt
-grep -q "4 passed" /tmp/out.txt || { echo "FALSE PASS: expected 4 tests"; exit 1; }
+# BEFORE planning "wrap existing test X": confirm the assertions/tests exist.
+grep -rnE 'setenv|os\.environ|KEYSTONE_|monkeypatch' tests/*.py
+# Empty result + no tests/test_config.py ⇒ the "existing test to wrap" is PHANTOM.
 
-# 4. Collection parity — net-new test cannot be silently absent:
-pytest --collect-only -q | tail -1   # must equal baseline + N-new
+# REAL gate — assert the expected COUNT and enforce the warning:
+pytest tests/test_config_deprecation.py -W error::DeprecationWarning -q | tee /tmp/out.txt
+grep -q "4 passed" /tmp/out.txt || { echo "FALSE PASS: expected 4 tests"; exit 1; }
+pytest --collect-only -q | tail -1   # collection parity: must equal baseline + N-new
+
+# === ctest / CMake variant (added v1.1.0, plan-only) ===
+# FALSE PASS to avoid — orphaned test source ⇒ regex matches 0 tests, exits 0:
+ctest -R Healthcheck        # "No tests were found" but exit 0 if no target built it
+
+# STEP A — prove the test source is wired into a build target (else the gate is a no-op):
+grep -q test_healthcheck test/CMakeLists.txt || { echo "ORPHANED: test in no target"; exit 1; }
+
+# STEP B — empty-match guard: FAIL when the name filter matches zero registered tests:
+ctest -R Healthcheck --show-only | grep -qE 'Test #' || { echo "FALSE PASS: 0 tests matched"; exit 1; }
 ```
 
-## Verified Workflow
+```cmake
+# STEP C — wire the orphaned test into its OWN executable and inject the
+# binary-under-test path via $<TARGET_FILE:...>, NEVER a hard-coded literal path.
+add_executable(ProjectAgamemnon_healthcheck_tests test/src/test_healthcheck.cpp)
+target_link_libraries(ProjectAgamemnon_healthcheck_tests PRIVATE GTest::gtest_main)
+# pass the real binary location into the test as a compile definition (build-time):
+target_compile_definitions(ProjectAgamemnon_healthcheck_tests PRIVATE
+  HEALTHCHECK_BINARY_PATH="$<TARGET_FILE:ProjectAgamemnon_healthcheck>")
+add_dependencies(ProjectAgamemnon_healthcheck_tests ProjectAgamemnon_healthcheck)
+gtest_discover_tests(ProjectAgamemnon_healthcheck_tests)
+```
 
-_Not applicable_ — unverified; no workflow was executed. Captured during an R1 re-planning session; the gate above is a hypothesis to be confirmed by CI/execution.
+### Detailed Steps
+
+1. **Classify every test command a plan cites as an acceptance gate.** Does it run a FIXED target (whole suite/binary), or a NAME-FILTERED subset (`-k` / `-R` / `-run`)? Name-filtered → treat as suspect until proven non-empty.
+2. **For name-filtered gates, prove the source is wired into a target.** `grep <test_file_stem> <build-config>` (e.g. `test/CMakeLists.txt`). No match → the gate is a no-op and the plan is unsound until fixed.
+3. **For pytest "wrap/modify existing test X":** grep-confirm X exists first. Empty result ⇒ phantom; net-new code needs a NET-NEW test, not a wrapped phantom assertion.
+4. **Add an explicit empty-match guard** so the gate FAILS on zero matches: `ctest -R X --show-only | grep -qE 'Test #' || exit 1` or `grep -q "<N> passed"` for pytest. Never trust the bare exit code of a name-filtered run.
+5. **When wiring an orphaned test that shells out to a built binary**, inject the binary's path via the build system's target-location primitive (CMake `$<TARGET_FILE:tgt>` + `add_dependencies`), never a hard-coded relative path — relative paths break when the binaryDir/output-dir differs from the assumed CWD (e.g. `./build/healthcheck` vs `build/debug/ProjectAgamemnon_healthcheck`).
+6. **Enforce, don't merely permit** (pytest): run with `-W error::DeprecationWarning` and check `--collect-only` count parity so a missing or regressed test fails the build.
 
 ## Failed Attempts
 
@@ -70,21 +96,28 @@ _Not applicable_ — unverified; no workflow was executed. Captured during an R1
 | 1 | Plan: "wrap each legacy-var assertion in `pytest.warns`" to verify the new deprecation shim | `grep -rnE 'setenv\|os.environ\|KEYSTONE_\|monkeypatch' tests/*.py` returned nothing and no `test_config.py` existed — the assertions to wrap were phantom | Before writing "wrap/modify existing test X", grep-confirm X exists; net-new code needs a NET-NEW test, not a wrapped phantom |
 | 2 | `pytest -k config` as the verification gate for the change | It matched 0 tests, exited 0 (green), and gated nothing — a FALSE PASS; net-new shim shipped untested | A `pytest -k` gate matching zero tests is a false pass; assert the expected pass COUNT (e.g. `grep -q "4 passed"`) so a zero-match run fails |
 | 3 | Allowed the DeprecationWarning to merely fire (default filter) | A merely-allowed warning never fails the build, so a regression on the deprecation path would pass silently | Run with `-W error::DeprecationWarning` to enforce the warning, and use `--collect-only` count parity (baseline + N-new) so a missing test can't hide |
+| 4 (plan-only) | Cited `ctest -R Healthcheck` as an acceptance gate without checking the test was wired into a target | `test/src/test_healthcheck.cpp` was in NO CMake target, so the regex matched 0 tests, exited 0, and proved nothing; the plan reviewer correctly NOGO'd it | Always guard name-filtered gates with an empty-match check AND verify the source is in a build target: `grep <stem> test/CMakeLists.txt` then `ctest -R X --show-only \| grep -qE 'Test #'` |
+| 5 (plan-only) | Test hard-coded `./build/healthcheck` (wrong binary name AND wrong relative path) | Would never find the real binary under `build/debug/ProjectAgamemnon_healthcheck`; relative path assumes a specific CWD | Inject the binary path via CMake `$<TARGET_FILE:...>` (+ `add_dependencies`), not a literal — it resolves correctly regardless of output dir |
+| 6 (plan-only) | Marked a plan's verification step "proves the binary still behaves correctly" while the underlying test was orphaned | False confidence — the gate ran zero tests | A verification step is only as real as the target it runs; an orphaned test file silently no-ops the gate |
 
 ## Results & Parameters
 
-- **False-pass command:** `pytest -k config` → "no tests ran", exit 0.
-- **Phantom-detection grep:** `grep -rnE 'setenv|os\.environ|KEYSTONE_|monkeypatch' tests/*.py` (empty result ⇒ no test to wrap).
-- **Real gate:** `pytest <net-new-test> -W error::DeprecationWarning -q` AND `grep -q "<N> passed"` on the output.
-- **Collection parity:** `pytest --collect-only -q | tail -1` == baseline + N-new.
-- **Rules:** (1) grep-confirm a test exists before "wrapping" it; (2) net-new code → net-new test; (3) assert pass count, not just exit code; (4) enforce warnings as errors.
-- **Status:** unverified (planning-only); gate not executed, no CI run.
+- **pytest false-pass command:** `pytest -k config` → "no tests ran", exit 0.
+- **ctest false-pass command (plan-only):** `ctest -R Healthcheck` → "No tests were found", exit 0, when the source is in no target.
+- **Phantom-detection grep (pytest):** `grep -rnE 'setenv|os\.environ|KEYSTONE_|monkeypatch' tests/*.py` (empty ⇒ no test to wrap).
+- **Orphaned-target grep (ctest):** `grep -q test_healthcheck test/CMakeLists.txt` (no match ⇒ orphaned; gate is a no-op).
+- **Empty-match guards:** pytest `grep -q "<N> passed"`; ctest `ctest -R X --show-only | grep -qE 'Test #' || exit 1`.
+- **Orphaned-test wiring (CMake):** `add_executable` + `target_compile_definitions(... HEALTHCHECK_BINARY_PATH="$<TARGET_FILE:tgt>")` + `add_dependencies` + `gtest_discover_tests`.
+- **Open reviewer risks (plan-only, ctest case):** (1) the new `ProjectAgamemnon_healthcheck_tests` target was written but NEVER compiled — `gtest_discover_tests` runs the binary at build time, so a segfault/missing runtime dep breaks discovery; (2) the suite name `HealthcheckTest.*` was read from `TEST_F(HealthcheckTest, …)` but not confirmed via `--show-only`; (3) `$<TARGET_FILE:...>` injected as a string into `system("PORT=… " + HEALTHCHECK_BINARY_PATH)` — shell-quoting/escaping for paths with spaces or metacharacters not considered; (4) the test shells out and binds real localhost ports under the `debug` preset (sanitizers ON) — subprocess + port-binding can be flaky/slow under ASan; unverified.
+- **Externally-cited-but-unverified:** cpp-httplib Conan recipe `with_openssl=False` (from prior reviewer, not re-inspected); nats.c TLS build flags (deferred to a runtime `ldd` check — good, but causal claim unverified); team-KB `cpp-cmake-ci-build-and-test-fixes` Fix 2/Fix 4f cited as authority for the `$<TARGET_FILE>` approach (sound, but applied to an unbuilt target).
+- **Rules:** (1) classify every gate as fixed-target vs name-filtered; (2) for name-filtered gates prove the source is in a build target; (3) add an empty-match guard that fails on zero tests; (4) inject binary paths via `$<TARGET_FILE:...>`, never literals; (5) for pytest, assert pass count and enforce warnings as errors.
+- **Status:** unverified (planning-only); gates not executed, no CI run.
 
 ## Verified On
 
 | Item | Value |
 |------|-------|
-| Migration | ProjectKeystone → ProjectAgamemnon |
-| Meta-repo | Odysseus |
-| Issue | #143 (R1 planning) |
-| Verification | unverified — not executed |
+| Project | ProjectAgamemnon |
+| pytest case | #143 (R1 planning) — `pytest -k config` zero-match false pass; ProjectKeystone → ProjectAgamemnon deprecation shim; meta-repo Odysseus |
+| ctest case | #279 (plan-only / unverified, R1 re-plan after NOGO) — `ctest -R Healthcheck` orphaned-target false pass; `test/src/test_healthcheck.cpp` in no CMake target |
+| Verification | unverified — neither gate executed |


### PR DESCRIPTION
## Summary

Amends the existing testing skill from **v1.0.0 → v1.1.0** (MINOR). Generalizes the zero-test false-pass lesson from pytest-only to **all name-filtered acceptance gates** (`pytest -k`, `ctest -R`, `go test -run`) and adds the C++/CMake manifestation.

Captured during a ProjectAgamemnon issue **#279** R1 re-plan (the plan was NOGO'd and revised). The previous plan cited `ctest -R Healthcheck` as an acceptance gate, but `test/src/test_healthcheck.cpp` was compiled into **no CMake target** (orphaned), so the regex matched zero tests and exited 0 — a silent false-positive gate. The reviewer correctly NOGO'd it.

- New planning rule: a cited name-filtered gate must be proven non-empty (filter matches >=1 test AND source is wired into a build target) before it can be trusted.
- Empty-match guard: `ctest -R X --show-only | grep -qE 'Test #' || exit 1`.
- Fix mechanics: wire the orphaned test into its own executable; inject the binary-under-test path via CMake `$<TARGET_FILE:...>` (+ `add_dependencies`), never a hard-coded relative path.
- 3 new Failed Attempts rows (plan-only), a new `### Detailed Steps` workflow, tag + description updates.

## Verification Level

**unverified (plan-only)** — the revised plan was never executed (no build, no `ctest`, no Docker run); all facts come from static source reading + the plan reviewer's own verification. The skill's overall level stays `unverified`; the new ctest/CMake rows are marked `unverified (plan-only)` inline. CI validation of the *plan itself* is pending.

## Key Findings

**What Worked**:
- Grepping the build config (`test/CMakeLists.txt`) to prove a test source is wired into a target before trusting a `ctest -R` gate.
- `ctest -R X --show-only | grep -qE 'Test #'` as an empty-match guard.
- `$<TARGET_FILE:tgt>` generator expression to inject the binary path regardless of output dir.

**What Failed**:
- `ctest -R Healthcheck` cited as an acceptance gate on an orphaned test → matched 0 tests, exited 0, proved nothing.
- Hard-coded `./build/healthcheck` path → wrong name and wrong relative location vs `build/debug/ProjectAgamemnon_healthcheck`.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (487/487 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with keywords: ctest, orphaned test, false positive gate, plan review

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>