### PR TITLE
amend(skill): generalize pip-audit transitive-lock skill to pixi + lock-propagation & v7-read-block dimensions (v1.1.0)

### DIFF
--- a/skills/python-sca-pip-audit-update-transitive-lock.history
+++ b/skills/python-sca-pip-audit-update-transitive-lock.history
@@ -1,0 +1,54 @@
+## v1.0.0 — 2026-06-19
+
+**Snapshot of skill at v1.0.0 before first amendment.**
+
+Documented how to resolve a GitHub Actions Python SCA / pip-audit failure caused by a vulnerable **transitive** dev dependency in a **uv.lock** file, without weakening or bypassing pip-audit.
+
+Key outcomes documented:
+- The failing `python-sca` / pip-audit job log often shows only a terse summary (`Found 1 known vulnerability in 1 package`); the full details (package, advisory, fixed version) are in the uploaded `pip-audit-report` artifact (`pip-audit.json`).
+- Reproduce locally with the EXACT CI command (`uv run --locked --extra dev python -m pip_audit --local --format=json --output=...`); in a restricted sandbox, redirect both `UV_CACHE_DIR` and `XDG_CACHE_HOME` to writable `/tmp` paths.
+- Trace transitivity with `pip show <pkg> <parent> pip-audit` (`Required-by`) before changing any manifest.
+- Prefer a minimal targeted refresh: `uv lock --upgrade-package <vulnerable-package>`; confirm only the intended package/version changed via `git diff -- uv.lock`.
+- Keep the SCA job fail-closed when a fixed version exists — update the lock, never suppress.
+
+Failed attempts documented:
+1. Weaken/bypass SCA — hides a real, remediable advisory.
+2. Rely on the job-log summary only — lacks package/advisory/fixed-version detail; download the artifact.
+3. Assume the package is direct — it was transitive through a dev tool; use `pip show` metadata.
+4. Run pip-audit with default cache paths in a restricted sandbox — `OSError: [Errno 30] Read-only file system`; redirect caches to `/tmp`.
+5. Broad dependency refresh — increases review risk; use `uv lock --upgrade-package`.
+
+Verified on: Inference360 PR #254 (head `4086627`, 2026-06-19) — `python-sca`, `validate`, `sast`, `secrets`, CodeQL all passed after the targeted `uv.lock` update.
+
+Vulnerability remediated in the verified case:
+- Package `msgpack` `1.1.2` → `1.2.1`, advisory `GHSA-6v7p-g79w-8964`, transitive via `CacheControl` ← `pip-audit`.
+
+Frontmatter at v1.0.0: `category: ci-cd`, `date: 2026-06-19`, `version: "1.0.0"`, `verification: verified-ci` (no `history:` field), tags: github-actions, python-sca, pip-audit, uv, uv-lock, lockfile, dependency-scanning, transitive-dependency, cachecontrol, msgpack.
+
+---
+
+## v1.1.0 — 2026-06-28
+
+**Amendment: generalize from uv.lock to pixi.lock and add two fleet-scale lock-propagation / read-block dimensions (both verified-ci across multiple HomericIntelligence repos).**
+
+The core principle is unchanged — *clear a transitive CVE by regenerating the lock to pick up the patched version, never by weakening pip-audit* — but it now applies to **pixi.lock** as well as uv.lock. `pixi update <pkg>` is the pixi analogue of `uv lock --upgrade-package <pkg>`. The pip-audit advisory table goes to `$GITHUB_STEP_SUMMARY`, NOT stdout — reproduce locally to read `Found N known vulnerability… <pkg> <ver> <GHSA> <fixed-ver>`.
+
+New content added:
+- **Dimension 1 — Stale-lock-after-main-fix propagation (the fleet dimension).** After a red `main` is fixed by a dep-bump PR that regenerates the lock, every OTHER open PR branched before it still carries the OLD vulnerable lock and keeps failing the required `security/dependency-scan` (pip-audit). A plain `git rebase onto main` does NOT regenerate the lock. Two sub-cases:
+  - Constraint already allows the patch (e.g. `pydantic-settings >=2.0` but lock pins `2.13.1`, `GHSA-4xgf-cpjx-pc3j`): plain `pixi lock` re-solves with locked content and does NOT bump → use `pixi update <pkg>` (→ `2.14.2`) for a minimal targeted bump.
+  - Fix added an explicit `pixi.toml` pin (e.g. `msgpack >= 1.2.1`, `GHSA-6v7p-g79w-8964`, transitive via cachecontrol): rebase onto fixed `main` brings the pin, then `pixi install`/`pixi lock` picks it up. Batch as one lock-regen sub-agent per repo.
+- **Dimension 2 — Pixi lock-format v7 that CI's pinned pixi cannot read.** A PR shipping a v7 `pixi.lock` fails the ENTIRE pipeline at `pixi install` (`× Lock-file version 7 is newer than supported … Maximum supported version: 6 (pixi v0.67.2)`) when CI pins an older pixi. This is a READ incompatibility (distinct from the v6/v7 churn issue). Fix: bump the CI `pixi-version` (e.g. `v0.67.2` → `v0.70.2`). Verified safe on main: a newer pixi reads a v6 lock via `pixi install --locked` (exit 0, warn-only, no rewrite), so it won't red a v6 main.
+
+New failed-attempts rows:
+1. Plain `pixi lock` to clear a transitive CVE when the constraint already allows the patch → does NOT bump (re-solves with locked content) → use `pixi update <pkg>`.
+2. Plain rebase-onto-fixed-main to propagate a lock fix → does NOT regenerate the lock; old vulnerable pin persists → explicitly regenerate per PR and `git diff -- pixi.lock` to confirm.
+3. Shipped a v7 `pixi.lock` against CI's older pinned pixi → whole pipeline dies at `pixi install` → bump CI `pixi-version`, verifying a newer pixi reads v6 locks via `--locked`.
+
+Frontmatter changes: `date` `2026-06-19` → `2026-06-28`; `version` `1.0.0` → `1.1.0`; added `history:` field; broadened `description` (uv.lock OR pixi.lock + propagation + v7 read-block triggers); added tags: security-dependency-scan, pixi-lock, pixi-update, lockfile-propagation, lock-format-v7, ci-pixi-version, pydantic-settings.
+
+Cross-links added (References section): tooling-pixi-lockfile-churn-self-reference (v6/v7 churn/format angle), dependabot-lockfile-rebase-regenerate-resign, automation-multi-repo-pr-sweep-rebase-resolve.
+
+Verification: verified-ci —
+- Telemachy: 23 PRs, `pydantic-settings 2.13.1 → 2.14.2` via `pixi update` (Dimension 1, sub-case A).
+- Agamemnon: 7 PRs, `msgpack 1.1.2 → 1.2.1` via rebase onto main after PR #434 pinned it (Dimension 1, sub-case B).
+- Telemachy PR #288: CI `pixi-version` `v0.67.2 → v0.70.2` to read a v7 `pixi.lock` (Dimension 2).

