### PR TITLE
feat: amend convention-guard skill with bidirectional mirror sub-pattern

### DIFF
--- a/skills/architecture-executable-convention-guard-pattern.history
+++ b/skills/architecture-executable-convention-guard-pattern.history
@@ -1,0 +1,21 @@
+# architecture-executable-convention-guard-pattern — History
+
+## v1.1.0 (2026-06-24)
+
+**Changed by:** ProjectHephaestus issue #1543 (PLANNING learning — tests/unit/ dirs breaking the hephaestus/ mirror invariant).
+**Verification:** unverified (PLAN only — code not executed, CI not run)
+
+### What changed
+- Added a new sub-pattern section, "Sub-Pattern: Bidirectional Mirror / Parity Invariants," documenting that a "X mirrors Y" invariant has TWO directions and an existing guard usually enforces only the forward one (`src - test`); the reverse (`test - src - allowlist`) is the silently-unguarded drift surface.
+- Added a "Proposed Workflow" subsection with an unverified warning (this insight is a plan, not validated end-to-end).
+- Added 3 new Failed Attempts rows: trusted the audit's "5 dirs" count (re-derive empirically with `comm -23`); assumed the existing guard was bidirectional (it only enforced forward); considered deleting flagged dirs (drops real coverage — use a sanctioned allowlist).
+- Added "When to Use" triggers for mirror/parity invariants and reverse-direction gaps.
+- Added Results & Parameters notes: allowlist-with-rationale (`frozenset` + inline comment per entry), reuse the already-wired gate (no new CI job), reuse the shared dir-filtering helper for both directions, coverage risk on the new negative-path branch.
+- Updated tags.
+
+### Why
+Issue #1543 surfaced that ProjectHephaestus's `check_test_structure()` enforced only the forward direction of the `tests/unit/` ↔ `hephaestus/` mirror invariant (`src_packages - test_packages`), so a test dir with no source counterpart drifted in silently. The plan adds the reverse check (`test_packages - src_packages - allowlist`) and an allowlist of sanctioned non-package test targets, fixes the prose in CLAUDE.md to match, and rides the already-wired gate rather than adding a new CI job. The audit's "5 dirs violate" count was imprecise (ground truth = 4; `scripts_lib/` is mirrored). These generalize the v1.0.0 "make a prose invariant executable" pattern to the bidirectional case.
+
+### Previous version (v1.0.0) snapshot
+
+The v1.0.0 rendered `.md` content prior to this amendment is preserved in git history at the parent commit of this amendment (the original single-case coredump `verify_crash_bundle` writeup, `verification: verified-local`, no sub-pattern section).

--- a/skills/architecture-executable-convention-guard-pattern.md
+++ b/skills/architecture-executable-convention-guard-pattern.md
@@ -1,11 +1,12 @@
 ---
 name: architecture-executable-convention-guard-pattern
-description: "Turn an un-guarded documented invariant (a prose convention) into a tested, blocking, reusable executable check that CI or any consumer can call. Use when: (1) a contract like 'absence of artifact X means stage Y never ran' lives only in docstrings/comments and nothing asserts it, (2) you are adding an enforcement gate whose whole purpose is signal fidelity and must pick a collision-free exit code distinct from argparse's usage-error 2 and sibling CLIs, (3) a verification step must resolve its inputs strictly read-only and must NOT fabricate the very signal whose absence it checks (e.g. a resolver that mkdir()s the directory), (4) you classify a log/marker line and must anchor on the line prefix instead of a free substring scan vulnerable to user-controlled tokens, (5) you relax argparse requirements (nargs='?') for a new mode and must re-guard the original mode so it does not silently no-op, (6) the same convention is documented in two places (module docstring + sibling shell comment) and must be kept in sync when made executable."
+description: "Turn an un-guarded documented invariant (a prose convention) into a tested, blocking, reusable executable check that CI or any consumer can call. Use when: (1) a contract like 'absence of artifact X means stage Y never ran' lives only in docstrings/comments and nothing asserts it, (2) you are adding an enforcement gate whose whole purpose is signal fidelity and must pick a collision-free exit code distinct from argparse's usage-error 2 and sibling CLIs, (3) a verification step must resolve its inputs strictly read-only and must NOT fabricate the very signal whose absence it checks (e.g. a resolver that mkdir()s the directory), (4) you classify a log/marker line and must anchor on the line prefix instead of a free substring scan vulnerable to user-controlled tokens, (5) you relax argparse requirements (nargs='?') for a new mode and must re-guard the original mode so it does not silently no-op, (6) the same convention is documented in two places (module docstring + sibling shell comment) and must be kept in sync when made executable, (7) you are planning a fix for any 'X mirrors Y' / parity / directory-structure invariant audit finding and must determine WHICH direction(s) the existing guard asserts — the defect is usually the un-asserted reverse direction (test_packages - src_packages), and the fix is an allowlist-with-rationale plus the reverse check, NOT deletion of flagged items."
 category: architecture
