### PR TITLE
feat(skills): amend audit-stale-version-comment to v1.1.0 (same-turn-closure)

### DIFF
--- a/skills/audit-stale-version-comment-version-agnostic-fix.md
+++ b/skills/audit-stale-version-comment-version-agnostic-fix.md
@@ -3,7 +3,7 @@ name: audit-stale-version-comment-version-agnostic-fix
 description: "Use when planning a fix for an audit finding that flags a stale tool/dependency version inside a source COMMENT (e.g. pyproject.toml comment saying 'CI tests only mypy 1.x' while the lock resolves 2.x; a Dockerfile comment '# requires Node 16' while the base image is 20; a setup.cfg comment '# pinned for Python 3.8 compat' while ranges allow 3.10+). The replacement comment MUST be version-AGNOSTIC — embedding a new specific version number (`mypy 2.1.0`, `Node 20`, `Python 3.10`) re-creates the exact staleness anti-pattern the audit is fixing; it merely shifts the lie from the old number to the new one at the next bump. Trigger: (1) an audit / NITPICK / linter finding cites a `file:line` containing a stale version assertion in a comment, (2) the audit asserts what the 'real' resolved version is (e.g. 'lockfile resolves X.Y.Z') — verify that claim against `pixi.lock` / `uv.lock` / `poetry.lock` / `package-lock.json` AT PLANNING TIME before writing any replacement, (3) the audit asserts 'CI exercises Y' / 'CI tests Z' — grep `.github/workflows/` AND `.pre-commit-config.yaml` AT PLANNING TIME before repeating that claim, (4) the cited `file:LINE-LINE` coordinates came from an audit run that pre-dates the current HEAD — re-locate the comment by stable content substring (`grep -n`), not by line number, (5) you are tempted to write 'currently 2.1.0' or 'tested with Node 20' in the replacement — STOP and rewrite version-agnostically ('version is pinned via pixi.lock', 'version follows the base image'). This skill is the comment-specific specialization of `code-quality-enforcement-gates` §10 (ground-truth verification) and §11 (tracking-doc checkbox drift)."
 category: documentation
 date: 2026-06-21
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: unverified
 tags:
@@ -20,6 +20,10 @@ tags:
   - line-number-drift
   - planning-stage-verification
   - cross-reference-code-quality-enforcement-gates
+  - same-turn-closure
+  - learning-loop
+  - replanning
+  - negative-grep
 ---
 
 # Audit-Driven Stale Version Comment Fix: Write Version-AGNOSTIC Replacements
@@ -143,6 +147,46 @@ pixi run mypy --version   # optional: shows the actually-resolved version
 
 8. **Cross-reference the parent principle in the plan/PR body.** Note that this fix follows `code-quality-enforcement-gates` §10 (verify audit claims at planning time) and `audit-doc-consistency-fix-verify-coordinates-on-disk` (re-anchor coordinates on disk). This anchors the next reviewer / next planner against the same anti-pattern.
 
+### Same-turn learning-loop closure (mandatory for replanning rounds)
+
+When a self-critique step (`/learn`, plan-self-review, reviewer critique) flags
+that the plan body contains a stale-version-in-comment pattern, a positive-grep
+acceptance check, or an unverified CI claim, fix all three in the SAME planning
+turn before resubmission. The `/learn` output is not a footnote; it is a
+punch-list the same turn must execute against. A learning that doesn't change
+the artifact is not a learning, it's a confession. Specifically:
+
+1. **Strip every digit-dot-digit token** from the proposed replacement comment.
+   Add a property check in the Verification section:
+
+   ```bash
+   awk '/<start-marker>/,/<end-marker>/' <file> | grep -E '^\s*#' \
+     | (! grep -E '[0-9]+\.[0-9]+')
+   ```
+
+2. **Replace any positive-grep acceptance check with a NEGATIVE grep** asserting
+   the false-claim phrase is gone:
+
+   ```bash
+   ! grep -nE "<exact false phrase>" <file>
+   ```
+
+   A positive grep on the topic word (e.g. `grep -n "mypy" pyproject.toml`)
+   cannot prove a false claim is gone — only that the noun is still present.
+   The acceptance criterion for a stale-comment fix is the **absence of the
+   false sentence**, not the presence of the topic.
+
+3. **For every CI claim in the replacement text, grep at planning time** —
+   `.github/workflows/`, `.pre-commit-config.yaml`, and the task-runner config
+   (`pixi.toml`, `noxfile.py`, `justfile`, etc.) FOR THE TOOL NAME — and cite
+   the resulting `file:line` references in the plan body. If you cannot cite
+   the CI invocation, you cannot assert "exercised by CI".
+
+4. **Re-read the target file at planning time to confirm line numbers.** Do
+   NOT trust the audit/issue body's `file:LINE-LINE` references; locate by
+   content substring. Audit-supplied line refs are HINTS, not coordinates;
+   they drift between audit run and plan run.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -153,6 +197,11 @@ pixi run mypy --version   # optional: shows the actually-resolved version
 | Asserting CI behavior unverified | Wrote "exercised by CI" in the new comment without grepping `.github/workflows/` or `.pre-commit-config.yaml` | If CI does not actually invoke mypy where the comment claims, the new comment is just as false as the old one. The audit may have been wrong about the CI claim too | Grep `.github/workflows/` AND `.pre-commit-config.yaml` at planning time before repeating any CI assertion in a comment |
 | Scope creep into version bump | Bundled a "while we are here" mypy version bump or constraint-range tightening into the same PR as the comment fix | Conflates two concerns (comment hygiene vs. dependency policy); makes review/revert harder; the dependency change has different review gates and risk profile | Refuse scope creep. The audit was scoped to a comment; deliver the smallest possible diff. File a separate issue for any incidental dep change |
 | Polishing surrounding comments | Tidied adjacent unrelated comments in the same diff | Expands review surface, hides the actual fix in noise, and re-anchors line numbers (making any future audit harder to match) | The diff should change exactly the stale-comment lines and nothing else. Resist the urge to "while I am here" |
