### PR TITLE
feat: add resilience-circuit-breaker-per-target-vs-service-failure skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,11 +6,11 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 639,
+  "total_plugins": 641,
   "categories": {
     "architecture": 132,
     "ci-cd": 122,
-    "debugging": 62,
+    "debugging": 64,
     "documentation": 40,
     "evaluation": 12,
     "optimization": 7,
@@ -18,7 +18,7 @@
     "tooling": 174,
     "training": 7
   },
-  "last_updated": "2026-07-09T04:58:32Z",
+  "last_updated": "2026-07-09T17:24:55Z",
   "plugins": [
     {
       "name": "agent-config-validation-and-integrity",
@@ -6235,6 +6235,23 @@
       ]
     },
     {
+      "name": "llm-corruption-repro-artifact-review",
+      "description": "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts.",
+      "version": "1.0.0",
+      "source": "./skills/llm-corruption-repro-artifact-review.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "corruption",
+        "reproducibility",
+        "artifacts",
+        "manual-review",
+        "logits",
+        "tokens",
+        "redaction"
+      ]
+    },
+    {
       "name": "logging-subprocess-context-tracking",
       "description": "Add diagnostic context (working directory, command, cwd) to subprocess execution logging. Use when: (1) run_git_cmd or similar subprocess runners log execution without showing which directory the command ran in, (2) debugging multi-directory workflows where cwd context is critical for tracing, (3) writing tests for subprocess execution and caplog fixture fails with custom logger handlers (propagate=False).",
       "version": "1.0.0",
@@ -6358,6 +6375,24 @@
         "fail-open",
         "argparse",
         "repr-truncation"
+      ]
+    },
+    {
+      "name": "sampling-degeneration-seed-token-debugging",
+      "description": "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support.",
+      "version": "1.0.0",
+      "source": "./skills/sampling-degeneration-seed-token-debugging.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "sampling",
+        "seed",
+        "logits",
+        "top-k",
+        "top-p",
+        "degeneration",
+        "xllm",
+        "issue-257"
       ]
     },
     {

--- a/skills/llm-corruption-repro-artifact-review.md
+++ b/skills/llm-corruption-repro-artifact-review.md
@@ -1,0 +1,165 @@
+---
+name: llm-corruption-repro-artifact-review
+description: "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [llm, corruption, reproducibility, artifacts, manual-review, logits, tokens, redaction]
+---
+
+# LLM Corruption Repro Artifact Review
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Make LLM corruption investigations durable, rerunnable, and reviewable by standardizing per-seed run artifacts and manual-review tooling. |
+| **Outcome** | Store issue-specific scripts, docs, summaries, and review state under a durable repro directory; keep each run self-contained; report corruption rates by seed totals; keep private artifacts out of git or redacted. |
+| **Verification** | verified-local from local Inference360 issue 257 scripts, tests, and PR work. ProjectMnemosyne PR CI is separate and must not be claimed until checks prove it. |
+
+## When to Use
+
+- You are debugging long-running LLM text corruption, output degeneration, cache instability, or token/logit divergence across many seeds.
+- A run must be replayable by another host, cluster, or reviewer without relying on chat history, shell history, or an agent's local session state.
+- You need raw `tokens.jsonl` or `logits.jsonl` from broad sweeps so the same data can support later first-bad-token, prefix-comparison, or force-token intervention analysis.
+- Manual review must label candidate corruption events without losing state, double-counting bursts, or flooding reviewers with per-token dumps by default.
+- You are preparing docs, PRs, issue comments, or repro packages that must redact internal paths, endpoints, checkpoints, prompts, tokens, cookies, and user-specific locations.
+
+## Verified Workflow
+
+Verification status: `verified-local`. The workflow was validated through local Inference360 issue 257 repro scripts/tests and PR work. Do not mark this skill `verified-ci` unless the ProjectMnemosyne PR checks are observed green.
+
+### Quick Reference
+
+```text
+1. Create a durable issue-specific repro root: repro/<issue-id>/.
+2. Put scripts, docs, run directions, summaries, and reviewer tools there.
+3. Emit one self-contained run root per backend/model/config/seed.
+4. Store repro.sh, output.txt or assistant.txt, tokens.jsonl, logits.jsonl,
+   request/config metadata, and summary.json in each run root.
+5. Keep large/private artifacts outside git or replace them with placeholders.
+6. Review with scripts that auto-discover run roots and persist labels.
+7. Report rates as bad seeds / total seeds, not candidate or burst totals.
+```
+
+### Detailed Steps
+
+1. **Create the repro root first.** Use `repro/<issue-id>/` as the durable home for issue-specific scripts, run directions, summaries, reviewer tools, and small sanitized fixtures. Keep large raw artifacts in a private artifact root and reference them with placeholders such as `<REDACTED_ARTIFACT_ROOT>`.
+2. **Make every run self-contained.** Write each seed to a path like `runs/<backend>/<seed>/` or `runs/<model>/<config>/<seed>/`. Each run root should contain `repro.sh`, `output.txt` or `assistant.txt`, `tokens.jsonl`, `logits.jsonl`, `request.json`, `config.json`, and `summary.json`.
+3. **Make `repro.sh` rerunnable.** It should reconstruct one seed independently from explicit metadata, not from chat context, shell state, or untracked environment assumptions. Use placeholders for private endpoints and checkpoints, for example `<REDACTED_ENDPOINT>` and `<REDACTED_CHECKPOINT_PATH>`.
+4. **Capture raw tokens and logits during broad sweeps.** Approach-3 sweeps should preserve raw `tokens.jsonl` and `logits.jsonl` even if the first analysis only needs a binary label. The same files enable later approach-1 and approach-2 work: aggregate failing seeds, find first bad token, compare closest good/bad prefixes, and run force-token interventions.
+5. **Summarize in machine-readable form.** Each `summary.json` should include issue id, backend or model alias, config name, seed, prompt hash, output hash, label, candidate count, first bad token index when known, artifact schema version, and the redacted run-root shape.
+6. **Write processing scripts instead of reading artifacts manually.** Reviewer tools should auto-discover run roots, read summary and JSONL files, and print compact per-model/per-config counts. Per-token dumps should require `--verbose`.
+7. **Persist manual labels.** Store review decisions in a state file such as `review_state.json` so a reviewer can resume, audit who labeled which seed, and avoid re-reviewing the same seed after every script invocation.
+8. **Advance review after labeling one seed.** The loop should move to the next seed once a seed receives a label, but it must inspect all candidate events in a log when the first candidate is benign.
+9. **Review all corruption classes.** Do not hard-code the loop to the first ellipsis-like event. The classifier should allow every candidate class the investigation tracks, including text degeneration, stop/control-token artifacts, repetition bursts, JSON/tool-call corruption, tokenizer artifacts, and backend-specific logit divergence.
+10. **Treat benign ellipsis and control-token artifacts separately.** Comma-adjacent ellipsis fragments that function as array separators are usually benign. Stop-token or control-token renderings should be classified as artifacts unless the surrounding plain text actually degenerates.
+11. **Report seed-level rates.** Use `bad seeds / total seeds (%)` per model and config. Candidate count and burst count can be supporting diagnostics, but they are not the denominator for corruption rate.
+12. **Redact before publishing.** Docs, PRs, issue comments, and committed repro files must not include internal absolute paths, endpoint addresses, checkpoint names, private prompts, token-bearing artifacts, cookies, or user-specific locations. Keep shape with placeholders such as `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Candidate-count denominator | Counted corruption candidates or bursts instead of seeds | Burst totals made the rate look like a complete sample, for example reporting `2/2` reviewed bad cases instead of `2/256` seed rate | Always report `bad seeds / total seeds (%)`; keep candidate and burst counts as secondary diagnostics |
+| First-candidate-only review | Stopped after the first candidate event in each log | A benign first candidate hid later real corruption events in the same seed output | When the first candidate is benign, continue scanning every candidate event before labeling the seed clean |
+| Noisy default token dump | Printed every token/logit line during normal review | Reviewers could not scan model/config rates or labeling progress efficiently | Default to compact summaries; require `--verbose` for per-token dumps |
+| Manual artifact reading | Opened run logs by hand and labeled from ad hoc notes | Labels were hard to resume, audit, or reproduce, and later reviewers could not tell what had been reviewed | Build review scripts with auto-discovery, persistent state, and deterministic summaries |
+| Dropped raw sweep data | Kept only final text or binary labels from approach-3 sweeps | Later first-bad-token, prefix comparison, and force-token intervention analyses had to rerun expensive seeds | Preserve raw `tokens.jsonl` and `logits.jsonl` for every relevant seed |
+| Checked-in raw operations | Committed run artifacts without masking paths, endpoints, checkpoints, prompts, or token-bearing files | Durable repo artifacts can leak operational details even when docs are sanitized | Keep raw artifacts private, commit only sanitized scripts/summaries, and scan files before PRs/issues |
+| Ellipsis/control-token false positive | Treated comma-adjacent ellipsis fragments or stop/control-token renderings as text corruption | Parser and formatting artifacts inflated the corruption count | Add benign classifications for separator ellipses and control-token artifacts; require surrounding text degeneration for a bad label |
+
+## Results & Parameters
+
+### Durable Layout
+
+```text
+repro/<issue-id>/
+  README.md
+  run_sweep.py
+  review_corruption.py
+  summarize_runs.py
+  review_state.json
+  summaries/
+    latest.json
+    latest.md
+  runs/
+    <backend>/<seed>/
+      repro.sh
+      output.txt
+      assistant.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+    <model>/<config>/<seed>/
+      repro.sh
+      output.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+```
+
+### Per-Run Contract
+
+| Artifact | Purpose |
+|----------|---------|
+| `repro.sh` | Replays exactly one seed from explicit metadata and redacted placeholders |
+| `output.txt` or `assistant.txt` | Human-readable model output for quick review |
+| `tokens.jsonl` | Token IDs, text fragments, offsets, stop/control-token indicators, and candidate markers |
+| `logits.jsonl` | Raw or summarized logits needed for first-bad-token and prefix-comparison analysis |
+| `request.json` | Sanitized request shape, prompt hash, seed, sampling settings, and model/config alias |
+| `config.json` | Backend, model alias, artifact schema version, runtime flags, and redacted artifact-root shape |
+| `summary.json` | Machine-readable label, counts, hashes, first bad token index, and reviewer metadata |
+
+### Review Script Contract
+
+```text
+review_corruption.py --root repro/<issue-id>
+review_corruption.py --root repro/<issue-id> --model <model-alias> --config <config-name>
+review_corruption.py --root repro/<issue-id> --verbose
+summarize_runs.py --root repro/<issue-id> --by model,config
+```
+
+Expected summary shape:
+
+```text
+model=<model-alias> config=<config-name> bad=2/256 (0.78%) reviewed=256/256
+model=<model-alias> config=<other-config> bad=0/256 (0.00%) reviewed=256/256
+```
+
+State file shape:
+
+```json
+{
+  "schema_version": 1,
+  "labels": {
+    "<model>/<config>/<seed>": {
+      "label": "bad",
+      "class": "text-degeneration",
+      "reviewed_at": "2026-07-09T00:00:00Z",
+      "notes": "First non-benign degeneration after a benign separator ellipsis."
+    }
+  }
+}
+```
+
+### Redaction Checklist
+
+- Replace private artifact roots with `<REDACTED_ARTIFACT_ROOT>`.
+- Replace endpoints with `<REDACTED_ENDPOINT>`.
+- Replace checkpoint or tokenizer paths with `<REDACTED_CHECKPOINT_PATH>`.
+- Do not publish private prompts, token-bearing artifacts, cookies, bearer tokens, user-specific locations, hostnames, ports, or absolute infrastructure paths.
+- Keep examples structural, for example `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`, without exposing real operational values.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Issue 257 local corruption investigation scripts/tests and PR work | Durable per-run repro layout, raw token/logit capture, review-state tooling, seed-level rate reporting, and redaction rules were validated locally. Verification is `verified-local`, not `verified-ci`, until the ProjectMnemosyne PR checks prove this skill file. |

--- a/skills/resilience-circuit-breaker-per-target-vs-service-failure.md
+++ b/skills/resilience-circuit-breaker-per-target-vs-service-failure.md
@@ -1,0 +1,188 @@
+---
+name: resilience-circuit-breaker-per-target-vs-service-failure
+description: "A circuit breaker must not count 'the service answered correctly about one target' errors (404, could-not-resolve, no-checks) as failures — split per-target errors from per-credential errors, add a generic ignore predicate, and ANCHOR the classifying regexes or you fail OPEN. Use when: (1) adding or reviewing a circuit breaker that shells out to a CLI/HTTP service, (2) a handful of deterministic 404-style errors is opening a breaker and failing unrelated calls, (3) porting a retry (non-transient) classifier into a breaker (service-down) classifier."
+category: architecture
+date: 2026-07-10
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - circuit-breaker
+  - resilience
+  - fail-open
+  - error-classification
+  - regex-anchoring
+---
+
+# Resilience: Per-Target vs Service Failure in a Circuit Breaker
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-10 |
+| **Objective** | Stop a circuit breaker from counting "the service answered correctly about one specific target" errors (HTTP 404, could-not-resolve, no-checks-reported) toward its failure threshold, so a handful of deterministic per-target errors can no longer open the breaker and fail every unrelated call behind it (the #1795 cascade). |
+| **Outcome** | Successful. Added a generic keyword-only `ignore` predicate to `CircuitBreaker`; GitHub-specific anchored patterns live in the client. Fixed a CRITICAL fail-open hole found by strict review (bare `not found` matched real outages). PR #2049 merged to ProjectHephaestus main, all CI green. |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- You are adding, or reviewing, a circuit breaker that fronts a service reached via a CLI or HTTP call whose errors mix "service is down" with "service is up and told me about a specific target."
+- A small number of deterministic errors (a missing issue, a 404) is opening a breaker and then failing unrelated calls that share it.
+- You are tempted to copy a retry classifier's "is this non-transient?" regexes into a breaker's "is the service down?" classifier — they tolerate error in OPPOSITE directions and this port is a fail-open.
+- You are tempted to "just record a success on 404" to keep the breaker closed — this masks a real outage building underneath.
+- You are writing or reviewing a HALF_OPEN test and need to know why a `state is HALF_OPEN` assertion cannot fail.
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# GENERIC layer (resilience/circuit_breaker.py): optional, keyword-only.
+class CircuitBreaker:
+    def __init__(self, *, ignore: Callable[[BaseException], bool] | None = None, ...):
+        self._ignore = ignore
+
+    def call(self, fn, *a, **k):
+        self._enter()  # may consume a HALF_OPEN probe slot
+        try:
+            result = fn(*a, **k)
+        except BaseException as exc:
+            if self._ignore is not None and self._ignore(exc):
+                self._release_half_open_slot()  # MUST release, or slots leak
+                raise                            # re-raise: NOT failure, NOT success
+            self._record_failure()
+            raise
+        else:
+            self._record_success()
+            return result
+```
+
+```python
+# DOMAIN layer (github/client.py): anchored, service-specific patterns.
+# Per-TARGET (service answered correctly about one target) -> DO NOT open breaker:
+_PER_TARGET = re.compile(
+    r"HTTP 404"
+    r"|could not resolve to (an )?(issue|pull ?request)"  # note: pull ?request
+    r"|Expected VALUE, actual: UNKNOWN_CHAR"              # anchored, not bare "Parse error"
+    r"|Body is not editable"
+    r"|no checks reported on the",
+    re.IGNORECASE,
+)
+# Per-CREDENTIAL (401/403/token-scope/400/422) is DELIBERATELY EXCLUDED here:
+# it recurs on every call, so it SHOULD open the breaker (fail fast).
+gh_breaker = get_circuit_breaker("gh", ignore=lambda e: bool(_PER_TARGET.search(str(e))))
+```
+
+### Detailed Steps
+
+1. **Name the two questions and keep them separate.** "Non-transient?" is a RETRY
+   question (should we retry?). "Service down?" is a BREAKER question (is the target
+   unavailable?). They are not the same predicate and must not share one regex set.
+2. **Add a generic `ignore` predicate to the breaker** (resilience layer), keyword-only,
+   defaulting to `None`. A matched exception is re-raised but recorded as NEITHER
+   failure NOR success. Other breaker consumers pass nothing and are unaffected.
+3. **Put the service-specific anchored patterns in the domain client**, not in the
+   generic breaker. Keep the resilience layer ignorant of GitHub.
+4. **Anchor every per-target pattern** to the service's ACTUAL per-target rendering
+   (`HTTP 404`, `could not resolve to ...`, `no checks reported on the`). Never use a
+   bare substring like `not found` or `Parse error` (see Failed Attempts).
+5. **Classify per-credential errors as service failures** (401/403/token-scope/400/422):
+   they recur on every call, so failing fast via the breaker is correct. Do NOT add
+   them to the ignore set.
+6. **Release the HALF_OPEN probe slot** on an ignored exception, or a burst of ignored
+   errors leaks slots and wedges the breaker in HALF_OPEN.
+7. **Run the adversarial-string check and the mutation test** (Results & Parameters)
+   before claiming the classifier is safe.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Copy retry regexes into the breaker | Reused the retry classifier's non-transient patterns verbatim as the breaker's ignore set | CRITICAL fail-open. Bare `not found` matched `gh: command not found` (CLI missing), `ssh: Could not resolve hostname github.com: ... not found` (DNS failure), and `GitHub is temporarily unavailable. Page not found.` (outage page). Bare `Parse error` matched a truncated 502 HTML body fed to a JSON parser. All of these mean the service IS down, yet they were excluded from the breaker. | Over-matching is SAFE in a retry classifier (you just skip a retry) but UNSAFE in a breaker classifier (you blind it to a real outage). Anchor per-target patterns to the service's exact renderings. |
+| Record a success on 404 | "Naive fix": on an ignored per-target error, call `record_success()` to keep the breaker closed | A success ZEROES the accumulating failure count, masking a genuine outage building underneath. | An ignored error is NEITHER failure NOR success. Do not record either. |
+| Forget the HALF_OPEN slot | Ignored exceptions re-raised but the consumed HALF_OPEN probe slot was never released | A burst of ignored errors leaks slots; the next probe hits HALF_OPEN_EXHAUSTED and the breaker wedges in HALF_OPEN. | Releasing the probe slot on an ignored exception is part of "ignore," not an optimization. |
+| Assert only `state is HALF_OPEN` | HALF_OPEN test asserted the breaker state was unchanged after an ignored exception | The state doesn't change whether or not the slot was released, so the test CANNOT FAIL. Mutation test: neuter `_release_half_open_slot` to `pass` — the test stays green while the slot leaks. | Assert the slot is RETURNED: with `half_open_max_calls=1`, admit a LATER probe through the single slot and assert `_half_open_calls == 0`. Test the behaviour, not the unobservable state. |
+| Assert subset on regex source strings | Verified the invariant by set-comparing `.pattern` strings of the per-target vs non-transient regexes | Breaks the moment you correctly NARROW a pattern, and never proved the semantic implication anyway. | Assert the invariant on BEHAVIOUR against real stderr samples: "anything classified per-target must also be non-transient." Not a `.pattern` set comparison. |
+| Re-register breaker with a new predicate | Called `get_circuit_breaker("gh", ignore=...)` a second time for an already-registered name | `get_circuit_breaker` is a singleton-per-NAME registry; the second call SILENTLY DISCARDS the `ignore` predicate and returns the existing instance. | Document the footgun and pin it with a test. Wire the predicate at first construction. |
+| `pull request` with a space | A prior fix (#1806) matched the GraphQL type as `pull request` | gh emits the type name as `PullRequest` (no space) for a missing PR, so the pattern missed and the call was retried 6x. | Use `pull ?request` in both the retry and breaker patterns to tolerate both renderings. |
+
+## Results & Parameters
+
+**Adversarial-string check** — every string below means the SERVICE IS DOWN and MUST
+be classified as a failure (i.e. the ignore predicate must return `False`). Run this
+against your final anchored predicate; the naive bare-`not found` version fails it:
+
+```python
+import re
+
+PER_TARGET = re.compile(
+    r"HTTP 404"
+    r"|could not resolve to (an )?(issue|pull ?request)"
+    r"|Expected VALUE, actual: UNKNOWN_CHAR"
+    r"|Body is not editable"
+    r"|no checks reported on the",
+    re.IGNORECASE,
+)
+is_per_target = lambda s: bool(PER_TARGET.search(s))
+
+SERVICE_DOWN = [
+    "gh: command not found",                                             # CLI missing
+    "ssh: Could not resolve hostname github.com: Name or service not found",  # DNS
+    "GitHub is temporarily unavailable. Page not found.",                # outage page
+    "<html><title>502 Bad Gateway</title> Parse error: unexpected <",    # truncated 502
+    "HTTP 401: Bad credentials",                                         # per-credential
+    "HTTP 403: token scope insufficient",                               # per-credential
+    "HTTP 422: Validation Failed",                                       # per-credential
+]
+leaked = [s for s in SERVICE_DOWN if is_per_target(s)]
+assert not leaked, f"FAIL-OPEN: breaker would ignore real outages: {leaked}"
+
+PER_TARGET_OK = [
+    "GraphQL: Could not resolve to an Issue with the number 999 (repository.issue)",
+    "GraphQL: Could not resolve to a PullRequest with the number 42",
+    "gh: HTTP 404: Not Found (https://api.github.com/repos/x/y/issues/1)",
+    "no checks reported on the 'abc123' ref",
+    "Body is not editable",
+]
+missed = [s for s in PER_TARGET_OK if not is_per_target(s)]
+assert not missed, f"per-target errors misclassified as service-down: {missed}"
+print("adversarial-string check PASSED")
+```
+
+**Mutation test for the HALF_OPEN slot release** — proves the test can actually fail.
+A `state is HALF_OPEN` assertion survives this mutation; the slot-return assertion does not:
+
+```python
+def test_ignored_exception_releases_half_open_slot():
+    # Single probe slot so a leak is observable.
+    cb = CircuitBreaker(name="t", failure_threshold=1, half_open_max_calls=1,
+                        ignore=lambda e: isinstance(e, PerTargetError))
+    cb._force_open_then_half_open()  # drive to HALF_OPEN in your test harness
+
+    # First probe raises an IGNORED exception -> must RELEASE the slot.
+    with pytest.raises(PerTargetError):
+        cb.call(lambda: (_ for _ in ()).throw(PerTargetError("HTTP 404")))
+
+    # If the slot was released, a LATER probe is admitted through the single slot.
+    assert cb._half_open_calls == 0            # slot returned
+    assert cb.call(lambda: "ok") == "ok"       # later probe admitted
+    # Mutation: replace _release_half_open_slot body with `pass`.
+    #   -> _half_open_calls stays 1, the later probe is rejected -> THIS TEST FAILS.
+    #   A test asserting only `cb.state is HALF_OPEN` stays GREEN under that mutation.
+```
+
+**Layering contract:**
+
+- Generic `ignore` predicate lives in `resilience/circuit_breaker.py` — no GitHub knowledge.
+- Anchored per-target patterns live in `github/client.py`.
+- Per-credential errors (401/403/token-scope/400/422) are EXCLUDED from ignore — they
+  correctly open the breaker.
+- Import-time `ignore=<name>` requires the predicate be DEFINED ABOVE the breaker
+  construction (see companion import-order skill).
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #2049 (merged, all CI green); `hephaestus/github/client.py` + `hephaestus/resilience/circuit_breaker.py`. Fail-open hole and fix both reproduced with runnable scripts and mutation-tested. Companion to the #1795 cascade skill. | verified-ci |

--- a/skills/sampling-degeneration-seed-token-debugging.md
+++ b/skills/sampling-degeneration-seed-token-debugging.md
@@ -1,0 +1,141 @@
+---
+name: sampling-degeneration-seed-token-debugging
+description: "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - llm
+  - sampling
+  - seed
+  - logits
+  - top-k
+  - top-p
+  - degeneration
+  - xllm
+  - issue-257
+---
+
+# Sampling Degeneration Seed Token Debugging
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Diagnose LLM garbled output when matched runs differ only by seed, and separate bad random draws from prompt, weight, tokenizer, backend, or deterministic-forward differences. |
+| **Outcome** | Successful locally. The useful pivot was asking why seed mattered: seed changes the random draw from the next-token distribution, not the prompt, weights, tokenizer, or deterministic forward pass. That moved the investigation from whole-trace comparison to the first bad sampled token in one trace. |
+| **Verification** | verified-local. Evidence came from redacted Inference360 issue #257 scripts, dense-model sweeps, direct XLLM checks, and manual review. ProjectMnemosyne CI validation is pending for this skill PR. |
+
+## When to Use
+
+- The same model, prompt, backend, tokenizer, and generation config produce readable output for one seed and garbled output for another.
+- A generation degenerates into repeated ellipsis, newline loops, prompt-framing leakage, or similar hard corruption after an apparently valid prefix.
+- You need to decide whether top-k, top-p, greedy, temperature, or stop-token behavior is changing the actual sampler support.
+- A trace-diff approach is producing too much noise and not explaining why a specific seed fails.
+- A script reports `top_k=N`, but there is any chance `N` is only the top-N dump/reporting limit instead of the sampler's support.
+
+## Verified Workflow
+
+Verified locally only through redacted Inference360 issue #257 scripts and manual review. Do not claim verified-ci until this skill PR's `validate` and `markdownlint` checks pass.
+
+### Quick Reference
+
+```bash
+# Capture a per-step trace for one failing seed.
+python <trace-script>.py \
+  --model <model-id> \
+  --prompt-file <REDACTED_PROMPT_FILE> \
+  --seed 116 \
+  --temperature 1 \
+  --top-k 20 \
+  --top-k-dump 50 \
+  --output <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl
+
+# Inspect the selected token rank and probability near the first hard-corruption step.
+python <analyze-trace-script>.py \
+  <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --window 80:100 \
+  --top-n 20
+
+# Replay the divergence step by forcing plausible alternatives.
+python <force-token-script>.py \
+  --trace <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --force-step 90 \
+  --force-rank 1,2,3,4 \
+  --output <REDACTED_ARTIFACT_ROOT>/forced-alternatives.jsonl
+```
+
+### Detailed Steps
+
+1. **Ask why seed matters before comparing whole traces.** With the same prompt, weights, backend, tokenizer, and generation config, seed should only affect random sampling from the next-token distribution. It should not change the deterministic forward pass. This narrows the first question to: which sampled token draw sent the trace into a bad basin?
+2. **Collect per-step token evidence.** For each generated step, log the selected token id/text, selected rank, selected probability, logits or post-filter probabilities, top-N alternatives, active sampler config, stop/control-token flags, and the decoded prefix.
+3. **Stop at the first hard-corruption token.** Do not start by explaining every downstream token. Find the first selected token after which the continuation becomes repeated ellipsis/newline variants, prompt-framing leakage, or another stable corruption pattern.
+4. **Inspect selected rank and nearby alternatives.** A low-probability selected token can be a valid sampler draw even when rank 1 is overwhelmingly more likely. The key diagnostic is whether the selected token was inside the configured sampler support and whether higher-ranked alternatives preserve readable continuation.
+5. **Force plausible alternatives at the divergence step.** Replay from the same prefix while forcing rank-1, rank-2, rank-3, and the originally selected token. If the top alternatives stay readable and the original draw degenerates, the corruption is primarily a sampling-tail trajectory, not a whole-trace backend mismatch.
+6. **Sweep sampler support deliberately.** Compare greedy or top-k=1, small top-k, larger top-k, no top-k, and top-p thresholds such as 0.9, 0.95, 0.99, and 0.999. Keep dense-model and MoE results separate, and label partial MoE data as revalidation-needed.
+7. **Separate sampler controls from diagnostic dumps.** `--top-k` should control sampler support. A separate `--top-k-dump` or `--top-n-dump` should only limit the logged alternatives. Logs must print both actual sampler support and dump size.
+8. **Manually review labels.** Do not auto-label every newline or comma-adjacent ellipsis fragment as corruption. Repeated ellipsis bursts, newline loops, and prompt-framing leakage are the meaningful class. Numeric-array fragments such as `,...`, `...,`, `,…`, or `…,'` can be benign formatting artifacts and need context.
+9. **Treat stop/control-token artifacts separately.** If a suspicious case is caused by a special stop/control token or a harness stop condition, record it as an artifact unless the decoded continuation itself demonstrates model-output corruption.
+10. **Record verification honestly.** Local sweeps and manual review support `verified-local`. Only mark `verified-ci` when the skill PR's validation gates are observed green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Compare whole good/bad traces first | Diffed two generations that differed only by seed | The diff grew after divergence and obscured the causal draw | Ask what seed changes, then stop at the first bad sampled token in one failing trace |
+| Treat newline spam alone as corruption | Counted newline-heavy output as bad without reviewing decoded context | Some newline behavior was prompt or formatting related, not hard model degeneration | Label repeated ellipsis bursts, newline loops, and prompt-framing leakage; manually review ambiguous cases |
+| Use top-k dump count as sampler top-k | A script reported `top_k=N` from the logged top-N dump limit while actual `sampling_top_k` was infinite | The report implied a bounded sampler even when the sampler could draw from the full distribution | Use `--top-k` for sampler support and `--top-k-dump` only for diagnostic logging |
+| Assume low-probability draw means backend bug | Treated a very unlikely selected token as impossible | Sampling at temperature 1 can draw low-probability in-support tokens | Inspect rank/probability and replay forced alternatives before blaming logits computation |
+| Mistake stop-token artifacts for corruption | Counted special control or stop-token effects as bad model output | The harness boundary, not the model's decoded continuation, caused some suspicious cases | Track stop/control-token status and keep those cases out of true corruption counts |
+
+## Results & Parameters
+
+### Representative Local Finding
+
+A redacted 4B dense-model run with temperature explicitly set to 1, top-k=20, and seed 116 selected an ellipsis-family token around step 90. The selected token was rank 4 at about 0.01% probability while rank 1 was about 75%. After that draw, the next-token distribution flattened into ellipsis and newline variants and the text degenerated. Replaying the divergence while forcing rank-1, rank-2, or rank-3 alternatives kept the continuation readable.
+
+Direct XLLM sweeps showed greedy/top-k=1 removed the observed failures. Top-k=5, top-k=20, and no top-k still had failures. Top-p 0.9 and 0.95 mostly or entirely removed true ellipsis degeneration in the reviewed dense sweep.
+
+### Top-p Sweep Evidence
+
+The following are local issue #257 dense-model manual-review rates across 256 seeds per model where runs completed. Treat them as redacted local evidence, not ProjectMnemosyne CI evidence.
+
+| Sampler | 4B | 7B | 32B | 36B | Notes |
+|---------|----|----|-----|-----|-------|
+| top-p 0.9 | 0/256 | 0/256 | 0/256 | 0/256 | No manually reviewed true bad dense cases where runs completed |
+| top-p 0.95 | 0/256 | 2/256 suspicious | 0/256 | 0/256 | The 7B suspicious cases looked likely to be stop-token artifacts rather than true ellipsis degeneration |
+| top-p 0.99 | 1/256 | 2/256 | 2/256 | 0/256 | Low reviewed true bad rates |
+| top-p 0.999 | 3/256 | 5/256 | 14/256 | 20/256 | Higher reviewed true bad rates as the tail widened |
+
+MoE partial data from the same investigation is revalidation-needed and should not be generalized until dense and MoE runs complete under the same review protocol.
+
+### Config Contract
+
+Use separate flags for sampler behavior and diagnostic visibility:
+
+```text
+--top-k 20        # sampler support: only ranks inside top 20 are eligible
+--top-k-dump 50   # diagnostic dump: log up to 50 alternatives, does not affect sampling
+--top-p 0.95      # sampler support: nucleus threshold
+--temperature 1   # explicit temperature, not an implicit default
+```
+
+Sanity checks for trace/report scripts:
+
+- The emitted report field for sampler support must come from the actual sampling config, not the dump limit.
+- The logged top-N count may exceed sampler support if it is used only for diagnostics.
+- The trace should record selected rank after all active sampler filters.
+- The manual-review label should distinguish true degeneration from formatting fragments and stop/control-token artifacts.
+
+### Review Caveat
+
+Comma-adjacent ellipsis fragments in numeric arrays, including `,...`, `...,`, `,…`, and `…,'`, should not be auto-labeled as corruption. Review decoded context. Meaningful corruption is repeated ellipsis bursts, newline loops, or prompt-framing leakage that persists after the first bad draw.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Redacted issue #257 local scripts and manual review, 2026-07-09 | Dense-model traces and sweeps supported the first-bad-token workflow, forced-alternative replay, top-k/top-p findings, and the sampler-vs-dump caution. MoE partial data remains revalidation-needed. |


### PR DESCRIPTION
## Summary

New skill. A circuit breaker must not count "the service answered correctly about one specific target" errors (HTTP 404, could-not-resolve, no-checks-reported) toward its failure threshold — otherwise a handful of deterministic per-target errors open the breaker and fail every unrelated call behind it (the #1795 cascade).

- Split per-TARGET errors (service is up, answered about one target) from per-CREDENTIAL errors (401/403/400/422 — recur on every call, SHOULD open the breaker).
- Add a generic keyword-only `ignore` predicate to `CircuitBreaker`; a matched exception is re-raised but recorded as NEITHER failure NOR success, and RELEASES its HALF_OPEN probe slot.
- ANCHOR the classifying regexes to the service's real renderings — porting a retry (non-transient) classifier's bare `not found` into a breaker (service-down) classifier is a CRITICAL fail-open.

## Verification Level

**verified-ci** — ProjectHephaestus PR #2049 merged to main, all CI green. The fail-open hole and the fix were both reproduced with runnable scripts and mutation-tested.

## Key Findings

**What Worked**:
- Generic `ignore` predicate in the resilience layer; anchored GitHub-specific patterns in the client.
- Behaviour-based tests: assert the HALF_OPEN slot is returned (later probe admitted) and assert the per-target-implies-non-transient invariant against real stderr samples.

**What Failed**:
- Copying retry regexes verbatim into the breaker → bare `not found` / `Parse error` matched real outages (missing CLI, DNS failure, 502 page) → fail-open.
- Recording a success on 404 → zeroes the accumulating failure count, masks a genuine outage.
- Forgetting to release the HALF_OPEN slot → slots leak, breaker wedges in HALF_OPEN.
- Asserting only `state is HALF_OPEN` → test cannot fail (survives neutering `_release_half_open_slot`).

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (642/642 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>