--- a/skills/python-sca-pip-audit-update-transitive-lock.md
+++ b/skills/python-sca-pip-audit-update-transitive-lock.md
@@ -1,22 +1,30 @@
 ---
 name: python-sca-pip-audit-update-transitive-lock
-description: "Resolve GitHub Actions Python SCA pip-audit failures caused by vulnerable transitive dev dependencies in a uv.lock file. Use when: (1) python-sca or pip-audit fails with only a summary in the job log, (2) the failing package is transitive through a dev tool, (3) uv --locked reproduction needs cache paths redirected in a restricted sandbox."
+description: "Resolve GitHub Actions Python SCA / security-dependency-scan pip-audit failures caused by vulnerable transitive dependencies in a uv.lock OR pixi.lock file, including stale-lock propagation across sibling PRs after a red-main dep-fix merges. Use when: (1) python-sca or pip-audit fails with only a summary in the job log, (2) the failing package is transitive through a dev tool, (3) uv --locked reproduction needs cache paths redirected in a restricted sandbox, (4) a red-main dependency fix merged but sibling PRs branched before it still fail pip-audit on the OLD vulnerable lock (a plain rebase does not regenerate the lock), (5) a pixi.lock at format v7 fails CI's older pinned pixi with 'Lock-file version 7 is newer than supported'."
 category: ci-cd
