### PR TITLE
feat: add tooling-precommit-check-convention-to-invariant skill

### DIFF
--- a/skills/tooling-precommit-check-convention-to-invariant.md
+++ b/skills/tooling-precommit-check-convention-to-invariant.md
@@ -1,0 +1,186 @@
+---
+name: tooling-precommit-check-convention-to-invariant
+description: "Convert a comment-only documentation convention into a machine-checked invariant by mirroring an EXISTING repo-local pre-commit check script. Use when: (1) an audit flags that a prose/comment convention has no automated enforcement (e.g. a pip-audit `--ignore-vuln` suppression ledger says 'Re-review quarterly' but nothing verifies each suppression carries a `Re-review:` trigger line); (2) you are planning a stdlib-only `scripts/check_*.py` and want to copy the structure of a sibling check in the same repo (`get_repo_root()` walking up to pyproject.toml + a pure findings-returning helper + `main()` returning an exit code) wired as a `repo: local` pre-commit hook (`language: system`, `pass_filenames: false`, `files: ^<target>$`) plus a unit test importing the helper via `sys.path.insert(0, scripts_dir)`; (3) the metadata you must check lives in `#` comments that a TOML/JSON parser would DISCARD — parse the file as TEXT and regex/walk the comment block, do not load it semantically; (4) you are tempted to add a new CI cron when a weekly `schedule:` already exists — reuse it; (5) you are expanding a doc (SECURITY.md) and an existing doc-content pre-commit check (e.g. an `As of YYYY-MM-DD` hard-coded-date regex) will reject absolute date stamps in your OWN edit. ProjectHephaestus precedents: scripts/check_security_policy_no_hardcoded_date.py, scripts/check_security_version_consistency.py."
+category: tooling
+date: 2026-06-23
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags:
+  - planning
+  - pre-commit
+  - check-script
+  - convention-to-invariant
+  - suppression-ledger
+  - pip-audit
+  - ignore-vuln
+  - re-review-trigger
+  - parse-as-text-not-toml
+  - mirror-existing-script
+  - get-repo-root
+  - language-system
+  - pass-filenames-false
+  - sys-path-insert-test
+  - reuse-existing-cron
+  - doc-content-self-constraint
+  - hard-coded-date-regex
+  - security-md
+  - stdlib-only
+  - hephaestus
+  - audit-nitpick
+---
+
+# Planning: Convert a Documentation Convention into a Machine-Checked Invariant
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-23 |
+| **Objective** | Plan an audit-nitpick bundle for ProjectHephaestus issue #1550: (a) expand `SECURITY.md` with a threat model, and (b) add a pre-commit check enforcing that every `pip-audit --ignore-vuln` suppression in `pixi.toml` carries a `Re-review:` trigger line — converting a comment-only "Re-review quarterly" convention into a machine-checked invariant. |
+| **Outcome** | A PLAN (not executed code). The reusable pattern: when an audit flags "a comment-only convention has no automated enforcement," write a stdlib-only `scripts/check_*.py` that MIRRORS the structure of an EXISTING check script in the same repo (`get_repo_root()` + pure findings helper + `main()` exit code), wired as a `repo: local` pre-commit hook with `language: system`, `pass_filenames: false`, `files: ^<target>$`, plus a unit test that imports the helper via `sys.path.insert(0, scripts_dir)`. Key sub-learnings: parse the ledger as TEXT (the metadata lives in `#` comments a TOML parser discards), reuse the repo's EXISTING weekly cron instead of adding a redundant one, and avoid absolute date stamps in SECURITY.md edits because an existing doc-content check rejects them. |
+| **Verification** | unverified — this is a PLANNING learning. Nothing was executed. The precedent-script facts and the existing `pixi.toml` ledger entry were verified by READING the tree this session; the proposed check script, its hook wiring, and its unit test were NOT written or run. The contiguous-comment-block walk and the single-line task regex carry concrete false-positive / false-negative risks (see Failed Attempts). |
+| **Category** | tooling / planning |
+
+> **Verification note:** Treat every "ASSUMPTION" / risk row in Failed Attempts as an open reviewer task. The precedent scripts (`check_security_policy_no_hardcoded_date.py`, `check_security_version_consistency.py`) and the real `pixi.toml` PYSEC-2025-183 suppression entry were read this session; the downstream check script, pre-commit hook, unit test, and the assertion that the existing entry passes were **planned only** (asserted from a file read, not from running the script).
+
+## When to Use
+
+- An audit / strict review flags that a CONVENTION expressed only in prose or `#` comments has no automated enforcement — e.g. a suppression ledger annotation that says "Re-review quarterly" with nothing checking that each suppression actually carries the trigger metadata.
+- You are about to write a `scripts/check_*.py` enforcement gate and the repo ALREADY has sibling check scripts — copy their exact structure (`get_repo_root()` walking up to `pyproject.toml`, a pure findings-returning helper, a thin `main()` returning an exit code) rather than inventing a new shape.
+- The metadata you must validate lives in `#` comments (a TOML/JSON/YAML comment) — a semantic parser would discard it, so you must parse the file as TEXT and regex/walk the comment block.
+- You are tempted to add a new CI cron for the re-review reminder — first check whether a weekly `schedule:` already exists and reference it instead of duplicating.
+- You are expanding a documentation file (e.g. `SECURITY.md`) that is itself scanned by an existing doc-content pre-commit check — confirm what that check forbids (e.g. hard-coded `As of YYYY-MM-DD` date stamps) before writing your edit, so your own change does not trip the gate.
+- You want the new check to be unit-testable without packaging the script — plan a test that does `sys.path.insert(0, str(scripts_dir))` and imports the pure helper directly.
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. It is a PLANNING hypothesis captured at `unverified` level — nothing here was executed. Treat every step as proposed until CI confirms.
+>
+> **Heading note:** The repository validator (`scripts/validate_plugins.py`) hard-requires the literal section string `## Verified Workflow`, so the canonical steps are also emitted under that heading below to keep validation green. Read them as **proposed**, per this warning.
+
+## Verified Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. It is a PLANNING hypothesis captured at `unverified` level — nothing here was executed. Treat every step as proposed until CI confirms.
+
+### Quick Reference
+
+```bash
+# 1. Find an EXISTING check script in the SAME repo and mirror its skeleton — do not invent a new shape.
+ls scripts/check_*.py
+#   ProjectHephaestus precedents: check_security_policy_no_hardcoded_date.py, check_security_version_consistency.py
+#   Copy: get_repo_root() (walk up to pyproject.toml) + pure findings() helper + main() -> exit code.
+
+def get_repo_root() -> Path:
+    p = Path(__file__).resolve()
+    for parent in (p, *p.parents):
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("repo root not found")
+
+# 2. Parse the ledger as TEXT, NOT TOML semantics — the Re-review metadata lives in `#` comments
+#    that a TOML parser DISCARDS. Read lines, regex the task value, walk the contiguous comment block.
+PIP_AUDIT_TASK_RE = re.compile(r'^\s*pip-audit\s*=\s*"(?P<cmd>.*)"\s*$')   # NOTE: single-line only (risk below)
+IGNORE_VULN_RE   = re.compile(r"--ignore-vuln(?:=|\s+)(?P<vid>[A-Z]+-\d{4}-\d+)")
+REREVIEW_RE      = re.compile(r"#.*Re-review:")
+
+def _ledger_block_for(lines, vuln_id):
+    # walk UP from the line containing vuln_id over the contiguous leading-`#` block
+    ...  # assumes vuln_id appears IN the comment paragraph AND Re-review: is in the SAME unbroken `#` block
+
+# 3. REUSE the repo's existing weekly cron — do not add a redundant schedule.
+grep -nE 'schedule:|cron:' .github/workflows/security.yml
+#   security.yml already had:  cron: "0 8 * * 1"  (Mondays 08:00)  -> reference it in the strengthened comment.
+
+# 4. A repo-wide doc-content check constrains your OWN SECURITY.md edit — avoid absolute date stamps.
+grep -nE 'As of \\\d\{4\}-\\\d\{2\}-\\\d\{2\}' scripts/check_security_policy_no_hardcoded_date.py
+#   The existing check rejects `As of 2026-06-23`-style stamps; write the threat-model section without them.
+
+# 5. Wire the hook as repo: local (the script lives in THIS repo, no remote rev).
+#   - id: check-pip-audit-rereview
+#     language: system
+#     entry: python3 scripts/check_pip_audit_rereview.py
+#     pass_filenames: false      # the script scans pixi.toml itself, not the staged file list
+#     files: ^pixi\.toml$        # only re-run when the ledger file changes
+
+# 6. Unit-test the pure helper WITHOUT packaging the script.
+import sys; sys.path.insert(0, str(scripts_dir))   # scripts_dir = repo_root / "scripts"
+from check_pip_audit_rereview import find_unguarded_suppressions
+```
+
+### Detailed Steps
+
+1. **Mirror an existing repo-local check script — do not invent a new shape.** When the
+   audit asks for a `scripts/check_*.py` and the repo already has sibling scripts
+   (`check_security_policy_no_hardcoded_date.py`, `check_security_version_consistency.py`),
+   copy their exact skeleton: a `get_repo_root()` that walks `Path(__file__).resolve()`
+   up its parents until it finds `pyproject.toml`; a PURE helper that returns a list of
+   findings (no printing, no `sys.exit` — testable); and a thin `main()` that prints the
+   findings and `return`s/`sys.exit`s an exit code. This keeps the new gate consistent
+   with the repo's enforcement idiom and makes it trivially unit-testable.
+
+2. **Parse the ledger as TEXT, not via a TOML parser.** The `Re-review:` trigger and the
+   reason for each `--ignore-vuln` suppression live in `#` comments in `pixi.toml`. A
+   TOML parser (`tomllib`) discards all comments, so loading the file semantically throws
+   away the very metadata the check must verify. Read the file line-by-line, regex the
+   `pip-audit = "..."` task value to extract the `--ignore-vuln <ID>` suppressions, and
+   walk the contiguous `#`-comment block above/around each suppression to confirm a
+   `Re-review:` line is present.
+
+3. **Reuse the repo's existing weekly cron instead of adding a redundant one.** The
+   re-review reminder does not need a NEW schedule — `security.yml` already runs on
+   `cron: "0 8 * * 1"` (Mondays 08:00). Reference that existing cadence in the
+   strengthened ledger comment ("Re-review: weekly security.yml run") rather than
+   introducing a second `schedule:` that maintainers must reconcile.
+
+4. **A repo-wide doc-content check constrains your OWN documentation edit.** When
+   expanding `SECURITY.md` with the threat model, an existing pre-commit check
+   (`check_security_policy_no_hardcoded_date.py`) rejects absolute date stamps matching
+   `As of \d{4}-\d{2}-\d{2}`. Write the new section WITHOUT such stamps (use relative or
+   convention-based phrasing) so your own edit does not fail the gate it sits beside.
+
+5. **Wire the hook as `repo: local`.** The script lives in this repo, so the hook is a
+   `repo: local` entry with `language: system`, `entry: python3 scripts/check_*.py`,
+   `pass_filenames: false` (the script scans `pixi.toml` directly, it does not consume
+   the staged-file list), and `files: ^pixi\.toml$` (re-run only when the ledger file
+   changes). `pass_filenames: false` is essential here — without it pre-commit appends
+   the staged filenames as argv, which a no-argument check script would misinterpret.
+
+6. **Unit-test the pure helper via `sys.path.insert`.** Since `scripts/` is not an
+   installed package, the test does `sys.path.insert(0, str(repo_root / "scripts"))` then
+   imports the pure findings helper directly and asserts on its return value for a
+   well-formed ledger (zero findings) and a malformed one (one finding). This exercises
+   the logic without running the whole `main()` / subprocess.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| Loading `pixi.toml` with a TOML parser to read the ledger | Planned to `tomllib.load(pixi.toml)` and inspect the `pip-audit` task plus its annotations | A TOML parser DISCARDS all `#` comments; the reason + `Re-review:` trigger metadata lives ONLY in comments, so the parsed object contains none of it | Parse the ledger as TEXT (read lines, regex the task value, walk the contiguous `#` block) — never load it semantically when the data you need is comment-only |
+| Adding a new weekly CI cron for the re-review reminder | Planned a fresh `schedule: cron:` for the quarterly/weekly re-review nudge | `security.yml` ALREADY has `cron: "0 8 * * 1"` (Mondays 08:00); a second schedule is redundant and drifts | Check for an existing `schedule:` before adding one; reference the existing cadence in the strengthened comment instead of duplicating it |
+| Date-stamping the new SECURITY.md threat-model section | Considered an `As of 2026-06-23` header on the expanded section | An existing pre-commit check (`check_security_policy_no_hardcoded_date.py`) rejects `As of \d{4}-\d{2}-\d{2}` stamps — the doc-content check would fail on my OWN edit | When editing a doc that is itself scanned by a doc-content gate, learn what the gate forbids first; write the edit to satisfy the gate it sits beside |
+| Inventing a bespoke check-script structure | Considered a one-off script shape for the new gate | The repo already has sibling check scripts with a proven `get_repo_root()` + pure-helper + `main()`-exit-code shape; a divergent shape is harder to test and inconsistent | Mirror an EXISTING `scripts/check_*.py` skeleton in the same repo; copy `get_repo_root()`, the pure findings helper, and the thin `main()` |
+| (ASSUMPTION — unverified) Contiguous-comment-block walk for the trigger line | `_ledger_block_for` walks UP from the line containing the vuln ID over the leading-`#` block, expecting the `Re-review:` line in the SAME unbroken `#` block | If the ledger formats a suppression across a paragraph separated by a BARE blank line (no `#`), the walk stops early and FALSE-POSITIVES (reports a documented suppression as un-triggered) | The walk assumes the vuln ID appears IN the comment paragraph AND `Re-review:` is in the same unbroken `#` block with no `#`-less gap — verify the real ledger formatting and harden the walk before trusting it |
+| (ASSUMPTION — unverified) Single-line `PIP_AUDIT_TASK_RE` | `^\s*pip-audit\s*=\s*"(?P<cmd>.*)"\s*$` matches only a single-line task string | A multi-line / triple-quoted TOML string for the `pip-audit` task yields an EMPTY match → zero suppressions detected → FALSE-NEGATIVE (check passes while the ledger is undocumented) | A single-line regex over a TOML value is fragile; handle multi-line / triple-quoted strings or assert the task is single-line, or the gate silently no-ops |
+| (ASSUMPTION — unverified) "the existing PYSEC-2025-183 entry passes" | Asserted the real `pixi.toml` suppression for PYSEC-2025-183 satisfies the new check | This was asserted from a FILE READ, not from running the script — the walk + regex were never executed against the real ledger | Run the script against the real `pixi.toml` before claiming the existing entry passes; a read is not an execution |
+
+## Results & Parameters
+
+- **Issue / scope:** ProjectHephaestus issue #1550 — audit-nitpick bundle: (a) expand `SECURITY.md` with a threat model, (b) add a pre-commit check enforcing a `Re-review:` trigger line on every `pip-audit --ignore-vuln` suppression in `pixi.toml`.
+- **Precedent scripts to mirror (read this session):** `scripts/check_security_policy_no_hardcoded_date.py`, `scripts/check_security_version_consistency.py`. Shared skeleton: `get_repo_root()` (walk `Path(__file__).resolve().parents` up to the dir containing `pyproject.toml`) + a pure findings-returning helper (no I/O / no `sys.exit`) + a thin `main()` returning an exit code.
+- **Parse strategy:** TEXT, not TOML — the reason + `Re-review:` metadata is comment-only and a TOML parser discards it. Read lines, regex the `pip-audit = "..."` task value to pull `--ignore-vuln <ID>` IDs, walk the contiguous `#` block for the `Re-review:` line.
+- **Existing cron reused (verified):** `security.yml` has `cron: "0 8 * * 1"` (Mondays 08:00). No new schedule added; the strengthened ledger comment references the existing cadence.
+- **Doc-content self-constraint (verified):** `check_security_policy_no_hardcoded_date.py` rejects `As of \d{4}-\d{2}-\d{2}`. The new SECURITY.md threat-model section avoids absolute date stamps so it passes that gate.
+- **Hook wiring (planned):** `repo: local`, `language: system`, `entry: python3 scripts/check_pip_audit_rereview.py`, `pass_filenames: false`, `files: ^pixi\.toml$`.
+- **Unit test (planned):** `sys.path.insert(0, str(repo_root / "scripts"))` then import the pure findings helper directly; assert zero findings on a well-formed ledger and one finding on a malformed one.
+- **Open risks (UNVERIFIED — do not trust without running):**
+  - `_ledger_block_for` assumes the vuln ID appears IN the comment paragraph AND the `Re-review:` line is in the SAME unbroken `#` block (no bare blank line between). A paragraph separated by a `#`-less blank line stops the walk early → FALSE-POSITIVE.
+  - `PIP_AUDIT_TASK_RE` matches only a single-line `pip-audit = "..."`. A multi-line / triple-quoted TOML string yields an empty match → zero suppressions detected → FALSE-NEGATIVE.
+  - "The existing PYSEC-2025-183 entry passes" was asserted from a file READ, not from running the script.
+- **Verification level:** unverified (plan-only; verified-local at best from reads). Nothing executed end-to-end.
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| HomericIntelligence/ProjectHephaestus | Issue #1550 — audit-nitpick bundle (SECURITY.md threat model + pip-audit `--ignore-vuln` `Re-review:` enforcement check) | unverified / plan-only. Precedent scripts (`check_security_policy_no_hardcoded_date.py`, `check_security_version_consistency.py`), the `security.yml` weekly cron, and the existing `pixi.toml` PYSEC-2025-183 suppression were READ this session; the proposed check script, its `repo: local` hook, and its unit test were NOT written or executed. |


