### PR TITLE
feat: amend python-import-patterns skill (v1.4.0)

### DIFF
--- a/skills/python-import-patterns-and-compatibility-guards.history
+++ b/skills/python-import-patterns-and-compatibility-guards.history
@@ -2,6 +2,36 @@
 
 # History: python-import-patterns-and-compatibility-guards
 
+## v1.4.0 (2026-06-24)
+
+**Changed by:** ProjectHephaestus issue #1545 — executed the access-time `DeprecationWarning` implementation for the deprecated `retry_with_jitter` lazy shim. The v1.3.0 plan was followed end-to-end and all tests passed locally.
+**Verification:** `verified-local` for section F (all tests pass locally; CI pending after the ProjectHephaestus PR merges). Pre-existing sections remain verified-ci / verified-local.
+
+### What changed
+
+- Upgraded section F from "Proposed Workflow — planning an access-time DeprecationWarning (UNVERIFIED)" to "Verified Workflow — adding an access-time DeprecationWarning (verified-local)". Removed the "Warning: never executed" banner and replaced it with a "Verification: verified-local" note.
+- Replaced the unverified `__getattr__` snippet (using a `set`-based `_DEPRECATED_LAZY`) with the actual verified implementation: `_DEPRECATED_LAZY: dict[str, str]` with a full deprecation message string, and the exact `__getattr__` body used in the PR.
+- Replaced the minimal unverified test stub with the full verified test `test_retry_with_jitter_access_emits_deprecation_warning` including the `__dict__.pop` cache-bust, `callable(symbol)` assertion, `DeprecationWarning` category check, message content check, and `stacklevel=2` filename assertion (`access_warnings[0].filename == __file__`).
+- Added verified test passage block (3 tests in `test_deprecation_warnings.py`, 7 in `test_retry.py -k jitter`, `test_import_surface.py`, `test_automation_boundary.py`, ruff, mypy).
+- Confirmed and documented `stacklevel=2` as correct for `__getattr__` (call stack: user access line → `__getattr__` → `warnings.warn`; `stacklevel=2` skips `__getattr__` and attributes to user's line).
+- Updated Overview verification row: removed "unverified (section F)" clause; added "verified-local (access-time deprecation-warning implementation — section F executed end-to-end)".
+- Updated Overview objective/outcome to reflect implementation rather than planning.
+- Updated the "When to Use" bullet for access-time deprecation warning from "(PLANNING, unverified)" to "(verified-local)" with concrete confirmed facts.
+- Updated all 5 formerly-`unverified` Failed Attempts rows (trust `__all__` claim; dedup layers; one-shot test without cache reset; treat as additive; skip prose doc) from `unverified` to `verified-local`.
+- Updated the `stacklevel=2` Failed Attempts row from "PLANNING, UNVERIFIED — may be wrong" to confirmed correct with evidence.
+- Replaced "PROPOSED pattern (UNVERIFIED)" Results & Parameters subsection with "verified pattern (verified-local)" containing the actual implementation, actual test, and actual test pass results.
+- Updated Verified On row for issue #1545 from "PLAN ONLY / unverified" to "executed / verified-local" with full detail.
+- Removed `planning` tag; added `stacklevel` and `warnings-warn` tags.
+- Bumped version 1.3.0 → 1.4.0.
+
+### Why
+
+v1.3.0 added a planning checklist (section F) for the access-time `DeprecationWarning` across the PEP 562 lazy-loader seam, but all material was `unverified` — edits and tests were never executed. Issue #1545 in ProjectHephaestus then executed the plan end-to-end: the `_DEPRECATED_LAZY` dict approach with `dict[str, str]` values (full message strings) proved correct; `stacklevel=2` inside `__getattr__` correctly attributes to the caller's file (confirmed by `access_warnings[0].filename == __file__`); `module.__dict__.pop(name, None)` correctly forces `__getattr__` to re-run; the stale-tolerant test (`test_retry_with_jitter_reachable_from_top_level_lazy_loader`) had to be fully replaced; `import warnings` deferred inside the condition is safe for the automation boundary; and `COMPATIBILITY.md` needed updating. All assumptions from the plan were confirmed correct, so this amendment upgrades from plan-only to verified implementation.
+
+### Previous version (v1.3.0) snapshot
+
+The full v1.3.0 skill text is the previous section below. Key difference from v1.4.0: section F was titled "Proposed Workflow (UNVERIFIED)" with a warning banner; `_DEPRECATED_LAZY` was a `set[str]` rather than `dict[str, str]`; the test was a minimal stub without the filename assertion; and all access-time deprecation entries in Failed Attempts were tagged `unverified`.
+
 ## v1.3.0 (2026-06-24)
 
 **Changed by:** ProjectHephaestus issue #1545 — implementation PLAN for an access-time `DeprecationWarning` on the deprecated `retry_with_jitter` lazy shim exposed via the PEP 562 `__getattr__` loader in `hephaestus/__init__.py`.

--- a/skills/python-import-patterns-and-compatibility-guards.md
+++ b/skills/python-import-patterns-and-compatibility-guards.md
@@ -1,9 +1,9 @@
 ---
 name: python-import-patterns-and-compatibility-guards
-description: "Use when: (1) a child module would create circular dependencies by importing the parent at module level — use function-local imports to defer the lookup and keep the import graph acyclic; (2) extending a public SDK surface with peer classes using lazy-loading __init__.py infrastructure (lazy exports pattern via __getattr__) to prevent eager-load regressions when adding new peers to __all__; (3) code uses a stdlib module added in a later Python version (tomllib in 3.11+, ExceptionGroup in 3.11+) and the CI matrix includes older Python — add a version-gated try/except import guard so the module remains importable; (4) adding cross-OS CI matrix and Windows jobs fail with ModuleNotFoundError for POSIX-only stdlib modules (curses, fcntl, grp, tzdata) — add conditional import guards and ensure tzdata is listed as an optional Windows dependency; (5) a hardcoded surface-pinning test (set(__all__) == literal) fails on CI with 'Extra items in the left set' because a peer export landed on main via an independent PR while your branch was open — fix the stale test literal, not the (correct) source, and use env -i / git stash / grep-the-CI-log to separate real failures from live-session environment noise; (6) a branch widening a lazy SDK surface (_LAZY_EXPORTS/__all__/__getattr__ in __init__.py) goes DIRTY/CONFLICTING on rebase because a sibling PR already landed the identical export — resolve by keeping ONE copy of the shared entry, and FIRST check mergeStateStatus=DIRTY when a PR reads as CI-failing but no test actually failed; (7) PLANNING a DeprecationWarning at ACCESS time (not just call time) for a deprecated lazy shim exposed via a PEP 562 package __getattr__ loader — grep the named symbol against the source first because the issue may misname the mechanism (in _LAZY_IMPORTS vs __all__), keep access-time and call-time warnings as complementary layers, force a fresh resolve in the regression test via module.__dict__.pop(name) because PEP 562 caches into globals, rewrite any stale-tolerant test that documents the current silent behavior, and update the prose deprecation doc (COMPATIBILITY.md) in the same PR."
+description: "Use when: (1) a child module would create circular dependencies by importing the parent at module level — use function-local imports to defer the lookup and keep the import graph acyclic; (2) extending a public SDK surface with peer classes using lazy-loading __init__.py infrastructure (lazy exports pattern via __getattr__) to prevent eager-load regressions when adding new peers to __all__; (3) code uses a stdlib module added in a later Python version (tomllib in 3.11+, ExceptionGroup in 3.11+) and the CI matrix includes older Python — add a version-gated try/except import guard so the module remains importable; (4) adding cross-OS CI matrix and Windows jobs fail with ModuleNotFoundError for POSIX-only stdlib modules (curses, fcntl, grp, tzdata) — add conditional import guards and ensure tzdata is listed as an optional Windows dependency; (5) a hardcoded surface-pinning test (set(__all__) == literal) fails on CI with 'Extra items in the left set' because a peer export landed on main via an independent PR while your branch was open — fix the stale test literal, not the (correct) source, and use env -i / git stash / grep-the-CI-log to separate real failures from live-session environment noise; (6) a branch widening a lazy SDK surface (_LAZY_EXPORTS/__all__/__getattr__ in __init__.py) goes DIRTY/CONFLICTING on rebase because a sibling PR already landed the identical export — resolve by keeping ONE copy of the shared entry, and FIRST check mergeStateStatus=DIRTY when a PR reads as CI-failing but no test actually failed; (7) adding a DeprecationWarning at ACCESS time (not just call time) for a deprecated lazy shim exposed via a PEP 562 package __getattr__ loader — grep the named symbol against the source first because the issue may misname the mechanism (in _LAZY_IMPORTS vs __all__), keep access-time and call-time warnings as complementary layers (both needed for different access paths), force a fresh resolve in the regression test via module.__dict__.pop(name) because PEP 562 caches into globals, rewrite any stale-tolerant test that documents the current silent behavior, use stacklevel=2 inside __getattr__ (verified: user line → __getattr__ → warn, so stacklevel=2 attributes to user's access line), and update the prose deprecation doc (COMPATIBILITY.md) in the same PR (verified-local, ProjectHephaestus issue #1545)."
 category: architecture
 date: 2026-06-24
-version: "1.3.0"
+version: "1.4.0"
 user-invocable: false
 history: python-import-patterns-and-compatibility-guards.history
 tags:
@@ -35,7 +35,8 @@ tags:
   - getattr
   - stale-tolerant-test
   - doc-drift
-  - planning
+  - stacklevel
+  - warnings-warn
 ---
 
 # Python Import Patterns and Compatibility Guards
@@ -45,9 +46,9 @@ tags:
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-06-24 |
-| **Objective** | Manage the Python import graph and import compatibility across versions and platforms: avoid circular dependencies with function-local imports, extend public SDK surfaces via lazy exports without eager-load regressions, guard stdlib imports that vary by Python version or OS, keep hardcoded surface-pinning tests from going stale when peers land via parallel PRs, and plan an access-time `DeprecationWarning` across the PEP 562 lazy-loader seam |
-| **Outcome** | Acyclic import graphs, Windows-importable packages, CI matrices green on older Python and POSIX-only stdlib, lazy SDK surfaces that scale to new peer classes, a decision procedure for fixing stale pinned-`__all__` tests (test vs source) without chasing live-session environment noise, and a planning checklist for emitting a deprecation warning at `__getattr__` access time without breaking caching, stale-tolerant tests, or prose docs |
-| **Verification** | verified-ci (function-local / version-guard / Windows-guard / lazy-exports); verified-local (surface-pin-stale fix — CI re-run confirmation pending); **unverified** (access-time deprecation-warning planning — section F is a PLAN that was never executed) |
+| **Objective** | Manage the Python import graph and import compatibility across versions and platforms: avoid circular dependencies with function-local imports, extend public SDK surfaces via lazy exports without eager-load regressions, guard stdlib imports that vary by Python version or OS, keep hardcoded surface-pinning tests from going stale when peers land via parallel PRs, and emit an access-time `DeprecationWarning` across the PEP 562 lazy-loader seam |
+| **Outcome** | Acyclic import graphs, Windows-importable packages, CI matrices green on older Python and POSIX-only stdlib, lazy SDK surfaces that scale to new peer classes, a decision procedure for fixing stale pinned-`__all__` tests (test vs source) without chasing live-session environment noise, and a verified workflow for emitting a deprecation warning at `__getattr__` access time — confirming `stacklevel=2` is correct, `module.__dict__.pop(name)` busts the PEP 562 cache, both access-time and call-time warning layers are needed, the stale-tolerant test must be rewritten not supplemented, and `COMPATIBILITY.md` must be updated in the same PR |
+| **Verification** | verified-ci (function-local / version-guard / Windows-guard / lazy-exports); verified-local (surface-pin-stale fix, access-time deprecation-warning implementation — section F executed end-to-end with all tests passing locally; CI pending after ProjectHephaestus PR merges) |
 
 ## When to Use
 
@@ -57,7 +58,7 @@ tags:
 - **Windows / POSIX-only stdlib guard**: Adding a cross-OS CI matrix where Windows jobs fail with `ModuleNotFoundError` for `curses`/`fcntl`/`termios`/`grp`/`pwd`, or `zoneinfo.ZoneInfo` raises `ZoneInfoNotFoundError` on Windows (needs `tzdata`).
 - **Lazy-export add/add rebase conflict**: A branch widens the lazy SDK surface (`_LAZY_EXPORTS` + `__all__` + `__getattr__`) and goes `DIRTY`/`CONFLICTING` because a *sibling PR already landed the identical export* on main. The PR reads as "CI failing" but the logs show only runner/setup steps and **no test actually failed** — the merge conflict itself is the blocker. Resolve by keeping ONE copy of the shared entry.
 - **Stale surface-pin test (branch-divergence / merge-skew)**: A hardcoded surface-pinning test (`assert set(__all__) == {literal}`) fails on CI with `Extra items in the left set: '<Symbol>'`, where `<Symbol>` is a *legitimate* peer export that landed on `main` via an independent PR while your feature branch was open. The production `__init__.py` is correct; the test literal went stale. You need to decide whether the test or the source is wrong, then fix only the stale party — and to do that you must separate the real CI failure from environment noise that only appears when the local suite runs inside a live automation session.
-- **Access-time deprecation warning across the lazy-loader seam (PLANNING, unverified)**: You are planning to make a deprecated lazy shim (e.g. `retry_with_jitter`) warn at *attribute-access* time, not only when called, by adding a `warnings.warn(...)` inside the package `__getattr__` / `_LAZY_IMPORTS` resolver. The plan must reconcile: the issue may misname *where* the symbol lives (`_LAZY_IMPORTS` vs `__all__`); the existing call-time warning is a *different* layer (keep both); PEP 562 caches the resolved name into module globals so the access path runs once per process (the test must `__dict__.pop` to re-trigger); an existing regression test may *document and tolerate* the current silent resolve and must be rewritten; and a prose doc (`COMPATIBILITY.md`) may describe the warning as firing "when called" and must be updated in the same PR.
+- **Access-time deprecation warning across the lazy-loader seam (verified-local)**: You need to make a deprecated lazy shim (e.g. `retry_with_jitter`) warn at *attribute-access* time, not only when called, by adding a `warnings.warn(...)` inside the package `__getattr__` / `_LAZY_IMPORTS` resolver. Key verified facts: the issue may misname *where* the symbol lives (`_LAZY_IMPORTS` vs `__all__`) — grep first; the existing call-time warning is a *different* layer covering a different access path (keep both); PEP 562 caches the resolved name into module globals so the access warning fires once per process — the test must `module.__dict__.pop(name, None)` to re-trigger `__getattr__`; `stacklevel=2` IS correct inside `__getattr__` (call stack: user access line → `__getattr__` → `warnings.warn`); an existing regression test that documents the current silent resolve must be *rewritten*, not supplemented; and a prose doc (`COMPATIBILITY.md`) describing the warning as firing "when called" must be updated in the same PR.
 
 ## Verified Workflow
 
@@ -256,45 +257,88 @@ General pattern + known backports:
 6. **Scope tests honestly**: runtime guards make the package *importable* on Windows, not the POSIX-only CLIs *functional*. Skip those tests on Windows via `pytest.skip(...)` rather than scattering inline `if sys.platform == "win32"` assertions.
 7. **Track the full cross-OS port as a separate issue** (file-mode bits, path encoding, coredump handlers). Keep the matrix ubuntu-only until that lands; keep the import guards so downstream consumers stay Windows-importable.
 
-#### F. Proposed Workflow — planning an access-time DeprecationWarning across the PEP 562 lazy-loader seam (UNVERIFIED)
+#### F. Verified Workflow — adding an access-time DeprecationWarning across the PEP 562 lazy-loader seam (verified-local)
 
-> **Warning:** This workflow has not been validated end-to-end. It is a PLAN produced for ProjectHephaestus issue #1545 (warn at *access* time, not only call time, for the deprecated `retry_with_jitter` shim exposed via `hephaestus/__init__.py`'s PEP 562 `__getattr__` loader). The edits and the regression test were **never executed** — line numbers were read, not run. Verification level = `unverified`. Treat every step as a hypothesis until CI confirms it.
+> **Verification:** This workflow was executed end-to-end for ProjectHephaestus issue #1545 (warn at *access* time, not only call time, for the deprecated `retry_with_jitter` shim exposed via `hephaestus/__init__.py`'s PEP 562 `__getattr__` loader). All steps below are verified locally — tests pass, ruff and mypy clean. CI confirmation pending after the ProjectHephaestus PR merges. Verification level = `verified-local`.
 
-1. **Grep the named symbol against the source BEFORE trusting the issue's structural claim.** Issue #1545 said the shim was "in `__all__`", but `retry_with_jitter` is actually only in `_LAZY_IMPORTS` (the lazy resolver map), not `__all__`. The fix location — the `__getattr__` lazy-loader seam — is the same either way, but the plan MUST call out the discrepancy or a reviewer flags the plan as wrong.
+1. **Grep the named symbol against the source BEFORE trusting the issue's structural claim.** Issue #1545 said the shim was "in `__all__`", but `retry_with_jitter` is actually only in `_LAZY_IMPORTS` (the lazy resolver map), not `__all__`. The fix location — the `__getattr__` lazy-loader seam — is the same either way, but you must understand where the symbol actually lives before editing.
    ```bash
    grep -n "retry_with_jitter" hephaestus/__init__.py   # is it in _LAZY_IMPORTS or __all__? (here: _LAZY_IMPORTS only)
    grep -rn "def retry_with_jitter" hephaestus/         # where the real impl + any call-time warning lives
    ```
-2. **Treat access-time and call-time warnings as COMPLEMENTARY layers, not duplicates — keep both.** A deprecated shim may already warn *inside its function body* (fires on `hephaestus.utils.X` direct call). Adding a warning in the package `__getattr__` covers a *different* access path — binding `hephaestus.X` via attribute lookup, even if the symbol is never called. Different users hit different paths; do NOT "dedup" them.
-3. **Force a fresh resolve in the regression test — PEP 562 `__getattr__` caches into module globals.** After the first `hephaestus.retry_with_jitter` access, the resolved name is written into the module's `__dict__`, so `__getattr__` (and the access warning) never runs again that process. A prior test that already touched the symbol makes the warning assertion a flaky false-negative. Pop it first:
-   ```python
-   import hephaestus, warnings
 
-   def test_access_emits_deprecation_warning():
-       hephaestus.__dict__.pop("retry_with_jitter", None)   # force __getattr__ to re-run
+2. **Treat access-time and call-time warnings as COMPLEMENTARY layers, not duplicates — keep both.** A deprecated shim may already warn *inside its function body* (fires on `hephaestus.utils.X` direct call). Adding a warning in the package `__getattr__` covers a *different* access path — binding `hephaestus.X` via attribute lookup, even if the symbol is never called. Different users hit different paths; do NOT "dedup" them.
+
+3. **Add a `_DEPRECATED_LAZY` dict alongside `_LAZY_IMPORTS` and check it inside `__getattr__`.** The warning message should name the canonical replacement. Defer the `import warnings` inside the condition — it is stdlib, safe, and does not breach the automation boundary (`test_automation_boundary.py` confirmed):
+   ```python
+   # hephaestus/__init__.py — add after _LAZY_IMPORTS closes
+   _DEPRECATED_LAZY: dict[str, str] = {
+       "retry_with_jitter": (
+           "hephaestus.retry_with_jitter is deprecated; use "
+           "retry_with_backoff(jitter=True, max_delay=...) instead. "
+           "It will be removed no earlier than the next major version after 1.0."
+       ),
+   }
+
+   def __getattr__(name: str) -> Any:
+       """Lazy-load public symbols on first access (PEP 562)."""
+       if name in _LAZY_IMPORTS:
+           if name in _DEPRECATED_LAZY:
+               import warnings
+               warnings.warn(_DEPRECATED_LAZY[name], DeprecationWarning, stacklevel=2)
+           module_name, attr = _LAZY_IMPORTS[name]
+           import importlib
+           module = importlib.import_module(module_name)
+           value = getattr(module, attr)
+           globals()[name] = value
+           return value
+       raise AttributeError(f"module 'hephaestus' has no attribute {name!r}")
+   ```
+
+4. **`stacklevel=2` IS correct for `__getattr__` — verified.** The call stack when a user writes `hephaestus.retry_with_jitter` is: (1) user's access line → (2) `__getattr__` → (3) `warnings.warn`. `stacklevel=2` skips `__getattr__` (frame 2) and attributes the warning to frame 1 (the user's line). Confirmed by asserting `access_warnings[0].filename == __file__` in the test.
+
+5. **Force a fresh resolve in the regression test — PEP 562 `__getattr__` caches into module globals.** After the first `hephaestus.retry_with_jitter` access, the resolved name is written into the module's `__dict__`, so `__getattr__` (and the access warning) never runs again that process. A prior test that already touched the symbol makes the warning assertion a false-negative. Pop it first:
+   ```python
+   def test_retry_with_jitter_access_emits_deprecation_warning(self) -> None:
+       import hephaestus
+
+       # Bust PEP 562 cache — force __getattr__ to re-run
+       hephaestus.__dict__.pop("retry_with_jitter", None)
+
        with warnings.catch_warnings(record=True) as caught:
            warnings.simplefilter("always")
-           _ = hephaestus.retry_with_jitter             # ACCESS, do not call
-       assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+           symbol = hephaestus.retry_with_jitter  # ACCESS only, do not call
+
+       assert callable(symbol)
+       access_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+       assert access_warnings, "Accessing hephaestus.retry_with_jitter must emit DeprecationWarning"
+       assert "retry_with_jitter" in str(access_warnings[0].message)
+       # stacklevel=2 must attribute the warning to the caller's file
+       assert access_warnings[0].filename == __file__, (
+           f"DeprecationWarning should be attributed to the caller's file "
+           f"({__file__}); got {access_warnings[0].filename}. Check stacklevel."
+       )
    ```
-4. **Grep for stale-tolerant tests that ASSERT the about-to-change behavior, then REWRITE them — a change is not "additive" if a passing test documents the old contract.** An existing test (`test_deprecation_warnings.py:49-66`) explicitly documented and tolerated the silent lazy resolve ("the lazy resolve itself is silent; only CALLING warns"). The plan had to find and rewrite that test, not merely add a new one — otherwise the change contradicts a green test's documented contract.
+
+6. **Grep for stale-tolerant tests that ASSERT the about-to-change behavior, then REWRITE them — a change is not "additive" if a passing test documents the old contract.** The existing test `test_retry_with_jitter_reachable_from_top_level_lazy_loader` explicitly documented and tolerated the silent lazy resolve ("the lazy resolve itself is silent; only CALLING warns"). It had to be replaced, not supplemented — its docstring said the old behavior was intentional.
    ```bash
    grep -rn "silent\|lazy resolve\|only CALLING\|does not warn" tests/ | grep -i deprecat
    ```
-5. **Update the prose deprecation doc in the SAME PR — behavior/doc drift is a review trap.** `COMPATIBILITY.md` had a bullet stating the warning fires "when called". A doc-cross-check test (e.g. `test_compatibility_doc_mentions_*`) or a reviewer will catch the drift if the prose still says "when called" after the behavior now also fires on access.
-6. **Re-confirm the import-surface boundary still holds.** Adding `warnings.warn` inside `__getattr__` is low-risk (`warnings` is stdlib), but verify it does not trip `test_import_surface.py` / `test_automation_boundary.py` — *unverified* in this plan.
-7. **Validate the `stacklevel`.** A direct-call warning uses `stacklevel=2` to point at the caller. In a `__getattr__` indirection the access is an *attribute lookup*, not a call, so the correct `stacklevel` for the access warning may differ — this is an UNVERIFIED assumption; check the rendered warning location against a real access line before committing.
+
+7. **Update the prose deprecation doc in the SAME PR — behavior/doc drift is a review trap.** `COMPATIBILITY.md` had a bullet stating the warning fires "when called". Update it to reflect that the warning now fires both when accessed via `hephaestus.retry_with_jitter` AND when called.
+
+8. **Re-confirm the import-surface boundary still holds.** Adding `import warnings` inside `__getattr__` is low-risk (`warnings` is stdlib, deferred inside the condition), but run `test_import_surface.py` and `test_automation_boundary.py` after the change — both passed for issue #1545.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Trust the issue's "in `__all__`" claim about the deprecated shim (PLANNING) | Issue #1545 stated `retry_with_jitter` was exposed via `__all__`; planned the fix from that structural claim | The symbol is actually only in `_LAZY_IMPORTS`, not `__all__`. A reviewer comparing the plan to source would flag it as wrong even though the fix seam (`__getattr__`) is identical | Grep the named symbol against the source before trusting an issue's structural claim; call out any discrepancy in the plan. `unverified` |
-| Assume the access-time warning duplicates the existing call-time warning (PLANNING) | Considered "deduping" by relying on the function-body warning alone | Access-time (`hephaestus.X` binding) and call-time (`hephaestus.utils.X(...)`) are DIFFERENT access paths firing for different users; dropping either silently loses coverage | Keep both warnings — they are complementary layers, not duplicates. `unverified` |
-| Write a one-shot warning-assertion test without resetting the cache (PLANNING) | `with pytest.warns(DeprecationWarning): _ = hephaestus.retry_with_jitter` | PEP 562 caches the resolved name into module globals on first access; a prior test that touched the symbol means `__getattr__` never re-runs → false-negative / flaky | Call `module.__dict__.pop(name, None)` before asserting, to force a fresh `__getattr__` resolve. `unverified` |
-| Treat the change as purely additive (new test only) (PLANNING) | Planned to add a new warning-assertion test and leave existing tests alone | An existing regression test (`test_deprecation_warnings.py:49-66`) explicitly documented and tolerated the silent lazy resolve; the new behavior contradicts that green test | Grep for tests asserting the CURRENT (about-to-change) behavior; rewrite the stale-tolerant one, don't just append. `unverified` |
-| Change the behavior without touching the prose doc (PLANNING) | Planned source + test edits only | `COMPATIBILITY.md` said the warning fires "when called"; a doc-cross-check test or reviewer catches the drift after access-time firing is added | Update the prose deprecation doc that describes the deprecation in the same PR. `unverified` |
-| Reuse `stacklevel=2` from the call-time warning for the access-time warning (PLANNING, UNVERIFIED) | Assumed `stacklevel=2` points at the user's access line inside `__getattr__` | Attribute-lookup indirection differs from a direct function call; the correct stacklevel for an access may not be 2. Never validated against a rendered warning | Validate `stacklevel` against a real access line before committing; do not copy the call-time value blindly. `unverified` |
+| Trust the issue's "in `__all__`" claim about the deprecated shim | Issue #1545 stated `retry_with_jitter` was exposed via `__all__`; planned the fix from that structural claim | The symbol is actually only in `_LAZY_IMPORTS`, not `__all__`. The fix seam (`__getattr__`) is the same either way, but the implementation differs slightly | Grep the named symbol against the source before trusting an issue's structural claim; don't assume `__all__` and `_LAZY_IMPORTS` always overlap. `verified-local` |
+| Assume the access-time warning duplicates the existing call-time warning | Considered "deduping" by relying on the function-body warning alone | Access-time (`hephaestus.X` binding) and call-time (`hephaestus.utils.X(...)`) are DIFFERENT access paths firing for different users; dropping either silently loses coverage | Keep both warnings — they are complementary layers, not duplicates. `verified-local` |
+| Write a one-shot warning-assertion test without resetting the cache | `with pytest.warns(DeprecationWarning): _ = hephaestus.retry_with_jitter` | PEP 562 caches the resolved name into module globals on first access; a prior test that touched the symbol means `__getattr__` never re-runs → false-negative / flaky | Call `module.__dict__.pop(name, None)` before asserting, to force a fresh `__getattr__` resolve. `verified-local` |
+| Treat the change as purely additive (new test only) | Planned to add a new warning-assertion test and leave existing tests alone | The existing test `test_retry_with_jitter_reachable_from_top_level_lazy_loader` explicitly documented and tolerated the silent lazy resolve; the new behavior contradicts that green test's documented contract | Grep for tests asserting the CURRENT (about-to-change) behavior; REWRITE the stale-tolerant one (don't just append a new test next to it). `verified-local` |
+| Change the behavior without touching the prose doc | Planned source + test edits only | `COMPATIBILITY.md` said the warning fires "when called"; a doc-cross-check test or reviewer catches the drift after access-time firing is added | Update the prose deprecation doc that describes the deprecation in the same PR. `verified-local` |
+| Assume `stacklevel=2` might be wrong for `__getattr__` indirection | Worried that attribute-lookup indirection might need a different stacklevel than the call-time warning | Not actually wrong — `stacklevel=2` IS correct. Call stack: user access line (frame 1) → `__getattr__` (frame 2) → `warnings.warn`. `stacklevel=2` skips `__getattr__` and correctly attributes the warning to the user's access line. Verified by `access_warnings[0].filename == __file__` assertion passing | `stacklevel=2` is correct for `__getattr__`. The attribute-lookup indirection has the same two-frame depth as a direct one-level helper call. `verified-local` |
 | Module-level child→parent import | `from hephaestus.logging.utils import get_current_correlation_id` at top of `helpers.py` | `CircularImportError`/`ImportError` at startup because `logging.utils` already imports `utils.helpers` | Any child-to-parent import at module level creates a cycle if the parent imports the child; use a function-local import |
 | Thread correlation ID as a parameter | `run_subprocess(cmd, cid=None)` plumbed through the call chain | Intermediate functions must accept a param they never use; refactor becomes painful | Reserve parameters for true call-level args; use ambient context (contextvars) for ambient state |
 | Move the helper function to dodge the edge | Relocate `get_current_correlation_id()` into `utils` | Creates a god-module, couples `utils.helpers` to logging concerns, violates SRP | Move the import, not the function — keep it where it semantically belongs |
@@ -444,48 +488,75 @@ def test_entry_point_importable(module_path: str) -> None:
     importlib.import_module(module_path)
 ```
 
-### Access-time DeprecationWarning across the lazy-loader seam — PROPOSED pattern (UNVERIFIED)
+### Access-time DeprecationWarning across the lazy-loader seam — verified pattern (verified-local)
 
-> **Warning:** The snippets below are from a plan that was never executed. Line numbers were read, not run. Treat as a hypothesis.
+Executed end-to-end for ProjectHephaestus issue #1545. All tests listed below passed.
 
 ```python
-# hephaestus/__init__.py — add an access-time warning inside the PEP 562 loader.
+# hephaestus/__init__.py — _DEPRECATED_LAZY dict + modified __getattr__
 # retry_with_jitter lives in _LAZY_IMPORTS (NOT __all__ — the issue misnamed this).
-import warnings
 
-_DEPRECATED_LAZY = {"retry_with_jitter"}  # access-time-deprecated shims
+_DEPRECATED_LAZY: dict[str, str] = {
+    "retry_with_jitter": (
+        "hephaestus.retry_with_jitter is deprecated; use "
+        "retry_with_backoff(jitter=True, max_delay=...) instead. "
+        "It will be removed no earlier than the next major version after 1.0."
+    ),
+}
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
+    """Lazy-load public symbols on first access (PEP 562)."""
     if name in _LAZY_IMPORTS:
         if name in _DEPRECATED_LAZY:
-            warnings.warn(
-                f"hephaestus.{name} is a deprecated shim; import from its "
-                "canonical module instead.",
-                DeprecationWarning,
-                stacklevel=2,   # UNVERIFIED for an attribute-lookup indirection
-            )
-        module = importlib.import_module(_LAZY_IMPORTS[name])
-        value = getattr(module, name)
-        globals()[name] = value   # PEP 562 caches → __getattr__ won't re-run for `name`
+            import warnings
+            warnings.warn(_DEPRECATED_LAZY[name], DeprecationWarning, stacklevel=2)
+        module_name, attr = _LAZY_IMPORTS[name]
+        import importlib
+        module = importlib.import_module(module_name)
+        value = getattr(module, attr)
+        globals()[name] = value
         return value
-    raise AttributeError(name)
+    raise AttributeError(f"module 'hephaestus' has no attribute {name!r}")
 ```
 
 ```python
-# Regression test MUST pop the cached name to force a fresh resolve.
-def test_access_time_deprecation_warning():
-    import hephaestus, warnings
-    hephaestus.__dict__.pop("retry_with_jitter", None)   # without this → false-negative
+# Regression test — replaces stale-tolerant test_retry_with_jitter_reachable_from_top_level_lazy_loader
+def test_retry_with_jitter_access_emits_deprecation_warning(self) -> None:
+    import hephaestus
+
+    # Bust PEP 562 cache — force __getattr__ to re-run
+    hephaestus.__dict__.pop("retry_with_jitter", None)
+
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        _ = hephaestus.retry_with_jitter                 # ACCESS only, no call
-    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        symbol = hephaestus.retry_with_jitter  # ACCESS only, do not call
+
+    assert callable(symbol)
+    access_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert access_warnings, "Accessing hephaestus.retry_with_jitter must emit DeprecationWarning"
+    assert "retry_with_jitter" in str(access_warnings[0].message)
+    # stacklevel=2 must attribute the warning to the caller's file
+    assert access_warnings[0].filename == __file__, (
+        f"DeprecationWarning should be attributed to the caller's file "
+        f"({__file__}); got {access_warnings[0].filename}. Check stacklevel."
+    )
 ```
 
-Companion edits the plan identified but did NOT execute: rewrite the stale-tolerant
-`tests/test_deprecation_warnings.py:49-66` (it documented the silent resolve), and update
-the `COMPATIBILITY.md` bullet that says the warning fires "when called". Keep the existing
-call-time warning in the shim body — the two layers are complementary.
+Tests that passed:
+
+```text
+tests/unit/utils/test_deprecation_warnings.py — 3 passed
+tests/unit/utils/test_retry.py -k jitter — 7 passed
+tests/unit/validation/test_import_surface.py — passed
+tests/unit/validation/test_automation_boundary.py — passed
+ruff check hephaestus/__init__.py tests/unit/utils/test_deprecation_warnings.py — all checks passed
+ruff format --check — 2 files already formatted
+mypy — clean
+```
+
+Key confirmed values: `stacklevel=2` inside `__getattr__` correctly points at the user's access line
+(confirmed by `access_warnings[0].filename == __file__` assertion passing). `import warnings` deferred
+inside the `if name in _DEPRECATED_LAZY:` block does not breach `test_automation_boundary.py`.
 
 ## Verified On
 
@@ -497,4 +568,4 @@ call-time warning in the shim body — the two layers are complementary.
 | ProjectHephaestus | Issue #775 / PR #968 vs #1067 — stale surface-pin repair | `test_public_surface_pins_expected_symbols` failed on every Py leg with `Extra items in the left set: 'AuditReviewer'`; `AuditReviewer` was a legitimate peer added on `main` by independent PR #1067. Fixed the stale test literal (one-line add, alphabetised), zero source change. `verified-local` — CI re-run confirmation pending. 2 sibling local failures (`HEPH_*_MODEL` env leak; live `gh` auth past a mock) proven environmental via `env -i` + `git stash` + grep-the-CI-log |
 | ProjectHephaestus | PR #657 — fix broken main CI | `sys.version_info` guard for `tomllib`/`tomli` in `tests/unit/ci/test_bandit_config.py`; conditional deps in `pyproject.toml`/`pixi.toml`; 2590 tests pass |
 | ProjectHephaestus | PRs #534, #536, #538 (issue #539 tracks full port) — Windows-importability | curses guard in `CursesUI`, fcntl guard in `planner.py`, `tzdata` for `hephaestus.github.rate_limit` |
-| ProjectHephaestus | Issue #1545 — access-time DeprecationWarning for `retry_with_jitter` (PLAN ONLY) | Produced an implementation PLAN to warn at `__getattr__` access time (`hephaestus/__init__.py:88/97`, `retry.py:240`, `config/utils.py:334`) in addition to the existing call-time warning; rewrite stale-tolerant `test_deprecation_warnings.py:49-66`; update `COMPATIBILITY.md`. Symbol is in `_LAZY_IMPORTS`, not `__all__` (issue misnamed it). **unverified** — edits + regression test were never executed; `stacklevel`, import-surface-boundary, and warning-filter UX assumptions all unvalidated |
+| ProjectHephaestus | Issue #1545 — access-time DeprecationWarning for `retry_with_jitter` | Executed end-to-end: added `_DEPRECATED_LAZY` dict + modified `__getattr__` in `hephaestus/__init__.py`; replaced stale-tolerant `test_retry_with_jitter_reachable_from_top_level_lazy_loader` with `test_retry_with_jitter_access_emits_deprecation_warning` (including `__dict__.pop` cache-bust and `stacklevel=2` filename assertion); updated `COMPATIBILITY.md` bullet. Symbol is in `_LAZY_IMPORTS`, not `__all__` (issue misnamed it). All tests passed: 3 in `test_deprecation_warnings.py`, 7 in `test_retry.py -k jitter`, `test_import_surface.py`, `test_automation_boundary.py`. Ruff + mypy clean. **verified-local** — CI pending after PR merges |


### PR DESCRIPTION
Upgrade section F of `python-import-patterns-and-compatibility-guards` from "Proposed Workflow (unverified)" to "Verified Workflow (verified-local)" after executing the access-time DeprecationWarning implementation for ProjectHephaestus issue #1545 end-to-end.

## Summary

- Section F promoted from unverified plan to verified-local implementation
- Replaced unverified `__getattr__` snippet (set-based `_DEPRECATED_LAZY`) with the exact verified implementation (`dict[str, str]` with full message strings, deferred `import warnings`)
- Replaced minimal test stub with full verified test including `__dict__.pop` cache-bust, callable assertion, message content check, and `stacklevel=2` filename attribution assertion
- All 5 formerly-`unverified` Failed Attempts rows confirmed and upgraded to `verified-local`
- `stacklevel=2` inside `__getattr__` confirmed correct (call stack: user access line → `__getattr__` → `warnings.warn`)
- Added actual test passage evidence (3 + 7 + boundary tests, ruff, mypy all clean)
- Updated Verified On row from "PLAN ONLY / unverified" to "verified-local"
- Updated Overview, When to Use bullet, tags (`planning` → `stacklevel`, `warnings-warn`)
- Added v1.4.0 history entry
- Version bump: 1.3.0 → 1.4.0
- Validator: 515/515 skills valid

Closes #2811