### PR TITLE
feat: amend ci-readme-blockquote-markdownlint-break skill (v1.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,11 +6,11 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 639,
+  "total_plugins": 641,
   "categories": {
     "architecture": 132,
     "ci-cd": 122,
-    "debugging": 62,
+    "debugging": 64,
     "documentation": 40,
     "evaluation": 12,
     "optimization": 7,
@@ -18,7 +18,7 @@
     "tooling": 174,
     "training": 7
   },
-  "last_updated": "2026-07-09T04:58:32Z",
+  "last_updated": "2026-07-09T17:24:55Z",
   "plugins": [
     {
       "name": "agent-config-validation-and-integrity",
@@ -6235,6 +6235,23 @@
       ]
     },
     {
+      "name": "llm-corruption-repro-artifact-review",
+      "description": "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts.",
+      "version": "1.0.0",
+      "source": "./skills/llm-corruption-repro-artifact-review.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "corruption",
+        "reproducibility",
+        "artifacts",
+        "manual-review",
+        "logits",
+        "tokens",
+        "redaction"
+      ]
+    },
+    {
       "name": "logging-subprocess-context-tracking",
       "description": "Add diagnostic context (working directory, command, cwd) to subprocess execution logging. Use when: (1) run_git_cmd or similar subprocess runners log execution without showing which directory the command ran in, (2) debugging multi-directory workflows where cwd context is critical for tracing, (3) writing tests for subprocess execution and caplog fixture fails with custom logger handlers (propagate=False).",
       "version": "1.0.0",
@@ -6358,6 +6375,24 @@
         "fail-open",
         "argparse",
         "repr-truncation"
+      ]
+    },
+    {
+      "name": "sampling-degeneration-seed-token-debugging",
+      "description": "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support.",
+      "version": "1.0.0",
+      "source": "./skills/sampling-degeneration-seed-token-debugging.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "sampling",
+        "seed",
+        "logits",
+        "top-k",
+        "top-p",
+        "degeneration",
+        "xllm",
+        "issue-257"
       ]
     },
     {

--- a/skills/ci-readme-blockquote-markdownlint-break.history
+++ b/skills/ci-readme-blockquote-markdownlint-break.history
@@ -1,0 +1,113 @@
+# ci-readme-blockquote-markdownlint-break — History
+
+## v1.1.0 (2026-07-09)
+
+**Changed by:** ProjectMnemosyne skill PR #3022 — a line-wrapped GitHub issue reference (`#1819`) landed at column 1 and markdownlint parsed it as a malformed ATX heading (MD018).
+**Verification:** verified-ci
+
+### What changed
+
+- Added a new "When to Use" trigger for MD018 / line-leading `#<digit>` in any doc or skill markdown.
+- Added a new subsection to the Verified Workflow: "MD018: line-wrapped issue reference parsed as a heading" with the `grep -nE '^#[0-9]'` detector and the wrap/inline-code fix.
+- Added 2 new Failed Attempts rows:
+  - Relied on `validate_plugins.py` passing (it does NOT run markdownlint).
+  - Reflowed the wrap once (moved the `#<digit>` to the start of the newly-wrapped line instead of removing it).
+- Broadened frontmatter description + tags to cover MD018 and line-leading issue references, so the "why did markdownlint CI fail on my doc/skill edit" search surface hits this skill.
+- Bumped version 1.0.0 → 1.1.0; updated date to 2026-07-09; added `history` frontmatter field.
+
+### Why
+
+The v1.0.0 skill covered only the MD028 blockquote-continuation failure mode. A second,
+adjacent failure mode shares the exact same search surface ("markdownlint CI failed on my
+doc/skill edit; pre-commit / plugin-validation passed but the CI all-files markdownlint run
+failed"): when a bold sentence wraps and the wrap puts a GitHub issue reference like `#1819`
+at column 1, markdownlint reads `#1819...` as an ATX heading with no space after `#` and
+raises MD018/no-missing-space-atx. Critically, `python3 scripts/validate_plugins.py` passed
+(634/634) because it does not invoke markdownlint — plugin-validation-green is NOT
+markdownlint-green. The reliable fix is asserting `grep -nE '^#[0-9]' <file>` returns EMPTY
+(a one-shot reflow can just move the `#<digit>` to the next line's start), then confirming
+with `markdownlint-cli2 <file>` → "Summary: 0 error(s)".
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: ci-readme-blockquote-markdownlint-break
+description: "Markdownlint CI fails when a multi-paragraph blockquote in README.md is missing the > continuation marker on blank lines between paragraphs. Use when: (1) CI markdownlint job fails on README after adding or editing a blockquote, (2) a blockquote renders as two separate blocks when you intended one, (3) pre-commit markdownlint passes on individual files but CI all-files run fails with MD028 or blank-line-in-blockquote."
+category: ci-cd
+date: 2026-06-23
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags: [ci-cd, markdownlint, readme, blockquote, md028, blank-line, pre-commit, ci-debug]
+---
+
+# CI: README Blockquote Continuation Breaks Markdownlint
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-23 |
+| **Objective** | Drive PR ProjectHephaestus#1570 to green CI |
+| **Outcome** | CI passed after adding missing `>` continuation marker to a blank line inside a README blockquote |
+| **Verification** | verified-ci |
+
+A multi-paragraph blockquote in Markdown requires every blank separator line between
+paragraphs to start with `>`. Without it, the renderer (and markdownlint) treats the
+blank line as ending the blockquote, starting a new one, which violates MD028
+(no-blanks-in-blockquote) and can also trip MD009/MD012. The fix is a single-character
+`>` on the otherwise-empty line.
+
+## When to Use
+
+- CI markdownlint job fails on README.md after editing or adding a blockquote block
+- A blockquote you intended as one unit renders as two separate blockquotes
+- `pre-commit run --files README.md` passes locally but CI `--all-files` catches the violation
+- CI log cites MD028 or a blank-line rule inside a blockquote in README.md or another doc file
+
+## Verified Workflow
+
+### Quick Reference
+
+    # Find broken blockquotes — look for blank lines inside a blockquote block without >
+    grep -n "^>" README.md | head -30
+    # Spot a gap in line numbers that corresponds to a blank line between > lines
+
+    # Fix: every blank line inside a blockquote must start with >
+    # Verify locally before pushing
+    pre-commit run markdownlint --files README.md
+
+### Detailed Steps
+
+1. Open README.md and locate the blockquote block that spans multiple paragraphs.
+2. Find blank lines inside the blockquote that are missing the `>` prefix.
+3. Add `>` (optionally with a space: `> `) to every blank separator line inside the blockquote.
+4. Run `pre-commit run markdownlint --files README.md` to confirm the rule passes locally.
+5. Commit the fix and push — CI markdownlint gate should go green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Running pre-commit on changed files only | `pre-commit run --files <diff-files>` passed | the fix was missing from an earlier commit | Always run `pre-commit run markdownlint --files README.md` any time README blockquotes are edited |
+
+## Results & Parameters
+
+The fix for PR #1570 / issue #1554 was a single-character change in README.md: adding `>` to
+the blank line between two blockquote paragraphs (MD028 / no-blanks-in-blockquote). CI commit
+`c7883e49` on branch `1554-auto-impl`.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #1570 / Issue #1554 — packaging scaffolding + MIGRATION link | CI markdownlint gate went green after adding `>` to blank continuation line; commit c7883e49 |
+```
+
+---
+
+## v1.0.0 (2026-06-23)
+
+**Initial version.** Documented the MD028 blockquote-continuation failure mode from
+ProjectHephaestus PR #1570 / issue #1554.

--- a/skills/ci-readme-blockquote-markdownlint-break.md
+++ b/skills/ci-readme-blockquote-markdownlint-break.md
@@ -1,12 +1,13 @@
 ---
 name: ci-readme-blockquote-markdownlint-break
-description: "Markdownlint CI fails when a multi-paragraph blockquote in README.md is missing the > continuation marker on blank lines between paragraphs. Use when: (1) CI markdownlint job fails on README after adding or editing a blockquote, (2) a blockquote renders as two separate blocks when you intended one, (3) pre-commit markdownlint passes on individual files but CI all-files run fails with MD028 or blank-line-in-blockquote."
+description: "Markdownlint CI fails on a specific markdown construct even though pre-commit / plugin-validation passed on the individual file — the CI all-files markdownlint run catches it. Covers (a) MD028 blank line without > inside a multi-paragraph blockquote, and (b) MD018 when a line-wrapped GitHub issue reference like #1234 lands at column 1 and is parsed as a malformed ATX heading. Use when: (1) CI markdownlint job fails on README/docs/skills after an edit, (2) CI log cites MD028 or MD018/no-missing-space-atx, (3) pre-commit or validate_plugins.py passes locally but the CI all-files markdownlint run fails."
 category: ci-cd
-date: 2026-06-23
-version: "1.0.0"
+date: 2026-07-09
+version: "1.1.0"
 user-invocable: false
 verification: verified-ci
-tags: [ci-cd, markdownlint, readme, blockquote, md028, blank-line, pre-commit, ci-debug]
+history: ci-readme-blockquote-markdownlint-break.history
+tags: [ci-cd, markdownlint, readme, blockquote, md028, md018, atx-heading, issue-reference, line-wrap, blank-line, pre-commit, ci-debug]
 ---
 
 # CI: README Blockquote Continuation Breaks Markdownlint
@@ -19,6 +20,7 @@ tags: [ci-cd, markdownlint, readme, blockquote, md028, blank-line, pre-commit, c
 | **Objective** | Drive PR ProjectHephaestus#1570 to green CI |
 | **Outcome** | CI passed after adding missing `>` continuation marker to a blank line inside a README blockquote |
 | **Verification** | verified-ci |
+| **History** | [changelog](./ci-readme-blockquote-markdownlint-break.history) |
 
 A multi-paragraph blockquote in Markdown requires every blank separator line between
 paragraphs to start with `>`. Without it, the renderer (and markdownlint) treats the
@@ -32,6 +34,8 @@ blank line as ending the blockquote, starting a new one, which violates MD028
 - A blockquote you intended as one unit renders as two separate blockquotes
 - `pre-commit run --files README.md` passes locally but CI `--all-files` catches the violation
 - CI log cites MD028 or a blank-line rule inside a blockquote in README.md or another doc file
+- CI log cites **MD018/no-missing-space-atx** and points at a line that starts with `#<digit>` (e.g. `#1819`) — a line-wrapped GitHub issue reference parsed as a malformed ATX heading
+- `python3 scripts/validate_plugins.py` passed but the CI `markdownlint` job still failed on a skill/doc `.md` — plugin-validation-green is NOT markdownlint-green
 
 ## Verified Workflow
 
@@ -66,11 +70,44 @@ pre-commit run markdownlint --files README.md
 4. Run `pre-commit run markdownlint --files README.md` to confirm the rule passes locally.
 5. Commit the fix and push — CI markdownlint gate should go green.
 
+### MD018: line-wrapped issue reference parsed as a heading
+
+A different construct produces the same "CI markdownlint failed but my local check passed"
+symptom. When a bold sentence wraps across lines and the wrap puts a GitHub issue reference
+at column 1, markdownlint reads that line as an ATX heading with no space after `#` and raises
+**MD018/no-missing-space-atx**. Example — the second line begins with `#1819`:
+
+```markdown
+**The verified workaround ... :** (drove epic #1809's
+#1819→#1823 cleanup wave ...).
+```
+
+CI failed at `<file>.md:101:1 MD018`. Note that `python3 scripts/validate_plugins.py` PASSED
+(634/634) because it never invokes markdownlint, and pre-commit on the individual file did not
+surface it — only the CI `markdownlint` job and `markdownlint-cli2 <file>` caught it.
+
+Fix: ensure **no line starts with `#<digit>`**. Detect and assert empty:
+
+```bash
+# MUST print nothing — any hit is a line-leading issue ref that markdownlint reads as a heading
+grep -nE '^#[0-9]' <file>.md
+
+# Then confirm zero markdownlint errors (repo config is honored automatically)
+markdownlint-cli2 <file>.md   # look for "Summary: 0 error(s)"
+```
+
+Reflow the wrap so a non-`#` word leads the line (move a word up), or inline-code the reference
+(`` `#1819` ``) so it can't be mistaken for a heading. A one-shot reflow is not enough — pulling
+`#1809's` down can just relocate the `#<digit>` to the start of the next wrapped line. Trust the
+`grep -nE '^#[0-9]'` = EMPTY assertion, not "I moved the wrap once."
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Running pre-commit on changed files only | `pre-commit run --files <diff-files>` passed, so the blockquote issue was not caught before push | pre-commit scoped to the diff did not catch the blank-line-without-> syntax because... actually it would have caught it if README was in the diff — the root cause was the fix was missing from an earlier commit | Always run `pre-commit run markdownlint --files README.md` any time README blockquotes are edited |
+| Trusting `validate_plugins.py` as the markdownlint gate | Ran `python3 scripts/validate_plugins.py` (634/634 pass) and pushed a skill `.md` | `validate_plugins.py` does not invoke markdownlint, so it green-lit a file the CI `markdownlint` job rejected (MD018 at `<file>.md:101:1`) | Plugin-validation-green ≠ markdownlint-green. Run `markdownlint-cli2 <file>.md` locally on any doc/skill edit before pushing |
+| Reflowing the wrapped line once | Moved `#1809's` down to the next line to un-wrap the offending line | The reflow just relocated the `#<digit>` to column 1 of the newly-wrapped line — `grep -nE '^#[0-9]'` still matched, MD018 still fired | Assert `grep -nE '^#[0-9]' <file>` returns EMPTY (not "I moved the wrap once"); wrap or inline-code (`` `#N` ``) any `#N` that would otherwise begin a line |
 
 ## Results & Parameters
 
@@ -97,3 +134,4 @@ must start with `>`. A blank line without `>` terminates the blockquote.
 | Project | Context | Details |
 |---------|---------|---------|
 | ProjectHephaestus | PR #1570 / Issue #1554 — packaging scaffolding + MIGRATION link | CI markdownlint gate went green after adding `>` to blank continuation line; commit c7883e49 |
+| ProjectMnemosyne | Skill PR #3022 — line-wrapped issue ref `#1819` at column 1 | CI `markdownlint` failed MD018 at `<file>.md:101:1` while `validate_plugins.py` passed 634/634; went green after reflowing so no line starts with `#<digit>` (`grep -nE '^#[0-9]'` empty) |

--- a/skills/llm-corruption-repro-artifact-review.md
+++ b/skills/llm-corruption-repro-artifact-review.md
@@ -1,0 +1,165 @@
+---
+name: llm-corruption-repro-artifact-review
+description: "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [llm, corruption, reproducibility, artifacts, manual-review, logits, tokens, redaction]
+---
+
+# LLM Corruption Repro Artifact Review
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Make LLM corruption investigations durable, rerunnable, and reviewable by standardizing per-seed run artifacts and manual-review tooling. |
+| **Outcome** | Store issue-specific scripts, docs, summaries, and review state under a durable repro directory; keep each run self-contained; report corruption rates by seed totals; keep private artifacts out of git or redacted. |
+| **Verification** | verified-local from local Inference360 issue 257 scripts, tests, and PR work. ProjectMnemosyne PR CI is separate and must not be claimed until checks prove it. |
+
+## When to Use
+
+- You are debugging long-running LLM text corruption, output degeneration, cache instability, or token/logit divergence across many seeds.
+- A run must be replayable by another host, cluster, or reviewer without relying on chat history, shell history, or an agent's local session state.
+- You need raw `tokens.jsonl` or `logits.jsonl` from broad sweeps so the same data can support later first-bad-token, prefix-comparison, or force-token intervention analysis.
+- Manual review must label candidate corruption events without losing state, double-counting bursts, or flooding reviewers with per-token dumps by default.
+- You are preparing docs, PRs, issue comments, or repro packages that must redact internal paths, endpoints, checkpoints, prompts, tokens, cookies, and user-specific locations.
+
+## Verified Workflow
+
+Verification status: `verified-local`. The workflow was validated through local Inference360 issue 257 repro scripts/tests and PR work. Do not mark this skill `verified-ci` unless the ProjectMnemosyne PR checks are observed green.
+
+### Quick Reference
+
+```text
+1. Create a durable issue-specific repro root: repro/<issue-id>/.
+2. Put scripts, docs, run directions, summaries, and reviewer tools there.
+3. Emit one self-contained run root per backend/model/config/seed.
+4. Store repro.sh, output.txt or assistant.txt, tokens.jsonl, logits.jsonl,
+   request/config metadata, and summary.json in each run root.
+5. Keep large/private artifacts outside git or replace them with placeholders.
+6. Review with scripts that auto-discover run roots and persist labels.
+7. Report rates as bad seeds / total seeds, not candidate or burst totals.
+```
+
+### Detailed Steps
+
+1. **Create the repro root first.** Use `repro/<issue-id>/` as the durable home for issue-specific scripts, run directions, summaries, reviewer tools, and small sanitized fixtures. Keep large raw artifacts in a private artifact root and reference them with placeholders such as `<REDACTED_ARTIFACT_ROOT>`.
+2. **Make every run self-contained.** Write each seed to a path like `runs/<backend>/<seed>/` or `runs/<model>/<config>/<seed>/`. Each run root should contain `repro.sh`, `output.txt` or `assistant.txt`, `tokens.jsonl`, `logits.jsonl`, `request.json`, `config.json`, and `summary.json`.
+3. **Make `repro.sh` rerunnable.** It should reconstruct one seed independently from explicit metadata, not from chat context, shell state, or untracked environment assumptions. Use placeholders for private endpoints and checkpoints, for example `<REDACTED_ENDPOINT>` and `<REDACTED_CHECKPOINT_PATH>`.
+4. **Capture raw tokens and logits during broad sweeps.** Approach-3 sweeps should preserve raw `tokens.jsonl` and `logits.jsonl` even if the first analysis only needs a binary label. The same files enable later approach-1 and approach-2 work: aggregate failing seeds, find first bad token, compare closest good/bad prefixes, and run force-token interventions.
+5. **Summarize in machine-readable form.** Each `summary.json` should include issue id, backend or model alias, config name, seed, prompt hash, output hash, label, candidate count, first bad token index when known, artifact schema version, and the redacted run-root shape.
+6. **Write processing scripts instead of reading artifacts manually.** Reviewer tools should auto-discover run roots, read summary and JSONL files, and print compact per-model/per-config counts. Per-token dumps should require `--verbose`.
+7. **Persist manual labels.** Store review decisions in a state file such as `review_state.json` so a reviewer can resume, audit who labeled which seed, and avoid re-reviewing the same seed after every script invocation.
+8. **Advance review after labeling one seed.** The loop should move to the next seed once a seed receives a label, but it must inspect all candidate events in a log when the first candidate is benign.
+9. **Review all corruption classes.** Do not hard-code the loop to the first ellipsis-like event. The classifier should allow every candidate class the investigation tracks, including text degeneration, stop/control-token artifacts, repetition bursts, JSON/tool-call corruption, tokenizer artifacts, and backend-specific logit divergence.
+10. **Treat benign ellipsis and control-token artifacts separately.** Comma-adjacent ellipsis fragments that function as array separators are usually benign. Stop-token or control-token renderings should be classified as artifacts unless the surrounding plain text actually degenerates.
+11. **Report seed-level rates.** Use `bad seeds / total seeds (%)` per model and config. Candidate count and burst count can be supporting diagnostics, but they are not the denominator for corruption rate.
+12. **Redact before publishing.** Docs, PRs, issue comments, and committed repro files must not include internal absolute paths, endpoint addresses, checkpoint names, private prompts, token-bearing artifacts, cookies, or user-specific locations. Keep shape with placeholders such as `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Candidate-count denominator | Counted corruption candidates or bursts instead of seeds | Burst totals made the rate look like a complete sample, for example reporting `2/2` reviewed bad cases instead of `2/256` seed rate | Always report `bad seeds / total seeds (%)`; keep candidate and burst counts as secondary diagnostics |
+| First-candidate-only review | Stopped after the first candidate event in each log | A benign first candidate hid later real corruption events in the same seed output | When the first candidate is benign, continue scanning every candidate event before labeling the seed clean |
+| Noisy default token dump | Printed every token/logit line during normal review | Reviewers could not scan model/config rates or labeling progress efficiently | Default to compact summaries; require `--verbose` for per-token dumps |
+| Manual artifact reading | Opened run logs by hand and labeled from ad hoc notes | Labels were hard to resume, audit, or reproduce, and later reviewers could not tell what had been reviewed | Build review scripts with auto-discovery, persistent state, and deterministic summaries |
+| Dropped raw sweep data | Kept only final text or binary labels from approach-3 sweeps | Later first-bad-token, prefix comparison, and force-token intervention analyses had to rerun expensive seeds | Preserve raw `tokens.jsonl` and `logits.jsonl` for every relevant seed |
+| Checked-in raw operations | Committed run artifacts without masking paths, endpoints, checkpoints, prompts, or token-bearing files | Durable repo artifacts can leak operational details even when docs are sanitized | Keep raw artifacts private, commit only sanitized scripts/summaries, and scan files before PRs/issues |
+| Ellipsis/control-token false positive | Treated comma-adjacent ellipsis fragments or stop/control-token renderings as text corruption | Parser and formatting artifacts inflated the corruption count | Add benign classifications for separator ellipses and control-token artifacts; require surrounding text degeneration for a bad label |
+
+## Results & Parameters
+
+### Durable Layout
+
+```text
+repro/<issue-id>/
+  README.md
+  run_sweep.py
+  review_corruption.py
+  summarize_runs.py
+  review_state.json
+  summaries/
+    latest.json
+    latest.md
+  runs/
+    <backend>/<seed>/
+      repro.sh
+      output.txt
+      assistant.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+    <model>/<config>/<seed>/
+      repro.sh
+      output.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+```
+
+### Per-Run Contract
+
+| Artifact | Purpose |
+|----------|---------|
+| `repro.sh` | Replays exactly one seed from explicit metadata and redacted placeholders |
+| `output.txt` or `assistant.txt` | Human-readable model output for quick review |
+| `tokens.jsonl` | Token IDs, text fragments, offsets, stop/control-token indicators, and candidate markers |
+| `logits.jsonl` | Raw or summarized logits needed for first-bad-token and prefix-comparison analysis |
+| `request.json` | Sanitized request shape, prompt hash, seed, sampling settings, and model/config alias |
+| `config.json` | Backend, model alias, artifact schema version, runtime flags, and redacted artifact-root shape |
+| `summary.json` | Machine-readable label, counts, hashes, first bad token index, and reviewer metadata |
+
+### Review Script Contract
+
+```text
+review_corruption.py --root repro/<issue-id>
+review_corruption.py --root repro/<issue-id> --model <model-alias> --config <config-name>
+review_corruption.py --root repro/<issue-id> --verbose
+summarize_runs.py --root repro/<issue-id> --by model,config
+```
+
+Expected summary shape:
+
+```text
+model=<model-alias> config=<config-name> bad=2/256 (0.78%) reviewed=256/256
+model=<model-alias> config=<other-config> bad=0/256 (0.00%) reviewed=256/256
+```
+
+State file shape:
+
+```json
+{
+  "schema_version": 1,
+  "labels": {
+    "<model>/<config>/<seed>": {
+      "label": "bad",
+      "class": "text-degeneration",
+      "reviewed_at": "2026-07-09T00:00:00Z",
+      "notes": "First non-benign degeneration after a benign separator ellipsis."
+    }
+  }
+}
+```
+
+### Redaction Checklist
+
+- Replace private artifact roots with `<REDACTED_ARTIFACT_ROOT>`.
+- Replace endpoints with `<REDACTED_ENDPOINT>`.
+- Replace checkpoint or tokenizer paths with `<REDACTED_CHECKPOINT_PATH>`.
+- Do not publish private prompts, token-bearing artifacts, cookies, bearer tokens, user-specific locations, hostnames, ports, or absolute infrastructure paths.
+- Keep examples structural, for example `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`, without exposing real operational values.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Issue 257 local corruption investigation scripts/tests and PR work | Durable per-run repro layout, raw token/logit capture, review-state tooling, seed-level rate reporting, and redaction rules were validated locally. Verification is `verified-local`, not `verified-ci`, until the ProjectMnemosyne PR checks prove this skill file. |

--- a/skills/sampling-degeneration-seed-token-debugging.md
+++ b/skills/sampling-degeneration-seed-token-debugging.md
@@ -1,0 +1,141 @@
+---
+name: sampling-degeneration-seed-token-debugging
+description: "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - llm
+  - sampling
+  - seed
+  - logits
+  - top-k
+  - top-p
+  - degeneration
+  - xllm
+  - issue-257
+---
+
+# Sampling Degeneration Seed Token Debugging
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Diagnose LLM garbled output when matched runs differ only by seed, and separate bad random draws from prompt, weight, tokenizer, backend, or deterministic-forward differences. |
+| **Outcome** | Successful locally. The useful pivot was asking why seed mattered: seed changes the random draw from the next-token distribution, not the prompt, weights, tokenizer, or deterministic forward pass. That moved the investigation from whole-trace comparison to the first bad sampled token in one trace. |
+| **Verification** | verified-local. Evidence came from redacted Inference360 issue #257 scripts, dense-model sweeps, direct XLLM checks, and manual review. ProjectMnemosyne CI validation is pending for this skill PR. |
+
+## When to Use
+
+- The same model, prompt, backend, tokenizer, and generation config produce readable output for one seed and garbled output for another.
+- A generation degenerates into repeated ellipsis, newline loops, prompt-framing leakage, or similar hard corruption after an apparently valid prefix.
+- You need to decide whether top-k, top-p, greedy, temperature, or stop-token behavior is changing the actual sampler support.
+- A trace-diff approach is producing too much noise and not explaining why a specific seed fails.
+- A script reports `top_k=N`, but there is any chance `N` is only the top-N dump/reporting limit instead of the sampler's support.
+
+## Verified Workflow
+
+Verified locally only through redacted Inference360 issue #257 scripts and manual review. Do not claim verified-ci until this skill PR's `validate` and `markdownlint` checks pass.
+
+### Quick Reference
+
+```bash
+# Capture a per-step trace for one failing seed.
+python <trace-script>.py \
+  --model <model-id> \
+  --prompt-file <REDACTED_PROMPT_FILE> \
+  --seed 116 \
+  --temperature 1 \
+  --top-k 20 \
+  --top-k-dump 50 \
+  --output <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl
+
+# Inspect the selected token rank and probability near the first hard-corruption step.
+python <analyze-trace-script>.py \
+  <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --window 80:100 \
+  --top-n 20
+
+# Replay the divergence step by forcing plausible alternatives.
+python <force-token-script>.py \
+  --trace <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --force-step 90 \
+  --force-rank 1,2,3,4 \
+  --output <REDACTED_ARTIFACT_ROOT>/forced-alternatives.jsonl
+```
+
+### Detailed Steps
+
+1. **Ask why seed matters before comparing whole traces.** With the same prompt, weights, backend, tokenizer, and generation config, seed should only affect random sampling from the next-token distribution. It should not change the deterministic forward pass. This narrows the first question to: which sampled token draw sent the trace into a bad basin?
+2. **Collect per-step token evidence.** For each generated step, log the selected token id/text, selected rank, selected probability, logits or post-filter probabilities, top-N alternatives, active sampler config, stop/control-token flags, and the decoded prefix.
+3. **Stop at the first hard-corruption token.** Do not start by explaining every downstream token. Find the first selected token after which the continuation becomes repeated ellipsis/newline variants, prompt-framing leakage, or another stable corruption pattern.
+4. **Inspect selected rank and nearby alternatives.** A low-probability selected token can be a valid sampler draw even when rank 1 is overwhelmingly more likely. The key diagnostic is whether the selected token was inside the configured sampler support and whether higher-ranked alternatives preserve readable continuation.
+5. **Force plausible alternatives at the divergence step.** Replay from the same prefix while forcing rank-1, rank-2, rank-3, and the originally selected token. If the top alternatives stay readable and the original draw degenerates, the corruption is primarily a sampling-tail trajectory, not a whole-trace backend mismatch.
+6. **Sweep sampler support deliberately.** Compare greedy or top-k=1, small top-k, larger top-k, no top-k, and top-p thresholds such as 0.9, 0.95, 0.99, and 0.999. Keep dense-model and MoE results separate, and label partial MoE data as revalidation-needed.
+7. **Separate sampler controls from diagnostic dumps.** `--top-k` should control sampler support. A separate `--top-k-dump` or `--top-n-dump` should only limit the logged alternatives. Logs must print both actual sampler support and dump size.
+8. **Manually review labels.** Do not auto-label every newline or comma-adjacent ellipsis fragment as corruption. Repeated ellipsis bursts, newline loops, and prompt-framing leakage are the meaningful class. Numeric-array fragments such as `,...`, `...,`, `,…`, or `…,'` can be benign formatting artifacts and need context.
+9. **Treat stop/control-token artifacts separately.** If a suspicious case is caused by a special stop/control token or a harness stop condition, record it as an artifact unless the decoded continuation itself demonstrates model-output corruption.
+10. **Record verification honestly.** Local sweeps and manual review support `verified-local`. Only mark `verified-ci` when the skill PR's validation gates are observed green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Compare whole good/bad traces first | Diffed two generations that differed only by seed | The diff grew after divergence and obscured the causal draw | Ask what seed changes, then stop at the first bad sampled token in one failing trace |
+| Treat newline spam alone as corruption | Counted newline-heavy output as bad without reviewing decoded context | Some newline behavior was prompt or formatting related, not hard model degeneration | Label repeated ellipsis bursts, newline loops, and prompt-framing leakage; manually review ambiguous cases |
+| Use top-k dump count as sampler top-k | A script reported `top_k=N` from the logged top-N dump limit while actual `sampling_top_k` was infinite | The report implied a bounded sampler even when the sampler could draw from the full distribution | Use `--top-k` for sampler support and `--top-k-dump` only for diagnostic logging |
+| Assume low-probability draw means backend bug | Treated a very unlikely selected token as impossible | Sampling at temperature 1 can draw low-probability in-support tokens | Inspect rank/probability and replay forced alternatives before blaming logits computation |
+| Mistake stop-token artifacts for corruption | Counted special control or stop-token effects as bad model output | The harness boundary, not the model's decoded continuation, caused some suspicious cases | Track stop/control-token status and keep those cases out of true corruption counts |
+
+## Results & Parameters
+
+### Representative Local Finding
+
+A redacted 4B dense-model run with temperature explicitly set to 1, top-k=20, and seed 116 selected an ellipsis-family token around step 90. The selected token was rank 4 at about 0.01% probability while rank 1 was about 75%. After that draw, the next-token distribution flattened into ellipsis and newline variants and the text degenerated. Replaying the divergence while forcing rank-1, rank-2, or rank-3 alternatives kept the continuation readable.
+
+Direct XLLM sweeps showed greedy/top-k=1 removed the observed failures. Top-k=5, top-k=20, and no top-k still had failures. Top-p 0.9 and 0.95 mostly or entirely removed true ellipsis degeneration in the reviewed dense sweep.
+
+### Top-p Sweep Evidence
+
+The following are local issue #257 dense-model manual-review rates across 256 seeds per model where runs completed. Treat them as redacted local evidence, not ProjectMnemosyne CI evidence.
+
+| Sampler | 4B | 7B | 32B | 36B | Notes |
+|---------|----|----|-----|-----|-------|
+| top-p 0.9 | 0/256 | 0/256 | 0/256 | 0/256 | No manually reviewed true bad dense cases where runs completed |
+| top-p 0.95 | 0/256 | 2/256 suspicious | 0/256 | 0/256 | The 7B suspicious cases looked likely to be stop-token artifacts rather than true ellipsis degeneration |
+| top-p 0.99 | 1/256 | 2/256 | 2/256 | 0/256 | Low reviewed true bad rates |
+| top-p 0.999 | 3/256 | 5/256 | 14/256 | 20/256 | Higher reviewed true bad rates as the tail widened |
+
+MoE partial data from the same investigation is revalidation-needed and should not be generalized until dense and MoE runs complete under the same review protocol.
+
+### Config Contract
+
+Use separate flags for sampler behavior and diagnostic visibility:
+
+```text
+--top-k 20        # sampler support: only ranks inside top 20 are eligible
+--top-k-dump 50   # diagnostic dump: log up to 50 alternatives, does not affect sampling
+--top-p 0.95      # sampler support: nucleus threshold
+--temperature 1   # explicit temperature, not an implicit default
+```
+
+Sanity checks for trace/report scripts:
+
+- The emitted report field for sampler support must come from the actual sampling config, not the dump limit.
+- The logged top-N count may exceed sampler support if it is used only for diagnostics.
+- The trace should record selected rank after all active sampler filters.
+- The manual-review label should distinguish true degeneration from formatting fragments and stop/control-token artifacts.
+
+### Review Caveat
+
+Comma-adjacent ellipsis fragments in numeric arrays, including `,...`, `...,`, `,…`, and `…,'`, should not be auto-labeled as corruption. Review decoded context. Meaningful corruption is repeated ellipsis bursts, newline loops, or prompt-framing leakage that persists after the first bad draw.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Redacted issue #257 local scripts and manual review, 2026-07-09 | Dense-model traces and sweeps supported the first-bad-token workflow, forced-alternative replay, top-k/top-p findings, and the sampler-vs-dump caution. MoE partial data remains revalidation-needed. |


### PR DESCRIPTION
## Summary

Amends the existing `ci-readme-blockquote-markdownlint-break` skill from v1.0.0 to v1.1.0, adding a second failure mode that shares the same search surface.

The skill already covered **MD028** (a blank line without `>` inside a multi-paragraph blockquote). This adds **MD018/no-missing-space-atx**: when a bold sentence wraps and the wrap puts a GitHub issue reference like `#1819` at column 1, markdownlint parses it as a malformed ATX heading.

- New Verified-Workflow subsection: "MD018: line-wrapped issue reference parsed as a heading" with the `grep -nE '^#[0-9]'` detector and the wrap/inline-code fix.
- New When-to-Use triggers for MD018 and "validate_plugins.py green != markdownlint green".
- 2 new Failed Attempts rows (trusted `validate_plugins.py`; single reflow just relocated the `#<digit>`).
- Broadened description + tags so "why did markdownlint CI fail on my doc/skill edit" routes here.
- Previous v1.0.0 snapshot archived in `ci-readme-blockquote-markdownlint-break.history`.

## Verification Level

**verified-ci** — This exact failure blocked ProjectMnemosyne skill PR #3022's `markdownlint` check (`<file>.md:101:1 MD018`) while `python3 scripts/validate_plugins.py` passed 634/634. Reflowing so no line starts with `#<digit>` made the `markdownlint` check pass.

## Key Findings

**What Worked**:
- Asserting `grep -nE '^#[0-9]' <file>` returns EMPTY, then confirming `markdownlint-cli2 <file>` reports "Summary: 0 error(s)".
- Wrapping/inline-coding (`` `#N` ``) any issue ref that would otherwise begin a line.

**What Failed**:
- Trusting `validate_plugins.py` as the markdownlint gate -> it never invokes markdownlint.
- A one-shot reflow -> just moved the `#<digit>` to the start of the next wrapped line; grep still matched.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` passes (641/641)
- [x] `markdownlint-cli2 skills/ci-readme-blockquote-markdownlint-break.md` -> 0 errors
- [x] `markdownlint-cli2 skills/ci-readme-blockquote-markdownlint-break.history` -> 0 errors

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>