### PR TITLE
feat: amend planning-audit-doc-nitpick-stamp-and-document skill (v1.1.0)

### DIFF
--- a/skills/planning-audit-doc-nitpick-stamp-and-document.history
+++ b/skills/planning-audit-doc-nitpick-stamp-and-document.history
@@ -1,0 +1,66 @@
+<!-- markdownlint-disable MD024 -->
+
+# planning-audit-doc-nitpick-stamp-and-document history
+
+Changelog and superseded-version archive for the skill.
+
+## v1.1.0 (2026-06-22)
+
+MINOR — capture the NOGO-resolution learning from the reviewer's [major]
+P7/POLA verdict on the FIRST plan. The v1 plan stamped `CODE_OF_CONDUCT.md`
+with `_Based on Contributor Covenant v2.1 · Last reviewed: 2026-06-22_`. The
+reviewer NOGO'd it: a hardcoded "Last reviewed: <today>" in a GOVERNANCE
+document asserts a human review that never happened AND goes stale the moment
+the PR sits in the merge queue. The issue asked for "a version stamp OR a
+last-reviewed date", so the converged-to-GO fix satisfies it with a VERSION
+STAMP ALONE (`_Adapted from the Contributor Covenant v2.1._`), dropping the
+date entirely; the stamp is phrased to MIRROR the version already asserted in
+the file's Attribution footer (CoC:89) so the two cannot drift.
+
+Generalizable rules added to the body:
+
+- For "missing date/version stamp" findings on governance/policy docs where the
+  requirement is "version stamp OR date", prefer the VERSION STAMP ALONE. Never
+  write a mechanical "Last reviewed: <today>" — it is a false provenance/POLA
+  violation a reviewer will NOGO.
+- A "last reviewed" / "reviewed on" date may only be added when a HUMAN review
+  actually occurred. A mechanical edit is not a review.
+- When adding a version/provenance stamp, MIRROR an existing in-file source of
+  truth (e.g. the Attribution footer) rather than asserting an independently
+  re-sourced value, so the stamp cannot diverge.
+- If your /learn captured a RISK in the first plan, ACT on it in the plan — do
+  not merely document it. The reviewer will hold you to your own flagged
+  concern. (The v1 plan flagged the stale-date risk but did not resolve it,
+  which is exactly what got NOGO'd — a recurrence of the planner's own
+  pre-flagged risk.)
+
+New Failed Attempts row: stamping CoC with a mechanical "Last reviewed:
+<today>" date. Still `verification: unverified` — the plan was authored,
+never executed.
+
+## v1.0.0 (2026-06-22)
+
+Initial capture. Extracted from an implementation PLAN authored for
+ProjectHephaestus issue #1555 — an audit-nitpick bundle pairing a docstring
+gap (finding S14, the non-`"json"` -> text fallback in `info.py`) with a
+missing `CODE_OF_CONDUCT.md` version stamp. Planning methodology:
+document-actual-behavior + pin-with-test + version-stamp-not-date-stamp, and
+flag every unverified source/coordinate/lint assumption for the reviewer. Plan
+authored but never executed, hence `verification: unverified`.
+
+### Superseded frontmatter from v1.0.0
+
+```yaml
+name: planning-audit-doc-nitpick-stamp-and-document
+category: documentation
+date: 2026-06-22
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+```
+
+The v1.0.0 `description` did not yet encode the version-stamp-ALONE-when-the-
+requirement-is-"version OR date" rule, the no-fabricated-review-date rule, the
+mirror-an-existing-in-file-source rule, or the act-on-your-own-flagged-risk
+rule. Those were added in v1.1.0 after the reviewer's [major] P7/POLA NOGO on
+the first plan's `Last reviewed: <today>` stamp.

--- a/skills/planning-audit-doc-nitpick-stamp-and-document.md
+++ b/skills/planning-audit-doc-nitpick-stamp-and-document.md
@@ -1,9 +1,10 @@
 ---
 name: planning-audit-doc-nitpick-stamp-and-document