+| Hardcoded "(currently 2.1.0)" as a placeholder | Plan body sketched the replacement comment using `(currently 2.1.0)` "as an example" with the intention of deciding the real wording at implementation | Re-introduced the exact staleness the issue was opened to fix — reviewer flagged as Major #2; would have shipped a fix that re-broke the same finding at the next mypy bump. The placeholder DID get shipped because no one removed it before submission | The replacement comment for a stale-version-in-comment fix must contain ZERO digit-dot-digit patterns AT EVERY DRAFT STAGE, including placeholders. Write a property regression check (`awk` extract the comment block + `(! grep -E '[0-9]+\.[0-9]+')`) — enforce, not promise. No placeholder is safe if it contains a version number |
+| Positive grep as acceptance check | Plan's Verification section opened with a positive grep proving the word `mypy` still exists in `pyproject.toml` | A positive grep cannot prove a false claim is gone — only that the topic word is present. The actual acceptance criterion for a stale-comment fix is the **absence of the false sentence**, not the presence of the noun | Stale-comment fixes need NEGATIVE acceptance grep (`! grep -nE "the false claim phrase" file`). A positive grep is the wrong shape of assertion for a deletion proof |
+| Unverified CI claim in replacement | Plan and replacement-comment text asserted CI runs mypy without checking `.github/workflows/`, `.pre-commit-config.yaml`, or `pixi.toml` tasks | The new comment could have been just as false as the old one; reviewer flagged as Minor #3. The fix's own correctness depended on a claim the planner never verified | When the replacement comment makes a CI claim, grep `.github/workflows/`, `.pre-commit-config.yaml`, AND the project's task runner config (`pixi.toml`, `noxfile.py`, `justfile`) FOR THE TOOL NAME at planning time. Cite the `file:line` of each invocation in the plan body |
+| Trusted /learn reply-bullets as "remediation done" | Treated the post-plan `/learn` step as documentation only; the bullets correctly identified the three flaws in the plan body but the plan body was not updated to address them | Reviewer graded the plan body against acceptance criteria, not against the `/learn` footnote. The footnote is invisible to the rubric; the plan body is what gets graded. Deterministic NOGO | If a self-critique step (`/learn`, plan-self-review, reviewer critique) surfaces a plan-body flaw, fix it in the SAME turn before submission. The `/learn` output is a punch-list the same turn must execute against, not a confession to be filed |
+| Trusted audit-supplied line range without re-reading | Issue body said `pyproject.toml:54-55`; plan used those numbers verbatim without opening the file at planning time | Real comment block was at lines 53-55, dep constraint at line 56. The mis-anchored coordinates would have forced the implementer to re-locate by content anyway, and risk patching the wrong region in the meantime | Re-read the target file at planning time and confirm line numbers by content substring. Audit-supplied line refs are HINTS, not coordinates; they drift between audit run and plan run. Cite the re-anchored `file:line` in the plan body |
 
 ## Results & Parameters
 
@@ -186,9 +235,18 @@ pixi run mypy --version   # optional: shows the actually-resolved version
 | Project | Context | Details |
 | --- | --- | --- |
 | ProjectHephaestus | issue #1549 planning session (NITPICK audit bundle #1518) | PLANNING-stage extraction, not yet implemented or CI-confirmed |