-date: 2026-06-19
-version: "1.0.0"
+date: 2026-06-28
+version: "1.1.0"
 user-invocable: false
 verification: verified-ci
+history: python-sca-pip-audit-update-transitive-lock.history
 tags:
   - github-actions
   - python-sca
+  - security-dependency-scan
   - pip-audit
   - uv
   - uv-lock
+  - pixi-lock
+  - pixi-update
   - lockfile
+  - lockfile-propagation
+  - lock-format-v7
+  - ci-pixi-version
   - dependency-scanning
   - transitive-dependency
   - cachecontrol
   - msgpack
+  - pydantic-settings
 ---
 
 # Python SCA Pip-Audit Transitive Lockfile Remediation
@@ -27,8 +35,10 @@ tags:
 |-------|-------|
 | **Date** | 2026-06-19 |
 | **Objective** | Resolve GitHub Actions Python SCA failures from a vulnerable transitive dev dependency in a locked uv environment without weakening or bypassing pip-audit. |
-| **Outcome** | Downloaded the pip-audit artifact, identified the exact advisory and fixed version, traced the vulnerable package through dev dependency metadata, refreshed only the affected package in `uv.lock`, reran the CI-equivalent audit with redirected caches, and confirmed GitHub checks passed. |
+| **Outcome** | Downloaded the pip-audit artifact, identified the exact advisory and fixed version, traced the vulnerable package through dev dependency metadata, refreshed only the affected package in `uv.lock`, reran the CI-equivalent audit with redirected caches, and confirmed GitHub checks passed. v1.1.0 generalizes the same principle to `pixi.lock`: targeted lock regeneration to clear a transitive CVE, plus two fleet-scale dimensions — propagating a lock fix to sibling PRs and unblocking a v7-lock-vs-old-CI-pixi read failure. |
 | **Verification** | verified-ci |
+
+> **Same principle, two lock formats.** The core idea — *clear a transitive CVE by regenerating the lock to pick up the patched version, never by weakening pip-audit* — applies identically to **uv.lock** and **pixi.lock**. The original workflow below is uv-centric; the **Pixi Lock Dimensions** section generalizes it to pixi (`pixi update <pkg>` is the pixi analogue of `uv lock --upgrade-package <pkg>`), and adds two fleet-scale failure modes seen across HomericIntelligence repos.
 
 ## When to Use
 
@@ -37,6 +47,9 @@ tags:
 - The vulnerable package is not declared directly in `pyproject.toml`, but comes from a dev tool such as `pip-audit`.
 - A uv-managed project uses `uv run --locked --extra dev ...` in CI and needs a minimal lockfile remediation.
 - Local reproduction fails in a restricted sandbox because pip-audit or uv tries to write caches under a read-only home directory.
+- **(pixi)** A `pixi`-managed project's required `security/dependency-scan` (pip-audit) fails on a vulnerable transitive pin in `pixi.lock` and needs a minimal targeted bump.
+- **(propagation)** A red `main` was fixed by a dependency-bump PR that regenerated the lock, and after merging it, every OTHER open PR branched before the fix still fails `security/dependency-scan` because it carries the OLD vulnerable lock — a plain `git rebase onto main` does NOT regenerate the lock.
+- **(v7 read block)** A PR ships a `pixi.lock` at format v7 and the ENTIRE pipeline fails at `pixi install` with `× Lock-file version 7 is newer than supported … Maximum supported version: 6 (pixi v0.67.2)` because CI pins an older pixi that cannot read v7.
 
 ## Verified Workflow
 