-description: "Use when planning a fix for a DOCUMENTATION-nitpick audit bundle (a docstring gap + a missing version/date stamp) where the issue asks only to DOCUMENT, not to change behavior. Triggers: (1) the finding wants a 'last reviewed' DATE stamp added to a policy doc (CODE_OF_CONDUCT.md / SECURITY.md) — a hardcoded today's-date goes stale by merge time AND falsely implies a human review occurred for a mechanical edit; prefer a version stamp alone or frame it as 'metadata added', and compute any date at author-time not from stale context; (2) a docstring is wrong/incomplete about a fallback (e.g. any non-'json' value -> text) — DOCUMENT the actual existing behavior and PIN it with a unit test (KISS/YAGNI), do NOT add validation/error-raising the issue never requested; (3) a version number (e.g. Contributor Covenant 2.1) read from an existing footer is propagated into a new header WITHOUT independent verification against the upstream source; (4) cited file:line coordinates and assumed markdownlint (MD022 blanks-around-headings) outcomes were read/assumed at plan time but never re-derived or actually run. Headline: for doc-nitpick findings, document-actual-behavior + pin-with-test + version-stamp-not-date-stamp, and flag every unverified source/coordinate/lint assumption for the reviewer."
+description: "Use when planning a fix for a DOCUMENTATION-nitpick audit bundle (a docstring gap + a missing version/date stamp) where the issue asks only to DOCUMENT, not to change behavior. Triggers: (1) the finding wants a 'last reviewed' DATE stamp added to a policy/governance doc (CODE_OF_CONDUCT.md / SECURITY.md). When the requirement is 'version stamp OR last-reviewed date', prefer the VERSION STAMP ALONE — a hardcoded 'Last reviewed: <today>' is a [major] P7/POLA NOGO: it asserts a human governance review that never happened for a mechanical edit AND goes stale the moment the PR sits in the merge queue. A 'last reviewed' / 'reviewed on' date may ONLY be added when a HUMAN review actually occurred; a mechanical edit is not a review. When adding the version stamp, MIRROR an existing in-file source of truth (e.g. the Attribution footer) so the two cannot drift, instead of asserting a freshly-re-sourced value; (2) a docstring is wrong/incomplete about a fallback (e.g. any non-'json' value -> text) — DOCUMENT the actual existing behavior and PIN it with a unit test (KISS/YAGNI), do NOT add validation/error-raising the issue never requested; (3) a version number (e.g. Contributor Covenant 2.1) read from an existing footer is propagated into a new header WITHOUT independent verification against the upstream source; (4) cited file:line coordinates and assumed markdownlint (MD022 blanks-around-headings) outcomes were read/assumed at plan time but never re-derived or actually run; (5) your /learn captured a RISK in the FIRST plan — ACT on it in the plan, do not merely document it; the reviewer will hold you to your own flagged concern (a stale-date risk flagged-but-unresolved is exactly what got the first plan NOGO'd). Headline: for doc-nitpick findings, document-actual-behavior + pin-with-test + version-stamp-ALONE-not-date-stamp + mirror-an-existing-in-file-source, never fabricate a review date, and act on your own pre-flagged risks."
 category: documentation
 date: 2026-06-22
-version: "1.0.0"
+version: "1.1.0"
+history: planning-audit-doc-nitpick-stamp-and-document.history
 user-invocable: false
 verification: unverified
 tags:
@@ -12,8 +13,13 @@ tags:
   - audit-nitpick
   - docstring-gap
   - version-stamp
+  - version-stamp-alone
   - date-stamp-staleness
   - last-reviewed-claim
+  - false-review-provenance
+  - p7-pola-nogo
+  - mirror-in-file-source
+  - act-on-flagged-risk
   - document-existing-behavior
   - pin-with-test
   - kiss-yagni