+| ProjectHephaestus | issue #1549 R1 replan after R0 NOGO (2026-06-21) | R0 `/learn` reply-bullets flagged three plan-body flaws (positive-grep acceptance check, hardcoded `(currently 2.1.0)` in the proposed comment, unverified CI claim); the R0 plan was submitted with those flaws unrepaired and was deterministically NOGO'd. R1 reads at planning time confirmed: (a) actual comment line range is 53-55 (not 54-55), (b) constraint spec `mypy>=1.8.0,<3` lives in both `pyproject.toml:56` and `pixi.toml:71`, (c) CI exercises `pixi run mypy` in `release.yml:66`, `_required.yml:174`, and `.pre-commit-config.yaml:48-51`. R1 plan adds a NEGATIVE-grep acceptance check, a digit-dot-digit regression check on the comment block, and cited CI references. R1 plan is itself still unverified at the time this amendment was authored. |
 
 ### Cross-references
 
 - **Parent principle:** `code-quality-enforcement-gates` §10 (ground-truth verification of audit/reviewer findings before acting) and §11 (tracking-doc checkbox drift — the analogous "stale state in a markdown doc" pattern). This skill is the **comment-specific specialization** of §10.
 - **Coordinate-drift companion:** `audit-doc-consistency-fix-verify-coordinates-on-disk` covers the orthogonal failure mode where `file:line` coordinates inherited from an audit have drifted; this skill assumes you have already applied that re-anchoring discipline and focuses on the *content* of the replacement.
 - **Premise verification:** `planning-verify-issue-premises-against-main` for the analogous failure mode where an issue body asserts a state that does not match `main`.
+- **Same-turn closure (general principle):** The "same-turn learning-loop closure" sub-section in this skill's Verified Workflow generalizes beyond stale-version comments: any self-critique step (`/learn`, plan-self-review, reviewer critique) that surfaces a plan-body flaw must be applied to the artifact in the SAME turn before submission — the critique is a punch-list, not a footnote. This principle is not tied to a single sibling skill; it applies wherever a planning artifact and a self-critique step coexist in one turn.
+
+## History
+
+| Date | Version | Change |
+| --- | --- | --- |
+| 2026-06-21 | 1.0.0 | Initial extraction (PR #2765) — version-agnostic replacement, content-anchored line lookup, lockfile/CI ground-truth verification, scope-creep refusal. |
+| 2026-06-21 | 1.1.0 | R1 amendment after R0 NOGO on ProjectHephaestus issue #1549: added five Failed-Attempts rows (hardcoded "currently 2.1.0" placeholder, positive-grep acceptance, unverified CI claim, treating `/learn` bullets as confession not punch-list, trusting audit line refs without re-reading); added "Same-turn learning-loop closure" sub-section to the Verified Workflow with negative-grep + digit-dot-digit regression check + cited CI references; added R1 Verified-On row; added cross-reference describing same-turn-closure as a general principle. No core recommendation change. |


### PR DESCRIPTION
## Summary

Amend `audit-stale-version-comment-version-agnostic-fix.md` (added in PR #2765 earlier this session) with R1 learnings from the ProjectHephaestus issue #1549 replan round.

R0 was NOGO'd because its own `/learn` reply-bullets flagged three plan-body flaws (positive-grep acceptance, hardcoded `(currently 2.1.0)` in the proposed comment, unverified CI claim) but the plan body was submitted with those flaws unrepaired. The durable lesson — and the principal addition in this PR — is the **same-turn learning-loop closure** discipline: a self-critique step is a punch-list the same turn must execute against, not a footnote.

## Changes

- Bump version 1.0.0 -> 1.1.0 (minor)
- Add "Same-turn learning-loop closure (mandatory for replanning rounds)" sub-section to the Verified Workflow — negative-grep acceptance, digit-dot-digit regression check, cited CI references, re-anchor by content
- Add 5 Failed-Attempts rows, each mapping to one R0 NOGO finding:
  - Hardcoded `(currently 2.1.0)` placeholder shipped because no one removed it
  - Positive grep as acceptance check (cannot prove deletion)
  - Unverified CI claim in replacement
  - Trusted `/learn` reply-bullets as "remediation done"
  - Trusted audit-supplied line range without re-reading
- Add R1 Verified-On row with re-anchored line refs (53-55, not 54-55) and cited CI invocations (`release.yml:66`, `_required.yml:174`, `.pre-commit-config.yaml:48-51`)
- Add same-turn-closure cross-reference as a general principle (applies wherever a planning artifact and a self-critique step coexist in one turn)
- Add History table documenting v1.0.0 -> v1.1.0
- New tags: `same-turn-closure`, `learning-loop`, `replanning`, `negative-grep`

No core recommendation change. Verification level remains `unverified` — the R1 plan itself is still pending review at the time of this amendment.

## Test plan

- [x] `python3 scripts/validate_plugins.py` -> Valid 489/489
- [x] Commit GPG-signed (`git log --show-signature -1` -> Good signature)
- [x] Pre-commit hooks pass on push

## Provenance

Amends `audit-stale-version-comment-version-agnostic-fix.md` introduced by PR #2765 (merged earlier today). Same skill, no rename, minor version bump.