### PR TITLE
feat: amend architecture-executable-convention-guard-pattern skill (v1.3.0)

### DIFF
--- a/skills/architecture-executable-convention-guard-pattern.history
+++ b/skills/architecture-executable-convention-guard-pattern.history
@@ -1,5 +1,24 @@
 # architecture-executable-convention-guard-pattern — History
 
+## v1.3.0 (2026-06-24)
+
+**Changed by:** ProjectHephaestus issue #1516 (PLANNING learning — making the documented DCO `Signed-off-by` trailer mechanically enforced).
+**Verification:** unverified (PLAN only — code not executed, CI not run). Frontmatter `verification` lowered from `verified-local` to `unverified` to reflect that the most recently added sub-patterns (v1.1.0–v1.3.0) are plan-only.
+
+### What changed
+- Added a new sub-pattern section, "Sub-Pattern: Commit-Trailer Convention Guards (DCO / Co-Authored-By)," documenting that a prose-only commit-message-TRAILER convention is the same executable-convention-guard pattern: ship a stdlib predicate + a dual gate (a step in an already-wired required CI job + a `commit-msg` pre-commit hook), mirroring the repo's existing sibling checker verbatim.
+- Added a "Proposed Workflow" subsection (7 steps) with an unverified warning, capturing the DCO-specific lessons: mirror `scripts/check_conventional_commit.py` verbatim; consume the FULL `.commit.message` (trailers live in the body, reuse the already-fetched `commits.json`, NUL-join multi-line records); anchor on `^Signed-off-by: .+ <…@…>$` (prefix + structure, never a substring scan); strip `#`-comment lines in `commit-msg` file-path mode; exempt `dependabot[bot]` identically to the sibling checks; ride the existing pr-policy job as Check 4 (no new workflow); mind the self-application bootstrap (`git commit -s -S`).
+- Added 4 Failed Attempts rows phrased as "assumed X without executing → must verify Y": the `jq` NUL round-trip, the cited line numbers (`_required.yml`/`.pre-commit-config.yaml`/`CONTRIBUTING.md`), the pr-policy `steps.fetch` id + `commits.json` filename, and the `commit-msg` hook self-application bootstrap.
+- Added a "Commit-trailer generalization (v1.3.0, unverified)" note to Results & Parameters and a row to the Verified On table (issue #1516, PLAN — unverified).
+- Added tags: `commit-trailer`, `dco-signoff`, `precommit-hook`, `sibling-checker-mirror`. Bumped frontmatter version 1.2.0 → 1.3.0.
+
+### Why
+ProjectHephaestus issue #1516 produced a PLAN (never executed, no CI) to turn the documented DCO `Signed-off-by` convention from prose into a mechanically enforced guard. It is another concrete instance of this skill's core pattern, with trailer-specific generalizations (full-message consumption, body-vs-subject distinction, NUL-joining for multi-line bodies, prefix+structure anchoring of the trailer line, comment-line stripping, bot exemption) that belong in the same skill. All of it is unverified — the jq round-trip, the line numbers, and the pr-policy step wiring were each assumed and must be empirically confirmed before merge — so the additions are framed as a Proposed Workflow plus "assumed X without executing → must verify Y" cautions.
+
+### Previous version (v1.2.0) snapshot
+
+The v1.2.0 rendered `.md` content prior to this amendment is preserved in git history at the parent commit of this amendment. It carried `verification: verified-local`, the coredump `verify_crash_bundle` v1.0.0 material, the v1.1.0 bidirectional mirror/parity sub-pattern, and the v1.2.0 coverage-altitude step 8 + supporting Failed-Attempts rows — but did NOT yet contain the commit-trailer (DCO) sub-pattern.
+
 ## v1.2.0 (2026-06-24)
 
 **Changed by:** ProjectHephaestus issue #1543 re-plan (after a reviewer NOGO on the bidirectional mirror-guard plan — a TEST-COVERAGE lesson from the review iteration).

--- a/skills/architecture-executable-convention-guard-pattern.md
+++ b/skills/architecture-executable-convention-guard-pattern.md
@@ -3,9 +3,9 @@ name: architecture-executable-convention-guard-pattern
 description: "Turn an un-guarded documented invariant (a prose convention) into a tested, blocking, reusable executable check that CI or any consumer can call. Use when: (1) a contract like 'absence of artifact X means stage Y never ran' lives only in docstrings/comments and nothing asserts it, (2) you are adding an enforcement gate whose whole purpose is signal fidelity and must pick a collision-free exit code distinct from argparse's usage-error 2 and sibling CLIs, (3) a verification step must resolve its inputs strictly read-only and must NOT fabricate the very signal whose absence it checks (e.g. a resolver that mkdir()s the directory), (4) you classify a log/marker line and must anchor on the line prefix instead of a free substring scan vulnerable to user-controlled tokens, (5) you relax argparse requirements (nargs='?') for a new mode and must re-guard the original mode so it does not silently no-op, (6) the same convention is documented in two places (module docstring + sibling shell comment) and must be kept in sync when made executable, (7) you are planning a fix for any 'X mirrors Y' / parity / directory-structure invariant audit finding and must determine WHICH direction(s) the existing guard asserts — the defect is usually the un-asserted reverse direction (test_packages - src_packages), and the fix is an allowlist-with-rationale plus the reverse check, NOT deletion of flagged items."
 category: architecture
 date: 2026-06-24
-version: "1.2.0"
+version: "1.3.0"
 user-invocable: false
-verification: verified-local
+verification: unverified
 history: architecture-executable-convention-guard-pattern.history
 tags:
   - executable-convention
@@ -21,6 +21,10 @@ tags:
   - mirror-parity
   - allowlist-with-rationale
   - test-structure
+  - commit-trailer
+  - dco-signoff
+  - precommit-hook
+  - sibling-checker-mirror
   - hephaestus
 ---
 
@@ -175,6 +179,30 @@ When auditing or planning a fix for ANY "X mirrors Y" finding, **grep the existi
    - **Verification commands that mutate the real working tree are a hygiene risk.** A manual negative test like `mkdir tests/unit/rogue && <run checker> && rmdir tests/unit/rogue` leaves a stray dir if the checker aborts mid-run. Demote it BELOW the unit-level negative test (the primary guard) and wrap it in a subshell with `trap '... rmdir' EXIT` so cleanup runs even on abort. Prefer a `tmp_path`/`capsys` unit test over tree mutation whenever possible.
    - **When adding a new allowlist/skip set, confirm it doesn't visually collide with an existing one on a different axis.** Here `docs`/`scripts` appear in BOTH `_detect_src_package`'s `skip` set (source-package-detection axis) AND the new `SANCTIONED_EXTRA_TEST_DIRS` (test-dir-allowlist axis). There is no code conflict, but add an inline comment naming the distinct axis so a future reader doesn't conflate the two lists (POLA).
 
+## Sub-Pattern: Commit-Trailer Convention Guards (DCO / Co-Authored-By)
+
+> **Warning:** This sub-pattern (added in v1.3.0, from ProjectHephaestus issue #1516) is **unverified** — it is a PLAN, the code was NOT executed or CI-validated. Treat as a hypothesis until CI confirms. The v1.0.0 coredump material remains `verified-local`; the v1.1.0/v1.2.0/v1.3.0 sub-patterns are plan-only.
+
+A documented **commit-message-trailer convention** (DCO `Signed-off-by:`, `Co-Authored-By:`, `Implemented-By:`, etc.) enforced only in prose (CONTRIBUTING.md) is the SAME executable-convention-guard pattern: ship a stdlib predicate + a **dual gate** (a step in an ALREADY-WIRED required CI job + a `commit-msg` pre-commit hook), riding existing infrastructure rather than adding a new workflow. The DCO case (issue #1516) adds trailer-specific lessons that generalize to any trailer check.
+
+### Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+1. **Mirror the repo's existing sibling checker VERBATIM.** The repo already had `scripts/check_conventional_commit.py` (subject-line check). Copy its exact shape for the new `scripts/check_dco_signoff.py`: `validate_*()` + `_*_from_args()` + `main() -> int`, exit `0`/`1`, dual invocation supporting BOTH `pass_filenames` file-path mode (pre-commit `commit-msg` hook hands a file path) AND a stdin `-` mode (the CI step pipes the message). One stdlib module, no deps. Re-grep for the sibling's name (`check_conventional_commit`) to confirm its shape before copying — do not trust remembered line numbers.
+
+2. **Consume the FULL commit message — trailers live in the BODY, not the subject.** Unlike a subject-only check (conventional-commit takes `.commit.message | split("\n")[0]`), a trailer check must read the WHOLE message. The pr-policy GraphQL already fetches `.commit.message` (full message), so NO new GraphQL fetch is needed — reuse the existing `commits.json`. Pipe records with a **NUL (`\x00`) separator** (`jq -j ... + " "`) so multi-line bodies survive stdin; a newline separator would corrupt multi-line messages. (UNVERIFIED — the exact jq incantation and the `git log -z` / GraphQL `.commit.message` → Python `split("\x00")` round-trip were never executed; the implementer MUST run the CI snippet against a real multi-commit PR.)
+
+3. **Anchor the trailer match on a line prefix + structural shape — never a free substring scan.** Require `^Signed-off-by: .+ <…@…>$`: a non-empty name AND an `@`-bearing bracketed email, so a bare `Signed-off-by:` (no identity) does NOT pass. This is the v1.0.0 log-line-anchoring lesson generalized to trailer lines: anchor on the line prefix and validate structure, do not scan for the substring `Signed-off-by` anywhere.
+
+4. **In `commit-msg` file-path mode, strip `#`-comment lines before checking.** Git strips `#`-comment lines before applying the trailer, and `git commit -s` appends the `Signed-off-by` trailer BELOW the comment block in some templates. A naive whole-file read would miss the trailer or misclassify a commented-out one — strip `#`-prefixed lines first (matching git's own behavior).
+
+5. **Exempt bot authors identically to the sibling checks.** Bot commits (`dependabot[bot]`) are not human DCO attestations. Reuse the EXACT `if [ "$PR_AUTHOR" = "dependabot[bot]" ]` short-circuit the other pr-policy checks already use, so the new gate does not block bot PRs. Do not invent a new bot-detection mechanism.
+
+6. **Ride the already-wired required CI job — add a step, not a workflow.** The DCO check is wired as **Check 4** of the existing `pr-policy` job (already required, already fetches commits) plus a `commit-msg` pre-commit hook entry. Re-grep `dependabot\[bot\]`, `check_conventional_commit`, `default_install_hook_types`, and the DCO heading in CONTRIBUTING.md before editing — the line numbers cited in the plan (`_required.yml:382/419/425/435`, `.pre-commit-config.yaml:25/284`, `CONTRIBUTING.md:224-247`) were read ONCE and may drift. Verify the pr-policy `steps.fetch` output id and the `commits.json` filename in the ACTUAL workflow before appending Check 4.
+
+7. **Beware the self-application bootstrap.** Once the `commit-msg` hook lands, the implementing commit ITSELF must carry a `Signed-off-by` trailer or the hook blocks its own creation. The plan's commit step MUST use `git commit -s -S` (sign-off AND cryptographic signature) — easy to forget, and the failure is circular (the commit that adds the rule can't be made).
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -190,6 +218,10 @@ When auditing or planning a fix for ANY "X mirrors Y" finding, **grep the existi
 | Classify success via `" wrote " in line` | Free substring scan over every log line | Misclassifies an `ERROR:` line whose path embeds `" wrote "` as success (exe basename is user-controlled, can contain spaces) | Anchor on the log-line prefix (split timestamp, message `startswith`); add a regression test for the adversarial path |
 | Make positionals optional without re-guarding | Set positionals to `nargs="?"` so `--verify` runs without kernel tokens | Silently weakened the capture path — a malformed `core_pattern` line missing tokens no longer errored | When you relax arg requirements for one mode, add an explicit missing-arg guard for the other mode and test it |
 | Leave an unneeded `# noqa: SIM103` | Added a noqa the helper didn't actually need | Would trip RUF100 (unused-noqa) | Only add `noqa` for a rule that actually fires |
+| Assumed `jq -j ... + "\x00"` NUL-joining round-trips without executing it | Planned to NUL-join commit messages in jq and `split("\x00")` in Python | The exact jq incantation and that `git log -z --format='%B'` / GraphQL `.commit.message` survive the round-trip were assumed, not tested | Must actually run the CI snippet against a real multi-commit PR with multi-line bodies and confirm Python `split("\x00")` reconstructs each full message |
+| Trusted the cited line numbers (`_required.yml:382/419/425/435`, `.pre-commit-config.yaml:25/284`, `CONTRIBUTING.md:224-247`) | Planned edits against offsets read once | Line numbers drift between read and edit | Must re-grep `dependabot\[bot\]`, `check_conventional_commit`, `default_install_hook_types`, and the DCO heading before editing rather than trusting the offsets |
+| Assumed the pr-policy `steps.fetch` id and `commits.json` filename matched the plan | Planned to append Check 4 reusing an assumed step-output id / artifact filename | The actual step id and filename were never verified against the real workflow | Must verify the existing pr-policy fetch-step id and the `commits.json` filename in the actual `_required.yml` before wiring Check 4 |
+| Forgot the `commit-msg` hook's self-application bootstrap | Planned the implementing commit without ensuring it carries `Signed-off-by` | Once the hook lands, the very commit that adds it is blocked unless it has the trailer — a circular failure | Must verify the implementing commit step uses `git commit -s -S` so the new hook does not block its own creation |
 
 ## Results & Parameters
 
@@ -238,6 +270,8 @@ target = next((Path(c) for c in cleaned if Path(c).is_dir()), Path(cleaned[-1]))
 
 **Bidirectional-invariant generalization (v1.1.0, unverified):** For any structural "X mirrors Y" invariant, a guard has TWO directions and the existing one usually asserts only the forward one (`src - test`). The reverse direction (`test - src - allowlist`) is the silent drift surface — confirm which direction the checker asserts and ADD the missing one. Re-derive any "N violate" audit count empirically (`comm -23`) rather than trusting it. Encode legitimate exceptions as a **sanctioned `frozenset` allowlist with per-entry rationale** (never delete real coverage), reuse the **same dir-filtering helper for both directions**, **sync prose and code**, and **ride the already-wired gate** (no new CI job). Cover the new negative-path branch so module coverage stays above the gate.
 
+**Commit-trailer generalization (v1.3.0, unverified):** A documented commit-message-TRAILER convention (DCO `Signed-off-by:`, `Co-Authored-By:`, etc.) enforced only in prose is the same executable-convention-guard pattern. Ship a stdlib predicate + a **dual gate** (a step in an already-wired required CI job + a `commit-msg` pre-commit hook) — do NOT add a new workflow. Mirror the repo's existing sibling checker VERBATIM (`scripts/check_conventional_commit.py`: `validate_*()` + `_*_from_args()` + `main() -> int`, exit 0/1, dual file-path + stdin `-` invocation). Trailers live in the message BODY, so consume the FULL `.commit.message` (already fetched by pr-policy — reuse `commits.json`, no new GraphQL); NUL-join multi-line records (`jq -j ... + "\x00"`) so they survive stdin. Anchor on a line prefix + structural shape (`^Signed-off-by: .+ <…@…>$`), never a free substring scan, so a bare `Signed-off-by:` fails. Strip `#`-comment lines in `commit-msg` file-path mode (git strips them; `git commit -s` may append the trailer below the comment block). Exempt bot authors identically to the sibling checks (`dependabot[bot]` short-circuit). Mind the self-application bootstrap — the implementing commit must use `git commit -s -S` or the new hook blocks its own creation. **Most-uncertain assumptions (all UNVERIFIED): the `jq` NUL round-trip, the cited line numbers, and the pr-policy step-id/`commits.json` filename must each be empirically confirmed before merge.**
+
 **Coverage-altitude generalization (v1.2.0, unverified):** A tested low-level predicate does NOT cover the integration-level branch that consumes it. When a pure helper is wired into an orchestrator, a helper-only unit test leaves the orchestrator's failure branch (its `sys.stderr` print loop + remediation hint) unexecuted — which can drop module coverage below the line-coverage gate (83%) even though the logic is "tested." Add a SEPARATE orchestrator-altitude failure test using `capsys` that asserts both the offending name AND the remediation hint on stderr, mirroring the sibling failure tests for the other checks in the same orchestrator (add a Check-N-failure test at the same altitude as the existing Check-1/Check-2 tests). Demote any tree-mutating manual negative test below the unit test and wrap it in a `trap '... rmdir' EXIT` subshell. When a new allowlist/skip set shares names with an existing one on a different axis (e.g. `docs`/`scripts` in both the source-detection `skip` set and the test-dir allowlist), add an inline comment naming the distinct axis (POLA).
 
 ## Verified On
@@ -247,7 +281,8 @@ target = next((Path(c) for c in cleaned if Path(c).is_dir()), Path(cleaned[-1]))
 | ProjectHephaestus | issue #1207 / PR #1247 | coredump handler `verify_crash_bundle` + `--verify` mode; exit 3 distinct from argparse 2; read-only no-fabricate resolution; prefix-anchored log classification |
 | ProjectHephaestus | issue #1543 (PLAN — **unverified**) | bidirectional mirror sub-pattern: reverse check `test_packages - src_packages - allowlist` added to existing `check_test_structure()`; sanctioned `frozenset` allowlist with per-entry rationale; prose + code synced; rides already-wired gate (no new CI job) |
 | ProjectHephaestus | issue #1543 re-plan (PLAN — **unverified**, post-NOGO) | coverage-altitude lesson: orchestrator-vs-helper test gap — helper-only tests leave the orchestrator's stderr print loop uncovered under the 83% gate; add a `capsys` orchestrator-altitude failure test asserting dir name + remediation hint; `trap ... EXIT` for any tree-mutating manual test; POLA inline comment for cross-axis allowlist name collisions |
+| ProjectHephaestus | issue #1516 (PLAN — **unverified**) | commit-trailer sub-pattern: stdlib `scripts/check_dco_signoff.py` (mirrors `check_conventional_commit.py`) enforcing DCO `Signed-off-by` via a dual gate (pr-policy Check 4 + `commit-msg` hook); consume FULL `.commit.message` (reuse `commits.json`, NUL-joined); prefix+structure-anchored `^Signed-off-by: .+ <…@…>$`; strip `#`-comment lines in file-path mode; exempt `dependabot[bot]`; `git commit -s -S` to survive self-application |
 
 ## Tags
 
-`#executable-convention` `#invariant-guard` `#exit-code-collision` `#fail-safe` `#read-only-verification` `#log-line-anchoring` `#observability` `#cli-verify-mode` `#ci-gate` `#bidirectional-invariant` `#mirror-parity` `#allowlist-with-rationale` `#test-structure` `#hephaestus`
+`#executable-convention` `#invariant-guard` `#exit-code-collision` `#fail-safe` `#read-only-verification` `#log-line-anchoring` `#observability` `#cli-verify-mode` `#ci-gate` `#bidirectional-invariant` `#mirror-parity` `#allowlist-with-rationale` `#test-structure` `#commit-trailer` `#dco-signoff` `#precommit-hook` `#sibling-checker-mirror` `#hephaestus`


### PR DESCRIPTION
## Summary

Amends the `architecture-executable-convention-guard-pattern` skill (v1.2.0 → **v1.3.0**) with a new sub-pattern: **Commit-Trailer Convention Guards (DCO / Co-Authored-By)**, captured from ProjectHephaestus issue #1516.

Issue #1516 produced an implementation PLAN (never executed, no CI) to turn the documented DCO `Signed-off-by` trailer into a mechanically enforced guard via a stdlib `scripts/check_dco_signoff.py` validator wired into the existing `pr-policy` CI job (Check 4) AND a `commit-msg` pre-commit hook. This is another concrete instance of this skill's core pattern (prose convention → tested executable guard), so it AMENDS the skill rather than creating a new one.

## What changed

- New "Sub-Pattern: Commit-Trailer Convention Guards" section + 7-step **Proposed Workflow** (unverified).
- Durable trailer-specific lessons: mirror the sibling `check_conventional_commit.py` verbatim; consume the FULL `.commit.message` (trailers live in the body — reuse the already-fetched `commits.json`, NUL-join multi-line records); anchor on `^Signed-off-by: .+ <…@…>$` (prefix + structure, never a substring scan); strip `#`-comment lines in `commit-msg` file-path mode; exempt `dependabot[bot]`; ride the already-wired pr-policy job; mind the `commit-msg` self-application bootstrap (`git commit -s -S`).
- 4 new Failed-Attempts rows phrased as "assumed X without executing → must verify Y" (jq NUL round-trip, drifting line numbers, pr-policy step id / `commits.json` filename, hook self-application).
- New Verified-On row, generalization note, tags; prior v1.2.0 snapshot archived in the `.history` file.

## Verification

**Verification level: unverified.** This was a PLAN only — no code executed, no CI run. Frontmatter `verification` lowered `verified-local` → `unverified` to reflect that the most recent sub-patterns (v1.1.0–v1.3.0) are plan-only. `python3 scripts/validate_plugins.py` passes (516/516).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>