-date: 2026-06-12
-version: "1.0.0"
+date: 2026-06-24
+version: "1.1.0"
 user-invocable: false
 verification: verified-local
+history: architecture-executable-convention-guard-pattern.history
 tags:
   - executable-convention
   - invariant-guard
@@ -16,6 +17,10 @@ tags:
   - observability
   - cli-verify-mode
   - ci-gate
+  - bidirectional-invariant
+  - mirror-parity
+  - allowlist-with-rationale
+  - test-structure
   - hephaestus
 ---
 
@@ -41,7 +46,13 @@ Apply this pattern when a documented contract is currently enforced by nothing b
 - You **relax argparse requirements** (`nargs="?"`) to let a new mode run without the positionals the original mode required, and you must re-guard the original path.
 - The **same convention is documented in two homes** (a Python module docstring AND a sibling shell handler comment) that will drift if only one is updated.
 
-**Key trigger:** you find yourself writing "we rely on convention that …" in a docstring with nothing that fails if the convention is violated.
+Also apply this pattern when the un-guarded convention is a **structural mirror / parity invariant** (see the dedicated sub-pattern below):
+
+- You are planning a fix for an audit finding of the form **"X mirrors Y"** — e.g. "every `tests/unit/` subpackage mirrors a `hephaestus/` source subpackage," "every header has a matching `.cpp`," "every module has a doc page."
+- An existing guard already enforces ONE direction of such an invariant (the forward direction) and you suspect the **reverse direction is silently unguarded** — that asymmetry is exactly where drift accumulates.
+- The flagged "violations" are **intentional** (test dirs covering non-package targets such as a top-level `scripts/`, `docs/`, shell installers, or a single-file module) and the right answer is a **sanctioned allowlist with rationale**, not deletion.
+
+**Key trigger:** you find yourself writing "we rely on convention that …" in a docstring with nothing that fails if the convention is violated — OR an audit says "N items break the mirror invariant" and you cannot point at the line of code that asserts BOTH directions of that mirror.
 
 ## Verified Workflow
 
@@ -103,11 +114,70 @@ grep -rn "return [0-9]" path/to/module/
 
 7. **Sync the documented contract in all its homes.** The same convention was documented in a Python module docstring AND a sibling shell handler comment. When you make it executable, update BOTH to reference the new guard (e.g. "a CI artifact step MUST run `--verify` and fail on exit 3 / NOT_RUN") so the two copies of the contract don't drift.
 
