### PR TITLE
feat: add CI markdownlint blockquote and worktree recovery skills

### DIFF
--- a/skills/ci-readme-blockquote-markdownlint-break.md
+++ b/skills/ci-readme-blockquote-markdownlint-break.md
@@ -1,0 +1,99 @@
+---
+name: ci-readme-blockquote-markdownlint-break
+description: "Markdownlint CI fails when a multi-paragraph blockquote in README.md is missing the > continuation marker on blank lines between paragraphs. Use when: (1) CI markdownlint job fails on README after adding or editing a blockquote, (2) a blockquote renders as two separate blocks when you intended one, (3) pre-commit markdownlint passes on individual files but CI all-files run fails with MD028 or blank-line-in-blockquote."
+category: ci-cd
+date: 2026-06-23
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags: [ci-cd, markdownlint, readme, blockquote, md028, blank-line, pre-commit, ci-debug]
+---
+
+# CI: README Blockquote Continuation Breaks Markdownlint
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-23 |
+| **Objective** | Drive PR ProjectHephaestus#1570 to green CI |
+| **Outcome** | CI passed after adding missing `>` continuation marker to a blank line inside a README blockquote |
+| **Verification** | verified-ci |
+
+A multi-paragraph blockquote in Markdown requires every blank separator line between
+paragraphs to start with `>`. Without it, the renderer (and markdownlint) treats the
+blank line as ending the blockquote, starting a new one, which violates MD028
+(no-blanks-in-blockquote) and can also trip MD009/MD012. The fix is a single-character
+`>` on the otherwise-empty line.
+
+## When to Use
+
+- CI markdownlint job fails on README.md after editing or adding a blockquote block
+- A blockquote you intended as one unit renders as two separate blockquotes
+- `pre-commit run --files README.md` passes locally but CI `--all-files` catches the violation
+- CI log cites MD028 or a blank-line rule inside a blockquote in README.md or another doc file
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# Find broken blockquotes — look for blank lines inside a blockquote block without >
+grep -n "^>" README.md | head -30
+# Spot a gap in line numbers that corresponds to a blank line between > lines
+
+# Fix: every blank line inside a blockquote must start with >
+# Before (broken):
+# > First paragraph of the note.
+#                                   <- blank line WITHOUT >
+# > **Note on naming.**  ...
+#
+# After (fixed):
+# > First paragraph of the note.
+# >                                  <- blank line WITH >
+# > **Note on naming.**  ...
+
+# Verify locally before pushing
+pre-commit run markdownlint --files README.md
+```
+
+### Detailed Steps
+
+1. Open README.md and locate the blockquote block that spans multiple paragraphs.
+2. Find blank lines inside the blockquote that are missing the `>` prefix.
+   A symptom: `grep -n "^>" README.md` shows non-consecutive line numbers in the middle of a blockquote.
+3. Add `>` (optionally with a space: `> `) to every blank separator line inside the blockquote.
+4. Run `pre-commit run markdownlint --files README.md` to confirm the rule passes locally.
+5. Commit the fix and push — CI markdownlint gate should go green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running pre-commit on changed files only | `pre-commit run --files <diff-files>` passed, so the blockquote issue was not caught before push | pre-commit scoped to the diff did not catch the blank-line-without-> syntax because... actually it would have caught it if README was in the diff — the root cause was the fix was missing from an earlier commit | Always run `pre-commit run markdownlint --files README.md` any time README blockquotes are edited |
+
+## Results & Parameters
+
+The fix for PR #1570 / issue #1554 was a single-character change in README.md:
+
+```diff
+ > Upgrading? When moving across a major version, read the
+ > [migration guide](docs/MIGRATION.md) for required consumer changes.
+-
++>
+ > **Note on naming.** `pip install hephaestus` installs the
+ > `HomericIntelligence-Hephaestus` distribution...
+```
+
+The blank line between the two blockquote paragraphs lacked the `>` prefix. Markdownlint
+flagged this as a rule violation (MD028 / no-blanks-in-blockquote). The CI commit was
+`c7883e49` on branch `1554-auto-impl`.
+
+Key invariant: every blank line inside a Markdown blockquote that continues the blockquote
+must start with `>`. A blank line without `>` terminates the blockquote.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #1570 / Issue #1554 — packaging scaffolding + MIGRATION link | CI markdownlint gate went green after adding `>` to blank continuation line; commit c7883e49 |

--- a/skills/worktree-deleted-mid-session-recovery.md
+++ b/skills/worktree-deleted-mid-session-recovery.md
@@ -1,0 +1,109 @@
+---
+name: worktree-deleted-mid-session-recovery
+description: "When a git worktree directory is deleted between sessions (by git worktree prune, automation cleanup, or OS temp-dir purge), the shell cwd becomes invalid and Path.cwd() / os.getcwd() throws FileNotFoundError. Use when: (1) pytest or pixi run fails with FileNotFoundError on cwd, (2) git worktree list shows an entry but the directory is gone from disk, (3) resuming work on a branch after a gap and finding the worktree path missing."
+category: ci-cd
+date: 2026-06-23
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [git, worktree, cwd, FileNotFoundError, recovery, prune, mid-session, pytest, pixi]
+---
+
+# Worktree Deleted Mid-Session Recovery
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-23 |
+| **Objective** | Recover a deleted git worktree so tests and builds can resume on the correct branch |
+| **Outcome** | Worktree recreated successfully; 4976 tests passed at 85.83% coverage |
+| **Verification** | verified-local |
+
+When a git worktree directory is removed from disk (by `git worktree prune`, an automation
+sweep of `build/.worktrees/`, or a prior session's cleanup script), the shell's CWD becomes
+invalid. Any tool that calls `Path.cwd()` or `os.getcwd()` — including pytest, pixi, and many
+Python utilities — throws `FileNotFoundError: [Errno 2] No such file or directory`. The fix
+is to recreate the worktree with `git worktree add`.
+
+Note: this is distinct from the "removed from inside the worktree" anti-pattern covered in
+`git-worktree-parallel-execution-lifecycle`. Here the directory was deleted externally and the
+branch still exists; there are no stashed edits to recover.
+
+## When to Use
+
+- `pixi run pytest` or `python -m pytest` fails immediately with `FileNotFoundError` from `Path.cwd()`
+- `git worktree list` shows a branch entry but the directory on disk is absent
+- A worktree was last known to be at `build/.worktrees/<issue-name>` but that path no longer exists
+- Resuming after a long gap: an automation process (e.g., `git worktree prune`, a CI cleanup job) removed the directory since the last session
+- The shell recovers to `$HOME` or `/` after `cd`-ing into the deleted path, causing subsequent commands to run in the wrong location
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Confirm the branch still exists
+git -C <repo-root> branch --list <branch-name>
+
+# 2. List all registered worktrees to see the stale entry
+git -C <repo-root> worktree list
+
+# 3. Recreate the deleted worktree on the same branch
+git -C <repo-root> worktree add build/.worktrees/<issue-name> <branch-name>
+
+# 4. Verify it's back on disk
+ls build/.worktrees/<issue-name>
+
+# 5. Confirm HEAD is the expected commit
+git -C build/.worktrees/<issue-name> log --oneline -1
+```
+
+### Detailed Steps
+
+1. Notice the error: `FileNotFoundError: [Errno 2] No such file or directory` from `Path.cwd()`
+   or `getcwd`, typically surfaced by pytest, pixi, or the shell after `cd` into a deleted path.
+2. Run `git -C <repo-root> worktree list` to see all registered worktrees.
+   Identify any entry whose path does not exist on disk.
+3. If the branch still exists (`git -C <repo-root> branch --list <branch>`), recreate the worktree:
+   ```bash
+   git -C <repo-root> worktree add <path> <branch>
+   ```
+4. If `git worktree list` still shows the stale entry after recreation, run:
+   ```bash
+   git -C <repo-root> worktree prune
+   ```
+   to clean up stale metadata, then recreate.
+5. Resume work inside the recreated worktree path.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running pytest from deleted cwd | Shell recovered to home dir; pytest ran from the wrong directory | Tests ran from the repo root, not the worktree branch checkout; imports and coverage metrics were misleading | Always verify `pwd` and `git rev-parse --abbrev-ref HEAD` before running tests to confirm you are in the correct worktree |
+
+## Results & Parameters
+
+Example recovery command used for ProjectHephaestus issue #1554 (branch `1554-auto-impl`,
+worktree at `build/.worktrees/issue-1554`):
+
+```bash
+git -C /home/mvillmow/Projects/ProjectHephaestus worktree add \
+    build/.worktrees/issue-1554 1554-auto-impl
+# Output: Preparing worktree (checking out '1554-auto-impl')
+# HEAD is now at c7883e49 fix: Address CI failures for PR ProjectHephaestus#1570
+```
+
+After recreation, `pixi run python -m pytest tests/ -v` produced 4976 passed, 85.83% coverage.
+
+Root cause of the deletion: likely `git worktree prune` or an automation process sweeping
+`build/.worktrees/` between sessions. Any process that calls `git worktree prune` or removes
+files under `build/.worktrees/` can silently invalidate an in-progress session. Before pruning,
+check for active branch sessions with `git -C <repo-root> worktree list` and verify no
+automation is running on those branches.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #1554, branch 1554-auto-impl — worktree missing between CI fix sessions | Recreated with `git worktree add`; all 4976 tests passed at 85.83% coverage |


### PR DESCRIPTION
## Summary

Adds two skills from driving ProjectHephaestus#1570 (issue #1554) to green CI.

### 1. ci-readme-blockquote-markdownlint-break
- Markdownlint fails when blank lines inside a README blockquote are missing the `>` continuation prefix (MD028)
- Fix: add `>` to every blank separator line within the blockquote
- Verified in CI (PR #1570 went green after this fix; commit c7883e49)

### 2. worktree-deleted-mid-session-recovery
- When a worktree directory is deleted between sessions (by prune, automation, or OS cleanup), `Path.cwd()` throws `FileNotFoundError`
- Fix: `git -C <repo-root> worktree add <path> <branch>`
- Verified locally — 4976 tests passed at 85.83% coverage after recovery

## Verification Level

**verified-ci** (markdownlint fix), **verified-local** (worktree recovery)

## Test Plan

- [x] Validated with `python3 scripts/validate_plugins.py` — 508/508 pass
- [ ] Verify skills appear in marketplace
- [ ] Test skill discovery with keywords: blockquote, markdownlint, worktree, cwd, FileNotFoundError

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>