### PR TITLE
feat: add python-import-time-forward-reference-lambda-guard skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,11 +6,11 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 639,
+  "total_plugins": 641,
   "categories": {
     "architecture": 132,
     "ci-cd": 122,
-    "debugging": 62,
+    "debugging": 64,
     "documentation": 40,
     "evaluation": 12,
     "optimization": 7,
@@ -18,7 +18,7 @@
     "tooling": 174,
     "training": 7
   },
-  "last_updated": "2026-07-09T04:58:32Z",
+  "last_updated": "2026-07-09T17:24:55Z",
   "plugins": [
     {
       "name": "agent-config-validation-and-integrity",
@@ -6235,6 +6235,23 @@
       ]
     },
     {
+      "name": "llm-corruption-repro-artifact-review",
+      "description": "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts.",
+      "version": "1.0.0",
+      "source": "./skills/llm-corruption-repro-artifact-review.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "corruption",
+        "reproducibility",
+        "artifacts",
+        "manual-review",
+        "logits",
+        "tokens",
+        "redaction"
+      ]
+    },
+    {
       "name": "logging-subprocess-context-tracking",
       "description": "Add diagnostic context (working directory, command, cwd) to subprocess execution logging. Use when: (1) run_git_cmd or similar subprocess runners log execution without showing which directory the command ran in, (2) debugging multi-directory workflows where cwd context is critical for tracing, (3) writing tests for subprocess execution and caplog fixture fails with custom logger handlers (propagate=False).",
       "version": "1.0.0",
@@ -6358,6 +6375,24 @@
         "fail-open",
         "argparse",
         "repr-truncation"
+      ]
+    },
+    {
+      "name": "sampling-degeneration-seed-token-debugging",
+      "description": "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support.",
+      "version": "1.0.0",
+      "source": "./skills/sampling-degeneration-seed-token-debugging.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "sampling",
+        "seed",
+        "logits",
+        "top-k",
+        "top-p",
+        "degeneration",
+        "xllm",
+        "issue-257"
       ]
     },
     {

--- a/skills/llm-corruption-repro-artifact-review.md
+++ b/skills/llm-corruption-repro-artifact-review.md
@@ -1,0 +1,165 @@
+---
+name: llm-corruption-repro-artifact-review
+description: "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [llm, corruption, reproducibility, artifacts, manual-review, logits, tokens, redaction]
+---
+
+# LLM Corruption Repro Artifact Review
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Make LLM corruption investigations durable, rerunnable, and reviewable by standardizing per-seed run artifacts and manual-review tooling. |
+| **Outcome** | Store issue-specific scripts, docs, summaries, and review state under a durable repro directory; keep each run self-contained; report corruption rates by seed totals; keep private artifacts out of git or redacted. |
+| **Verification** | verified-local from local Inference360 issue 257 scripts, tests, and PR work. ProjectMnemosyne PR CI is separate and must not be claimed until checks prove it. |
+
+## When to Use
+
+- You are debugging long-running LLM text corruption, output degeneration, cache instability, or token/logit divergence across many seeds.
+- A run must be replayable by another host, cluster, or reviewer without relying on chat history, shell history, or an agent's local session state.
+- You need raw `tokens.jsonl` or `logits.jsonl` from broad sweeps so the same data can support later first-bad-token, prefix-comparison, or force-token intervention analysis.
+- Manual review must label candidate corruption events without losing state, double-counting bursts, or flooding reviewers with per-token dumps by default.
+- You are preparing docs, PRs, issue comments, or repro packages that must redact internal paths, endpoints, checkpoints, prompts, tokens, cookies, and user-specific locations.
+
+## Verified Workflow
+
+Verification status: `verified-local`. The workflow was validated through local Inference360 issue 257 repro scripts/tests and PR work. Do not mark this skill `verified-ci` unless the ProjectMnemosyne PR checks are observed green.
+
+### Quick Reference
+
+```text
+1. Create a durable issue-specific repro root: repro/<issue-id>/.
+2. Put scripts, docs, run directions, summaries, and reviewer tools there.
+3. Emit one self-contained run root per backend/model/config/seed.
+4. Store repro.sh, output.txt or assistant.txt, tokens.jsonl, logits.jsonl,
+   request/config metadata, and summary.json in each run root.
+5. Keep large/private artifacts outside git or replace them with placeholders.
+6. Review with scripts that auto-discover run roots and persist labels.
+7. Report rates as bad seeds / total seeds, not candidate or burst totals.
+```
+
+### Detailed Steps
+
+1. **Create the repro root first.** Use `repro/<issue-id>/` as the durable home for issue-specific scripts, run directions, summaries, reviewer tools, and small sanitized fixtures. Keep large raw artifacts in a private artifact root and reference them with placeholders such as `<REDACTED_ARTIFACT_ROOT>`.
+2. **Make every run self-contained.** Write each seed to a path like `runs/<backend>/<seed>/` or `runs/<model>/<config>/<seed>/`. Each run root should contain `repro.sh`, `output.txt` or `assistant.txt`, `tokens.jsonl`, `logits.jsonl`, `request.json`, `config.json`, and `summary.json`.
+3. **Make `repro.sh` rerunnable.** It should reconstruct one seed independently from explicit metadata, not from chat context, shell state, or untracked environment assumptions. Use placeholders for private endpoints and checkpoints, for example `<REDACTED_ENDPOINT>` and `<REDACTED_CHECKPOINT_PATH>`.
+4. **Capture raw tokens and logits during broad sweeps.** Approach-3 sweeps should preserve raw `tokens.jsonl` and `logits.jsonl` even if the first analysis only needs a binary label. The same files enable later approach-1 and approach-2 work: aggregate failing seeds, find first bad token, compare closest good/bad prefixes, and run force-token interventions.
+5. **Summarize in machine-readable form.** Each `summary.json` should include issue id, backend or model alias, config name, seed, prompt hash, output hash, label, candidate count, first bad token index when known, artifact schema version, and the redacted run-root shape.
+6. **Write processing scripts instead of reading artifacts manually.** Reviewer tools should auto-discover run roots, read summary and JSONL files, and print compact per-model/per-config counts. Per-token dumps should require `--verbose`.
+7. **Persist manual labels.** Store review decisions in a state file such as `review_state.json` so a reviewer can resume, audit who labeled which seed, and avoid re-reviewing the same seed after every script invocation.
+8. **Advance review after labeling one seed.** The loop should move to the next seed once a seed receives a label, but it must inspect all candidate events in a log when the first candidate is benign.
+9. **Review all corruption classes.** Do not hard-code the loop to the first ellipsis-like event. The classifier should allow every candidate class the investigation tracks, including text degeneration, stop/control-token artifacts, repetition bursts, JSON/tool-call corruption, tokenizer artifacts, and backend-specific logit divergence.
+10. **Treat benign ellipsis and control-token artifacts separately.** Comma-adjacent ellipsis fragments that function as array separators are usually benign. Stop-token or control-token renderings should be classified as artifacts unless the surrounding plain text actually degenerates.
+11. **Report seed-level rates.** Use `bad seeds / total seeds (%)` per model and config. Candidate count and burst count can be supporting diagnostics, but they are not the denominator for corruption rate.
+12. **Redact before publishing.** Docs, PRs, issue comments, and committed repro files must not include internal absolute paths, endpoint addresses, checkpoint names, private prompts, token-bearing artifacts, cookies, or user-specific locations. Keep shape with placeholders such as `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Candidate-count denominator | Counted corruption candidates or bursts instead of seeds | Burst totals made the rate look like a complete sample, for example reporting `2/2` reviewed bad cases instead of `2/256` seed rate | Always report `bad seeds / total seeds (%)`; keep candidate and burst counts as secondary diagnostics |
+| First-candidate-only review | Stopped after the first candidate event in each log | A benign first candidate hid later real corruption events in the same seed output | When the first candidate is benign, continue scanning every candidate event before labeling the seed clean |
+| Noisy default token dump | Printed every token/logit line during normal review | Reviewers could not scan model/config rates or labeling progress efficiently | Default to compact summaries; require `--verbose` for per-token dumps |
+| Manual artifact reading | Opened run logs by hand and labeled from ad hoc notes | Labels were hard to resume, audit, or reproduce, and later reviewers could not tell what had been reviewed | Build review scripts with auto-discovery, persistent state, and deterministic summaries |
+| Dropped raw sweep data | Kept only final text or binary labels from approach-3 sweeps | Later first-bad-token, prefix comparison, and force-token intervention analyses had to rerun expensive seeds | Preserve raw `tokens.jsonl` and `logits.jsonl` for every relevant seed |
+| Checked-in raw operations | Committed run artifacts without masking paths, endpoints, checkpoints, prompts, or token-bearing files | Durable repo artifacts can leak operational details even when docs are sanitized | Keep raw artifacts private, commit only sanitized scripts/summaries, and scan files before PRs/issues |
+| Ellipsis/control-token false positive | Treated comma-adjacent ellipsis fragments or stop/control-token renderings as text corruption | Parser and formatting artifacts inflated the corruption count | Add benign classifications for separator ellipses and control-token artifacts; require surrounding text degeneration for a bad label |
+
+## Results & Parameters
+
+### Durable Layout
+
+```text
+repro/<issue-id>/
+  README.md
+  run_sweep.py
+  review_corruption.py
+  summarize_runs.py
+  review_state.json
+  summaries/
+    latest.json
+    latest.md
+  runs/
+    <backend>/<seed>/
+      repro.sh
+      output.txt
+      assistant.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+    <model>/<config>/<seed>/
+      repro.sh
+      output.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+```
+
+### Per-Run Contract
+
+| Artifact | Purpose |
+|----------|---------|
+| `repro.sh` | Replays exactly one seed from explicit metadata and redacted placeholders |
+| `output.txt` or `assistant.txt` | Human-readable model output for quick review |
+| `tokens.jsonl` | Token IDs, text fragments, offsets, stop/control-token indicators, and candidate markers |
+| `logits.jsonl` | Raw or summarized logits needed for first-bad-token and prefix-comparison analysis |
+| `request.json` | Sanitized request shape, prompt hash, seed, sampling settings, and model/config alias |
+| `config.json` | Backend, model alias, artifact schema version, runtime flags, and redacted artifact-root shape |
+| `summary.json` | Machine-readable label, counts, hashes, first bad token index, and reviewer metadata |
+
+### Review Script Contract
+
+```text
+review_corruption.py --root repro/<issue-id>
+review_corruption.py --root repro/<issue-id> --model <model-alias> --config <config-name>
+review_corruption.py --root repro/<issue-id> --verbose
+summarize_runs.py --root repro/<issue-id> --by model,config
+```
+
+Expected summary shape:
+
+```text
+model=<model-alias> config=<config-name> bad=2/256 (0.78%) reviewed=256/256
+model=<model-alias> config=<other-config> bad=0/256 (0.00%) reviewed=256/256
+```
+
+State file shape:
+
+```json
+{
+  "schema_version": 1,
+  "labels": {
+    "<model>/<config>/<seed>": {
+      "label": "bad",
+      "class": "text-degeneration",
+      "reviewed_at": "2026-07-09T00:00:00Z",
+      "notes": "First non-benign degeneration after a benign separator ellipsis."
+    }
+  }
+}
+```
+
+### Redaction Checklist
+
+- Replace private artifact roots with `<REDACTED_ARTIFACT_ROOT>`.
+- Replace endpoints with `<REDACTED_ENDPOINT>`.
+- Replace checkpoint or tokenizer paths with `<REDACTED_CHECKPOINT_PATH>`.
+- Do not publish private prompts, token-bearing artifacts, cookies, bearer tokens, user-specific locations, hostnames, ports, or absolute infrastructure paths.
+- Keep examples structural, for example `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`, without exposing real operational values.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Issue 257 local corruption investigation scripts/tests and PR work | Durable per-run repro layout, raw token/logit capture, review-state tooling, seed-level rate reporting, and redaction rules were validated locally. Verification is `verified-local`, not `verified-ci`, until the ProjectMnemosyne PR checks prove this skill file. |

--- a/skills/python-import-time-forward-reference-lambda-guard.md
+++ b/skills/python-import-time-forward-reference-lambda-guard.md
@@ -1,0 +1,237 @@
+---
+name: python-import-time-forward-reference-lambda-guard
+description: "Diagnose and correctly fix the trap where a module-level call captures a name defined LATER in the same file via a lambda (deferring the lookup to call time), and a lint autofix that inlines the lambda into a direct reference turns it into an import-time NameError. Use when: (1) EVERY test job across ALL Python versions fails identically during collection with the SAME NameError right after a lint/Copilot-Autofix bot commit — the tell-tale signature of an import-time break (uniform red), not a logic bug (which fails a specific subset); (2) a module-level construction passes a callback as a keyword arg via `ignore=lambda exc: _predicate(exc)` where `_predicate` is defined below the construction — the lambda is LOAD-BEARING because `ignore=` is evaluated at import but the lambda body is not evaluated until call time; (3) an 'Unnecessary lambda' lint finding is autofixed to a direct reference (`ignore=_predicate`) and import breaks with `NameError: name '_predicate' is not defined`; (4) you need the CORRECT fix (not restoring the lambda): MOVE the predicate and any tables it consults ABOVE the construction, use the direct reference, add a comment that `ignore=` is import-time so a forward reference raises NameError; (5) you need a regression guard for an import-time break — NO in-process test can catch it because importing the test module already imported the module under test, so you need a SUBPROCESS import test (`subprocess.run([sys.executable, '-c', 'import the.module'])`, assert returncode==0), a SOURCE-ORDER assertion (read the file, assert `source.index('def _predicate') < source.index('_X = construct(')`), and an assertion that the constructed object actually carries the wiring (`_GH_BREAKER._ignore is not None`), not a stale None; (6) you need the process lesson: a lint-autofix bot's FINDING can be correct while its PATCH is WRONG — the removed construct may be load-bearing for a reason the linter cannot see (deferred evaluation, side effects, definition ordering); verify a bot autofix by actually importing/running, not by trusting 'it's just a lint fix'."
+category: debugging
+date: 2026-07-10
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - import-time-error
+  - forward-reference
+  - lambda
+  - deferred-evaluation
+  - nameerror
+  - lint-autofix
+  - copilot-autofix
+  - unnecessary-lambda
+  - definition-order
+  - circuit-breaker
+  - subprocess-import-test
+  - source-order-guard
+  - ci-signature
+  - uniform-failure
+  - collection-error
+  - regression-guard
+  - load-bearing-construct
+  - bot-patch-verification
+---
+
+# Python Import-Time Forward-Reference Lambda Guard
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-10 |
+| **Objective** | Diagnose "every test job failed with the same NameError after a lint-autofix bot commit", understand why a load-bearing lambda deferred an import-time forward-reference lookup, apply the correct fix (reorder the definition, do not restore the lambda), and add a regression guard that can actually catch an import-time break |
+| **Outcome** | Successful — break and fix both reproduced with a runnable subprocess import; fix merged in ProjectHephaestus PR #2049 with all CI green |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- **Uniform CI red after a bot autofix**: EVERY test job on EVERY Python version fails identically during collection with the SAME `NameError`, and the failing commit is a lint / GitHub Copilot Autofix bot commit. Uniform-across-the-matrix failure is the tell-tale signature of an **import-time** error (the module can't even be imported), not a logic bug (which fails a specific subset of tests).
+- **A module-level construction takes a callback keyword arg referencing a name defined LATER in the file**: e.g. `_GH_BREAKER = get_circuit_breaker(..., ignore=lambda exc: _breaker_should_ignore(exc))` where `_breaker_should_ignore` is defined ~130 lines *below*. The lambda is **load-bearing** — `ignore=` is evaluated at import (it's a keyword arg to a call that runs at import), but the lambda *body* isn't evaluated until the breaker actually invokes `ignore` at call time, so the forward reference resolves later and import succeeds.
+- **An "Unnecessary lambda" lint finding is autofixed into a direct reference**: the bot rewrites `ignore=lambda exc: _breaker_should_ignore(exc)` → `ignore=_breaker_should_ignore`. Now the name resolves at import — and it doesn't exist yet: `NameError: name '_breaker_should_ignore' is not defined`. Because the module is imported by nearly everything, every test job fails.
+- **You need the CORRECT fix, not a revert**: satisfy BOTH the lint finding AND import by MOVING the predicate (and any tables it consults) above the construction, then using the direct reference. Do not restore the lambda — it was masking a definition-order problem.
+- **You need a regression guard for an import-time break**: no in-process test can catch it (importing the test file already imported the module under test). You need a subprocess-import test, a source-order assertion, and a wiring-not-None assertion.
+- **A bot autofix looks trivial ("it's just a lint fix")**: a lint-autofix bot's *finding* can be correct while its *patch* is wrong. The removed construct may be load-bearing for a reason the linter can't see (deferred evaluation, side effects, definition ordering). Verify by importing/running, not by trusting the diff.
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# THE TRAP — the lambda is LOAD-BEARING (defers a forward-reference lookup to call time)
+# module top:
+_GH_BREAKER = get_circuit_breaker(
+    "github-api", ...,
+    ignore=lambda exc: _breaker_should_ignore(exc),  # import OK: body not evaluated until call
+)
+# ~130 lines BELOW:
+def _breaker_should_ignore(exc: Exception) -> bool: ...
+
+# THE BOT AUTOFIX ("Unnecessary lambda") — breaks import:
+_GH_BREAKER = get_circuit_breaker("github-api", ..., ignore=_breaker_should_ignore)
+#   ignore= is evaluated at IMPORT → NameError: name '_breaker_should_ignore' is not defined
+
+# THE CORRECT FIX — reorder, keep the direct reference (satisfies BOTH lint AND import):
+def _breaker_should_ignore(exc: Exception) -> bool: ...   # MOVED ABOVE the construction
+# ... plus any tables _breaker_should_ignore consults, also moved above ...
+_GH_BREAKER = get_circuit_breaker(
+    "github-api", ...,
+    # The predicate is defined above on purpose: `ignore=` is evaluated at import,
+    # so a forward reference here raises NameError.
+    ignore=_breaker_should_ignore,
+)
+```
+
+```bash
+# CI SIGNATURE — all jobs red uniformly ⇒ suspect import-time before logic
+# pytest reports a COLLECTION error, not a test failure:
+pixi run python -m pytest hephaestus/ -q
+#   → "Interrupted: N errors during collection"
+#   → the SAME NameError on EVERY Python version = import-time, not logic
+```
+
+```python
+# REGRESSION GUARD — the ONLY in-suite way to catch an import-time break: a SUBPROCESS import.
+# (An in-process `import hephaestus.github.client` here would already have run at collection,
+#  so it cannot fail the test the way CI fails.)
+import subprocess, sys
+
+def test_client_module_imports_in_a_fresh_interpreter() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-c", "import hephaestus.github.client"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr   # fails on the offending commit with the NameError
+```
+
+```python
+# SOURCE-ORDER GUARD — fast, readable assertion on the ordering invariant.
+from pathlib import Path
+import hephaestus.github.client as client
+
+def test_predicate_is_defined_before_the_breaker_construction() -> None:
+    source = Path(client.__file__).read_text()
+    assert source.index("def _breaker_should_ignore") < source.index("_GH_BREAKER = "), (
+        "_breaker_should_ignore must be defined ABOVE the _GH_BREAKER construction; "
+        "`ignore=` is evaluated at import, so a forward reference raises NameError."
+    )
+
+# WIRING GUARD — the constructed object must actually carry the callback, not a stale None.
+def test_breaker_ignore_predicate_is_wired() -> None:
+    assert client._GH_BREAKER._ignore is not None
+```
+
+### Detailed Steps
+
+1. **Read the CI signature first.** When ALL test jobs across ALL Python versions fail identically during collection, suspect an **import-time error before a logic bug**. `pytest ... -q` shows `Interrupted: N errors during collection` and the same traceback everywhere. A logic bug fails a *specific subset* of tests; an import break fails *everything that imports the module* — uniformly.
+2. **Find the offending commit.** If the uniform red starts at a lint / Copilot-Autofix bot commit, read that commit's diff. Do not assume "it's just a lint fix" — inspect what construct was removed.
+3. **Identify the load-bearing deferral.** The autofix inlined a lambda: `ignore=lambda exc: _predicate(exc)` → `ignore=_predicate`. Confirm the referenced name is defined *below* the construction (`grep -n "def _predicate" file; grep -n "_X = construct(" file` and compare line numbers). The lambda was deferring the name lookup from import time to call time — that is why import used to succeed.
+4. **Do NOT restore the lambda.** The lint finding was *correct* (the lambda was unnecessary as a wrapper); the lambda was merely masking a definition-order problem. Reverting re-introduces the lint finding and leaves the real defect (bad ordering) in place.
+5. **Apply the correct fix: reorder.** Move the predicate function — and any module-level tables/constants it consults — ABOVE the construction. Then use the direct reference `ignore=_predicate`. This satisfies both the lint finding and import.
+6. **Leave a comment at the construction site** explaining the invariant: e.g. `# The predicate is defined above on purpose: ignore= is evaluated at import, so a forward reference raises NameError.` This stops a future reader (or bot) from "tidying" the ordering back.
+7. **Add three regression guards** (see Quick Reference): (a) a subprocess-import test that runs `import the.module` in a fresh interpreter and asserts `returncode == 0` — the ONLY in-suite way to catch an import-time break; (b) a source-order assertion that reads the module file and asserts the predicate is defined before the construction; (c) an assertion that the constructed object actually carries the wiring (`_GH_BREAKER._ignore is not None`), not a stale `None`.
+8. **Mutation-test the guards against the offending commit.** All three should FAIL on the pre-fix commit and PASS on the fix. If a guard passes on the broken commit, it is vacuous — the classic in-process-import mistake fails silently this way.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust the bot's autofix | Accepted the "Unnecessary lambda" Copilot Autofix (`ignore=lambda exc: _breaker_should_ignore(exc)` → `ignore=_breaker_should_ignore`) as a harmless lint fix | `ignore=` is evaluated at IMPORT; the inlined name was defined ~130 lines below → `NameError: name '_breaker_should_ignore' is not defined`; the module is imported by nearly everything, so every test job on every Python version failed | A lint-autofix bot's FINDING can be correct while its PATCH is WRONG — the removed construct may be load-bearing (deferred evaluation) for a reason the linter can't see. Verify a bot autofix by actually importing/running, not by trusting "it's just a lint fix". |
+| Assume a logic bug | Started debugging the circuit-breaker predicate logic when CI went red | The failure was import-time (collection error), not logic; the predicate never even ran. Chasing logic wastes time | When ALL test jobs across ALL Python versions fail identically, suspect an import-time error first. `pytest -q` shows "Interrupted: N errors during collection". Uniform red = import break; subset red = logic bug. |
+| Restore the lambda | Reverted the autofix to bring back `ignore=lambda exc: _breaker_should_ignore(exc)` | Import works again, but the "Unnecessary lambda" lint finding returns AND the underlying definition-order defect remains (the lambda was only masking it) | Don't restore the deferral — MOVE the predicate (and any tables it consults) ABOVE the construction and use the direct reference. That satisfies BOTH the lint finding and import. |
+| In-process import regression test | Added `import hephaestus.github.client` inside a test function to "guard" against the break | Importing the test module already imported the module under test during collection, so the guard is vacuous — it cannot reproduce the fresh-interpreter NameError and passes even on the broken commit | NO in-process test can catch an import-time break in the module under test. Use a SUBPROCESS import (`subprocess.run([sys.executable, "-c", "import the.module"])`, assert returncode==0). Mutation-test it against the offending commit to prove it actually fails there. |
+| `git commit --amend` on the bot's pushed commit | Considered amending the Copilot Autofix commit to fix it in place | Amending a pushed commit that isn't yours rewrites shared history; the squash-merge collapses everything anyway | Prefer a follow-up commit over `--amend` on someone else's pushed commit; the squash-merge makes the extra commit invisible in history. |
+
+## Results & Parameters
+
+### The trap, the break, and the fix (verified in `hephaestus/github/client.py`)
+
+```python
+# ---- BEFORE (works at import; lambda defers the forward-reference lookup) ----
+_GH_BREAKER = get_circuit_breaker(
+    "github-api",
+    failure_threshold=5,
+    ...,
+    ignore=lambda exc: _breaker_should_ignore(exc),   # body evaluated at CALL time
+)
+# ... ~130 lines later ...
+_IGNORED_STATUS_CODES = frozenset({404, 422})           # table the predicate consults
+def _breaker_should_ignore(exc: Exception) -> bool:
+    return getattr(exc, "status_code", None) in _IGNORED_STATUS_CODES
+
+# ---- BOT AUTOFIX (breaks import) ----
+_GH_BREAKER = get_circuit_breaker("github-api", ..., ignore=_breaker_should_ignore)
+#   NameError: name '_breaker_should_ignore' is not defined   (raised at IMPORT)
+
+# ---- AFTER (correct fix: reorder, keep the direct reference) ----
+_IGNORED_STATUS_CODES = frozenset({404, 422})           # table moved ABOVE too
+def _breaker_should_ignore(exc: Exception) -> bool:
+    return getattr(exc, "status_code", None) in _IGNORED_STATUS_CODES
+
+_GH_BREAKER = get_circuit_breaker(
+    "github-api",
+    failure_threshold=5,
+    ...,
+    # The predicate is defined above on purpose: `ignore=` is evaluated at import,
+    # so a forward reference here raises NameError.
+    ignore=_breaker_should_ignore,
+)
+```
+
+### Runnable subprocess-import reproduction (fails on the broken commit, passes on the fix)
+
+```bash
+# Reproduce the break directly — no pytest needed:
+python3 -c "import hephaestus.github.client"
+#   BEFORE fix: NameError: name '_breaker_should_ignore' is not defined  (exit 1)
+#   AFTER  fix: (no output, exit 0)
+echo "exit=$?"
+```
+
+```python
+# The same thing as an in-suite regression test:
+import subprocess, sys
+
+def test_client_module_imports_in_a_fresh_interpreter() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-c", "import hephaestus.github.client"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+```
+
+### Source-order guard (fast, readable ordering invariant)
+
+```python
+from pathlib import Path
+import hephaestus.github.client as client
+
+def test_predicate_defined_before_breaker_construction() -> None:
+    source = Path(client.__file__).read_text()
+    assert source.index("def _breaker_should_ignore") < source.index("_GH_BREAKER = "), (
+        "_breaker_should_ignore must be defined ABOVE the _GH_BREAKER construction; "
+        "`ignore=` is evaluated at import, so a forward reference raises NameError."
+    )
+```
+
+### Wiring guard (object actually carries the callback, not a stale None)
+
+```python
+def test_breaker_ignore_predicate_is_wired() -> None:
+    import hephaestus.github.client as client
+    assert client._GH_BREAKER._ignore is not None
+```
+
+### Diagnostic one-liners
+
+```bash
+# Confirm import-time vs logic: uniform collection error across the matrix ⇒ import-time
+pixi run python -m pytest hephaestus/ -q 2>&1 | grep -i "errors during collection"
+
+# Prove the ordering defect on disk (line number of def vs construction)
+grep -n "def _breaker_should_ignore" hephaestus/github/client.py
+grep -n "_GH_BREAKER = "            hephaestus/github/client.py
+#   def line number > construction line number ⇒ forward reference ⇒ will break under a direct reference
+```
+
+Verified on: ProjectHephaestus, `hephaestus/github/client.py`, fix merged in PR #2049 to `main`, all CI green; break and fix both reproduced with a runnable subprocess import (`verified-ci`).
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | `hephaestus/github/client.py` — Copilot Autofix inlined a load-bearing lambda in the `_GH_BREAKER` circuit-breaker construction, turning a deferred forward reference into an import-time NameError that failed every test job; fixed by reordering the predicate above the construction (PR #2049, CI green) | Break/fix reproduced via `python3 -c "import hephaestus.github.client"`; three regression guards (subprocess import, source-order, wiring) mutation-tested against the offending commit |

--- a/skills/sampling-degeneration-seed-token-debugging.md
+++ b/skills/sampling-degeneration-seed-token-debugging.md
@@ -1,0 +1,141 @@
+---
+name: sampling-degeneration-seed-token-debugging
+description: "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - llm
+  - sampling
+  - seed
+  - logits
+  - top-k
+  - top-p
+  - degeneration
+  - xllm
+  - issue-257
+---
+
+# Sampling Degeneration Seed Token Debugging
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Diagnose LLM garbled output when matched runs differ only by seed, and separate bad random draws from prompt, weight, tokenizer, backend, or deterministic-forward differences. |
+| **Outcome** | Successful locally. The useful pivot was asking why seed mattered: seed changes the random draw from the next-token distribution, not the prompt, weights, tokenizer, or deterministic forward pass. That moved the investigation from whole-trace comparison to the first bad sampled token in one trace. |
+| **Verification** | verified-local. Evidence came from redacted Inference360 issue #257 scripts, dense-model sweeps, direct XLLM checks, and manual review. ProjectMnemosyne CI validation is pending for this skill PR. |
+
+## When to Use
+
+- The same model, prompt, backend, tokenizer, and generation config produce readable output for one seed and garbled output for another.
+- A generation degenerates into repeated ellipsis, newline loops, prompt-framing leakage, or similar hard corruption after an apparently valid prefix.
+- You need to decide whether top-k, top-p, greedy, temperature, or stop-token behavior is changing the actual sampler support.
+- A trace-diff approach is producing too much noise and not explaining why a specific seed fails.
+- A script reports `top_k=N`, but there is any chance `N` is only the top-N dump/reporting limit instead of the sampler's support.
+
+## Verified Workflow
+
+Verified locally only through redacted Inference360 issue #257 scripts and manual review. Do not claim verified-ci until this skill PR's `validate` and `markdownlint` checks pass.
+
+### Quick Reference
+
+```bash
+# Capture a per-step trace for one failing seed.
+python <trace-script>.py \
+  --model <model-id> \
+  --prompt-file <REDACTED_PROMPT_FILE> \
+  --seed 116 \
+  --temperature 1 \
+  --top-k 20 \
+  --top-k-dump 50 \
+  --output <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl
+
+# Inspect the selected token rank and probability near the first hard-corruption step.
+python <analyze-trace-script>.py \
+  <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --window 80:100 \
+  --top-n 20
+
+# Replay the divergence step by forcing plausible alternatives.
+python <force-token-script>.py \
+  --trace <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --force-step 90 \
+  --force-rank 1,2,3,4 \
+  --output <REDACTED_ARTIFACT_ROOT>/forced-alternatives.jsonl
+```
+
+### Detailed Steps
+
+1. **Ask why seed matters before comparing whole traces.** With the same prompt, weights, backend, tokenizer, and generation config, seed should only affect random sampling from the next-token distribution. It should not change the deterministic forward pass. This narrows the first question to: which sampled token draw sent the trace into a bad basin?
+2. **Collect per-step token evidence.** For each generated step, log the selected token id/text, selected rank, selected probability, logits or post-filter probabilities, top-N alternatives, active sampler config, stop/control-token flags, and the decoded prefix.
+3. **Stop at the first hard-corruption token.** Do not start by explaining every downstream token. Find the first selected token after which the continuation becomes repeated ellipsis/newline variants, prompt-framing leakage, or another stable corruption pattern.
+4. **Inspect selected rank and nearby alternatives.** A low-probability selected token can be a valid sampler draw even when rank 1 is overwhelmingly more likely. The key diagnostic is whether the selected token was inside the configured sampler support and whether higher-ranked alternatives preserve readable continuation.
+5. **Force plausible alternatives at the divergence step.** Replay from the same prefix while forcing rank-1, rank-2, rank-3, and the originally selected token. If the top alternatives stay readable and the original draw degenerates, the corruption is primarily a sampling-tail trajectory, not a whole-trace backend mismatch.
+6. **Sweep sampler support deliberately.** Compare greedy or top-k=1, small top-k, larger top-k, no top-k, and top-p thresholds such as 0.9, 0.95, 0.99, and 0.999. Keep dense-model and MoE results separate, and label partial MoE data as revalidation-needed.
+7. **Separate sampler controls from diagnostic dumps.** `--top-k` should control sampler support. A separate `--top-k-dump` or `--top-n-dump` should only limit the logged alternatives. Logs must print both actual sampler support and dump size.
+8. **Manually review labels.** Do not auto-label every newline or comma-adjacent ellipsis fragment as corruption. Repeated ellipsis bursts, newline loops, and prompt-framing leakage are the meaningful class. Numeric-array fragments such as `,...`, `...,`, `,…`, or `…,'` can be benign formatting artifacts and need context.
+9. **Treat stop/control-token artifacts separately.** If a suspicious case is caused by a special stop/control token or a harness stop condition, record it as an artifact unless the decoded continuation itself demonstrates model-output corruption.
+10. **Record verification honestly.** Local sweeps and manual review support `verified-local`. Only mark `verified-ci` when the skill PR's validation gates are observed green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Compare whole good/bad traces first | Diffed two generations that differed only by seed | The diff grew after divergence and obscured the causal draw | Ask what seed changes, then stop at the first bad sampled token in one failing trace |
+| Treat newline spam alone as corruption | Counted newline-heavy output as bad without reviewing decoded context | Some newline behavior was prompt or formatting related, not hard model degeneration | Label repeated ellipsis bursts, newline loops, and prompt-framing leakage; manually review ambiguous cases |
+| Use top-k dump count as sampler top-k | A script reported `top_k=N` from the logged top-N dump limit while actual `sampling_top_k` was infinite | The report implied a bounded sampler even when the sampler could draw from the full distribution | Use `--top-k` for sampler support and `--top-k-dump` only for diagnostic logging |
+| Assume low-probability draw means backend bug | Treated a very unlikely selected token as impossible | Sampling at temperature 1 can draw low-probability in-support tokens | Inspect rank/probability and replay forced alternatives before blaming logits computation |
+| Mistake stop-token artifacts for corruption | Counted special control or stop-token effects as bad model output | The harness boundary, not the model's decoded continuation, caused some suspicious cases | Track stop/control-token status and keep those cases out of true corruption counts |
+
+## Results & Parameters
+
+### Representative Local Finding
+
+A redacted 4B dense-model run with temperature explicitly set to 1, top-k=20, and seed 116 selected an ellipsis-family token around step 90. The selected token was rank 4 at about 0.01% probability while rank 1 was about 75%. After that draw, the next-token distribution flattened into ellipsis and newline variants and the text degenerated. Replaying the divergence while forcing rank-1, rank-2, or rank-3 alternatives kept the continuation readable.
+
+Direct XLLM sweeps showed greedy/top-k=1 removed the observed failures. Top-k=5, top-k=20, and no top-k still had failures. Top-p 0.9 and 0.95 mostly or entirely removed true ellipsis degeneration in the reviewed dense sweep.
+
+### Top-p Sweep Evidence
+
+The following are local issue #257 dense-model manual-review rates across 256 seeds per model where runs completed. Treat them as redacted local evidence, not ProjectMnemosyne CI evidence.
+
+| Sampler | 4B | 7B | 32B | 36B | Notes |
+|---------|----|----|-----|-----|-------|
+| top-p 0.9 | 0/256 | 0/256 | 0/256 | 0/256 | No manually reviewed true bad dense cases where runs completed |
+| top-p 0.95 | 0/256 | 2/256 suspicious | 0/256 | 0/256 | The 7B suspicious cases looked likely to be stop-token artifacts rather than true ellipsis degeneration |
+| top-p 0.99 | 1/256 | 2/256 | 2/256 | 0/256 | Low reviewed true bad rates |
+| top-p 0.999 | 3/256 | 5/256 | 14/256 | 20/256 | Higher reviewed true bad rates as the tail widened |
+
+MoE partial data from the same investigation is revalidation-needed and should not be generalized until dense and MoE runs complete under the same review protocol.
+
+### Config Contract
+
+Use separate flags for sampler behavior and diagnostic visibility:
+
+```text
+--top-k 20        # sampler support: only ranks inside top 20 are eligible
+--top-k-dump 50   # diagnostic dump: log up to 50 alternatives, does not affect sampling
+--top-p 0.95      # sampler support: nucleus threshold
+--temperature 1   # explicit temperature, not an implicit default
+```
+
+Sanity checks for trace/report scripts:
+
+- The emitted report field for sampler support must come from the actual sampling config, not the dump limit.
+- The logged top-N count may exceed sampler support if it is used only for diagnostics.
+- The trace should record selected rank after all active sampler filters.
+- The manual-review label should distinguish true degeneration from formatting fragments and stop/control-token artifacts.
+
+### Review Caveat
+
+Comma-adjacent ellipsis fragments in numeric arrays, including `,...`, `...,`, `,…`, and `…,'`, should not be auto-labeled as corruption. Review decoded context. Meaningful corruption is repeated ellipsis bursts, newline loops, or prompt-framing leakage that persists after the first bad draw.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Redacted issue #257 local scripts and manual review, 2026-07-09 | Dense-model traces and sweeps supported the first-bad-token workflow, forced-alternative replay, top-k/top-p findings, and the sampler-vs-dump caution. MoE partial data remains revalidation-needed. |


### PR DESCRIPTION
## Summary

New skill (not an amendment).

**Amend-vs-create decision:** I evaluated amending `python-import-patterns-and-compatibility-guards.md` (v1.8.0, 855 lines). Its "When to Use" triggers are exclusively about the *import graph*: circular deps via function-local imports, lazy exports / PEP 562 `__getattr__` surfaces, version/OS stdlib guards, surface-pin test staleness, and COMPATIBILITY.md alignment. The learning captured here is a distinct trigger — a **lambda deferring an import-time forward-reference lookup**, broken by a **lint autofix bot**, diagnosed by the **all-jobs-fail-identically CI signature**, and guarded by a **subprocess-import + source-order test**. None of those overlap the existing skill's search surface; someone hitting "every test job failed with NameError after a bot autofix commit" would not think to look in a circular-import/lazy-loading skill. Folding it in would dilute an already-enormous file. Hence a **new skill**.

Documents the trap where a module-level call captures a name defined LATER in the same file via a load-bearing lambda (deferring the lookup to call time), and a lint autofix that inlines the lambda into a direct reference turns it into an import-time `NameError`.

- **CI signature**: EVERY test job on EVERY Python version failing identically during collection is the tell-tale sign of an import-time error, not a logic bug (which fails a specific subset). `pytest -q` shows "Interrupted: N errors during collection".
- **Root cause**: `ignore=lambda exc: _breaker_should_ignore(exc)` deferred a forward reference (`_breaker_should_ignore` defined ~130 lines below) to call time, so import succeeded. A Copilot Autofix "Unnecessary lambda" fix inlined it to `ignore=_breaker_should_ignore`, which resolves at import → `NameError`.
- **Correct fix**: MOVE the predicate (and tables it consults) above the construction and keep the direct reference — satisfies both the lint finding and import. Do NOT restore the lambda (it was masking a definition-order defect).
- **Regression guard**: no in-process test can catch an import-time break (the test module already imported it); use a subprocess import test, a source-order assertion, and a wiring-not-None assertion. All three mutation-tested against the offending commit.
- **Process lesson**: a lint-autofix bot's finding can be correct while its patch is wrong; verify by importing/running, not by trusting "it's just a lint fix".

## Verification Level

**verified-ci** — fix merged in ProjectHephaestus PR #2049 to `main`, all CI green; the break and fix both reproduced with a runnable subprocess import (`python3 -c "import hephaestus.github.client"`).

## Key Findings

**What Worked**:
- Reordering the predicate above the `_GH_BREAKER` construction and using the direct reference (satisfies lint + import).
- Subprocess-import regression test as the only in-suite way to catch an import-time break.

**What Failed**:
- Trusting the bot autofix as harmless → import-time NameError across every job.
- Assuming a logic bug → wasted debugging on a predicate that never ran.
- Restoring the lambda → lint finding returns, ordering defect remains.
- In-process import "guard" → vacuous (module already imported at collection).

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (642/642 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>