+## Sub-Pattern: Bidirectional Mirror / Parity Invariants
+
+> **Warning:** This sub-pattern (added in v1.1.0 from ProjectHephaestus issue #1543) is **unverified** — it is a PLAN, the code was NOT executed or CI-validated. Treat as a hypothesis until CI confirms. The v1.0.0 coredump material above remains `verified-local`.
+
+When the prose invariant being made executable is a **structural mirror** ("every X has a matching Y"), the v1.0.0 steps still apply, but a distinct failure mode dominates: the guard enforces only ONE direction. This is the central, generalizable insight.
+
+### The bidirectional gap (central insight)
+
+A "mirror" / "parity" invariant has **TWO directions**. An existing guard frequently enforces only the **forward** one and leaves the **reverse** silently unguarded — which is precisely how drift accumulates:
+
+| Direction | Set expression | Catches | Commonly guarded? |
+| --------- | -------------- | ------- | ----------------- |
+| Forward | `src_packages - test_packages` | a source subpackage with no test dir | usually YES |
+| Reverse | `test_packages - src_packages - allowlist` | a test dir with no source counterpart | usually **NO** (the gap) |
+
+When auditing or planning a fix for ANY "X mirrors Y" finding, **grep the existing checker and confirm WHICH direction(s) it asserts.** The defect is almost always the un-asserted direction. The fix **adds the reverse check** (`test_packages - src_packages - allowlist`) — it is NOT a rewrite of the forward check.
+
+### Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+1. **Re-derive the violation set empirically — do NOT trust the audit's count.** Audit "N items violate" counts are often imprecise. The issue claimed "5 dirs"; ground truth found only 4 (the 5th, `scripts_lib/`, IS mirrored by a same-named source subpackage). Compute the real set:
+
+   ```bash
+   comm -23 \
+     <(ls -d tests/unit/*/ | xargs -n1 basename | sort) \
+     <(ls -d src/*/ | xargs -n1 basename | sort)
+   ```
+
+   Plan against ground truth and note the discrepancy with the audit explicitly.
+
+2. **Confirm which direction the existing guard asserts.** Grep the checker (e.g. `check_test_structure()`). If it only does `src_packages - test_packages`, the reverse direction is the gap.
+
+3. **Reuse the shared dir-filtering helper for BOTH directions.** The reverse check's correctness depends on the same `__pycache__`/dotdir filtering the forward check uses. Reuse the existing helper (e.g. `_get_subpackages`) — do NOT re-implement directory enumeration — so both directions share identical filtering semantics. (Reviewer must confirm the helper is reused, not re-implemented.)
+
+4. **Allowlist legitimate "violations" with rationale — do NOT delete.** When flagged items are intentional (test dirs covering non-package targets), add a SANCTIONED allowlist (`frozenset`) where every entry carries an inline comment naming its non-package target. Deletion would drop real coverage. A new unsanctioned dir then fails the gate, forcing an explicit decision. This is the same "ignore + guard, never delete legitimate state" principle.
+
+   ```python
+   # Test dirs that intentionally do NOT mirror a hephaestus/ subpackage:
+   _SANCTIONED_EXTRA_TEST_DIRS: frozenset[str] = frozenset({
+       "scripts",    # tests for top-level scripts/, not a package
+       "docs",       # doc-build / link tests, not a package
+       # ...one entry per non-package target, each with its reason
+   })
+
+   def check_no_unsanctioned_test_dirs(src: Path, tests: Path) -> list[str]:
+       extra = _get_subpackages(tests) - _get_subpackages(src) - _SANCTIONED_EXTRA_TEST_DIRS
+       return sorted(extra)
+   ```
+
+5. **Fix prose AND code together.** The invariant lived only in prose (CLAUDE.md). Making it executable means BOTH adding the tested predicate AND correcting the prose to match the now-precise rule (mirror subpackages + a small sanctioned-extras set). Keep all documented copies of the contract in sync.
+
+6. **Reuse the already-wired gate; do NOT add a new CI job.** The checker was already invoked in CI (`_required.yml`, `test.yml`) and pre-commit. Wire the new reverse check INTO the existing `check_test_structure()` so it rides the already-required gate — no new workflow. (ci-hygiene "already-wired" pattern.) Re-grep `hephaestus-check-test-structure` to find the wiring rather than trusting line numbers (`_required.yml:552` / `test.yml:101` / `.pre-commit-config.yaml:158` were read once and may drift).
+
+7. **Cover the negative-path branch.** Adding a new function needs a `TestCheckNoUnsanctionedTestDirs` that exercises the `else` branch printing unsanctioned dirs, or module coverage can drop below the 83% gate. Prefer unit-test coverage over a manual mutation test (`mkdir tests/unit/rogue ... rmdir`) which mutates the working tree and can leave a stray dir if it fails mid-way.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | ---------------- | --------------- | ---------------- |
 | Reuse exit code 2 | Used `2` for the invariant violation | Collides with argparse usage-error `2` and a sibling CLI's `2` — a CI gate can't tell "signal lost" from "bad command line" | Grep existing exit codes (`grep -rn "return [0-9]"`), pick a distinct code, name it with a constant (`VERIFY_SIGNAL_LOST_EXIT = 3`) |
+| Trust the audit's "5 dirs" count | Planned the fix against the audit finding's stated number of violating dirs | Ground-truth `comm -23` found only 4 real violations — the 5th (`scripts_lib/`) IS mirrored by a same-named source subpackage, so it is not a violation | Re-derive the violation set empirically with `comm -23` of the two dir listings; plan against ground truth and note the discrepancy explicitly |
+| Assume the existing guard was bidirectional | Took for granted that `check_test_structure()` enforced both directions of the mirror | It only enforced the FORWARD direction (`src_packages - test_packages`); the reverse (`test_packages - src_packages`) was silently unguarded — the actual drift surface | Grep the checker and confirm WHICH direction(s) it asserts; the defect is the un-asserted direction. Add the reverse check, do not rewrite the forward one |
+| Delete the flagged test dirs | Considered removing the dirs that broke the mirror | The flagged dirs are intentional (test coverage for non-package targets: top-level `scripts/`, `docs/`, a single-file module); deletion drops real test coverage | Use a sanctioned `frozenset` allowlist with an inline rationale per entry; a NEW unsanctioned dir then fails the gate, forcing an explicit decision |
 | Assert `status == 2` | Test asserted the JSON envelope as `payload["status"] == 2` (a number) | `emit_json_status` sets `status` to the STRING `"ok"`/`"error"` and puts the numeric code in `exit_code` — the assert always failed | Read the envelope helper's source before asserting its shape; assert `status=="error"`, `exit_code==3`, and the custom field via `**extra` |
 | Call `resolve_target_dir()` in verify mode | Reused the normal resolver to find the log dir | It does `mkdir(parents=True, exist_ok=True)`, fabricating the very directory whose absence is the signal | Verification must be strictly read-only; inline a no-mkdir resolution and test that the dir is NOT created |
 | Classify success via `" wrote " in line` | Free substring scan over every log line | Misclassifies an `ERROR:` line whose path embeds `" wrote "` as success (exe basename is user-controlled, can contain spaces) | Anchor on the log-line prefix (split timestamp, message `startswith`); add a regression test for the adversarial path |
@@ -159,12 +229,15 @@ target = next((Path(c) for c in cleaned if Path(c).is_dir()), Path(cleaned[-1]))
 
 **Generalization (the durable, reusable pattern):** This applies to ANY documented "absence of artifact X means stage Y never ran" convention. Make it an **importable, tested predicate + a CLI verify mode** with a **distinct blocking exit code**; **resolve inputs read-only** (never fabricate the signal); **anchor any log/marker parsing** on a stable prefix rather than a free substring scan; and **keep all copies of the documented contract in sync**. The blocking decision is "was the SIGNAL lost," not "did the underlying operation succeed."
 
+**Bidirectional-invariant generalization (v1.1.0, unverified):** For any structural "X mirrors Y" invariant, a guard has TWO directions and the existing one usually asserts only the forward one (`src - test`). The reverse direction (`test - src - allowlist`) is the silent drift surface — confirm which direction the checker asserts and ADD the missing one. Re-derive any "N violate" audit count empirically (`comm -23`) rather than trusting it. Encode legitimate exceptions as a **sanctioned `frozenset` allowlist with per-entry rationale** (never delete real coverage), reuse the **same dir-filtering helper for both directions**, **sync prose and code**, and **ride the already-wired gate** (no new CI job). Cover the new negative-path branch so module coverage stays above the gate.
+
 ## Verified On
 
 | Repository | Issue / PR | What was applied |
 | ------------ | ------------ | ------------------ |
 | ProjectHephaestus | issue #1207 / PR #1247 | coredump handler `verify_crash_bundle` + `--verify` mode; exit 3 distinct from argparse 2; read-only no-fabricate resolution; prefix-anchored log classification |
+| ProjectHephaestus | issue #1543 (PLAN — **unverified**) | bidirectional mirror sub-pattern: reverse check `test_packages - src_packages - allowlist` added to existing `check_test_structure()`; sanctioned `frozenset` allowlist with per-entry rationale; prose + code synced; rides already-wired gate (no new CI job) |
 
 ## Tags
 
-`#executable-convention` `#invariant-guard` `#exit-code-collision` `#fail-safe` `#read-only-verification` `#log-line-anchoring` `#observability` `#cli-verify-mode` `#ci-gate` `#hephaestus`
+`#executable-convention` `#invariant-guard` `#exit-code-collision` `#fail-safe` `#read-only-verification` `#log-line-anchoring` `#observability` `#cli-verify-mode` `#ci-gate` `#bidirectional-invariant` `#mirror-parity` `#allowlist-with-rationale` `#test-structure` `#hephaestus`


### PR DESCRIPTION
## Summary

Amends `skills/architecture-executable-convention-guard-pattern.md` (1.0.0 -> 1.1.0) with the bidirectional/reverse-direction insight captured while planning ProjectHephaestus issue #1543 ("tests/unit/ has dirs breaking the hephaestus/ mirror invariant").

**Verification level: unverified** — this is a PLANNING learning. The described fix was NOT executed or CI-validated. The new sub-pattern section carries an explicit "Proposed Workflow" / hypothesis warning; the original v1.0.0 coredump material remains `verified-local`.

## Key findings captured

- **Bidirectional gap (central insight):** a "X mirrors Y" invariant has TWO directions; an existing guard usually enforces only the forward one (`src - test`). The reverse (`test - src - allowlist`) is silently unguarded — the real drift surface. Fix ADDS the reverse check; it is not a rewrite.
- **Re-derive audit counts empirically:** the issue claimed "5 dirs"; `comm -23` ground truth was 4 (`scripts_lib/` is mirrored). Trust `comm -23`, not the audit number.
- **Allowlist-with-rationale, never delete** legitimate test dirs covering non-package targets (`scripts/`, `docs/`, single-file modules) — a sanctioned `frozenset` with per-entry comments.
- **Sync prose and code**, and **ride the already-wired gate** (no new CI job); reuse the shared dir-filtering helper for both directions; cover the new negative-path branch to keep coverage above the 83% gate.

## Changes
- Bumped version 1.0.0 -> 1.1.0; added `history:` frontmatter + new `.history` file (v1.0.0 snapshot pointer).
- New "Sub-Pattern: Bidirectional Mirror / Parity Invariants" section with a Proposed Workflow + unverified warning.
- 3 new Failed Attempts rows (trusted "5 dirs" count; assumed guard was bidirectional; considered deleting flagged dirs).
- New When-to-Use triggers, tags, Verified-On row, and generalization note.

## Test plan
- `python3 scripts/validate_plugins.py` → 513/513 valid.