@@ -32,18 +38,21 @@ tags:
 | ------- | ------- |
 | **Date** | 2026-06-22 |
 | **Objective** | Plan a fix for a documentation-nitpick audit bundle (a docstring gap + a missing policy-doc version/date stamp) without over-engineering: document the actual existing behavior, pin it with a test, prefer a version stamp over a stale date stamp, and flag every unverified source/coordinate/lint assumption for the reviewer |
-| **Outcome** | A planning checklist that classifies the finding as document-only, chooses a version stamp over a hardcoded today-date, re-derives cited coordinates by content substring, verifies any propagated upstream version against its real source, pins documented fallback behavior with a unit test, and demands the linter actually run before claiming pass |
+| **Outcome** | A planning checklist that classifies the finding as document-only, satisfies a "version stamp OR date" requirement with a VERSION STAMP ALONE (never a fabricated "Last reviewed: <today>" — the first plan's date stamp drew a [major] P7/POLA NOGO), mirrors an existing in-file source of truth so the stamp cannot drift, re-derives cited coordinates by content substring, verifies any propagated upstream version against its real source, pins documented fallback behavior with a unit test, demands the linter actually run before claiming pass, and acts on its own pre-flagged risks rather than only documenting them |
 | **Verification** | unverified |
 
 ## When to Use
 
 - An audit bundles a **docstring gap** plus a **missing version/date stamp** on a policy doc, and the issue asks only to DOCUMENT — not to change behavior.
-- A finding wants a "last reviewed" **DATE stamp** added to `CODE_OF_CONDUCT.md` / `SECURITY.md` or another policy doc.
+- A finding asks for "a **version stamp OR a last-reviewed date**" on `CODE_OF_CONDUCT.md` / `SECURITY.md` or another **governance/policy** doc. Satisfy it with a **version stamp ALONE** — a mechanical `Last reviewed: <today>` is a **[major] P7/POLA NOGO**.
+- You are tempted to add a "last reviewed" / "reviewed on" date to a doc you **did not actually review** (a mechanical edit is not a review).
+- You are adding a version/provenance stamp and need to decide whether to **re-source the value** or **mirror an existing in-file source** (the Attribution footer at e.g. `CODE_OF_CONDUCT.md:89`) so the two cannot drift.
 - A docstring is wrong/incomplete about a **fallback** (e.g. any non-`"json"` value falls back to text output) and you must decide between documenting vs. "fixing" it.
 - A **version number** (e.g. Contributor Covenant 2.1) was read from an existing footer and is about to be propagated into a new header.
 - **Cited file:line coordinates** and **markdownlint** (MD022 blanks-around-headings) outcomes were read/assumed at plan time but never re-derived or actually run.
+- Your /learn run **flagged a risk** in the FIRST plan (e.g. "the date will go stale") — you must **ACT on it in the plan**, not merely note it; the reviewer will hold you to your own pre-flagged concern.
 
-**Trigger phrases**: "add a last-reviewed date", "document the fallback behavior", "docstring is incomplete", "add a version stamp", "Contributor Covenant version", "stamp the policy doc", "doc-nitpick audit".
+**Trigger phrases**: "add a last-reviewed date", "version stamp or last-reviewed date", "stamp the governance doc", "document the fallback behavior", "docstring is incomplete", "add a version stamp", "Contributor Covenant version", "stamp the policy doc", "doc-nitpick audit", "P7 POLA last reviewed".
 
 **Boundary**: IN — planning a document-only nitpick fix, choosing stamp form, pinning behavior with a test, flagging unverified assumptions. OUT — changing the documented behavior, adding new validation/error-raising, executing the plan (this skill is `unverified` — the plan was authored but never run).
 
@@ -66,12 +75,20 @@ tags:
    - Does the issue ask to DOCUMENT or to CHANGE behavior? If document-only,
      do NOT add validation/error-raising (KISS/YAGNI).
 
-2. STAMP form: prefer a VERSION stamp over a DATE stamp.
-   - A hardcoded "Last reviewed: <today>" goes stale by merge time AND
-     falsely implies a human content-review occurred for a mechanical edit.
-   - Use a version stamp alone, OR frame the date as "metadata added"
-     rather than "reviewed". If a date is truly needed, compute it at
-     author-time (e.g. `date +%F`), never copy it from stale conversation.
+2. STAMP form: when the requirement is "version stamp OR date", use the
+   VERSION STAMP ALONE. Drop the date entirely.
+   - A hardcoded "Last reviewed: <today>" on a GOVERNANCE doc is a [major]
+     P7/POLA NOGO: it asserts a human review that never happened for a
+     mechanical edit AND goes stale the moment the PR enters the merge queue.
+   - A "last reviewed" / "reviewed on" date may ONLY be added when a HUMAN
+     review actually occurred. A mechanical edit is not a review.
+   - MIRROR an existing in-file source of truth (e.g. the Attribution footer)
+     when phrasing the stamp, e.g. "_Adapted from the Contributor Covenant
+     v2.1._" mirroring the footer's asserted version — do NOT assert a
+     freshly-re-sourced value the footer could later contradict.
+   - A version stamp carries NO false temporal claim, so it is always safe;
+     reach for a date only as a last resort and label it "metadata added"
+     (never "reviewed"), computed at author-time (`date +%F`).
 
 3. RE-DERIVE cited coordinates by content substring, not by trusting line numbers:
      grep -n "def to_<format>" path/to/info.py
@@ -95,13 +112,22 @@ tags:
 7. STATE the verification level honestly:
    - Plan authored, never executed → "unverified". Title the section
      "Proposed Workflow" with a warning banner; do not claim "passes".
+
+8. ACT on every risk you flagged — do not merely document it.
+   - If your plan flagged "the date will go stale", RESOLVE it in the plan
+     (drop the date) instead of shipping it with a caveat. The reviewer will
+     NOGO you on your own pre-flagged concern. (The v1 plan flagged the
+     stale-date risk but kept the date → [major] P7/POLA NOGO.)
 ```
 
 ### Detailed Steps
 
 1. **Classify document-only vs. change-behavior.** Read the issue text. If it says "document", "note", "clarify", or "add a stamp", the scope is documentation. Resist the urge to "fix" the underlying behavior. For the source case (ProjectHephaestus #1555, finding S14), the fallback "any non-`"json"` value -> text output" was correct as-is; the ask was to document it, not to raise on invalid input.
 
-2. **Choose the stamp form (version over date).** For a "missing date stamp" finding, default to a **version stamp alone**. A hardcoded `Last reviewed: 2026-06-22` is stale the moment the PR merges, and "last reviewed" claims a human content-review that did not happen for a mechanical edit. If a date is genuinely required, label it as "metadata added" (not "reviewed") and compute it at author-time (`date +%F`) rather than copying a date out of possibly-stale conversation context.
+2. **Choose the stamp form — version stamp ALONE when the requirement is "version OR date".** The source issue (ProjectHephaestus #1555) asked for "a version stamp **OR** a last-reviewed date". The FIRST plan chose a date, stamping `CODE_OF_CONDUCT.md` with `_Based on Contributor Covenant v2.1 · Last reviewed: 2026-06-22_`. The reviewer issued a **[major] P7/POLA NOGO**: a hardcoded "Last reviewed: <today>" on a GOVERNANCE document asserts a human governance review that never occurred for a mechanical edit, and the date is stale the moment the PR sits in the merge queue. **The converged-to-GO fix dropped the date entirely** and satisfied the "OR" with a version stamp alone — `_Adapted from the Contributor Covenant v2.1._`. A version stamp carries no false temporal claim, so it is always the safe branch of the "OR".
+   - **Never fabricate a review date.** A "last reviewed" / "reviewed on" date may ONLY be added when a HUMAN review actually occurred. A mechanical edit is not a review.
+   - **Mirror an existing in-file source of truth.** Phrase the stamp to mirror the version already asserted elsewhere in the file (here, the Attribution footer at `CODE_OF_CONDUCT.md:89`) rather than asserting a freshly-re-sourced value — so the stamp and the footer cannot diverge. (Independent upstream verification per step 4 still applies to the value you mirror.)
+   - If a date is somehow genuinely required despite all the above, label it "metadata added" (never "reviewed") and compute it at author-time (`date +%F`), never copied from stale conversation context.
 
 3. **Re-derive every cited coordinate.** Treat plan-time `file:line` references (e.g. `info.py:232-243`, `info.py:243`, `CODE_OF_CONDUCT.md:89`, `test_info.py:147,165`) as approximate. Re-locate each by a stable content substring with `grep -n` at edit time. Files drift between audit and implementation.
 
@@ -113,11 +139,15 @@ tags:
 
 7. **Record the honest verification level.** If the plan was authored but never executed (no tests run, no markdownlint run), the verification level is `unverified`. Say so. Keep the workflow titled "Proposed Workflow" with the warning banner; never claim it "passes" CI you did not run.
 
+8. **Act on every risk you flagged — do not merely document it.** If your /learn captured a risk in the first plan, RESOLVE it in the plan rather than shipping the plan with a caveat next to it. The reviewer will hold you to your own pre-flagged concern. The v1 plan explicitly flagged the stale-date risk but kept the date stamp anyway; that flagged-but-unresolved risk is exactly what drew the [major] P7/POLA NOGO. Documenting a risk is necessary but not sufficient — close it.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | ------- | -------------- | ------------- | -------------- |
-| Hardcode today's date as "Last reviewed: 2026-06-22" | Inserted a fixed date implying a human review | Date is stale by merge time and falsely claims a review that did not occur | Prefer version stamp alone, or label as "metadata added"; compute date at author-time |
+| Stamped CoC with mechanical "Last reviewed: <today>" date (`_Based on Contributor Covenant v2.1 · Last reviewed: 2026-06-22_`) | Added the date branch of the issue's "version stamp OR date" requirement | [major] P7/POLA NOGO — implied a human governance review that didn't occur, and goes stale before merge | Use a version stamp ALONE when the requirement is "version OR date" (`_Adapted from the Contributor Covenant v2.1._`); never fabricate a review date |
+| Phrased the version stamp by re-asserting an independently-sourced value | Wrote the stamp's version separately from the file's existing footer | The stamp and the Attribution footer (CoC:89) could drift apart over time | MIRROR an existing in-file source of truth so the two cannot diverge |
+| Flagged the stale-date risk in the plan but kept the date stamp | Documented the risk as a caveat instead of resolving it | Reviewer held the plan to its own pre-flagged concern → [major] P7/POLA NOGO | ACT on a risk you flagged (drop the date) — documenting it is not enough |
 | Add validation/error-raising for non-"json" format | Tempted to "fix" the fallback by raising on invalid input | Issue only asked to DOCUMENT existing behavior; adding validation violates KISS/YAGNI and changes behavior | Document actual behavior, do not change it |
 | Document the fallback in prose only | Wrote the guarantee in the docstring without a test | Prose claims drift silently with no enforcement | Pin with `test_invalid_format_falls_back_to_text` |
 | Propagate Contributor Covenant "2.1" from the footer | Copied version from existing footer into new header | Footer value was never verified against contributor-covenant.org | Verify upstream version independently before propagating |
@@ -130,12 +160,15 @@ Copy-paste pre-merge checklist for a documentation-nitpick audit fix:
 
 ```text
 [ ] Document-only?  (issue asks to DOCUMENT, not change behavior — no new validation added)
-[ ] Version-stamp, not date-stamp?  (version alone, or date labeled "metadata added", computed at author-time)
-[ ] Upstream version verified?  (e.g. Contributor Covenant version checked against contributor-covenant.org, not the footer)
+[ ] Version-stamp ALONE?  (requirement was "version OR date" → used a version stamp, dropped the date entirely; NO "Last reviewed: <today>")
+[ ] No fabricated review date?  (a "last reviewed" date appears ONLY if a human review actually happened)
+[ ] Stamp mirrors an in-file source?  (phrased to mirror the Attribution footer, e.g. CoC:89, so it cannot drift)
+[ ] Upstream version verified?  (e.g. Contributor Covenant version checked against contributor-covenant.org, not just the footer)
 [ ] Coordinates re-derived?  (every file:line re-located by content substring via grep -n, not trusted from the plan)
 [ ] Test added?  (documented fallback pinned by a unit test, e.g. test_invalid_format_falls_back_to_text)
 [ ] Linter actually run?  (markdownlint / pixi lint executed locally; MD022 blanks-around-headings confirmed clean)
+[ ] Every flagged risk RESOLVED, not just noted?  (a risk you flagged in the plan is acted on, not shipped as a caveat)
 [ ] Verification level stated honestly?  (unverified if the plan was authored but not executed — keep "Proposed Workflow" + warning)
 ```
 
-**Source context**: Extracted from an implementation PLAN authored for ProjectHephaestus issue #1555 — an audit-nitpick bundle pairing a docstring gap (finding S14, the non-`"json"` -> text fallback in `info.py`) with a missing `CODE_OF_CONDUCT.md` version stamp. The plan was authored but NEVER EXECUTED (no tests run, no markdownlint run), hence `verification: unverified`.
+**Source context**: Extracted from an implementation PLAN authored for ProjectHephaestus issue #1555 — an audit-nitpick bundle pairing a docstring gap (finding S14, the non-`"json"` -> text fallback in `info.py`) with a missing `CODE_OF_CONDUCT.md` version stamp. The v1.0.0 plan stamped the CoC with `_Based on Contributor Covenant v2.1 · Last reviewed: 2026-06-22_` and drew a **[major] P7/POLA NOGO** from the reviewer (a fabricated governance-review date that goes stale before merge). v1.1.0 captures the converged-to-GO resolution: a **version stamp ALONE** (`_Adapted from the Contributor Covenant v2.1._`) that mirrors the file's Attribution footer (CoC:89) and carries no false temporal claim. The plan was authored but NEVER EXECUTED (no tests run, no markdownlint run), hence `verification: unverified`.


### PR DESCRIPTION
Amends the `planning-audit-doc-nitpick-stamp-and-document` skill (v1.0.0 -> v1.1.0) with the NOGO-resolution learning from the reviewer's [major] P7/POLA verdict on the first plan.

## What changed
- **The key learning:** the first plan stamped `CODE_OF_CONDUCT.md` with `_Based on Contributor Covenant v2.1 · Last reviewed: 2026-06-22_`. A hardcoded "Last reviewed: <today>" on a governance doc is a P7/POLA violation — it asserts a human review that never happened and goes stale before merge. The converged-to-GO fix satisfies the issue's "version stamp OR date" with a **version stamp ALONE** (`_Adapted from the Contributor Covenant v2.1._`), mirroring the file's Attribution footer (CoC:89) so the two cannot drift.
- New generalizable rules encoded in the body (When to Use, Quick Reference, Detailed Steps, Failed Attempts, checklist):
  1. Prefer the version stamp ALONE when the requirement is "version OR date".
  2. Never fabricate a "last reviewed" date — add one only when a human review actually occurred.
  3. Mirror an existing in-file source of truth when adding a version/provenance stamp.
  4. ACT on a risk you flagged in the plan rather than only documenting it.
- New `.history` file snapshotting v1.0.0; `version` bumped to 1.1.0; `date` updated; `history:` frontmatter field added.
- `verification: unverified` retained — the plan was authored, never executed.

`scripts/validate_plugins.py` passes (495/495, exit 0).