### PR TITLE
feat: amend automation-loop-early-exit-zero-work-convergence skill (v1.1.0)

### DIFF
--- a/skills/automation-loop-early-exit-zero-work-convergence.history
+++ b/skills/automation-loop-early-exit-zero-work-convergence.history
@@ -1,0 +1,120 @@
+# automation-loop-early-exit-zero-work-convergence — History
+
+## v1.1.0 (2026-06-21)
+
+**Changed by:** ProjectHephaestus PR #1564 / issue #1563 — human-facing per-loop
+summary (`_summarize_loop`) diverged from the machine convergence signal
+(`PhaseResult.produced_work` / `work_units`). Surfaced via a real 2026-06-21
+output.log.
+**Verification:** verified-local (CI for PR #1564 still pending at capture time)
+
+### What changed
+
+- Added a new "When to Use" trigger: auditing a per-loop / per-iteration human
+  summary for divergence from the convergence predicate.
+- Added a new finding section: **Human summary must read the SAME signal the
+  early-exit predicate reads** (`_summarize_loop` counted "phase ran" not "work
+  done").
+- Added 3 new Failed Attempts rows (summary `+= 1` per non-skipped phase;
+  trusting `work_units` for non-instrumented `implement` phase; warning on
+  empty auto-discovery passes).
+- Documented the fix: `_summarize_loop` counts plan via
+  `phase.work_units if phase.work_units is not None else 1` (conservative
+  fallback matching `produced_work`); `PlannerStateManager.filter` warns when an
+  EXPLICIT `--issues` set fully filters out, gated by new
+  `PlannerOptions.issues_explicit` set in `planner.main()` before
+  auto-discovery overwrites `args.issues`.
+- Bumped version 1.0.0 → 1.1.0; updated date to 2026-06-21; added `history`
+  frontmatter field.
+
+### Why
+
+v1.0.0 documented the convergence/early-exit machinery (`work_units`,
+`produced_work`, `_CONVERGENCE_PHASES`) but only from the predicate side. A real
+run scoped to `--issues 123,456,789,101` (all CLOSED) logged
+`loop 1: planned=4 implemented=4 skipped=0` directly above
+`Early exit ... produced 0 new plans` — the two lines contradicted each other.
+Nothing failed (the planner correctly filtered all closed issues), but the
+human-facing summary inflated the count and masked a fully no-op'd / mis-scoped
+run. Root cause: `_summarize_loop` incremented `total_planned += 1` for any
+non-skipped plan phase instead of consulting `phase.work_units`. This is the
+same `work_units` machinery as v1.0.0, so it belongs in this skill.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: automation-loop-early-exit-zero-work-convergence
+description: "How to wire and test early-exit in hephaestus-automation-loop when a full pass produces zero new work. Use when: (1) implementing loop convergence detection in run_loop, (2) adding tests for early-exit stub placeholders, (3) diagnosing whether early-exit scaffold already exists before implementing."
+category: tooling
+date: 2026-05-28
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [automation, loop-runner, early-exit, convergence, testing]
+---
+
+# Automation Loop Early-Exit on Zero-Work Pass
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-05-28 |
+| **Objective** | Break `run_loop` when a full pass across all repos produces 0 new plans and 0 non-skipped reviews so 5-loop runs don't spin 20 min re-processing converged repos |
+| **Outcome** | Successful — 6 tests implemented, all pre-commit hooks pass, PR #669 created |
+| **Verification** | verified-local (pre-commit + pytest; CI pending) |
+| **History** | N/A (initial version) |
+
+## When to Use
+
+- Implementing early-exit / convergence detection in an automation loop driver
+- Filling in `TestRunLoopEarlyExit` stub test placeholders that say "Deferred to implementation phase"
+- Before implementing: check whether the scaffolding (`PhaseResult.work_units`, `RepoResult.produced_work`, `_CONVERGENCE_PHASES`, `break` block) already exists from a prior issue
+- Adding new loop-convergence phases (must add to `_CONVERGENCE_PHASES` AND call `write_work_report`)
+
+## Verified Workflow
+
+### Quick Reference
+
+(see v1.0.0 body — preserved in git history at commit 3fbe3544)
+
+### Detailed Steps
+
+1. Audit existing scaffold — grep for produced_work / work_units / _CONVERGENCE_PHASES / break block.
+2. Understand _CONVERGENCE_PHASES — only phases in this frozenset count toward early-exit ({"plan", "review-plans"}).
+3. The early-exit condition in run_loop (loop_idx < cfg.loops AND not any failure AND not any produced_work).
+4. Implement the six test scenarios.
+5. Run checks (ruff + pytest).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Redundant loop_results reassignment | re-filtered loop_results from all_results after the pool block | loop_results already contains only current-loop results | Remove the redundant line |
+| Checking review-prs in convergence | Assumed review-prs should be a convergence phase | review-prs is not instrumented with write_work_report | Only phases that call write_work_report belong in _CONVERGENCE_PHASES |
+
+## Results & Parameters
+
+Six required test scenarios for TestRunLoopEarlyExit + helper factories
+(_zero_work_result, _work_result, _failed_result, _unknown_work_result).
+
+Net change: loop_runner.py +14 LOC; test_loop_runner_early_exit.py +137 LOC.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #614 — early-exit loop on zero-work pass | PR #669; 736 automation tests pass locally |
+```
+
+> Full verbatim v1.0.0 content is preserved in git history at commit 3fbe3544
+> (the abbreviated snapshot above captures the structure and key decisions).
+
+---
+
+## v1.0.0 (2026-05-28)
+
+**Initial version.** Documents wiring + testing early-exit in
+`hephaestus-automation-loop` when a full pass produces zero new work
+(ProjectHephaestus issue #614, PR #669).

--- a/skills/automation-loop-early-exit-zero-work-convergence.md
+++ b/skills/automation-loop-early-exit-zero-work-convergence.md
@@ -1,12 +1,13 @@
 ---
 name: automation-loop-early-exit-zero-work-convergence
-description: "How to wire and test early-exit in hephaestus-automation-loop when a full pass produces zero new work. Use when: (1) implementing loop convergence detection in run_loop, (2) adding tests for early-exit stub placeholders, (3) diagnosing whether early-exit scaffold already exists before implementing."
+description: "How to wire and test early-exit in hephaestus-automation-loop when a full pass produces zero new work, and how to keep the human-facing per-loop summary consistent with the machine convergence signal. Use when: (1) implementing loop convergence detection in run_loop, (2) adding tests for early-exit stub placeholders, (3) diagnosing whether early-exit scaffold already exists before implementing, (4) auditing a per-loop/iteration summary that contradicts the early-exit message."
 category: tooling
-date: 2026-05-28
-version: "1.0.0"
+date: 2026-06-21
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
-tags: [automation, loop-runner, early-exit, convergence, testing]
+history: automation-loop-early-exit-zero-work-convergence.history
+tags: [automation, loop-runner, early-exit, convergence, testing, summary, work-units]
 ---
 
 # Automation Loop Early-Exit on Zero-Work Pass
@@ -15,11 +16,11 @@ tags: [automation, loop-runner, early-exit, convergence, testing]
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-05-28 |
-| **Objective** | Break `run_loop` when a full pass across all repos produces 0 new plans and 0 non-skipped reviews so 5-loop runs don't spin 20 min re-processing converged repos |
-| **Outcome** | Successful — 6 tests implemented, all pre-commit hooks pass, PR #669 created |
-| **Verification** | verified-local (pre-commit + pytest; CI pending) |
-| **History** | N/A (initial version) |
+| **Date** | 2026-06-21 (v1.1.0); 2026-05-28 (v1.0.0) |
+| **Objective** | Break `run_loop` when a full pass produces 0 new work AND keep the human-facing per-loop summary (`_summarize_loop`) reading the same `work_units` signal the early-exit predicate reads, so the two never contradict each other |
+| **Outcome** | Successful — v1.0.0 early-exit (PR #669); v1.1.0 summary/convergence consistency fix (PR #1564 / issue #1563) |
+| **Verification** | verified-local (pre-commit + pytest; CI pending for #1564) |
+| **History** | [changelog](./automation-loop-early-exit-zero-work-convergence.history) |
 
 ## When to Use
 
@@ -27,6 +28,8 @@ tags: [automation, loop-runner, early-exit, convergence, testing]
 - Filling in `TestRunLoopEarlyExit` stub test placeholders that say "Deferred to implementation phase"
 - Before implementing: check whether the scaffolding (`PhaseResult.work_units`, `RepoResult.produced_work`, `_CONVERGENCE_PHASES`, `break` block) already exists from a prior issue
 - Adding new loop-convergence phases (must add to `_CONVERGENCE_PHASES` AND call `write_work_report`)
+- **Auditing a human-facing per-loop / per-iteration summary** (e.g. `_summarize_loop`) that contradicts the early-exit / convergence message — grep for `+= 1` next to a phase-name check; it likely counts "phase ran" instead of "phase did work"
+- Deciding whether a fully-filtered issue set should warn or stay silent (explicit `--issues` vs auto-discovery)
 
 ## Verified Workflow
 
@@ -86,12 +89,78 @@ def test_early_exit_fires(tmp_path):
    pixi run pytest tests/unit/automation/ -q --no-cov
    ```
 
+## Keep the Human Summary Consistent with the Convergence Signal (v1.1.0)
+
+The early-exit predicate above reads `work_units` / `produced_work`. The
+human-facing per-loop summary (`_summarize_loop` in
+`hephaestus/automation/loop_runner.py`) MUST read the **same** signal — otherwise
+the two silently disagree.
+
+### The bug (real 2026-06-21 output.log)
+
+A run scoped to `--issues 123,456,789,101` (all CLOSED) logged:
+
+```text
+loop 1: planned=4 implemented=4 skipped=0
+Early exit ... produced 0 new plans
+```
+
+Two adjacent lines contradict each other. Nothing actually failed — the planner
+correctly filtered all closed issues — but the summary inflated the count,
+masking a fully no-op'd / mis-scoped run.
+
+### Root cause
+
+`_summarize_loop` incremented `total_planned += 1` for any non-skipped plan
+phase, never consulting `phase.work_units`. The `plan` phase DOES populate
+reliable `work_units` via the work-report file
+(`planner.py` `write_work_report` → `loop_runner.py` `_read_work_report` →
+`PhaseResult.work_units`). The `implement` phase writes NO work-report, so its
+`work_units` is always `None`.
+
+### The fix
+
+1. **Count plan by `work_units`, not "ran":**
+
+   ```python
+   # _summarize_loop — count actual work, conservatively
+   total_planned += phase.work_units if phase.work_units is not None else 1
+   ```
+
+   The `is not None → else 1` fallback matches `produced_work`'s "unknown counts
+   as work, conservatively" convention (`loop_runner.py:224-225`). Leave
+   `implement` as-is (no work-report to count).
+
+2. **Warn on a fully-filtered EXPLICIT issue set** (mis-scoped run made obvious):
+
+   ```python
+   # PlannerStateManager.filter (planner_state.py)
+   if options.issues_explicit and not remaining:
+       LOG.warning("All %d explicitly-requested issues filtered out "
+                   "(closed / already-planned) — nothing to plan", n_requested)
+   ```
+
+   Gated by a new `PlannerOptions.issues_explicit` flag set in `planner.main()`
+   **before** auto-discovery overwrites `args.issues`. Auto-discovery stays quiet
+   — a converged repo legitimately empties every pass, and re-introducing a
+   warning there would just be loop spam.
+
+### Audit heuristic
+
+When a loop/iteration summary disagrees with the convergence message, grep for
+`+= 1` adjacent to a phase-name check. "Phase ran" (`rc == 0`, not skipped) is
+NOT "phase did work". Any human-facing summary must read the same `work_units` /
+`produced_work` signal as the early-exit predicate.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Redundant loop_results reassignment | `loop_results = [r for r in all_results if r.loop_idx == loop_idx]` was placed after the pool block | `loop_results` already contains only current-loop results; re-filtering from `all_results` is harmless but misleading | Remove the redundant line; rely on the list built during the pool phase |
 | Checking `review-prs` in convergence | Assumed `review-prs` should be a convergence phase | `review-prs` is not in `_CONVERGENCE_PHASES` — it is not instrumented with `write_work_report`; adding it would require also calling `write_work_report` in that phase | Only phases that actively call `write_work_report` belong in `_CONVERGENCE_PHASES` |
+| Summary counted "phase ran" not "work done" | `_summarize_loop` did `total_planned += 1` for any non-skipped plan phase | Diverged from the convergence predicate, which reads `work_units` — produced `planned=4` directly above `Early exit ... produced 0 new plans` | Any human-facing loop summary must read the SAME signal (`work_units`/`produced_work`) the early-exit predicate reads; grep for `+= 1` next to a phase check when auditing |
+| Trusting `work_units` for the `implement` phase | Considered counting `implement` by `work_units` too | `implement` writes no work-report, so its `work_units` is always `None`; counting it by `work_units` would always fall to the conservative `else 1` and tell you nothing | `work_units` reliability is per-phase: only `plan` reports it. Trust `work_units` only for instrumented phases; fall back conservatively otherwise |
+| Warning on every empty pass | Considered warning whenever `filter()` returns nothing | A converged repo under AUTO-discovery legitimately empties every pass → re-introduces loop spam | Warn only when an EXPLICIT `--issues` set fully filters out. Capture the explicit-vs-discovered distinction at the CLI boundary (`planner.main`, before discovery overwrites `args.issues`), since by `filter()` time `options.issues` is always populated either way |
 
 ## Results & Parameters
 
@@ -133,13 +202,41 @@ def _unknown_work_result(repo, loop_idx):
     return rr
 ```
 
-### Net Change
+### Net Change (v1.0.0)
 
 - `hephaestus/automation/loop_runner.py`: 14 LOC net (removed redundant reassignment, improved log message with loop/total/repo count)
 - `tests/unit/automation/test_loop_runner_early_exit.py`: +137 LOC net (6 stubs → 6 real tests + 4 helper factories)
+
+### Summary/Convergence Consistency (v1.1.0 — PR #1564 / issue #1563)
+
+- `_summarize_loop` (`loop_runner.py`): count plan via
+  `total_planned += phase.work_units if phase.work_units is not None else 1`
+  (conservative fallback mirrors `produced_work` at `loop_runner.py:224-225`);
+  `implement` left as-is.
+- `PlannerStateManager.filter` (`planner_state.py`): WARNING when an explicit
+  `--issues` set fully filters out; gated by new `PlannerOptions.issues_explicit`
+  set in `planner.main()` before auto-discovery overwrites `args.issues`.
+- **Verification (verified-local):** `pixi run pytest tests/unit/automation`
+  → 1851 passed; `ruff check` + `ruff format --check` + `mypy` (409 files) all
+  clean. End-to-end:
+  `pixi run hephaestus-automation-loop --dry-run --loops 1 --issues 123,456,789,101 -v`
+  now logs `loop 1: planned=0 ...` plus the all-filtered WARNING per issue.
+  CI for PR #1564 was still pending at capture time (NOT verified-ci).
+
+### Related Skills
+
+- [[automation-loop-post-loop-filter-omission]] — another caller-side
+  aggregation/filter divergence (per-loop vs post-loop results).
+- [[automation-loop-log-driven-layered-debug]] — the output.log methodology that
+  surfaced this divergence.
+
+> Context note: the GraphQL batch-fetch single-quote bug from an OLDER
+> 2026-06-10 log was already fixed by ProjectHephaestus #1148 (regression test
+> present) — not part of this learning.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectHephaestus | Issue #614 — early-exit loop on zero-work pass | PR #669; 736 automation tests pass locally; all pre-commit hooks pass |
+| ProjectHephaestus | Issue #1563 — summary/convergence divergence (`_summarize_loop` counted "ran" not "work done") | PR #1564; 1851 automation tests pass locally; ruff/mypy clean; CI pending |


### PR DESCRIPTION
## Summary

Amends existing skill from v1.0.0 to v1.1.0.

Documents that the automation-loop's human-facing per-loop summary (`_summarize_loop` in `hephaestus/automation/loop_runner.py`) diverged from its machine convergence signal (`PhaseResult.produced_work` / `work_units`) because it counted whether a phase RAN (rc=0, not skipped) instead of actual work done.

- Real 2026-06-21 output.log: a run scoped to `--issues 123,456,789,101` (all CLOSED) logged `loop 1: planned=4 implemented=4 skipped=0` directly above `Early exit ... produced 0 new plans` — two contradictory lines.
- Root cause: `_summarize_loop` did `total_planned += 1` per non-skipped plan phase, never consulting `phase.work_units`.
- Fix (Heph PR #1564 / issue #1563): count plan by `work_units` with conservative `None -> else 1` fallback; warn when an explicit `--issues` set fully filters out (gated by new `PlannerOptions.issues_explicit`).

## Verification Level

**verified-local**

`pixi run pytest tests/unit/automation` -> 1851 passed; ruff check + ruff format --check + mypy (409 files) clean; end-to-end dry-run now logs `planned=0` plus the all-filtered WARNING. CI for PR #1564 was still pending at capture time (NOT verified-ci).

## Key Findings

**What Worked**:
- Making the human summary read the same `work_units` signal as the early-exit predicate
- Capturing explicit-vs-auto-discovery distinction at the CLI boundary (planner.main, before discovery overwrites args.issues)

**What Failed**:
- Counting "phase ran" instead of "phase did work" -> summary contradicted the convergence message
- Trusting `work_units` for the `implement` phase -> it writes no work-report, always None
- Warning on every empty pass -> auto-discovery converged repos spam the log

## Test Plan

- [x] Validate with \`python3 scripts/validate_plugins.py\` (490/490 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>