@@ -87,6 +100,57 @@ git diff -- uv.lock
 
 7. **Run affected tests or static checks, commit only the lockfile if that is the only change, push, and confirm GitHub SCA passes.** Do not merge based on local output alone if the required CI job is the gate.
 
+## Pixi Lock Dimensions (v1.1.0)
+
+Everything above maps to pixi: the `pixi.lock` analogue of `uv lock --upgrade-package <pkg>` is `pixi update <pkg>` (a minimal targeted bump). The pip-audit advisory table goes to `$GITHUB_STEP_SUMMARY`, **not stdout** — reproduce locally to see `Found N known vulnerability… <pkg> <ver> <GHSA> <fixed-ver>`. Two fleet-scale failure modes seen this session:
+
+### Dimension 1 — Stale-lock-after-main-fix propagation (the fleet dimension)
+
+When a red `main` is fixed by a dependency-bump PR that adds/raises a constraint **and regenerates the lock**, merging that fix unblocks `main` — but every OTHER open PR branched before it still carries the OLD vulnerable lock and keeps failing the required `security/dependency-scan` (pip-audit). **A plain `git rebase onto main` does NOT regenerate the lock**, so the vulnerable pin persists. The fix, per PR, is to REGENERATE the lock so it picks up the patched version. There are two sub-cases:
+
+- **Constraint already allows the patched version** (e.g. `pydantic-settings >=2.0`, but the lock pins `2.13.1` which has `GHSA-4xgf-cpjx-pc3j`). A plain `pixi lock` re-solves with locked content and does **NOT** bump — you must run `pixi update <package>` (e.g. `pixi update pydantic-settings` → `2.14.2`) for a minimal targeted bump.
+- **Fix added an explicit pin in `pixi.toml`** (e.g. an explicit `msgpack >= 1.2.1` for `GHSA-6v7p-g79w-8964`, transitive via `cachecontrol`). Here, rebasing onto the fixed `main` brings the pin in, and a `pixi install` / `pixi lock` re-solve picks it up. (Even so, confirm the lock actually changed — a no-op rebase leaves the old pin.)
+
+**Batch this as one lock-regen sub-agent per repo** across the open PRs.
+
+```bash
+# Reproduce the advisory (table is in $GITHUB_STEP_SUMMARY, not stdout):
+pixi run pip-audit            # or the repo's exact CI command; read "Found N known vulnerability…"
+
+# Sub-case A — constraint already allows the patch: targeted bump (plain `pixi lock` will NOT bump):
+pixi update pydantic-settings
+grep -nE "name: *\"?pydantic-settings|pydantic-settings *[=@]" pixi.lock   # confirm 2.13.1 -> 2.14.2
+
+# Sub-case B — fix added an explicit pin upstream on main: rebase brings the pin, then re-solve:
+git rebase origin/main
+pixi install                  # or `pixi lock`
+grep -nE "name: *\"?msgpack|msgpack *[=@]" pixi.lock        # confirm 1.1.2 -> 1.2.1
+
+git diff -- pixi.lock         # verify ONLY the intended package/version changed
+```
+
+### Dimension 2 — Pixi lock-format v7 that CI's pinned pixi cannot read (a hard CI-read block)
+
+A PR shipping a `pixi.lock` at **format v7** fails the **ENTIRE** pipeline (every job, at `pixi install`) when the repo's CI pins an older pixi that can't read v7:
+
+```text
+× Lock-file version 7 is newer than supported … Maximum supported version: 6 (pixi v0.67.2)
+```
+
+This is **NOT** the v6/v7 churn issue (see `tooling-pixi-lockfile-churn-self-reference`) — it's a *read incompatibility* that bricks all checks. **FIX: bump the CI `pixi-version` in the workflows** (e.g. `v0.67.2` → `v0.70.2`) to a pixi that reads v7.
+
+Verify the bump is **SAFE on main first**: a newer pixi reads OLDER v6 locks fine — `pixi install --locked` against a v6 lock exits `0` (warn-only, does NOT rewrite), so the bump won't red a v6 `main`. Ecosystem precedent: a sibling repo already ran `v0.70.2` with v7 locks.
+
+```bash
+# Find every pin (workflows AND composite actions — see the churn skill's gotcha):
+grep -rn "pixi-version" .github/
+
+# Safety check on main BEFORE bumping: newer pixi reads a v6 lock without rewriting it:
+pixi install --locked        # against a v6 lock: exits 0, warn-only, no rewrite
+
+# Bump the pin (example): v0.67.2 -> v0.70.2 in all matched locations.
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -96,6 +160,9 @@ git diff -- uv.lock
 | Assume the package is direct | Looked for the vulnerable package in project dependency declarations | The package was transitive through a dev tool and not declared by the project | Use `pip show` metadata to trace `Required-by` before changing manifests |
 | Run pip-audit with default cache paths | Ran the CI-equivalent command in a restricted sandbox | pip-audit attempted to write under a read-only home cache and raised `OSError: [Errno 30] Read-only file system` | Redirect both `UV_CACHE_DIR` and `XDG_CACHE_HOME` to writable `/tmp` paths |
 | Broad dependency refresh | Could have run a full uv lock update | Full resolver churn increases review risk and can change unrelated packages | Use `uv lock --upgrade-package <package>` for a minimal lockfile change |
+| Plain `pixi lock` to clear a transitive CVE | Ran `pixi lock` expecting it to pick up the patched `pydantic-settings 2.14.2` | The constraint (`>=2.0`) already allowed the patch, so `pixi lock` re-solved with **locked content** and kept the vulnerable `2.13.1` pin | Use `pixi update <pkg>` (the pixi analogue of `uv lock --upgrade-package`) for a minimal targeted bump when the constraint already permits the fixed version |
+| Plain rebase-onto-fixed-main to propagate a lock fix | Rebased a sibling PR onto a `main` whose dep-fix had merged, expecting the vulnerable lock to clear | `git rebase onto main` does NOT regenerate the lock; the old vulnerable pin persisted and `security/dependency-scan` kept failing | Explicitly regenerate the lock per PR — `pixi update <pkg>` (constraint allows patch) or rebase-then-`pixi install` when the fix added an explicit `pixi.toml` pin; always `git diff -- pixi.lock` to confirm it actually changed |
+| Shipped a v7 `pixi.lock` against CI's older pinned pixi | Pushed a PR carrying a `pixi.lock` at format v7 while CI pinned `v0.67.2` | The WHOLE pipeline died at `pixi install` with `Lock-file version 7 is newer than supported … Maximum supported version: 6` — a read-incompatibility, not churn | Bump the CI `pixi-version` (e.g. `v0.67.2` → `v0.70.2`) across all `.github/` pins; verify safety first — a newer pixi reads v6 locks via `pixi install --locked` (exit 0, warn-only, no rewrite), so it won't red a v6 `main` |
 
 ## Results & Parameters
 
@@ -140,3 +207,12 @@ No known vulnerabilities found
 | Project | Context | Details |
 |---------|---------|---------|
 | Inference360 | PR #254, head `4086627`, 2026-06-19 | `python-sca`, `validate`, `sast`, `secrets`, and CodeQL passed after the targeted `uv.lock` update |
+| Telemachy | 23 PRs (lock-propagation sweep), 2026-06-28 | `pydantic-settings 2.13.1 → 2.14.2` via `pixi update pydantic-settings` (constraint `>=2.0` already allowed the patch; plain `pixi lock` would not bump). Cleared `GHSA-4xgf-cpjx-pc3j` on `security/dependency-scan` across all sibling PRs after the red-main dep-fix merged |
+| Telemachy | PR #288, 2026-06-28 | v7-lock read block: bumped CI `pixi-version` `v0.67.2 → v0.70.2` so the pinned pixi could read the v7 `pixi.lock`; verified safe on main (`pixi install --locked` against a v6 lock exits 0, warn-only, no rewrite); sibling-repo precedent already ran v0.70.2 with v7 locks |
+| Agamemnon | 7 PRs (lock-propagation sweep), 2026-06-28 | `msgpack 1.1.2 → 1.2.1` (`GHSA-6v7p-g79w-8964`, transitive via `cachecontrol`) via rebase onto `main` after PR #434 added the explicit `msgpack >= 1.2.1` pin; `pixi install` re-solve picked it up; `security/dependency-scan` green across siblings |
+
+## References
+
+- [tooling-pixi-lockfile-churn-self-reference](tooling-pixi-lockfile-churn-self-reference.md) — the v6/v7 lockfile *churn / format* angle (distinct from the v7 *read-incompatibility* block documented here)
+- [dependabot-lockfile-rebase-regenerate-resign](dependabot-lockfile-rebase-regenerate-resign.md) — rebase + lock-regenerate + re-sign mechanics for dependency PRs
+- [automation-multi-repo-pr-sweep-rebase-resolve](automation-multi-repo-pr-sweep-rebase-resolve.md) — the multi-repo PR sweep harness for batching the per-repo lock-regen sub-agents


### PR DESCRIPTION
## Summary

AMEND of the existing skill `python-sca-pip-audit-update-transitive-lock` (v1.0.0 → **v1.1.0**, 2026-06-28). The core principle is unchanged — *clear a transitive CVE by regenerating the lock to pick up the patched version, never by weakening pip-audit* — but it now generalizes from **uv.lock** to **uv.lock OR pixi.lock** (`pixi update <pkg>` is the analogue of `uv lock --upgrade-package`).

Adds two new, related dimensions discovered this session, both **verified-ci** across multiple HomericIntelligence repos.

### Dimension 1 — Stale-lock-after-main-fix propagation (the fleet dimension)
After a red `main` is fixed by a dep-bump PR that regenerates the lock, every OTHER open PR branched before it still carries the OLD vulnerable lock and keeps failing the required `security/dependency-scan`. A plain `git rebase onto main` does NOT regenerate the lock. Two sub-cases:
- **Constraint already allows the patch** → plain `pixi lock` won't bump; use `pixi update <pkg>`. *(Telemachy, 23 PRs, `pydantic-settings 2.13.1→2.14.2`, `GHSA-4xgf-cpjx-pc3j`.)*
- **Fix added an explicit `pixi.toml` pin** → rebase brings the pin, `pixi install` re-solves. *(Agamemnon, 7 PRs, `msgpack 1.1.2→1.2.1`, `GHSA-6v7p-g79w-8964` via cachecontrol.)*

### Dimension 2 — Pixi lock-format v7 that CI's pinned pixi cannot read
A v7 `pixi.lock` bricks the ENTIRE pipeline at `pixi install` (`Lock-file version 7 is newer than supported … Maximum supported version: 6 (pixi v0.67.2)`) when CI pins an older pixi. A read-incompatibility, distinct from the v6/v7 churn issue. Fix: bump CI `pixi-version` (`v0.67.2 → v0.70.2`). Safe on main — newer pixi reads v6 locks via `pixi install --locked` (warn-only, no rewrite). *(Telemachy PR #288.)*

## Changes
- Frontmatter: version → 1.1.0, date → 2026-06-28, broadened description + triggers, added `history:` field, new tags (security-dependency-scan, pixi-lock, pixi-update, lockfile-propagation, lock-format-v7, ci-pixi-version, pydantic-settings).
- New **Pixi Lock Dimensions** section with Quick-Reference commands.
- 3 new Failed-Attempts rows; 3 new Verified-On rows.
- Cross-links: tooling-pixi-lockfile-churn-self-reference, dependabot-lockfile-rebase-regenerate-resign, automation-multi-repo-pr-sweep-rebase-resolve.
- New `.history` file (v1.0.0 snapshot + v1.1.0 entry).

## Validation
`python3 scripts/validate_plugins.py` → **541/541 valid**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)