### PR TITLE
feat: amend planning-env-var-to-typed-cli-option-migration skill (v1.1.0)

### DIFF
--- a/skills/planning-env-var-to-typed-cli-option-migration.history
+++ b/skills/planning-env-var-to-typed-cli-option-migration.history
@@ -1,0 +1,77 @@
+# planning-env-var-to-typed-cli-option-migration -- History
+
+## v1.1.0 (2026-06-24)
+
+**Changed by:** ProjectHephaestus Issue #1526, R1 planning pass (second pass) -- assumptions verified against actual code
+**Verification:** unverified (still a PLAN; never executed, no CI)
+
+### What changed
+- Converted six R0 "assumptions to flag" into VERIFIED planning patterns after the
+  plan author got a NOGO on R0's implementation plan and then READ the actual code:
+  - **Per-knob granularity is the faithful mapping.** R0 collapsed 9 distinct
+    agent-timeout env vars onto one `agent_timeout` per command and got a NOGO for
+    dropping per-knob operator tunability. Faithful mapping = one flag + one typed
+    field PER knob; a shared sub-agent knob (`advise`) invoked from 3 commands gets
+    its OWN `advise_timeout` field on EACH command's options class.
+  - **The "every leaf holds self.options" assumption was VERIFIED FALSE for free
+    functions.** Four call sites are module-level free functions
+    (`learn.run_learn`, `follow_up.run_follow_up_issues`,
+    `comment_difficulty.classify_comments`, `pr_manager._invoke_git_message_agent`
+    via the `commit_changes`/`create_pr` chain). The fix mirrors an EXISTING threaded
+    param: these free functions already accept `model=`/`agent=` threaded down from an
+    option-holding method; the timeout threads the identical way.
+  - **A shared free-function entry invoked from multiple option-holders takes the
+    union of params.** `run_address_fix_session` (called from 3 option-holders) gains
+    `address_review_timeout` + `advise_timeout` + `git_message_timeout` and forwards
+    each; each caller passes its own `self.options.*`.
+  - **Blast radius verified empirically:** R0 claimed 36 importers; ground truth was
+    18 (the 36 counted git-worktree duplicates). Over-counting wrongly motivates
+    delete-and-rewrite over keeping a constants module.
+  - **Keep the env-reading module as a CONSTANTS module** (already in R0, now
+    reinforced as the correct call vs deleting it).
+  - **Pick BOTH an easy (method, already holds options) and a hard (free-function)
+    representative threading test;** the free-function path is where migration breaks.
+  - **Test blast radius includes mocks to NON-default sentinels** (e.g. a test
+    mocking `git_message_agent_timeout()` to 120); grep literal sentinel values too.
+- Added tags: per-knob-granularity, free-function-threading, blast-radius-verification,
+  constants-module.
+- Added a `history:` frontmatter field.
+- Bumped version 1.0.0 -> 1.1.0. Verification remains `unverified` (still a plan).
+- Kept three genuinely-uncertain items as risk rows: `post_merge_processor`'s
+  `learn_claude_timeout()` provider type (residual hand-wave), the surviving library
+  -layer `HEPH_GH_CLI_TIMEOUT`, and drifting line numbers.
+
+### Why
+R0 (PR #2815) captured planning ASSUMPTIONS as RISKS. In R1 the author got a NOGO on
+R0's implementation plan, then VERIFIED those assumptions by reading the real code in
+`hephaestus/automation/`. The durable learning is now the CONFIRMED resolution of
+those risks, so the existing skill was amended (not duplicated) to convert each
+flagged assumption into a verified pattern while keeping the still-uncertain residuals
+as risk rows.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: planning-env-var-to-typed-cli-option-migration
+description: "Plan a migration that REMOVES operator-facing env-var knobs (e.g. HEPH_*_TIMEOUT) and replaces them with explicit CLI flags threaded through typed options objects, across a large fan-out of call sites. Method: map each env-reading helper 1:1 to the typed options object that ALREADY reaches its call site via self.options; keep the helper module as the single source of DEFAULT CONSTANTS (don't delete it); use a None-sentinel CLI flag + pydantic field default (POLA); centralize new flags in a shared add_*_arg(parser); make the env-removal a TESTED invariant (helper IGNORES env + inspect.getsource has no os.environ). Use when: (1) planning an env-var -> typed CLI option migration, (2) a config knob is read by a helper called from many sites, (3) some leaf callers are FREE FUNCTIONS that do NOT hold the options object and need a threaded timeout parameter, (4) collapsing multiple per-phase env knobs onto one options field risks removing operator tunability, (5) a different default (e.g. git_message_timeout=300s vs agent_timeout=7200s) must stay a SEPARATE field."
+category: architecture
+date: 2026-06-24
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [planning, env-var-migration, typed-options, cli-design, argparse, fan-out-refactor, call-site-mapping, pola, hephaestus]
+---
+
+# Planning an Env-Var to Typed CLI-Option Migration Across a Fan-Out of Call Sites
+
+(v1.0.0 body: mapped each env-reading helper 1:1 to the reaching options object;
+kept the helper module as the single source of DEFAULT CONSTANTS; None-sentinel CLI
+flag deferring to the pydantic field default; centralized flags in a shared
+add_*_arg(parser); made env-removal a TESTED invariant. Failed-Attempts table framed
+six RISKS as "assumptions a plan author makes that are easy to get wrong" --
+free-function options reach, per-phase knob consolidation, different-default fold,
+line-number drift, surviving library-layer HEPH_GH_CLI_TIMEOUT, under-enumerated
+timeout-assertion test blast radius. Full v1.0.0 text retained in git history at
+PR #2815.)
+```

--- a/skills/planning-env-var-to-typed-cli-option-migration.md
+++ b/skills/planning-env-var-to-typed-cli-option-migration.md
@@ -3,10 +3,11 @@ name: planning-env-var-to-typed-cli-option-migration
 description: "Plan a migration that REMOVES operator-facing env-var knobs (e.g. HEPH_*_TIMEOUT) and replaces them with explicit CLI flags threaded through typed options objects, across a large fan-out of call sites. Method: map each env-reading helper 1:1 to the typed options object that ALREADY reaches its call site via self.options; keep the helper module as the single source of DEFAULT CONSTANTS (don't delete it); use a None-sentinel CLI flag + pydantic field default (POLA); centralize new flags in a shared add_*_arg(parser); make the env-removal a TESTED invariant (helper IGNORES env + inspect.getsource has no os.environ). Use when: (1) planning an env-var -> typed CLI option migration, (2) a config knob is read by a helper called from many sites, (3) some leaf callers are FREE FUNCTIONS that do NOT hold the options object and need a threaded timeout parameter, (4) collapsing multiple per-phase env knobs onto one options field risks removing operator tunability, (5) a different default (e.g. git_message_timeout=300s vs agent_timeout=7200s) must stay a SEPARATE field."
 category: architecture
 date: 2026-06-24
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
 verification: unverified
-tags: [planning, env-var-migration, typed-options, cli-design, argparse, fan-out-refactor, call-site-mapping, pola, hephaestus]
+history: planning-env-var-to-typed-cli-option-migration.history
+tags: [planning, env-var-migration, typed-options, cli-design, argparse, fan-out-refactor, call-site-mapping, pola, per-knob-granularity, free-function-threading, blast-radius-verification, constants-module, hephaestus]
 ---
 
 # Planning an Env-Var to Typed CLI-Option Migration Across a Fan-Out of Call Sites
@@ -17,8 +18,8 @@ tags: [planning, env-var-migration, typed-options, cli-design, argparse, fan-out
 |-------|-------|
 | **Date** | 2026-06-24 |
 | **Objective** | Plan ProjectHephaestus issue #1526: replace operator-facing `HEPH_*` automation timeout env vars with explicit, typed CLI options threaded through the existing options objects, across many call sites in `hephaestus/automation/`. |
-| **Outcome** | Implementation PLAN written (not executed): map each env-reading helper to the typed options object already reaching its call site; keep the helper module as the single source of DEFAULT CONSTANTS; add a `None`-sentinel CLI flag deferring to the pydantic field default; centralize flags in a shared `add_*_arg(parser)`; and make the env-removal a TESTED invariant. The plan was NOT implemented; its highest-risk assumptions are flagged below for the reviewer. |
-| **Verification** | unverified — planning session only; no code applied, no tests run, CI not confirmed. |
+| **Outcome** | Implementation PLAN written (not executed): map **each distinct env knob 1:1** to a typed-options field (one flag + one field PER knob — never collapse N knobs onto one field); keep the helper module as the single source of DEFAULT CONSTANTS; thread a `timeout=` param into **free-function** leaves the same way they already thread `model=`/`agent=`; add a `None`-sentinel CLI flag deferring to the pydantic field default; centralize flags in a shared `add_*_arg(parser)`; and make the env-removal a TESTED invariant. R0 (PR #2815) captured several assumptions as RISKS; R1 (this pass) got a NOGO on R0's implementation plan, then VERIFIED most of those risks against the actual code — they are now CONFIRMED patterns below. Three residual items remain genuinely uncertain and are kept as risk rows. |
+| **Verification** | unverified — the plan is still a PLAN; no code applied, no tests run, CI not confirmed. (R1 "verification" means assumptions were checked against the source, NOT that the migration executed.) |
 
 ## When to Use
 
@@ -27,6 +28,9 @@ tags: [planning, env-var-migration, typed-options, cli-design, argparse, fan-out
 - Some leaf callers are **free functions** (not methods on a class holding `self.options`) and will need a new `timeout`/value parameter genuinely threaded from their caller.
 - You are tempted to **collapse several distinct per-phase env knobs** onto one shared options field, and need to reason about the operator-capability surface you'd be removing.
 - Two knobs share a name shape but have **different defaults** (e.g. a 300s git-message timeout vs a 7200s agent timeout) and must stay separate fields.
+- The issue lists **N distinct env knobs** and you must decide field granularity — the faithful mapping is **one flag + one field PER knob**, not one-per-command (collapsing them silently drops per-knob operator tunability).
+- A **shared sub-agent knob** (e.g. `advise`) is invoked from *inside* several commands and needs its OWN field on EACH of those commands' options classes.
+- You need to **empirically count** the knobs and the import blast radius before scoping a sweep (worktree duplicates and over-counting inflate the perceived churn).
 - You want the env-var removal to be an **executable invariant** (a test that fails if the env var is ever re-honored), not just a deletion.
 
 ## Proposed Workflow
@@ -36,11 +40,21 @@ tags: [planning, env-var-migration, typed-options, cli-design, argparse, fan-out
 ### Quick Reference
 
 ```bash
+# 0. COUNT THE KNOBS EMPIRICALLY FIRST — one field PER distinct knob, never per command.
+grep -oE "HEPH_[A-Z_]+" hephaestus/automation/timeouts.py | sort -u   # the actual knob list
+
+# 0b. COUNT THE BLAST RADIUS EMPIRICALLY — strip worktree dupes & __pycache__.
+grep -rl "automation.timeouts" hephaestus/ | grep -v __pycache__ | wc -l   # ground-truth importers (R0 said 36; truth was 18)
+
 # 1. Find EVERY call site of each env-reading helper, then map each to the typed
 #    options object that already reaches that site (self.options vs free function).
 grep -rn "agent_timeout_seconds()" hephaestus/automation/
 grep -rn "git_message_timeout_seconds()" hephaestus/automation/
 grep -rn "HEPH_.*TIMEOUT" hephaestus/        # confirm which knobs survive (library layer)
+
+# 1b. For each leaf, is it a METHOD (self.options) or a FREE FUNCTION? If free, find the
+#     param it ALREADY threads (model=/agent=) and thread the timeout BESIDE it.
+grep -rn "def run_learn\|def run_follow_up_issues\|def classify_comments\|def run_address_fix_session\|model=\|agent=" hephaestus/automation/
 
 # 2. Confirm the helper module stays the single source of DEFAULT CONSTANTS.
 grep -rn "DEFAULT_AGENT_TIMEOUT\|DEFAULT_GIT_MESSAGE_TIMEOUT" hephaestus/automation/
@@ -49,8 +63,10 @@ grep -rn "DEFAULT_AGENT_TIMEOUT\|DEFAULT_GIT_MESSAGE_TIMEOUT" hephaestus/automat
 grep -rn "def add_.*_arg(parser" hephaestus/automation/
 grep -rn "def build_review_parser" hephaestus/automation/
 
-# 4. Enumerate the timeout-assertion tests that will break (full blast radius).
-grep -rn "timeout=7200\|timeout=300\|agent_timeout\|git_message_timeout" tests/
+# 4. Enumerate the timeout-assertion tests that will break (full blast radius) —
+#    INCLUDING tests that mock a helper to a NON-default sentinel (e.g. 120).
+grep -rn "agent_timeout\|git_message_timeout" tests/
+grep -rn "=120\|timeout=7200\|timeout=300\|timeout=600" tests/   # literal sentinel mocks
 ```
 
 ```python
@@ -80,17 +96,29 @@ options = ImplementerOptions(**kwargs)
 
 ### Detailed Steps
 
-1. **Grep every call site and map each helper 1:1 to its reaching options object.** For each env-reading helper, `grep -n "<helper>()" <pkg>/` and, for each hit, identify the typed options object that ALREADY arrives at that site via `self.options`. The migration is *cheap* only where the options object already reaches the leaf; it is *expensive* where a **free function** reads the helper directly and must gain a new `timeout` parameter threaded down from its caller. Classify every site as cheap-or-expensive before estimating effort.
+0. **Count the knobs and the blast radius EMPIRICALLY before scoping anything.** `grep -oE "HEPH_[A-Z_]+" <module> | sort -u` for the true knob list; `grep -rl <module> | grep -v __pycache__ | wc -l` for the true importer count. (R0 claimed 36 importers; ground truth was 18 — the 36 counted git-worktree duplicates. Over-counting inflates perceived churn and can wrongly motivate delete-and-rewrite over keeping a constants module.)
 
-2. **Keep the helper module as the single source of DEFAULT CONSTANTS — do NOT delete it.** Many files import the constants. Refactor each helper to `return DEFAULT_X` and delete only the env-reading inner logic. Options-class fields then default to those exported constants, so "omit the flag == unchanged behavior" is *exact* (one source of truth for the default).
+1. **One flag + one typed-options field PER distinct knob — never collapse N knobs onto one field.** When the issue lists DISTINCT env knobs, the faithful CLI mapping is one flag + one options field per knob, NOT one-per-command. A shared sub-agent knob (e.g. `advise`) invoked from inside 3 commands gets its OWN `advise_timeout` field on EACH of those 3 commands' options classes, distinct from each command's primary timeout. (R0 collapsed 9 distinct agent-timeout env vars onto a single `agent_timeout` per command and got a NOGO for silently dropping per-knob operator tunability.)
 
-3. **Use a `None`-sentinel CLI flag (POLA).** Declare each flag with `default=None`. At `main()` construction, pass the value into the options object only when `args.<flag> is not None`, letting the pydantic field default supply the real constant. This avoids duplicating the default (`default=<const>`) in two places.
+2. **Grep every call site and map each helper 1:1 to its reaching options object.** For each env-reading helper, `grep -n "<helper>()" <pkg>/` and, for each hit, identify the typed options object that ALREADY arrives at that site via `self.options`. The migration is *cheap* where the options object already reaches the leaf (a method); it is *expensive* where a **free function** reads the helper directly.
 
-4. **Centralize the new flags in a shared `add_*_arg(parser)` helper**, mirroring the existing arg helpers, and reuse any already-shared parser builder (e.g. a single `build_review_parser` feeding two CLIs) rather than adding flags ad hoc to each parser.
+3. **For free-function leaves, thread `timeout=` exactly where they already thread `model=`/`agent=`.** The R0 assumption "every leaf holds `self.options`" was VERIFIED FALSE: four call sites are module-level free functions (`learn.run_learn`, `follow_up.run_follow_up_issues`, `comment_difficulty.classify_comments`, `pr_manager._invoke_git_message_agent` via the `commit_changes`/`create_pr` chain). The CONFIRMED fix: these free functions ALREADY accept threaded params like `model=`/`agent=` passed down from an option-holding method caller, so the timeout threads the IDENTICAL way — add a `timeout: int = DEFAULT` keyword param, and the option-holding caller (e.g. `_followup_phase._run_learn`, which holds `self.options`) passes `self.options.<knob>_timeout`. HEURISTIC: per leaf, grep whether it is a METHOD (has `self.options`) or a FREE FUNCTION; if free, find the param it ALREADY threads and thread the timeout beside it — never hand-wave "add a param."
 
-5. **Make the removal a TESTED invariant.** Rewrite the helper's unit test to assert the helper now *IGNORES* the env var (set `HEPH_AGENT_TIMEOUT=1` in the environment and assert the helper still returns `DEFAULT_AGENT_TIMEOUT`) — an executable guard. Add an `inspect.getsource(module)` assertion that `os.environ` / the `HEPH_` env-prefix string no longer appears in the module, so a future regression that re-reads the env fails the test.
+4. **A shared free-function entry invoked from multiple option-holders takes the UNION of params and forwards each.** `run_address_fix_session` is a free function called from 3 different option-holding callers (implementer review phase, ci_driver, address_review). It gains `address_review_timeout` + `advise_timeout` + `git_message_timeout` params and forwards each to its own leaves; each of the 3 callers passes its own `self.options.*`.
 
-6. **Keep different defaults as different fields.** A 300s `git_message_timeout` folded into a 7200s `agent_timeout` would 24x the lightweight git-message budget. Audit every default before consolidating any two knobs.
+5. **Keep the helper module as the single source of DEFAULT CONSTANTS — do NOT delete it.** Refactor each `*_timeout()` helper to `return DEFAULT_X` and delete the `_read_int_env` inner function; the typed-options fields then default to those exported constants, so "omit the flag == unchanged behavior" is *exact*. This avoids editing every importer and gives one source of truth for the default — the right call confirmed once the importer count (18, not 36) was known.
+
+6. **Use a `None`-sentinel CLI flag (POLA).** Declare each flag with `default=None`. At `main()` construction, pass the value into the options object only when `args.<flag> is not None`, letting the pydantic field default supply the real constant. Avoids duplicating the default in two places.
+
+7. **Centralize the new flags in a shared `add_*_arg(parser)` helper**, mirroring the existing arg helpers, and reuse any already-shared parser builder (e.g. a single `build_review_parser` feeding two CLIs) rather than adding flags ad hoc to each parser.
+
+8. **Make the removal a TESTED invariant.** Rewrite the helper's unit test to assert the helper now *IGNORES* the env var (set `HEPH_AGENT_TIMEOUT=1` and assert the helper still returns `DEFAULT_AGENT_TIMEOUT`). Add an `inspect.getsource(module)` assertion that `os.environ` / the `HEPH_` prefix no longer appears in the module.
+
+9. **Pick BOTH an easy and a hard path for the representative threading test.** The acceptance criterion only requires "at least one representative command," but the easy path (a method that already holds options) is exactly the one LEAST likely to be wrong. Add a test for a free-function path too — that's where the migration actually breaks.
+
+10. **Sweep the FULL test blast radius, including mocks to NON-default sentinels.** A test mocking `git_message_agent_timeout()` to return 120 (not even the real 300 default) is easy to miss; grep the literal sentinel values too (`grep -rn "=120\|timeout=7200\|timeout=300\|timeout=600"`), not just the helper name.
+
+11. **Keep different defaults as different fields.** A 300s `git_message_timeout` folded into a 7200s `agent_timeout` would 24x the lightweight git-message budget. Audit every default before consolidating any two knobs.
 
 ## Verified Workflow
 
@@ -100,30 +128,41 @@ _Not applicable._ This skill was captured from a planning session and is `unveri
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| "Every leaf caller already holds `self.options`" | Plan hand-waved free-function helpers with "where a helper is a free function, add a `timeout` parameter." | UNVERIFIED for several modules: `learn.py`, `post_merge_processor.py`, `follow_up.py`, `comment_difficulty.py`, `pr_manager.py` may NOT hold the options object, so the new param has to be genuinely threaded from a caller that DOES — which may itself not have it. | Verify, per free-function site, that the options object actually reaches the caller, or that the param is threaded end-to-end. Don't assume `self.options` is everywhere. |
-| Collapse many per-phase env knobs onto ONE `agent_timeout` field | Folded `advise`, `learn`, `follow_up`, planner, implementer timeouts into a single per-options field, justified by "defaults are identical (7200s)." | Silently removes the **per-phase tunability** the separate env vars provided; identical defaults don't make a single field equivalent — it changes the operator-capability surface. | Confirm losing independent per-phase override is acceptable, or keep the fields separate. Identical defaults != identical capability. |
-| Fold `git_message_timeout` (300s) into `agent_timeout` (7200s) | Treated all timeouts as one knob. | Different defaults: 300s git-message vs 7200s agent. Folding 24x's the lightweight git-message budget. Easy to miss in a fan-out. | A knob with a DIFFERENT default must stay a SEPARATE field. Audit defaults before consolidating. |
-| Trust line numbers cited in the plan | Plan referenced `ci_driver.py:741,856`, `pr_reviewer.py:940`, etc., read once during planning. | Line numbers DRIFT between planning and implementation. | Re-grep the symbol/expression at implementation time; never edit by the planned line number. |
-| "No `HEPH_*` timeout env vars anymore" after the migration | Scoped OUT `gh_cli_timeout` / `HEPH_GH_CLI_TIMEOUT` because it lives in the library layer (`github/client.py`), not `automation/`. | Defensible, but it means ONE `HEPH_*` timeout env var SURVIVES; the "none anymore" claim is only true WITHIN `automation/`. | Confirm the issue's acceptance criterion tolerates the library-layer exception; state the exception explicitly in the plan. |
-| List "update the broken timeout tests" without enumerating them | Plan noted updating `test_ci_driver.py`, `test_stage_phases.py`, `test_planner_loop.py`. | Tests that ASSERT `timeout=<7200>` kwargs break when the value now flows from options; the FULL blast radius of timeout-assertion tests was not enumerated. | Grep all `timeout=`/`agent_timeout`/`git_message_timeout` assertions up front; the blast radius is larger than the named files. |
+| Collapse 9 distinct agent-timeout env vars onto ONE `agent_timeout` field per command | R0's implementation plan folded `advise`, `learn`, `follow_up`, planner, implementer, etc. timeouts into a single per-command options field, justified by "defaults are identical." | Got a NOGO: silently DROPS the per-knob operator tunability the separate env vars provided; identical defaults don't make a single field equivalent — it changes the operator-capability surface. | CONFIRMED (R1): when the issue lists DISTINCT knobs, map one flag + one field PER knob, never per-command. A shared sub-agent knob (`advise`) invoked from 3 commands gets its OWN `advise_timeout` field on EACH. Count knobs empirically: `grep -oE "HEPH_[A-Z_]+" <module> | sort -u`. |
+| "Every leaf caller already holds `self.options`" | R0 hand-waved free-function helpers with "where a helper is a free function, add a `timeout` parameter." | VERIFIED FALSE (R1): four sites are module-level free functions (`learn.run_learn`, `follow_up.run_follow_up_issues`, `comment_difficulty.classify_comments`, `pr_manager._invoke_git_message_agent` via the `commit_changes`/`create_pr` chain) — they do NOT hold the options object. | CONFIRMED FIX (R1): these free functions ALREADY thread `model=`/`agent=` down from an option-holding method; thread the timeout the IDENTICAL way (`timeout: int = DEFAULT` beside the existing param; the option-holder, e.g. `_followup_phase._run_learn`, passes `self.options.<knob>_timeout`). Per leaf, grep METHOD-vs-FREE; if free, thread beside the param it already threads. |
+| Treat a shared free-function entry as a single-param add | R0 did not account for a free function called from several different option-holders. | `run_address_fix_session` is called from 3 option-holding callers (implementer review phase, ci_driver, address_review). | CONFIRMED (R1): such an entry takes the UNION of params (`address_review_timeout` + `advise_timeout` + `git_message_timeout`) and forwards each to its own leaves; each of the 3 callers passes its own `self.options.*`. |
+| Trust the cited import/blast-radius COUNT | R0 claimed "36 files import the module" and used that to scope the sweep. | Ground truth was 18; the 36 counted git-worktree duplicates. | CONFIRMED (R1): verify the count empirically — `grep -rl <module> | grep -v __pycache__ | wc -l`. Over-counting inflates churn and can wrongly motivate delete-and-rewrite over keeping a constants module. |
+| Fold `git_message_timeout` (300s) into `agent_timeout` (7200s) | Treated all timeouts as one knob. | Different defaults: 300s git-message vs 7200s agent. Folding 24x's the lightweight git-message budget. | A knob with a DIFFERENT default must stay a SEPARATE field. Audit defaults before consolidating. |
+| Sweep the test blast radius by helper name only | R0 named `test_ci_driver.py`, `test_stage_phases.py`, `test_planner_loop.py`. | Tests that mock a helper to a NON-default sentinel (e.g. `git_message_agent_timeout()` -> 120, not even the real 300 default) are easy to miss. | CONFIRMED (R1): grep the literal sentinel values too (`grep -rn "=120\|timeout=7200\|timeout=300\|timeout=600"`), not just the helper name. The blast radius is larger than the named files. |
+| Test ONLY the easiest representative command | The acceptance criterion only requires "at least one representative command." | The easy path (a method already holding options) is exactly the one LEAST likely to be wrong; it would pass while the risky free-function threading stayed untested. | CONFIRMED (R1): add a test for a free-function path too — that's where the migration actually breaks. Pick BOTH an easy and a hard path. |
+| Trust line numbers cited in the plan | R0 referenced `ci_driver.py:741,856`, `pr_reviewer.py:940`, etc., read once during planning. | Line numbers DRIFT between planning and implementation. | **STILL A RISK** — re-grep the symbol/expression at implementation time; never edit by the planned line number. |
+| "No `HEPH_*` timeout env vars anymore" after the migration | Scoped OUT `gh_cli_timeout` / `HEPH_GH_CLI_TIMEOUT` because it lives in the library layer (`github/client.py`), not `automation/`. | ONE `HEPH_*` timeout env var SURVIVES; the "none anymore" claim is only true WITHIN `automation/`. | **STILL A RISK (reviewer judgment)** — whether the issue's "no ... anymore" criterion tolerates the library-layer exception is a reviewer call, not author-resolvable. State the exception explicitly. |
+| Assume `post_merge_processor.learn_claude_timeout()` has a `learn_timeout` provider | R0/R1 assume its options provider carries (or can carry) a `learn_timeout` field. | The exact provider TYPE was NOT pinned down in either pass. | **STILL A RISK (residual hand-wave)** — re-grep the provider type at implementation time before threading. |
 
-These rows are framed as **assumptions a plan author makes that are easy to get wrong** rather than executed-and-failed experiments: this skill is a planning-stage (`unverified`) capture, so each "Why It Failed" row records why the assumption is likely WRONG and must be VERIFIED by the implementer/reviewer before it is trusted.
+R1 update: the first six rows were R0 ASSUMPTIONS that R1 VERIFIED against the actual code after a NOGO on R0's implementation plan — each "Lesson Learned" now records the CONFIRMED resolution. The last three rows (line-number drift, surviving library-layer `HEPH_GH_CLI_TIMEOUT`, and the `post_merge_processor` provider type) remain genuinely uncertain and must still be verified by the implementer/reviewer. The skill as a whole stays `unverified`: the plan was never executed and CI never ran it.
 
 ## Results & Parameters
 
-**Most uncertain assumptions a reviewer should focus on (all UNVERIFIED):**
+**CONFIRMED in R1 (assumptions verified against the source after a NOGO on R0's impl plan):**
 
-- **Plan never executed.** No code applied, no tests run, CI not confirmed (verification = unverified). Everything here is a hypothesis.
-- **Free-function options reach.** The exact construction sites of each Options object in each `main()`, and whether `StageContext` re-exposes `ImplementerOptions` to every phase that needs `agent_timeout`, are assumed not proven. Whether `pr_manager` / `ci_fix_orchestrator` truly expose an options provider at the cited line is unverified.
-- **Per-phase consolidation is a capability change, not a no-op.** Collapsing distinct env knobs onto one field removes independent override even when defaults match — confirm acceptability.
+- **Per-knob granularity is the faithful mapping.** One flag + one field PER distinct knob; never collapse N knobs onto one field. A shared sub-agent knob (`advise`) gets its OWN field on EACH command that invokes it.
+- **Free-function leaves thread `timeout=` beside their existing `model=`/`agent=` param.** Four sites (`learn.run_learn`, `follow_up.run_follow_up_issues`, `comment_difficulty.classify_comments`, `pr_manager._invoke_git_message_agent`) are free functions; the option-holder caller passes `self.options.<knob>_timeout`.
+- **A shared free-function entry takes the UNION of params.** `run_address_fix_session` gains `address_review_timeout` + `advise_timeout` + `git_message_timeout`, forwarding each; its 3 option-holding callers each pass their own `self.options.*`.
+- **Blast radius is 18 importers, not 36** (the 36 counted git-worktree duplicates) — verified by `grep -rl | grep -v __pycache__ | wc -l`. This justified KEEPING the constants module over delete-and-rewrite.
+- **Test sweep must include mocks to NON-default sentinels** (e.g. `git_message_agent_timeout()` -> 120); grep literal sentinel values, not just the helper name.
+- **Test BOTH an easy (method) and a hard (free-function) representative path** — the free-function path is where the migration breaks.
 - **Different-default fields must stay separate.** `git_message_timeout` (300s) must not fold into `agent_timeout` (7200s).
-- **Library-layer exception survives.** `HEPH_GH_CLI_TIMEOUT` in `github/client.py` is intentionally excluded; "no HEPH_* timeout env vars" holds only within `automation/`.
-- **Line numbers drift; re-grep.** Every cited location must be re-located by symbol at implementation time.
-- **Timeout-assertion test blast radius under-enumerated.** Re-grep all `timeout=` assertions before declaring the test list complete.
+
+**STILL UNVERIFIED — residual risks a reviewer should focus on:**
+
+- **Plan never executed.** R1 verified the assumptions against the code, but NO code was applied, no tests run, CI not confirmed (verification = unverified). The migration itself is still a hypothesis.
+- **`post_merge_processor.learn_claude_timeout()` provider type.** The plan assumes its options provider carries (or can carry) a `learn_timeout`; the exact provider type was NOT pinned down — re-grep the provider type at implementation time. (The one residual hand-wave.)
+- **Library-layer exception survives.** `HEPH_GH_CLI_TIMEOUT` in `github/client.py` is intentionally excluded; "no HEPH_* timeout env vars" holds only within `automation/`. Whether the issue's "no ... anymore" criterion tolerates that is a reviewer judgment call.
+- **Line numbers drift; re-grep.** Every cited `file.py:NNN` location was read once during planning and must be re-located by symbol at implementation time.
 
 **Verified On / Integration point:** Captured from a planning session for **ProjectHephaestus issue #1526** ("Replace HEPH_* automation timeout env vars with explicit CLI options"). Integration points are the existing typed options objects (`ImplementerOptions` et al.), the timeout-constants helper module, and the shared `add_*_arg(parser)` / `build_review_parser` builders. Plan-stage only — **unverified**.
 
-**Generalization (the durable pattern):** When planning to replace operator env-var knobs with typed CLI options across a fan-out: (1) map each env-reading helper 1:1 to the options object already reaching its call site, separating cheap (options present) from expensive (free function, must thread a param) sites; (2) keep the helper module as the single source of DEFAULT CONSTANTS; (3) use a `None`-sentinel flag deferring to the pydantic field default (POLA, no duplicated default); (4) centralize flags in a shared `add_*_arg` helper; (5) make the env-removal an executable invariant via a helper-ignores-env test + `inspect.getsource` no-`os.environ` assertion. Flag to the reviewer: any "every caller has the options object" assumption, any per-phase-knob consolidation (capability loss), any different-default fold, any surviving env var in an out-of-scope layer, drifting line numbers, and the full timeout-assertion test blast radius.
+**Generalization (the durable pattern):** When planning to replace operator env-var knobs with typed CLI options across a fan-out: (0) count the knobs and the import blast radius EMPIRICALLY first (`grep -oE "HEPH_[A-Z_]+" | sort -u`; `grep -rl | grep -v __pycache__ | wc -l`) — worktree dupes over-count; (1) map ONE flag + ONE field PER distinct knob, never collapse N knobs onto one field, and give a shared sub-agent knob its own field on each command that invokes it; (2) for each leaf, grep METHOD-vs-FREE — methods read `self.options`, free functions thread `timeout=` beside the `model=`/`agent=` param they ALREADY thread (a shared free-function entry takes the UNION of params and forwards each); (3) keep the helper module as the single source of DEFAULT CONSTANTS (refactor `*_timeout()` to `return DEFAULT_X`, drop the `_read_int_env` inner fn); (4) use a `None`-sentinel flag deferring to the pydantic field default (POLA); (5) centralize flags in a shared `add_*_arg` helper; (6) make the env-removal an executable invariant (helper-ignores-env test + `inspect.getsource` no-`os.environ`); (7) test BOTH an easy method path and a hard free-function path, and sweep the test blast radius by literal sentinel value too, not just helper name. Residual reviewer judgment calls: a not-yet-pinned options-provider type for a stray helper, a surviving library-layer env var, and drifting line numbers.
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary

R1 (second) planning pass for ProjectHephaestus issue #1526 ("Replace HEPH_* automation timeout env vars with explicit CLI options"). After a NOGO on R0's implementation plan, the plan author VERIFIED R0's flagged assumptions by reading the actual code. This AMENDS the existing skill (created in PR #2815) to convert each confirmed risk into a verified pattern, rather than creating a competing file.

## Changes (v1.0.0 -> v1.1.0)

Converts six R0 "assumptions to flag" into CONFIRMED patterns:
1. **Per-knob granularity** — one flag + one field PER distinct knob; never collapse N knobs onto one field (R0 collapsed 9 -> NOGO). Shared sub-agent knob (`advise`) gets its own field on each invoking command.
2. **Free-function threading** — the "every leaf holds self.options" assumption was VERIFIED FALSE; four free functions (`learn.run_learn`, `follow_up.run_follow_up_issues`, `comment_difficulty.classify_comments`, `pr_manager._invoke_git_message_agent`) thread `timeout=` beside the `model=`/`agent=` param they already thread.
3. **Shared free-function entry takes the UNION of params** — `run_address_fix_session` gains 3 timeout params, one per option-holding caller.
4. **Blast radius is 18 importers, not 36** (worktree dupes) — verify empirically; justifies keeping the constants module.
5. **Constants-module retention** reinforced.
6. **Test BOTH easy and hard paths**, and sweep test blast radius by literal sentinel value (e.g. a mock returning 120).

Keeps three genuinely-uncertain items as residual risk rows: `post_merge_processor` provider type, surviving library-layer `HEPH_GH_CLI_TIMEOUT`, and line-number drift.

- Archives v1.0.0 into `.history` (newest-first); adds `history:` frontmatter and tags `per-knob-granularity, free-function-threading, blast-radius-verification, constants-module`.
- Stays `verification: unverified` — still a PLAN, never executed/CI-validated.
- `scripts/validate_plugins.py`: 516/516 valid.

Relates to ProjectHephaestus issue #1526 (cross-repo; no corresponding ProjectMnemosyne issue). Follows skill PR #2815.