### PR TITLE
feat: add git-stacked-prs-rebase-merge-worktree-orchestration skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,11 +6,11 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 639,
+  "total_plugins": 641,
   "categories": {
     "architecture": 132,
     "ci-cd": 122,
-    "debugging": 62,
+    "debugging": 64,
     "documentation": 40,
     "evaluation": 12,
     "optimization": 7,
@@ -18,7 +18,7 @@
     "tooling": 174,
     "training": 7
   },
-  "last_updated": "2026-07-09T04:58:32Z",
+  "last_updated": "2026-07-09T17:24:55Z",
   "plugins": [
     {
       "name": "agent-config-validation-and-integrity",
@@ -6235,6 +6235,23 @@
       ]
     },
     {
+      "name": "llm-corruption-repro-artifact-review",
+      "description": "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts.",
+      "version": "1.0.0",
+      "source": "./skills/llm-corruption-repro-artifact-review.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "corruption",
+        "reproducibility",
+        "artifacts",
+        "manual-review",
+        "logits",
+        "tokens",
+        "redaction"
+      ]
+    },
+    {
       "name": "logging-subprocess-context-tracking",
       "description": "Add diagnostic context (working directory, command, cwd) to subprocess execution logging. Use when: (1) run_git_cmd or similar subprocess runners log execution without showing which directory the command ran in, (2) debugging multi-directory workflows where cwd context is critical for tracing, (3) writing tests for subprocess execution and caplog fixture fails with custom logger handlers (propagate=False).",
       "version": "1.0.0",
@@ -6358,6 +6375,24 @@
         "fail-open",
         "argparse",
         "repr-truncation"
+      ]
+    },
+    {
+      "name": "sampling-degeneration-seed-token-debugging",
+      "description": "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support.",
+      "version": "1.0.0",
+      "source": "./skills/sampling-degeneration-seed-token-debugging.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "sampling",
+        "seed",
+        "logits",
+        "top-k",
+        "top-p",
+        "degeneration",
+        "xllm",
+        "issue-257"
       ]
     },
     {

--- a/skills/git-stacked-prs-rebase-merge-worktree-orchestration.md
+++ b/skills/git-stacked-prs-rebase-merge-worktree-orchestration.md
@@ -1,0 +1,165 @@
+---
+name: git-stacked-prs-rebase-merge-worktree-orchestration
+description: "End-to-end playbook for driving a stack of dependent PRs through a rebase-merge-ONLY GitHub repo (allow_merge_commit:false, allow_squash_merge:false) using parallel git worktrees. Use when: (1) a repo permits only rebase-merge and you must merge stacked PRs — retarget every still-open stacked PR to main BEFORE merging anything below it, because deleting a stack-base branch on merge makes GitHub CLOSE (not retarget) dependent PRs UNRECOVERABLY, (2) a stacked branch re-conflicts on its base's commits after those commits were rebase-merged into main with conflict resolutions — use `git rebase --onto origin/main <old-base-sha> <branch>` to replay only the branch's own commits, (3) preventing committed conflict markers from reaching main — check `git diff --name-only --diff-filter=U` AND `git grep -nE '^(<<<<<<< |>>>>>>> )'` before every `git rebase --continue`, plus a CI guard step, (4) parallel worktree agents on stacked branches keep conflicting on shared doc/registry/__init__/changelog files — resolve as chronological additive unions, never pick-one-side; regenerate (don't hand-merge) tool-generated report files, (5) `git worktree remove` fails on an agent-locked worktree (unlock first) or a chained checkout silently fails and later commands run on the wrong branch, (6) local main diverges patch-identically after rebase-merges — `git pull --rebase origin main` drops duplicates, (7) gh quirks: stale `gh pr diff` right after push, `--delete-branch` failing while a worktree holds the branch, GraphQL rate-limit exhaustion from tight CI-polling loops across many PRs."
+category: tooling
+date: 2026-07-10
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - git
+  - stacked-prs
+  - rebase-merge
+  - worktrees
+  - rebase-onto
+  - conflict-markers
+  - gh-cli
+  - multi-agent
+---
+
+# Git Stacked PRs Through a Rebase-Merge-Only Repo with Parallel Worktrees
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-10 |
+| **Objective** | Drive 6 dependent PRs, developed by parallel worktree agents, through a GitHub repo that permits ONLY rebase-merge — without losing any PR, committing conflict markers, or replaying already-merged conflicts |
+| **Outcome** | All 6 PRs merged with real CI passes; one committed-conflict-marker incident reached main and was remediated with a permanent CI guard; one stacked-PR class of unrecoverable closure identified and a prevention rule adopted |
+| **Verification** | verified-ci |
+
+Related skills (adjacent hazards, different merge methods or scopes):
+`parallel-pr-worktree-workflow` (squash-merge stacked-orphan variant, parallel-agent isolation),
+`pr-rebase-conflict-resolution-patterns` (general rebase-conflict taxonomy),
+`git-rebase-skip-duplicate-merged-commits` (patch-identical duplicates → `git rebase --skip`),
+`github-auto-merge-ci-gating-merge-method` (choosing/arming the merge method).
+This skill is specifically the rebase-merge-only stack-orchestration workflow.
+
+## When to Use
+
+- The target repo has `allow_merge_commit: false` and `allow_squash_merge: false` — every merge is a **rebase-merge that rewrites SHAs**, so stacked branches are never patch-identical to what lands on main.
+- You are about to merge the bottom PR of a stack and other stacked PRs are still open (the retarget-first rule below is MANDATORY — violation closes dependents unrecoverably).
+- A dependent branch's rebase onto `origin/main` re-conflicts on commits that belong to its already-merged base (the base was rebase-merged WITH conflict resolutions, so it is no longer patch-identical).
+- Multiple parallel agents each own a worktree + branch, dependent work is stacked on its dependency's branch, and shared registry-style files (CLAUDE.md status docs, `__init__` re-exports, changelogs/followup ledgers, regenerated reports) conflict on every rebase.
+- You need to guarantee no conflict markers ever reach main (pre-`--continue` checks + CI guard).
+- After several rebase-merges, local main "diverges" from origin with patch-identical commits.
+- `gh pr diff` shows a stale diff right after a push, `gh pr merge --delete-branch` can't delete a worktree-held local branch, or CI-polling loops start hitting GraphQL rate limits.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 0) One worktree + branch per work-stream; stack dependent work on its dependency's branch
+git worktree add /tmp/wt-featB -b featB featA   # NOT main, if B depends on A
+
+# 1) BEFORE merging any PR that other open PRs are stacked on: retarget the dependents to main
+gh pr edit <dependent-PR> --base main           # for EVERY still-open stacked PR, FIRST
+gh pr merge <base-PR> --rebase --delete-branch  # only THEN merge the base
+
+# 2) After the base rebase-merges into main (with conflict resolutions), replay ONLY the
+#    dependent branch's own commits — plain `git rebase origin/main` re-conflicts on base commits
+git fetch origin
+git rebase --onto origin/main <old-base-tip-sha> featB
+
+# 3) BEFORE every `git rebase --continue` (non-negotiable pair):
+git diff --name-only --diff-filter=U            # MUST print nothing
+git grep -nE '^(<<<<<<< |>>>>>>> )'             # MUST print nothing
+git rebase --continue
+
+# 4) CI guard step (permanent; note the trailing space in the patterns — a bare
+#    7-equals line is a legal markdown setext underline, so do NOT match '^=======$'):
+#      - name: No committed conflict markers
+#        run: |
+#          if git grep -nE '^(<<<<<<< |>>>>>>> )' -- ':!*.lock'; then
+#            echo "Conflict markers found"; exit 1
+#          fi
+
+# 5) Shared registry-file conflicts (status docs, __init__ re-exports, changelogs):
+#    resolve as chronological additive UNION — keep BOTH sides, ordered by execution date.
+#    Regenerated report files: resolve arbitrarily, then re-run the generator and amend.
+
+# 6) Worktree lifecycle
+git worktree unlock /path/to/wt 2>/dev/null; git worktree remove /path/to/wt
+git branch --show-current                       # verify after ANY chained checkout
+
+# 7) Local main diverged patch-identically after rebase-merges
+git pull --rebase origin main                   # drops the duplicate local commits cleanly
+
+# 8) gh freshness check after push (gh pr diff can serve a STALE diff)
+git rev-parse HEAD
+gh pr view <N> --json headRefOid --jq .headRefOid   # must match before trusting gh pr diff
+```
+
+### Detailed Steps
+
+1. **Set up one worktree per work-stream.** Each parallel agent gets its own `git worktree` and branch. If stream B depends on stream A's unmerged work, branch B **from A's branch**, not from main. This keeps B's diff reviewable (only B's own commits) and CI meaningful.
+
+2. **Merge order: retarget first, merge second.** Because the repo is rebase-merge-only, merging a PR rewrites its commits' SHAs on main and (with `--delete-branch`) deletes the head branch. If any still-open PR uses that branch as its base, GitHub **CLOSES** the dependent PR when the base branch is deleted — it does **not** retarget it, and a closed PR's base cannot be changed (`Cannot change the base branch of a closed pull request`). The close is unrecoverable; you must open a brand-new PR. Rule exercised in the session: **before merging anything below it, run `gh pr edit <N> --base main` on every still-open stacked PR.**
+
+3. **Replay dependents with `--onto`.** After the base merges, the base's commits on main are new SHAs and — if conflicts were resolved during its final rebase — no longer patch-identical. A plain `git rebase origin/main featB` therefore re-conflicts on the base's commits. Instead:
+
+   ```bash
+   git rebase --onto origin/main <old-base-tip-sha> featB
+   ```
+
+   where `<old-base-tip-sha>` is the tip of the dependency branch as featB last saw it (recover via `git merge-base featB <old-base-branch>` before deletion, or from reflog/PR head SHA). This replays ONLY featB's own commits. This avoided a full conflict replay twice in the session. (If the base commits ARE still patch-identical, plain rebase auto-skips them, or see `git-rebase-skip-duplicate-merged-commits`.)
+
+4. **Conflict-marker hygiene (incident-driven, both preventions adopted).** A real incident put conflict markers on main: during a rebase, `git add -A` staged a file whose conflict was never resolved, because the operator checked only `git status --short | head -3` and the conflicted file was below the cutoff. Preventions:
+   - Before every `git rebase --continue`: `git diff --name-only --diff-filter=U` must be empty AND `git grep -nE '^(<<<<<<< |>>>>>>> )'` must be empty. Run both, every time — never truncate status output.
+   - Permanent CI guard: `if git grep -nE '^(<<<<<<< |>>>>>>> )' -- ':!*.lock'; then exit 1; fi`. Match only the `<<<<<<< ` / `>>>>>>> ` forms **with a trailing space**; do not match a bare `=======` line — a 7-equals line is a legal markdown setext underline and matching it produces false positives.
+
+5. **Shared-file conflicts between streams are structural, not accidental.** Files every stream touches — CLAUDE.md-style status docs, `__init__` re-export files, changelog/followup ledgers, regenerated report files — conflict on EVERY cross-stream rebase. Resolve them as **chronological additive unions** (keep both sides, ordered by execution date); never pick one side, which silently drops a sibling stream's entries. Exception: regenerated report files (e.g., dated audit reports) — don't hand-merge; resolve arbitrarily, re-run the generating tool, and amend the commit.
+
+6. **Worktree lifecycle safety.** `git worktree remove` fails on an agent-locked worktree — run `git worktree unlock <path>` first, then remove (no `--force`). After ANY chained checkout (`git checkout X && ...`), verify `git branch --show-current`: a checkout silently blocked by an untracked regenerated file leaves you on the previous branch, and subsequent rebase commands then run on the **wrong branch**.
+
+7. **Post-merge local-main hygiene.** After rebase-merges, local main holds patch-identical commits with different SHAs than origin. `git pull --rebase origin main` detects the duplicates and drops them cleanly (do not `pull --ff-only`, which just fails; do not reset unless you've confirmed nothing local is unpushed).
+
+8. **gh CLI quirks (all observed in-session):**
+   - `gh pr merge N --rebase --delete-branch` fails to delete the **local** branch when a worktree holds it. Harmless — clean up the worktree first next time.
+   - `gh pr diff N` immediately after `git push` can serve a **stale** diff. Confirm `gh pr view N --json headRefOid` matches `git rev-parse HEAD` before trusting it.
+   - GitHub GraphQL rate limit (~5000/hr) is easy to exhaust with tight CI-polling loops across many PRs. Poll at 45–60 s with backoff, tolerate transient `i/o timeout` and `rate limit` lines, and run one poll loop per PR — not one per check.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Merge stack bottom-up without retargeting | Merged a stack-base PR with `--delete-branch` while dependent PRs still targeted its branch | Rebase-merge deleted the base branch; GitHub CLOSED (did not retarget) the stacked PRs, and a closed PR's base cannot be changed — unrecoverable, required opening brand-new PRs | Retarget EVERY still-open stacked PR to main (`gh pr edit N --base main`) BEFORE merging anything below it |
+| Plain `git rebase origin/main` on a dependent branch | Rebased the dependent after its base was rebase-merged into main with conflict resolutions | The base's commits on main were no longer patch-identical, so the rebase re-conflicted on all the base's commits — a full conflict replay | `git rebase --onto origin/main <old-base-sha> <branch>` replays only the branch's own commits (avoided the replay twice) |
+| `git add -A` + truncated status check during rebase | Staged everything, verified with `git status --short \| head -3`, then `git rebase --continue` | The still-conflicted file was below the `head -3` cutoff; conflict markers were committed and reached main via the rebase-merge | Before every `--continue`: `git diff --name-only --diff-filter=U` empty AND `git grep -nE '^(<<<<<<< \|>>>>>>> )'` empty; add the CI guard as a backstop |
+| CI conflict-marker guard matching `^=======$` | First guard draft matched all three marker forms including the bare equals line | A 7-equals line is a legal markdown setext-heading underline — false positives on documentation | Match only `^(<<<<<<< \|>>>>>>> )` with the trailing space, and exclude lockfiles (`':!*.lock'`) |
+| Pick-one-side resolution on shared registry files | Took ours/theirs on status docs, `__init__` re-exports, changelog ledgers | Silently dropped the sibling stream's entries; the loss resurfaced as a re-conflict or missing re-export later | Resolve as chronological additive UNION (both sides, execution-date order); regenerate tool-generated reports instead of hand-merging |
+| `git worktree remove` on an agent's worktree | Direct remove of a worktree an agent had locked | Fails on locked worktrees | `git worktree unlock <path>` first, then remove; verify `git branch --show-current` after chained checkouts |
+| Tight per-check CI polling across 6 PRs | Polled every few seconds, one loop per check | Exhausted the ~5000/hr GraphQL rate limit; polls started failing with rate-limit and `i/o timeout` errors | Poll at 45–60 s with backoff, tolerate transient error lines, one poll loop per PR |
+
+## Results & Parameters
+
+- **Session outcome:** 6 PRs merged into a rebase-merge-only repo, all with real CI passes; multi-agent parallel worktrees throughout.
+- **Repo merge settings that trigger this skill:** `allow_merge_commit: false`, `allow_squash_merge: false`, `allow_rebase_merge: true` (check with `gh api repos/<owner>/<repo> --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'`).
+- **Mandatory merge-ordering invariant:** number of open PRs based on a branch must be 0 before that branch's PR merges.
+- **Pre-`--continue` gate (both must be empty):**
+
+  ```bash
+  git diff --name-only --diff-filter=U
+  git grep -nE '^(<<<<<<< |>>>>>>> )'
+  ```
+
+- **CI guard step (copy-paste):**
+
+  ```yaml
+  - name: Fail on committed conflict markers
+    run: |
+      if git grep -nE '^(<<<<<<< |>>>>>>> )' -- ':!*.lock'; then
+        echo "Committed conflict markers detected"; exit 1
+      fi
+  ```
+
+- **Dependent-branch replay:** `git rebase --onto origin/main <old-base-tip-sha> <branch>`.
+- **Polling parameters:** 45–60 s interval, exponential backoff on `rate limit` / `i/o timeout`, one loop per PR.
+- **Local main after merges:** `git pull --rebase origin main`.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| predictive-coding-mojo | Multi-agent session, 6 PRs merged through a rebase-merge-only GitHub repo using parallel git worktrees; every practice above exercised with real CI passes and merges (verified-ci) | Stacked-PR retarget-first rule, `--onto` replay (used twice), committed-marker incident + CI guard remediation, union resolution of per-stream registry files, worktree unlock/checkout-verification, GraphQL rate-limit-aware polling |

--- a/skills/llm-corruption-repro-artifact-review.md
+++ b/skills/llm-corruption-repro-artifact-review.md
@@ -1,0 +1,165 @@
+---
+name: llm-corruption-repro-artifact-review
+description: "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [llm, corruption, reproducibility, artifacts, manual-review, logits, tokens, redaction]
+---
+
+# LLM Corruption Repro Artifact Review
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Make LLM corruption investigations durable, rerunnable, and reviewable by standardizing per-seed run artifacts and manual-review tooling. |
+| **Outcome** | Store issue-specific scripts, docs, summaries, and review state under a durable repro directory; keep each run self-contained; report corruption rates by seed totals; keep private artifacts out of git or redacted. |
+| **Verification** | verified-local from local Inference360 issue 257 scripts, tests, and PR work. ProjectMnemosyne PR CI is separate and must not be claimed until checks prove it. |
+
+## When to Use
+
+- You are debugging long-running LLM text corruption, output degeneration, cache instability, or token/logit divergence across many seeds.
+- A run must be replayable by another host, cluster, or reviewer without relying on chat history, shell history, or an agent's local session state.
+- You need raw `tokens.jsonl` or `logits.jsonl` from broad sweeps so the same data can support later first-bad-token, prefix-comparison, or force-token intervention analysis.
+- Manual review must label candidate corruption events without losing state, double-counting bursts, or flooding reviewers with per-token dumps by default.
+- You are preparing docs, PRs, issue comments, or repro packages that must redact internal paths, endpoints, checkpoints, prompts, tokens, cookies, and user-specific locations.
+
+## Verified Workflow
+
+Verification status: `verified-local`. The workflow was validated through local Inference360 issue 257 repro scripts/tests and PR work. Do not mark this skill `verified-ci` unless the ProjectMnemosyne PR checks are observed green.
+
+### Quick Reference
+
+```text
+1. Create a durable issue-specific repro root: repro/<issue-id>/.
+2. Put scripts, docs, run directions, summaries, and reviewer tools there.
+3. Emit one self-contained run root per backend/model/config/seed.
+4. Store repro.sh, output.txt or assistant.txt, tokens.jsonl, logits.jsonl,
+   request/config metadata, and summary.json in each run root.
+5. Keep large/private artifacts outside git or replace them with placeholders.
+6. Review with scripts that auto-discover run roots and persist labels.
+7. Report rates as bad seeds / total seeds, not candidate or burst totals.
+```
+
+### Detailed Steps
+
+1. **Create the repro root first.** Use `repro/<issue-id>/` as the durable home for issue-specific scripts, run directions, summaries, reviewer tools, and small sanitized fixtures. Keep large raw artifacts in a private artifact root and reference them with placeholders such as `<REDACTED_ARTIFACT_ROOT>`.
+2. **Make every run self-contained.** Write each seed to a path like `runs/<backend>/<seed>/` or `runs/<model>/<config>/<seed>/`. Each run root should contain `repro.sh`, `output.txt` or `assistant.txt`, `tokens.jsonl`, `logits.jsonl`, `request.json`, `config.json`, and `summary.json`.
+3. **Make `repro.sh` rerunnable.** It should reconstruct one seed independently from explicit metadata, not from chat context, shell state, or untracked environment assumptions. Use placeholders for private endpoints and checkpoints, for example `<REDACTED_ENDPOINT>` and `<REDACTED_CHECKPOINT_PATH>`.
+4. **Capture raw tokens and logits during broad sweeps.** Approach-3 sweeps should preserve raw `tokens.jsonl` and `logits.jsonl` even if the first analysis only needs a binary label. The same files enable later approach-1 and approach-2 work: aggregate failing seeds, find first bad token, compare closest good/bad prefixes, and run force-token interventions.
+5. **Summarize in machine-readable form.** Each `summary.json` should include issue id, backend or model alias, config name, seed, prompt hash, output hash, label, candidate count, first bad token index when known, artifact schema version, and the redacted run-root shape.
+6. **Write processing scripts instead of reading artifacts manually.** Reviewer tools should auto-discover run roots, read summary and JSONL files, and print compact per-model/per-config counts. Per-token dumps should require `--verbose`.
+7. **Persist manual labels.** Store review decisions in a state file such as `review_state.json` so a reviewer can resume, audit who labeled which seed, and avoid re-reviewing the same seed after every script invocation.
+8. **Advance review after labeling one seed.** The loop should move to the next seed once a seed receives a label, but it must inspect all candidate events in a log when the first candidate is benign.
+9. **Review all corruption classes.** Do not hard-code the loop to the first ellipsis-like event. The classifier should allow every candidate class the investigation tracks, including text degeneration, stop/control-token artifacts, repetition bursts, JSON/tool-call corruption, tokenizer artifacts, and backend-specific logit divergence.
+10. **Treat benign ellipsis and control-token artifacts separately.** Comma-adjacent ellipsis fragments that function as array separators are usually benign. Stop-token or control-token renderings should be classified as artifacts unless the surrounding plain text actually degenerates.
+11. **Report seed-level rates.** Use `bad seeds / total seeds (%)` per model and config. Candidate count and burst count can be supporting diagnostics, but they are not the denominator for corruption rate.
+12. **Redact before publishing.** Docs, PRs, issue comments, and committed repro files must not include internal absolute paths, endpoint addresses, checkpoint names, private prompts, token-bearing artifacts, cookies, or user-specific locations. Keep shape with placeholders such as `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Candidate-count denominator | Counted corruption candidates or bursts instead of seeds | Burst totals made the rate look like a complete sample, for example reporting `2/2` reviewed bad cases instead of `2/256` seed rate | Always report `bad seeds / total seeds (%)`; keep candidate and burst counts as secondary diagnostics |
+| First-candidate-only review | Stopped after the first candidate event in each log | A benign first candidate hid later real corruption events in the same seed output | When the first candidate is benign, continue scanning every candidate event before labeling the seed clean |
+| Noisy default token dump | Printed every token/logit line during normal review | Reviewers could not scan model/config rates or labeling progress efficiently | Default to compact summaries; require `--verbose` for per-token dumps |
+| Manual artifact reading | Opened run logs by hand and labeled from ad hoc notes | Labels were hard to resume, audit, or reproduce, and later reviewers could not tell what had been reviewed | Build review scripts with auto-discovery, persistent state, and deterministic summaries |
+| Dropped raw sweep data | Kept only final text or binary labels from approach-3 sweeps | Later first-bad-token, prefix comparison, and force-token intervention analyses had to rerun expensive seeds | Preserve raw `tokens.jsonl` and `logits.jsonl` for every relevant seed |
+| Checked-in raw operations | Committed run artifacts without masking paths, endpoints, checkpoints, prompts, or token-bearing files | Durable repo artifacts can leak operational details even when docs are sanitized | Keep raw artifacts private, commit only sanitized scripts/summaries, and scan files before PRs/issues |
+| Ellipsis/control-token false positive | Treated comma-adjacent ellipsis fragments or stop/control-token renderings as text corruption | Parser and formatting artifacts inflated the corruption count | Add benign classifications for separator ellipses and control-token artifacts; require surrounding text degeneration for a bad label |
+
+## Results & Parameters
+
+### Durable Layout
+
+```text
+repro/<issue-id>/
+  README.md
+  run_sweep.py
+  review_corruption.py
+  summarize_runs.py
+  review_state.json
+  summaries/
+    latest.json
+    latest.md
+  runs/
+    <backend>/<seed>/
+      repro.sh
+      output.txt
+      assistant.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+    <model>/<config>/<seed>/
+      repro.sh
+      output.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+```
+
+### Per-Run Contract
+
+| Artifact | Purpose |
+|----------|---------|
+| `repro.sh` | Replays exactly one seed from explicit metadata and redacted placeholders |
+| `output.txt` or `assistant.txt` | Human-readable model output for quick review |
+| `tokens.jsonl` | Token IDs, text fragments, offsets, stop/control-token indicators, and candidate markers |
+| `logits.jsonl` | Raw or summarized logits needed for first-bad-token and prefix-comparison analysis |
+| `request.json` | Sanitized request shape, prompt hash, seed, sampling settings, and model/config alias |
+| `config.json` | Backend, model alias, artifact schema version, runtime flags, and redacted artifact-root shape |
+| `summary.json` | Machine-readable label, counts, hashes, first bad token index, and reviewer metadata |
+
+### Review Script Contract
+
+```text
+review_corruption.py --root repro/<issue-id>
+review_corruption.py --root repro/<issue-id> --model <model-alias> --config <config-name>
+review_corruption.py --root repro/<issue-id> --verbose
+summarize_runs.py --root repro/<issue-id> --by model,config
+```
+
+Expected summary shape:
+
+```text
+model=<model-alias> config=<config-name> bad=2/256 (0.78%) reviewed=256/256
+model=<model-alias> config=<other-config> bad=0/256 (0.00%) reviewed=256/256
+```
+
+State file shape:
+
+```json
+{
+  "schema_version": 1,
+  "labels": {
+    "<model>/<config>/<seed>": {
+      "label": "bad",
+      "class": "text-degeneration",
+      "reviewed_at": "2026-07-09T00:00:00Z",
+      "notes": "First non-benign degeneration after a benign separator ellipsis."
+    }
+  }
+}
+```
+
+### Redaction Checklist
+
+- Replace private artifact roots with `<REDACTED_ARTIFACT_ROOT>`.
+- Replace endpoints with `<REDACTED_ENDPOINT>`.
+- Replace checkpoint or tokenizer paths with `<REDACTED_CHECKPOINT_PATH>`.
+- Do not publish private prompts, token-bearing artifacts, cookies, bearer tokens, user-specific locations, hostnames, ports, or absolute infrastructure paths.
+- Keep examples structural, for example `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`, without exposing real operational values.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Issue 257 local corruption investigation scripts/tests and PR work | Durable per-run repro layout, raw token/logit capture, review-state tooling, seed-level rate reporting, and redaction rules were validated locally. Verification is `verified-local`, not `verified-ci`, until the ProjectMnemosyne PR checks prove this skill file. |

--- a/skills/sampling-degeneration-seed-token-debugging.md
+++ b/skills/sampling-degeneration-seed-token-debugging.md
@@ -1,0 +1,141 @@
+---
+name: sampling-degeneration-seed-token-debugging
+description: "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - llm
+  - sampling
+  - seed
+  - logits
+  - top-k
+  - top-p
+  - degeneration
+  - xllm
+  - issue-257
+---
+
+# Sampling Degeneration Seed Token Debugging
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Diagnose LLM garbled output when matched runs differ only by seed, and separate bad random draws from prompt, weight, tokenizer, backend, or deterministic-forward differences. |
+| **Outcome** | Successful locally. The useful pivot was asking why seed mattered: seed changes the random draw from the next-token distribution, not the prompt, weights, tokenizer, or deterministic forward pass. That moved the investigation from whole-trace comparison to the first bad sampled token in one trace. |
+| **Verification** | verified-local. Evidence came from redacted Inference360 issue #257 scripts, dense-model sweeps, direct XLLM checks, and manual review. ProjectMnemosyne CI validation is pending for this skill PR. |
+
+## When to Use
+
+- The same model, prompt, backend, tokenizer, and generation config produce readable output for one seed and garbled output for another.
+- A generation degenerates into repeated ellipsis, newline loops, prompt-framing leakage, or similar hard corruption after an apparently valid prefix.
+- You need to decide whether top-k, top-p, greedy, temperature, or stop-token behavior is changing the actual sampler support.
+- A trace-diff approach is producing too much noise and not explaining why a specific seed fails.
+- A script reports `top_k=N`, but there is any chance `N` is only the top-N dump/reporting limit instead of the sampler's support.
+
+## Verified Workflow
+
+Verified locally only through redacted Inference360 issue #257 scripts and manual review. Do not claim verified-ci until this skill PR's `validate` and `markdownlint` checks pass.
+
+### Quick Reference
+
+```bash
+# Capture a per-step trace for one failing seed.
+python <trace-script>.py \
+  --model <model-id> \
+  --prompt-file <REDACTED_PROMPT_FILE> \
+  --seed 116 \
+  --temperature 1 \
+  --top-k 20 \
+  --top-k-dump 50 \
+  --output <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl
+
+# Inspect the selected token rank and probability near the first hard-corruption step.
+python <analyze-trace-script>.py \
+  <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --window 80:100 \
+  --top-n 20
+
+# Replay the divergence step by forcing plausible alternatives.
+python <force-token-script>.py \
+  --trace <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --force-step 90 \
+  --force-rank 1,2,3,4 \
+  --output <REDACTED_ARTIFACT_ROOT>/forced-alternatives.jsonl
+```
+
+### Detailed Steps
+
+1. **Ask why seed matters before comparing whole traces.** With the same prompt, weights, backend, tokenizer, and generation config, seed should only affect random sampling from the next-token distribution. It should not change the deterministic forward pass. This narrows the first question to: which sampled token draw sent the trace into a bad basin?
+2. **Collect per-step token evidence.** For each generated step, log the selected token id/text, selected rank, selected probability, logits or post-filter probabilities, top-N alternatives, active sampler config, stop/control-token flags, and the decoded prefix.
+3. **Stop at the first hard-corruption token.** Do not start by explaining every downstream token. Find the first selected token after which the continuation becomes repeated ellipsis/newline variants, prompt-framing leakage, or another stable corruption pattern.
+4. **Inspect selected rank and nearby alternatives.** A low-probability selected token can be a valid sampler draw even when rank 1 is overwhelmingly more likely. The key diagnostic is whether the selected token was inside the configured sampler support and whether higher-ranked alternatives preserve readable continuation.
+5. **Force plausible alternatives at the divergence step.** Replay from the same prefix while forcing rank-1, rank-2, rank-3, and the originally selected token. If the top alternatives stay readable and the original draw degenerates, the corruption is primarily a sampling-tail trajectory, not a whole-trace backend mismatch.
+6. **Sweep sampler support deliberately.** Compare greedy or top-k=1, small top-k, larger top-k, no top-k, and top-p thresholds such as 0.9, 0.95, 0.99, and 0.999. Keep dense-model and MoE results separate, and label partial MoE data as revalidation-needed.
+7. **Separate sampler controls from diagnostic dumps.** `--top-k` should control sampler support. A separate `--top-k-dump` or `--top-n-dump` should only limit the logged alternatives. Logs must print both actual sampler support and dump size.
+8. **Manually review labels.** Do not auto-label every newline or comma-adjacent ellipsis fragment as corruption. Repeated ellipsis bursts, newline loops, and prompt-framing leakage are the meaningful class. Numeric-array fragments such as `,...`, `...,`, `,…`, or `…,'` can be benign formatting artifacts and need context.
+9. **Treat stop/control-token artifacts separately.** If a suspicious case is caused by a special stop/control token or a harness stop condition, record it as an artifact unless the decoded continuation itself demonstrates model-output corruption.
+10. **Record verification honestly.** Local sweeps and manual review support `verified-local`. Only mark `verified-ci` when the skill PR's validation gates are observed green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Compare whole good/bad traces first | Diffed two generations that differed only by seed | The diff grew after divergence and obscured the causal draw | Ask what seed changes, then stop at the first bad sampled token in one failing trace |
+| Treat newline spam alone as corruption | Counted newline-heavy output as bad without reviewing decoded context | Some newline behavior was prompt or formatting related, not hard model degeneration | Label repeated ellipsis bursts, newline loops, and prompt-framing leakage; manually review ambiguous cases |
+| Use top-k dump count as sampler top-k | A script reported `top_k=N` from the logged top-N dump limit while actual `sampling_top_k` was infinite | The report implied a bounded sampler even when the sampler could draw from the full distribution | Use `--top-k` for sampler support and `--top-k-dump` only for diagnostic logging |
+| Assume low-probability draw means backend bug | Treated a very unlikely selected token as impossible | Sampling at temperature 1 can draw low-probability in-support tokens | Inspect rank/probability and replay forced alternatives before blaming logits computation |
+| Mistake stop-token artifacts for corruption | Counted special control or stop-token effects as bad model output | The harness boundary, not the model's decoded continuation, caused some suspicious cases | Track stop/control-token status and keep those cases out of true corruption counts |
+
+## Results & Parameters
+
+### Representative Local Finding
+
+A redacted 4B dense-model run with temperature explicitly set to 1, top-k=20, and seed 116 selected an ellipsis-family token around step 90. The selected token was rank 4 at about 0.01% probability while rank 1 was about 75%. After that draw, the next-token distribution flattened into ellipsis and newline variants and the text degenerated. Replaying the divergence while forcing rank-1, rank-2, or rank-3 alternatives kept the continuation readable.
+
+Direct XLLM sweeps showed greedy/top-k=1 removed the observed failures. Top-k=5, top-k=20, and no top-k still had failures. Top-p 0.9 and 0.95 mostly or entirely removed true ellipsis degeneration in the reviewed dense sweep.
+
+### Top-p Sweep Evidence
+
+The following are local issue #257 dense-model manual-review rates across 256 seeds per model where runs completed. Treat them as redacted local evidence, not ProjectMnemosyne CI evidence.
+
+| Sampler | 4B | 7B | 32B | 36B | Notes |
+|---------|----|----|-----|-----|-------|
+| top-p 0.9 | 0/256 | 0/256 | 0/256 | 0/256 | No manually reviewed true bad dense cases where runs completed |
+| top-p 0.95 | 0/256 | 2/256 suspicious | 0/256 | 0/256 | The 7B suspicious cases looked likely to be stop-token artifacts rather than true ellipsis degeneration |
+| top-p 0.99 | 1/256 | 2/256 | 2/256 | 0/256 | Low reviewed true bad rates |
+| top-p 0.999 | 3/256 | 5/256 | 14/256 | 20/256 | Higher reviewed true bad rates as the tail widened |
+
+MoE partial data from the same investigation is revalidation-needed and should not be generalized until dense and MoE runs complete under the same review protocol.
+
+### Config Contract
+
+Use separate flags for sampler behavior and diagnostic visibility:
+
+```text
+--top-k 20        # sampler support: only ranks inside top 20 are eligible
+--top-k-dump 50   # diagnostic dump: log up to 50 alternatives, does not affect sampling
+--top-p 0.95      # sampler support: nucleus threshold
+--temperature 1   # explicit temperature, not an implicit default
+```
+
+Sanity checks for trace/report scripts:
+
+- The emitted report field for sampler support must come from the actual sampling config, not the dump limit.
+- The logged top-N count may exceed sampler support if it is used only for diagnostics.
+- The trace should record selected rank after all active sampler filters.
+- The manual-review label should distinguish true degeneration from formatting fragments and stop/control-token artifacts.
+
+### Review Caveat
+
+Comma-adjacent ellipsis fragments in numeric arrays, including `,...`, `...,`, `,…`, and `…,'`, should not be auto-labeled as corruption. Review decoded context. Meaningful corruption is repeated ellipsis bursts, newline loops, or prompt-framing leakage that persists after the first bad draw.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Redacted issue #257 local scripts and manual review, 2026-07-09 | Dense-model traces and sweeps supported the first-bad-token workflow, forced-alternative replay, top-k/top-p findings, and the sampler-vs-dump caution. MoE partial data remains revalidation-needed. |


### PR DESCRIPTION
## Summary

New skill (v1.0.0).

Documents the end-to-end playbook for driving a stack of 6 dependent PRs through a rebase-merge-only GitHub repo (allow_merge_commit:false, allow_squash_merge:false) using parallel git worktree agents.

- Retarget-first merge ordering: rebase-merge branch deletion CLOSES stacked PRs unrecoverably — retarget every still-open dependent to main before merging anything below it
- `git rebase --onto origin/main <old-base-sha> <branch>` replays only a dependent branch's own commits after its base was rebase-merged with conflict resolutions (avoided full conflict replay twice)
- Committed-conflict-marker incident + preventions: pre-`--continue` gate (`git diff --name-only --diff-filter=U` + `git grep -nE '^(<<<<<<< |>>>>>>> )'`) and a CI guard that deliberately does NOT match bare `=======` (legal markdown setext underline)
- Chronological-additive-union resolution for per-stream registry/doc/__init__/changelog conflicts; regenerate tool-generated reports instead of hand-merging
- Worktree unlock-before-remove, branch verification after chained checkouts, `pull --rebase` main dedupe, gh stale-diff and GraphQL rate-limit quirks

Cross-references adjacent skills: parallel-pr-worktree-workflow (squash-merge orphan variant), pr-rebase-conflict-resolution-patterns, git-rebase-skip-duplicate-merged-commits, github-auto-merge-ci-gating-merge-method.

## Verification Level

**verified-ci**

Every practice was exercised in a real multi-agent session with real CI passes and 6 merged PRs (predictive-coding-mojo).

## Key Findings

**What Worked**:
- Retargeting all open stacked PRs to main before merging the stack base
- `--onto` replay of only the dependent branch's own commits
- Union resolution for files every work-stream touches; regenerating report files
- 45-60s per-PR CI polling with backoff

**What Failed**:
- Merging a stack base with --delete-branch while dependents were still stacked → GitHub closed them unrecoverably
- `git add -A` + `git status --short | head -3` during rebase → committed conflict markers reached main
- Guard matching bare `=======` → false positives on markdown setext underlines
- Tight per-check polling → GraphQL rate-limit exhaustion

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (642/642 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>