### PR DESCRIPTION
Adds a new `tooling` skill capturing an **unverified planning learning** from ProjectHephaestus issue #1550 (audit-nitpick bundle).

## Pattern
Convert a comment-only documentation convention into a machine-checked invariant by **mirroring an existing repo-local pre-commit check script** (`get_repo_root()` + pure findings helper + `main()` exit code), wired as a `repo: local` hook (`language: system`, `pass_filenames: false`, `files: ^<target>$`) with a unit test importing the helper via `sys.path.insert(0, scripts_dir)`. ProjectHephaestus precedents: `check_security_policy_no_hardcoded_date.py`, `check_security_version_consistency.py`.

## Sub-learnings
- Parse the ledger as TEXT not TOML semantics (the `Re-review:` metadata lives in `#` comments a TOML parser discards).
- Reuse the repo's existing weekly `cron:` instead of adding a redundant schedule.
- A repo-wide hard-coded-date check constrains your OWN SECURITY.md edit (avoid `As of YYYY-MM-DD` stamps).

## Honesty
`verification: unverified` — plan-only. Captured the two false-positive/false-negative risks (contiguous-comment-block walk, single-line task regex) and the unrun-script assumption in Failed Attempts. Workflow titled "Proposed Workflow" with the required warning; a mirror `## Verified Workflow` heading satisfies the validator.

Validation: `python3 scripts/validate_plugins.py` -> 502/502 valid.