### PR TITLE
feat: add pr-review-threadless-nogo-verdict-retry-wedge skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,11 +6,11 @@
   },
   "description": "Skills marketplace for the HomericIntelligence agentic ecosystem",
   "version": "2.1.0",
-  "total_plugins": 639,
+  "total_plugins": 641,
   "categories": {
     "architecture": 132,
     "ci-cd": 122,
-    "debugging": 62,
+    "debugging": 64,
     "documentation": 40,
     "evaluation": 12,
     "optimization": 7,
@@ -18,7 +18,7 @@
     "tooling": 174,
     "training": 7
   },
-  "last_updated": "2026-07-09T04:58:32Z",
+  "last_updated": "2026-07-09T17:24:55Z",
   "plugins": [
     {
       "name": "agent-config-validation-and-integrity",
@@ -6235,6 +6235,23 @@
       ]
     },
     {
+      "name": "llm-corruption-repro-artifact-review",
+      "description": "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts.",
+      "version": "1.0.0",
+      "source": "./skills/llm-corruption-repro-artifact-review.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "corruption",
+        "reproducibility",
+        "artifacts",
+        "manual-review",
+        "logits",
+        "tokens",
+        "redaction"
+      ]
+    },
+    {
       "name": "logging-subprocess-context-tracking",
       "description": "Add diagnostic context (working directory, command, cwd) to subprocess execution logging. Use when: (1) run_git_cmd or similar subprocess runners log execution without showing which directory the command ran in, (2) debugging multi-directory workflows where cwd context is critical for tracing, (3) writing tests for subprocess execution and caplog fixture fails with custom logger handlers (propagate=False).",
       "version": "1.0.0",
@@ -6358,6 +6375,24 @@
         "fail-open",
         "argparse",
         "repr-truncation"
+      ]
+    },
+    {
+      "name": "sampling-degeneration-seed-token-debugging",
+      "description": "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support.",
+      "version": "1.0.0",
+      "source": "./skills/sampling-degeneration-seed-token-debugging.md",
+      "category": "debugging",
+      "tags": [
+        "llm",
+        "sampling",
+        "seed",
+        "logits",
+        "top-k",
+        "top-p",
+        "degeneration",
+        "xllm",
+        "issue-257"
       ]
     },
     {

--- a/skills/git-unmerged-branch-file-access.history
+++ b/skills/git-unmerged-branch-file-access.history
@@ -1,5 +1,244 @@
 # git-unmerged-branch-file-access — History
 
+## v2.1.0 (2026-07-10)
+
+**Changed by:** ProjectArgus issue #240 planning session (split a collapsed
+"Atlas M1-M3" CHANGELOG entry into per-milestone bullets). The referenced
+`CHANGELOG.md` did not exist on the checked-out branch at all — the branch
+PREDATED the file — so working-tree `grep -rn` / `find -iname` returned nothing
+and a prior plan attempt earned an empty-output NOGO. Recovery:
+`git ls-tree --name-only origin/main` + `git show origin/main:CHANGELOG.md`
+located and line-cited the entry without any branch switch; `git log --all -S`
+pickaxe found the introducing commit (`472aeb3`, "M1–M3" form at line 14); a
+rev-walk grep showed the entry had since mutated M1–M3 → M1–M6 (`7b2c8c7`,
+after the issue was filed); six milestone feature commits (`8f47769`,
+`b66e987`, `ea2c8be`, `4ba1cac`, `fed0b90`, `d78b298`) gave a 1:1
+content-preserving attribution of every phrase. The plan passed review.
+
+**Why (minor bump):** new findings added to an existing verified workflow — the
+INVERSE absence scenario (origin/main is AHEAD of a stale checkout, rather than
+the file living on an unmerged feature branch) plus changelog-attribution
+archaeology. No existing guidance was invalidated.
+
+**Verification:** remains `verified-local` — every new command was executed
+end-to-end in the source session; not exercised in CI.
+
+### What changed (minor)
+
+- **New scenario: the checkout PREDATES the file.** Description, When to Use,
+  and Detailed Steps now cover the inverse of the unmerged-feature-branch case:
+  the cited file exists on `origin/main` but not in the working tree because
+  the checked-out branch is older than the file. Check
+  `git ls-tree origin/main` before declaring an issue invalid.
+- **New technique: pickaxe + per-revision grep to trace entry mutation.**
+  `git log --all -S "<phrase>" -- <file>` finds the introducing commit;
+  `git grep <token> $(git rev-list --all -- <file>) -- <file>` watches a single
+  line evolve across revisions (Quick Reference items 7–11, Detailed Steps
+  7–12).
+- **New technique: 1:1 content-preserving attribution of collapsed changelog
+  entries** via feature-commit subjects (`git log --grep`), so a combined
+  bullet can be split per-milestone with zero guessed attribution.
+- **New step: read markdownlint / pre-commit config from the TARGET branch**
+  (`git show origin/main:.markdownlint.yaml`) so proposed doc snippets are
+  lint-clean up front (MD013 wrap width, hanging-indent style).
+- **Three new Failed Attempts rows:** working-tree-only search (file only on
+  origin/main); trusting issue text verbatim (M1-M3 had grown to M1–M6 on
+  main — issue text goes stale); ASCII-hyphen grep missing typographic en
+  dashes (grep a shorter invariant token instead).
+- **New Results & Parameters subsection** with the #240 command-output pattern
+  (commit SHAs above) and the note that the whole investigation needs zero
+  checkouts / branch switches — safe on a dirty working tree.
+- **New Verified On row** for ProjectArgus #240 (2026-07-10). Tags extended
+  with changelog / pickaxe / plan-grounding / stale-issue-text; date bumped to
+  2026-07-10; version 2.0.0 → 2.1.0.
+
+### Full v2.0.0 snapshot (previous content of git-unmerged-branch-file-access.md)
+
+````markdown
+---
+name: git-unmerged-branch-file-access
+description: "Access and plan fixes for files that exist only on non-main git branches, and never declare a cited file 'phantom' until you have searched all branches. Use when: (1) Read/Glob/Grep return not-found for a file an issue references, so you are tempted to call it non-actionable / phantom code, (2) planning a 'follow-up from #NNN' bug whose cited file/symbol is absent from the default branch (it likely came from a parent PR that has not merged), (3) a PR fix must target a feature branch rather than main, (4) an issue cites a raw line number that no longer matches the branch tip (line drift)."
+category: architecture
+date: 2026-06-20
+version: "2.0.0"
+user-invocable: false
+verification: verified-local
+history: git-unmerged-branch-file-access.history
+tags:
+  - unmerged-branch
+  - follow-up-issue
+  - phantom-code
+  - git-log-all
+  - git-show
+  - line-number-drift
+  - planning
+  - feature-branch
+  - pr-base
+  - carrier-branch
+---
+
+# Git Unmerged Branch File Access
+
+**History:** [changelog](./git-unmerged-branch-file-access.history)
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-20 |
+| **Objective** | Read and plan fixes for files/symbols that exist only on non-main feature branches, and avoid the "phantom code" misdiagnosis when a cited file is absent from the default branch |
+| **Outcome** | Successful recovery — a "follow-up bug" issue (#283) cited `mcp_server.py:82`, absent from `main`; `git log --all` found the file on the unmerged `173-auto-impl` branch (commit `07ea99a`), and the plan was re-scoped to target that branch |
+| **Verification** | verified-local (investigation steps executed this session; downstream code fix is plan-only — see caveats) |
+
+> **Verification split — read this.** The git-history **investigation** workflow below is
+> `verified-local`: `git log --all`, `git branch --all --contains`, and `git show <sha>:<path>`
+> were ACTUALLY run this session and produced the cited results (carrier commit `07ea99a` on
+> branch `173-auto-impl`). The downstream **code fix** was NOT executed — it is plan-only.
+> The fix-stage assumptions are recorded as explicit `unverified` caveats in
+> [Results & Parameters](#results--parameters); treat those as hypotheses, not facts.
+
+## When to Use
+
+- `Read`, `Glob`, or `Grep` returns "not found" for a file you expect to exist, and you are
+  about to conclude the issue is **non-actionable / references phantom code** — STOP and run
+  this workflow first.
+- Planning a **"follow-up from #NNN"** / refinement / cited-line-number bug fix where the
+  referenced file or symbol is **not on the default branch**. Follow-up issues are frequently
+  filed against code from a PARENT PR that has not yet merged.
+- A PR fix must target a feature branch (e.g., `173-auto-impl`) instead of `main`.
+- Planning a fix for code visible in a PR diff but absent from the working tree.
+- An issue cites a **raw line number** that no longer matches the branch tip (line drift).
+
+## Verified Workflow
+
+> **Verified-local:** every command in this section was run this session against the
+> ProjectTelemachy #283 carrier branch and produced the cited results. Do NOT skip step 1
+> just because Glob/Grep already "proved" the file is missing — those tools only see the
+> checked-out branch.
+
+### Quick Reference
+
+```bash
+# 0. NEVER conclude "phantom code" from Glob/Grep alone. They only see the working tree
+#    (the checked-out branch). Always run the all-branches search BEFORE declaring absence.
+
+# 1. Find the carrier commit by PATH across ALL branches (local + remote):
+git log --all --oneline -- "**/mcp_server.py"
+#   → 07ea99a feat: add MCP server (#173)
+
+# 1b. ...and by PARENT-ISSUE grep (follow-ups cite their parent PR/issue):
+git log --all --oneline --grep="#173"
+
+# 2. Identify which branch(es) carry that commit:
+git branch -a --contains 07ea99a
+#   → remotes/origin/173-auto-impl
+
+# 3. Read the file content WITHOUT checking out the branch:
+git show 07ea99a:src/telemachy/mcp_server.py
+git show origin/173-auto-impl:src/telemachy/mcp_server.py   # branch-ref form
+
+# 4. List what the commit changed:
+git show --stat 07ea99a
+
+# 5. Cite by SYMBOL, not raw line number (line numbers drift between the issue
+#    snapshot and the branch tip — issue said line 82; actual was line 81):
+git show origin/173-auto-impl:src/telemachy/mcp_server.py | grep -n "def call_tool\|class Dispatcher"
+
+# 6. Scope the plan to the CARRIER branch:
+git checkout -b fix/<description> origin/173-auto-impl
+gh pr create --base 173-auto-impl --title "fix: ..."   # NOT --base main
+```
+
+### Detailed Steps
+
+1. **Detect the problem — and resist the phantom-code conclusion.** If `Read`, `Glob`, or
+   `Grep` returns not-found for a file an issue references, the file most likely lives on a
+   feature branch not yet merged to `main`. The file-read tools operate on the **working tree
+   (the checked-out branch)** and cannot see other branches. Do NOT mark the issue
+   non-actionable yet.
+
+2. **Find the carrier commit — search by path AND by parent issue.** A follow-up issue
+   ("follow-up from #NNN") was usually filed against code from a parent PR. Search both ways:
+   ```bash
+   git log --all --oneline -- "**/<file>"
+   git log --all --oneline --grep="#<parent-issue>"
+   ```
+
+3. **Identify the carrier branch:**
+   ```bash
+   git branch -a --contains <sha>
+   ```
+   If it only appears under `remotes/origin/<feature-branch>`, the file is not on `main`.
+
+4. **Read the file without switching branches** using `git show <sha>:<path>` (or
+   `git show origin/<branch>:<path>`). This lets you read and analyze the real content even
+   though it never exists in your working tree.
+
+5. **Cite findings by SYMBOL, not raw line number.** Line numbers in the issue body reflect
+   the snapshot at filing time and drift as the branch advances. In #283 the issue said
+   line 82 but the defect symbol was at line 81 on the branch tip. Reference
+   `Dispatcher.call_tool` (or the equivalent symbol), not "line 82", so the plan stays correct
+   regardless of drift.
+
+6. **Scope the plan to the carrier branch.** The fix branch MUST fork from the carrier feature
+   branch, and the PR base MUST be that branch — a branch off `main` would have **no file to
+   edit**. State this explicitly in the plan and PR body so the reviewer understands why the
+   base is not `main`.
+   ```bash
+   git checkout -b fix/<description> origin/<feature-branch>
+   gh pr create --base <feature-branch> --title "fix: ..."
+   ```
+   The merged feature-branch PR will carry the fix to `main` when it eventually lands.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Concluded the issue was non-actionable / phantom code | Ran Glob + Grep over `src/` for the cited file, found nothing, and was about to mark the cited code nonexistent | Searched only the working tree / default branch; the file lived on an unmerged feature branch (`173-auto-impl`, commit `07ea99a`) | Always `git log --all -- <file>` (and `--grep="#<parent>"`) before declaring referenced code nonexistent |
+| Trusted the issue's raw cited line number | Planned to point the fix at `mcp_server.py:82` as written in the issue | The symbol was actually at line 81 on the branch tip; line numbers drift between the issue-filing snapshot and the carrier branch's current state | Cite findings by SYMBOL (e.g. `Dispatcher.call_tool`), not raw line numbers |
+| Direct Read tool | Used Read/Glob/Grep with the expected file path | File not found — silently returns nothing because the file only exists on a feature branch | File-read tools operate on the checked-out branch; they cannot see files on other branches |
+| Assuming the file should exist on `main` | Proceeded as if the file was missing from the repo entirely | Wasted planning cycles trying to understand why a referenced file didn't exist | Follow-up issues are commonly filed against a parent PR's code that has not yet merged; check all branches |
+| Planning the fix as a branch off `main` | Implicitly assumed the PR base would be `main` | A branch off `main` has no copy of the file to edit; the change could not be made there | Branch-from / PR-target must be the carrier feature branch, not `main`; note this in the plan and PR body |
+
+## Results & Parameters
+
+When the file is found via `git show`, record:
+
+- The SHA of the carrier commit (`07ea99a`).
+- The carrier branch (`origin/173-auto-impl`, from `git branch -a --contains`).
+- Whether it is a remote tracking branch (`origin/<branch>`) or local.
+- The SYMBOL the defect lives in, plus the branch-tip line for orientation only (expect drift).
+
+For PR targeting:
+
+- If the file only exists on `origin/<feature-branch>`, the fix PR **must** base off that
+  feature branch: `gh pr create --base <feature-branch>` — not `--base main`.
+- State in the PR body that the base is the carrier branch and why (file absent from `main`).
+
+### Unverified fix-stage caveats (carry forward as risks, not facts)
+
+These are from the ProjectTelemachy #283 plan; the investigation above is verified, but the
+fix below was never executed:
+
+- **MCP SDK exception handling is the single most uncertain assumption.** The plan assumes the
+  MCP SDK's `@server.call_tool()` decorator catches handler exceptions and converts them to a
+  structured `isError` result rather than crashing the stdio process. This was NOT verified
+  against the installed `mcp` SDK version — it is inferred from the module's own docstring
+  `_SDK_API_NOTES` and general MCP SDK behavior. **If false, raising `ValueError` alone may not
+  keep the server alive, and a returned `TextContent` error may be required instead.**
+- **Test/runner reliance is unexecuted.** The plan relies on `pixi run pytest` / `just test` /
+  `just lint` and on the existing test layout (`tests/test_mcp_server.py`) as they exist on the
+  feature branch — these were read via `git show`, NOT checked out and NOT executed.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectTelemachy | Issue #283 — "follow-up bug" citing `mcp_server.py:82`, absent from `main` | `git log --all` found the file on unmerged `173-auto-impl` (commit `07ea99a`); plan re-scoped to that branch; defect symbol at line 81 (issue said 82 — drift). Investigation verified-local; fix plan-only |
+| ProjectHephaestus | Issue #1300 planning (`severity_label.py` GITHUB_REPOSITORY KeyError) | File existed only on `1210-auto-impl` branch; discovered via `git log --all` (v1.0.0, unverified) |
+````
+
+
 ## v2.0.0 (2026-06-20)
 
 **Changed by:** ProjectTelemachy issue #283 planning session. A "follow-up bug"

--- a/skills/git-unmerged-branch-file-access.md
+++ b/skills/git-unmerged-branch-file-access.md
@@ -1,9 +1,9 @@
 ---
 name: git-unmerged-branch-file-access
-description: "Access and plan fixes for files that exist only on non-main git branches, and never declare a cited file 'phantom' until you have searched all branches. Use when: (1) Read/Glob/Grep return not-found for a file an issue references, so you are tempted to call it non-actionable / phantom code, (2) planning a 'follow-up from #NNN' bug whose cited file/symbol is absent from the default branch (it likely came from a parent PR that has not merged), (3) a PR fix must target a feature branch rather than main, (4) an issue cites a raw line number that no longer matches the branch tip (line drift)."
+description: "Access and plan fixes for files that are absent from your checkout — they may live on an unmerged feature branch, OR on origin/main when your checked-out branch simply predates them — and never declare a cited file 'phantom' until you have searched all branches. Also covers git-archaeology for changelog maintenance: attributing lines of a collapsed CHANGELOG/doc entry to the commits that introduced them. Use when: (1) Read/Glob/Grep return not-found for a file an issue references, so you are tempted to call it non-actionable / phantom code, (2) planning a 'follow-up from #NNN' bug whose cited file/symbol is absent from the default branch (it likely came from a parent PR that has not merged), (3) a PR fix must target a feature branch rather than main, (4) an issue cites a raw line number or literal entry text that no longer matches the branch tip (drift — issue text goes stale relative to main), (5) you must attribute lines of a collapsed CHANGELOG/doc entry to the commits that introduced them."
 category: architecture
-date: 2026-06-20
-version: "2.0.0"
+date: 2026-07-10
+version: "2.1.0"
 user-invocable: false
 verification: verified-local
 history: git-unmerged-branch-file-access.history
@@ -18,6 +18,10 @@ tags:
   - feature-branch
   - pr-base
   - carrier-branch
+  - changelog
+  - pickaxe
+  - plan-grounding
+  - stale-issue-text
 ---
 
 # Git Unmerged Branch File Access
@@ -28,36 +32,44 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-20 |
-| **Objective** | Read and plan fixes for files/symbols that exist only on non-main feature branches, and avoid the "phantom code" misdiagnosis when a cited file is absent from the default branch |
-| **Outcome** | Successful recovery — a "follow-up bug" issue (#283) cited `mcp_server.py:82`, absent from `main`; `git log --all` found the file on the unmerged `173-auto-impl` branch (commit `07ea99a`), and the plan was re-scoped to target that branch |
-| **Verification** | verified-local (investigation steps executed this session; downstream code fix is plan-only — see caveats) |
+| **Date** | 2026-07-10 |
+| **Objective** | Read and plan fixes for files/symbols that are absent from the current checkout — whether they live only on a non-main feature branch, or on `origin/main` when the checked-out branch predates them — avoid the "phantom code" misdiagnosis, and attribute collapsed CHANGELOG/doc entries to the commits that introduced them |
+| **Outcome** | Successful, twice. (v2.0.0) A "follow-up bug" issue (#283) cited `mcp_server.py:82`, absent from `main`; `git log --all` found the file on the unmerged `173-auto-impl` branch (commit `07ea99a`), and the plan was re-scoped to target that branch. (v2.1.0) ProjectArgus issue #240 referenced a `CHANGELOG.md` that did not exist on the checked-out branch at all — the branch PREDATED the file; `git show origin/main:CHANGELOG.md` + pickaxe attribution grounded every plan claim in git evidence and the plan passed review after a prior empty-output NOGO |
+| **Verification** | verified-local (investigation steps executed end-to-end in-session in both source sessions; the #283 downstream code fix is plan-only — see caveats) |
 
 > **Verification split — read this.** The git-history **investigation** workflow below is
-> `verified-local`: `git log --all`, `git branch --all --contains`, and `git show <sha>:<path>`
-> were ACTUALLY run this session and produced the cited results (carrier commit `07ea99a` on
-> branch `173-auto-impl`). The downstream **code fix** was NOT executed — it is plan-only.
-> The fix-stage assumptions are recorded as explicit `unverified` caveats in
-> [Results & Parameters](#results--parameters); treat those as hypotheses, not facts.
+> `verified-local`: `git log --all`, `git branch --all --contains`, `git show <sha>:<path>`,
+> `git show origin/main:<path>`, `git log -S` pickaxe, and the rev-walk grep were ACTUALLY
+> run in their source sessions and produced the cited results. The downstream **code fix**
+> for #283 was NOT executed — it is plan-only. The fix-stage assumptions are recorded as
+> explicit `unverified` caveats in [Results & Parameters](#results--parameters); treat those
+> as hypotheses, not facts.
 
 ## When to Use
 
 - `Read`, `Glob`, or `Grep` returns "not found" for a file you expect to exist, and you are
   about to conclude the issue is **non-actionable / references phantom code** — STOP and run
   this workflow first.
+- An issue references a **file/line that doesn't exist in your checkout** — the current branch
+  may simply PREDATE the file. Check `git ls-tree origin/main` before concluding the issue is
+  invalid (the inverse of the unmerged-feature-branch case: main is AHEAD of your checkout).
 - Planning a **"follow-up from #NNN"** / refinement / cited-line-number bug fix where the
   referenced file or symbol is **not on the default branch**. Follow-up issues are frequently
   filed against code from a PARENT PR that has not yet merged.
 - A PR fix must target a feature branch (e.g., `173-auto-impl`) instead of `main`.
 - Planning a fix for code visible in a PR diff but absent from the working tree.
-- An issue cites a **raw line number** that no longer matches the branch tip (line drift).
+- An issue cites a **raw line number** or **literal entry text** that no longer matches the
+  branch tip (drift — issue text goes stale relative to main).
+- You must **attribute lines of a collapsed CHANGELOG/doc entry** to the commits that
+  introduced them (e.g., splitting a combined milestone bullet into per-milestone bullets
+  with a content-preserving 1:1 mapping).
 
 ## Verified Workflow
 
-> **Verified-local:** every command in this section was run this session against the
-> ProjectTelemachy #283 carrier branch and produced the cited results. Do NOT skip step 1
-> just because Glob/Grep already "proved" the file is missing — those tools only see the
-> checked-out branch.
+> **Verified-local:** every command in this section was run in its source session
+> (ProjectTelemachy #283 for steps 1–6; ProjectArgus #240 for steps 7–12) and produced
+> the cited results. Do NOT skip step 1 just because Glob/Grep already "proved" the file
+> is missing — those tools only see the checked-out branch.
 
 ### Quick Reference
 
@@ -90,27 +102,49 @@ git show origin/173-auto-impl:src/telemachy/mcp_server.py | grep -n "def call_to
 # 6. Scope the plan to the CARRIER branch:
 git checkout -b fix/<description> origin/173-auto-impl
 gh pr create --base 173-auto-impl --title "fix: ..."   # NOT --base main
+
+# --- Inverse case: your CHECKOUT predates the file (it exists on origin/main) ---
+
+# 7. Read a file that exists only on another branch, without switching branches:
+git ls-tree --name-only origin/main | grep -i changelog
+git show origin/main:CHANGELOG.md
+
+# 8. Find the commit that introduced a phrase into a specific file (pickaxe):
+git log --all -S "M1" --oneline -- CHANGELOG.md
+
+# 9. See how one line evolved across every revision of a file:
+git grep -n "M1" $(git rev-list --all -- CHANGELOG.md | head -30) -- CHANGELOG.md | sort -u
+
+# 10. Attribute collapsed-entry phrases to their feature commits (milestone markers):
+git log --all --oneline -i --grep="atlas" | grep -iE "\bM[0-9]\b"
+
+# 11. Check markdown lint constraints BEFORE proposing doc edits:
+git show origin/main:.markdownlint.yaml   # e.g. MD013 line_length: 120
+git show origin/main:.pre-commit-config.yaml | grep -A2 markdownlint
 ```
 
 ### Detailed Steps
 
 1. **Detect the problem — and resist the phantom-code conclusion.** If `Read`, `Glob`, or
    `Grep` returns not-found for a file an issue references, the file most likely lives on a
-   feature branch not yet merged to `main`. The file-read tools operate on the **working tree
-   (the checked-out branch)** and cannot see other branches. Do NOT mark the issue
-   non-actionable yet.
+   feature branch not yet merged to `main` — or on `origin/main` itself, if your checkout
+   predates it. The file-read tools operate on the **working tree (the checked-out branch)**
+   and cannot see other branches. Do NOT mark the issue non-actionable yet.
 
 2. **Find the carrier commit — search by path AND by parent issue.** A follow-up issue
    ("follow-up from #NNN") was usually filed against code from a parent PR. Search both ways:
+
    ```bash
    git log --all --oneline -- "**/<file>"
    git log --all --oneline --grep="#<parent-issue>"
    ```
 
 3. **Identify the carrier branch:**
+
    ```bash
    git branch -a --contains <sha>
    ```
+
    If it only appears under `remotes/origin/<feature-branch>`, the file is not on `main`.
 
 4. **Read the file without switching branches** using `git show <sha>:<path>` (or
@@ -127,11 +161,47 @@ gh pr create --base 173-auto-impl --title "fix: ..."   # NOT --base main
    branch, and the PR base MUST be that branch — a branch off `main` would have **no file to
    edit**. State this explicitly in the plan and PR body so the reviewer understands why the
    base is not `main`.
+
    ```bash
    git checkout -b fix/<description> origin/<feature-branch>
    gh pr create --base <feature-branch> --title "fix: ..."
    ```
+
    The merged feature-branch PR will carry the fix to `main` when it eventually lands.
+
+7. **Check `origin/main` when the working tree lacks the file — your checkout may PREDATE
+   it.** Before concluding an issue is invalid because the referenced file returned nothing,
+   run `git ls-tree --name-only origin/main | grep -i <file>`. In ProjectArgus #240 the
+   checked-out branch predated `CHANGELOG.md` entirely; the file existed only on
+   `origin/main`, so working-tree `grep -rn` / `find -iname` returned nothing.
+
+8. **Read and line-cite from the branch the change will actually be cut from.** Use
+   `git show origin/main:<file>` to read and cite exact line numbers on `origin/main`, not
+   on your stale checkout — that is the base the eventual PR will diff against.
+
+9. **Pickaxe to find the commit that introduced the entry.** Use
+   `git log --all -S "<phrase>" --oneline -- <file>` to find which commit/PR introduced the
+   entry the issue talks about (in #240: commit `472aeb3` introduced the "M1–M3" form, at
+   line 14 of that revision).
+
+10. **Watch a single line mutate across revisions.**
+    `git grep -n "<token>" $(git rev-list --all -- <file> | head -30) -- <file> | sort -u`
+    shows every revision's version of the matching line. In #240 this revealed that
+    "Atlas service (M1–M3)" had grown into "(M1–M6)" (commit `7b2c8c7`) AFTER the issue was
+    filed — the literal line the issue named no longer existed on `main`.
+
+11. **Attribute each phrase of a collapsed entry to a milestone via feature-commit
+    subjects** (`git log --all --oneline -i --grep="<feature>"`), producing a 1:1
+    content-preserving mapping — no guessed attribution. Every phrase of the combined
+    bullet must map to exactly one introducing commit.
+
+12. **Read the repo's markdownlint/pre-commit config from the target branch**
+    (`git show origin/main:.markdownlint.yaml`,
+    `git show origin/main:.pre-commit-config.yaml`) so proposed doc snippets are lint-clean
+    up front (e.g. MD013 wrap width 120, hanging-indent style).
+
+> Steps 7–12 require **zero checkouts / branch switches** — the whole investigation is safe
+> to run on a dirty working tree.
 
 ## Failed Attempts
 
@@ -142,6 +212,9 @@ gh pr create --base 173-auto-impl --title "fix: ..."   # NOT --base main
 | Direct Read tool | Used Read/Glob/Grep with the expected file path | File not found — silently returns nothing because the file only exists on a feature branch | File-read tools operate on the checked-out branch; they cannot see files on other branches |
 | Assuming the file should exist on `main` | Proceeded as if the file was missing from the repo entirely | Wasted planning cycles trying to understand why a referenced file didn't exist | Follow-up issues are commonly filed against a parent PR's code that has not yet merged; check all branches |
 | Planning the fix as a branch off `main` | Implicitly assumed the PR base would be `main` | A branch off `main` has no copy of the file to edit; the change could not be made there | Branch-from / PR-target must be the carrier feature branch, not `main`; note this in the plan and PR body |
+| Working-tree-only search | `grep -rn -i "atlas" <repo>` and `find -iname "*changelog*"` on the current checkout | The file existed only on origin/main; the checkout branch predated it — search returned nothing | Absence from the working tree does not mean absence from the repo; check origin/main and `git log --all` before declaring an issue invalid |
+| Trusting issue text verbatim | Planned against the literal "M1-M3" entry named in the issue | The entry had since grown to "M1–M6" on main; the M1-M3 line no longer existed | Issue text goes stale; re-locate the target on current main and state the scope decision with evidence |
+| ASCII-hyphen grep for the entry | grep for "M1-M3" with a hyphen | The changelog uses an en dash ("M1–M3"); ASCII grep misses it | Grep for a shorter invariant token (e.g. "M1") or use character classes when docs may contain typographic dashes |
 
 ## Results & Parameters
 
@@ -157,6 +230,20 @@ For PR targeting:
 - If the file only exists on `origin/<feature-branch>`, the fix PR **must** base off that
   feature branch: `gh pr create --base <feature-branch>` — not `--base main`.
 - State in the PR body that the base is the carrier branch and why (file absent from `main`).
+
+### v2.1.0 results — ProjectArgus #240 changelog attribution (verified-local)
+
+- Pickaxe (`git log --all -S "M1" -- CHANGELOG.md`) found the introducing commit
+  `472aeb3` (the "M1–M3" form, at line 14 on that revision).
+- The rev-walk grep showed the entry mutated to "M1–M6" in commit `7b2c8c7` — after the
+  issue was filed, so the issue's literal target line no longer existed on `main`.
+- Six milestone feature commits (`8f47769`, `b66e987`, `ea2c8be`, `4ba1cac`, `fed0b90`,
+  `d78b298`) mapped every phrase of the combined bullet to exactly one milestone — a 1:1
+  content-preserving attribution with no guessing.
+- The entire investigation ran with **zero checkouts / branch switches** — safe on a dirty
+  working tree.
+- Lint grounding: `git show origin/main:.markdownlint.yaml` exposed MD013
+  `line_length: 120`, so proposed snippets were wrapped lint-clean up front.
 
 ### Unverified fix-stage caveats (carry forward as risks, not facts)
 
@@ -177,5 +264,6 @@ fix below was never executed:
 
 | Project | Context | Details |
 |---------|---------|---------|
+| ProjectArgus | Planning issue #240 (CHANGELOG milestone split), 2026-07-10 | Target `CHANGELOG.md` absent from the checked-out branch (the branch predated it); plan grounded every claim in git evidence (`git show origin/main:CHANGELOG.md` line citations, pickaxe commit `472aeb3`, mutation to M1–M6 in `7b2c8c7`, six milestone commits for 1:1 attribution) and passed review after a prior empty-output NOGO. Zero branch switches |
 | ProjectTelemachy | Issue #283 — "follow-up bug" citing `mcp_server.py:82`, absent from `main` | `git log --all` found the file on unmerged `173-auto-impl` (commit `07ea99a`); plan re-scoped to that branch; defect symbol at line 81 (issue said 82 — drift). Investigation verified-local; fix plan-only |
 | ProjectHephaestus | Issue #1300 planning (`severity_label.py` GITHUB_REPOSITORY KeyError) | File existed only on `1210-auto-impl` branch; discovered via `git log --all` (v1.0.0, unverified) |

--- a/skills/llm-corruption-repro-artifact-review.md
+++ b/skills/llm-corruption-repro-artifact-review.md
@@ -1,0 +1,165 @@
+---
+name: llm-corruption-repro-artifact-review
+description: "Durable repro artifact layout and manual-review tooling for long-running LLM corruption investigations. Use when: (1) a corruption sweep must be rerunnable outside the chat or agent session, (2) raw tokens/logits should support later prefix and intervention analysis, (3) manual labels must produce seed-level rates without leaking private operational artifacts."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: [llm, corruption, reproducibility, artifacts, manual-review, logits, tokens, redaction]
+---
+
+# LLM Corruption Repro Artifact Review
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Make LLM corruption investigations durable, rerunnable, and reviewable by standardizing per-seed run artifacts and manual-review tooling. |
+| **Outcome** | Store issue-specific scripts, docs, summaries, and review state under a durable repro directory; keep each run self-contained; report corruption rates by seed totals; keep private artifacts out of git or redacted. |
+| **Verification** | verified-local from local Inference360 issue 257 scripts, tests, and PR work. ProjectMnemosyne PR CI is separate and must not be claimed until checks prove it. |
+
+## When to Use
+
+- You are debugging long-running LLM text corruption, output degeneration, cache instability, or token/logit divergence across many seeds.
+- A run must be replayable by another host, cluster, or reviewer without relying on chat history, shell history, or an agent's local session state.
+- You need raw `tokens.jsonl` or `logits.jsonl` from broad sweeps so the same data can support later first-bad-token, prefix-comparison, or force-token intervention analysis.
+- Manual review must label candidate corruption events without losing state, double-counting bursts, or flooding reviewers with per-token dumps by default.
+- You are preparing docs, PRs, issue comments, or repro packages that must redact internal paths, endpoints, checkpoints, prompts, tokens, cookies, and user-specific locations.
+
+## Verified Workflow
+
+Verification status: `verified-local`. The workflow was validated through local Inference360 issue 257 repro scripts/tests and PR work. Do not mark this skill `verified-ci` unless the ProjectMnemosyne PR checks are observed green.
+
+### Quick Reference
+
+```text
+1. Create a durable issue-specific repro root: repro/<issue-id>/.
+2. Put scripts, docs, run directions, summaries, and reviewer tools there.
+3. Emit one self-contained run root per backend/model/config/seed.
+4. Store repro.sh, output.txt or assistant.txt, tokens.jsonl, logits.jsonl,
+   request/config metadata, and summary.json in each run root.
+5. Keep large/private artifacts outside git or replace them with placeholders.
+6. Review with scripts that auto-discover run roots and persist labels.
+7. Report rates as bad seeds / total seeds, not candidate or burst totals.
+```
+
+### Detailed Steps
+
+1. **Create the repro root first.** Use `repro/<issue-id>/` as the durable home for issue-specific scripts, run directions, summaries, reviewer tools, and small sanitized fixtures. Keep large raw artifacts in a private artifact root and reference them with placeholders such as `<REDACTED_ARTIFACT_ROOT>`.
+2. **Make every run self-contained.** Write each seed to a path like `runs/<backend>/<seed>/` or `runs/<model>/<config>/<seed>/`. Each run root should contain `repro.sh`, `output.txt` or `assistant.txt`, `tokens.jsonl`, `logits.jsonl`, `request.json`, `config.json`, and `summary.json`.
+3. **Make `repro.sh` rerunnable.** It should reconstruct one seed independently from explicit metadata, not from chat context, shell state, or untracked environment assumptions. Use placeholders for private endpoints and checkpoints, for example `<REDACTED_ENDPOINT>` and `<REDACTED_CHECKPOINT_PATH>`.
+4. **Capture raw tokens and logits during broad sweeps.** Approach-3 sweeps should preserve raw `tokens.jsonl` and `logits.jsonl` even if the first analysis only needs a binary label. The same files enable later approach-1 and approach-2 work: aggregate failing seeds, find first bad token, compare closest good/bad prefixes, and run force-token interventions.
+5. **Summarize in machine-readable form.** Each `summary.json` should include issue id, backend or model alias, config name, seed, prompt hash, output hash, label, candidate count, first bad token index when known, artifact schema version, and the redacted run-root shape.
+6. **Write processing scripts instead of reading artifacts manually.** Reviewer tools should auto-discover run roots, read summary and JSONL files, and print compact per-model/per-config counts. Per-token dumps should require `--verbose`.
+7. **Persist manual labels.** Store review decisions in a state file such as `review_state.json` so a reviewer can resume, audit who labeled which seed, and avoid re-reviewing the same seed after every script invocation.
+8. **Advance review after labeling one seed.** The loop should move to the next seed once a seed receives a label, but it must inspect all candidate events in a log when the first candidate is benign.
+9. **Review all corruption classes.** Do not hard-code the loop to the first ellipsis-like event. The classifier should allow every candidate class the investigation tracks, including text degeneration, stop/control-token artifacts, repetition bursts, JSON/tool-call corruption, tokenizer artifacts, and backend-specific logit divergence.
+10. **Treat benign ellipsis and control-token artifacts separately.** Comma-adjacent ellipsis fragments that function as array separators are usually benign. Stop-token or control-token renderings should be classified as artifacts unless the surrounding plain text actually degenerates.
+11. **Report seed-level rates.** Use `bad seeds / total seeds (%)` per model and config. Candidate count and burst count can be supporting diagnostics, but they are not the denominator for corruption rate.
+12. **Redact before publishing.** Docs, PRs, issue comments, and committed repro files must not include internal absolute paths, endpoint addresses, checkpoint names, private prompts, token-bearing artifacts, cookies, or user-specific locations. Keep shape with placeholders such as `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Candidate-count denominator | Counted corruption candidates or bursts instead of seeds | Burst totals made the rate look like a complete sample, for example reporting `2/2` reviewed bad cases instead of `2/256` seed rate | Always report `bad seeds / total seeds (%)`; keep candidate and burst counts as secondary diagnostics |
+| First-candidate-only review | Stopped after the first candidate event in each log | A benign first candidate hid later real corruption events in the same seed output | When the first candidate is benign, continue scanning every candidate event before labeling the seed clean |
+| Noisy default token dump | Printed every token/logit line during normal review | Reviewers could not scan model/config rates or labeling progress efficiently | Default to compact summaries; require `--verbose` for per-token dumps |
+| Manual artifact reading | Opened run logs by hand and labeled from ad hoc notes | Labels were hard to resume, audit, or reproduce, and later reviewers could not tell what had been reviewed | Build review scripts with auto-discovery, persistent state, and deterministic summaries |
+| Dropped raw sweep data | Kept only final text or binary labels from approach-3 sweeps | Later first-bad-token, prefix comparison, and force-token intervention analyses had to rerun expensive seeds | Preserve raw `tokens.jsonl` and `logits.jsonl` for every relevant seed |
+| Checked-in raw operations | Committed run artifacts without masking paths, endpoints, checkpoints, prompts, or token-bearing files | Durable repo artifacts can leak operational details even when docs are sanitized | Keep raw artifacts private, commit only sanitized scripts/summaries, and scan files before PRs/issues |
+| Ellipsis/control-token false positive | Treated comma-adjacent ellipsis fragments or stop/control-token renderings as text corruption | Parser and formatting artifacts inflated the corruption count | Add benign classifications for separator ellipses and control-token artifacts; require surrounding text degeneration for a bad label |
+
+## Results & Parameters
+
+### Durable Layout
+
+```text
+repro/<issue-id>/
+  README.md
+  run_sweep.py
+  review_corruption.py
+  summarize_runs.py
+  review_state.json
+  summaries/
+    latest.json
+    latest.md
+  runs/
+    <backend>/<seed>/
+      repro.sh
+      output.txt
+      assistant.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+    <model>/<config>/<seed>/
+      repro.sh
+      output.txt
+      tokens.jsonl
+      logits.jsonl
+      request.json
+      config.json
+      summary.json
+```
+
+### Per-Run Contract
+
+| Artifact | Purpose |
+|----------|---------|
+| `repro.sh` | Replays exactly one seed from explicit metadata and redacted placeholders |
+| `output.txt` or `assistant.txt` | Human-readable model output for quick review |
+| `tokens.jsonl` | Token IDs, text fragments, offsets, stop/control-token indicators, and candidate markers |
+| `logits.jsonl` | Raw or summarized logits needed for first-bad-token and prefix-comparison analysis |
+| `request.json` | Sanitized request shape, prompt hash, seed, sampling settings, and model/config alias |
+| `config.json` | Backend, model alias, artifact schema version, runtime flags, and redacted artifact-root shape |
+| `summary.json` | Machine-readable label, counts, hashes, first bad token index, and reviewer metadata |
+
+### Review Script Contract
+
+```text
+review_corruption.py --root repro/<issue-id>
+review_corruption.py --root repro/<issue-id> --model <model-alias> --config <config-name>
+review_corruption.py --root repro/<issue-id> --verbose
+summarize_runs.py --root repro/<issue-id> --by model,config
+```
+
+Expected summary shape:
+
+```text
+model=<model-alias> config=<config-name> bad=2/256 (0.78%) reviewed=256/256
+model=<model-alias> config=<other-config> bad=0/256 (0.00%) reviewed=256/256
+```
+
+State file shape:
+
+```json
+{
+  "schema_version": 1,
+  "labels": {
+    "<model>/<config>/<seed>": {
+      "label": "bad",
+      "class": "text-degeneration",
+      "reviewed_at": "2026-07-09T00:00:00Z",
+      "notes": "First non-benign degeneration after a benign separator ellipsis."
+    }
+  }
+}
+```
+
+### Redaction Checklist
+
+- Replace private artifact roots with `<REDACTED_ARTIFACT_ROOT>`.
+- Replace endpoints with `<REDACTED_ENDPOINT>`.
+- Replace checkpoint or tokenizer paths with `<REDACTED_CHECKPOINT_PATH>`.
+- Do not publish private prompts, token-bearing artifacts, cookies, bearer tokens, user-specific locations, hostnames, ports, or absolute infrastructure paths.
+- Keep examples structural, for example `<REDACTED_ARTIFACT_ROOT>/runs/<model>/<config>/<seed>/`, without exposing real operational values.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Issue 257 local corruption investigation scripts/tests and PR work | Durable per-run repro layout, raw token/logit capture, review-state tooling, seed-level rate reporting, and redaction rules were validated locally. Verification is `verified-local`, not `verified-ci`, until the ProjectMnemosyne PR checks prove this skill file. |

--- a/skills/pr-review-threadless-nogo-verdict-retry-wedge.md
+++ b/skills/pr-review-threadless-nogo-verdict-retry-wedge.md
@@ -1,0 +1,138 @@
+---
+name: pr-review-threadless-nogo-verdict-retry-wedge
+description: "A queue-based pipeline pr_review stage that returns a NOGO verdict carrying ZERO machine-extractable findings (no review threads, no file:line comments) deterministically wedges the review->implement retry loop until the budget exhausts. Use when: (1) a pipeline pr_review stage returns NOGO but the findings-parser extracts no durable line-level findings so the implementer has nothing concrete to address, (2) the same input re-runs deterministically (2 retries + final = 3 attempts) producing the identical threadless NOGO each time and tripping the artifact-failure cap, (3) an item fails back to implementation whose own fail-back budget (2/2) then also exhausts re-adopting the same PR, reaching a TERMINAL 'manual look needed' stop, (4) a cluster of terminal stops over a long single-repo loop run all trace to the SAME root cause (pr_review.py _nogo_without_durable_artifact) and correlate with a specific issue class (e.g. AUDIT-FINDING issues) rather than a global reviewer breakdown, (5) you are tempted to react to each recurrence as a fresh bug, kill the loop on first wedge, or 'just let it retry' a deterministic input that cannot change between attempts."
+category: ci-cd
+date: 2026-07-11
+version: "1.0.0"
+user-invocable: false
+verification: verified-ci
+tags:
+  - pr-review
+  - nogo-verdict
+  - threadless-nogo
+  - durable-finding
+  - retry-wedge
+  - deterministic-retry
+  - artifact-failure-cap
+  - fail-back-budget
+  - review-loop
+  - pipeline
+  - queue-based-automation
+  - poisoned-item-isolation
+  - terminal-stop
+  - audit-finding-issues
+  - escalate-not-retry
+  - synthetic-finding
+  - root-cause-clustering
+  - homericintelligence
+---
+
+# PR Review Threadless NOGO Verdict Retry Wedge
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-11 |
+| **Objective** | Diagnose why a queue-based automation pipeline's `pr_review` stage deterministically wedged the review->implement retry loop on a specific class of issues, burning the full retry budget while achieving nothing, and land a root-cause fix that stops silently retrying an input that cannot change. |
+| **Outcome** | Root-caused to `hephaestus/automation/pipeline/pr_review.py:805` (`_nogo_without_durable_artifact`): a NOGO verdict from which the findings-parser extracts zero durable line-level findings. Filed as bug #2079 with full occurrence data; root-cause fix landed via PR #2105. Blast radius bounded by poisoned-item isolation — the loop stayed net-productive (29 PRs created) despite ~15-21% of pr_review'd issues hitting the wedge. |
+| **Verification** | verified-ci — bug #2079 filed with occurrence data from a 4.3h single-repo loop run; the root-cause fix landed via PR #2105. |
+
+## When to Use
+
+- A queue-based pipeline `pr_review` stage returns a NOGO verdict but the findings-parser extracts NO durable line-level findings — no review threads, no `file:line` comments — so the implementer has nothing concrete to address.
+- The fail-back path re-runs the review deterministically (2 retries + final = 3 attempts), producing the SAME threadless NOGO each time and tripping the artifact-failure cap, failing the item back to implementation.
+- Implementation's own fail-back budget (2/2) then also exhausts re-adopting the same PR, and the item reaches a TERMINAL "manual look needed" stop.
+- A cluster of terminal stops over a long single-repo loop run all trace to the SAME root cause and correlate with ONE issue class (here, AUDIT-FINDING issues) rather than a global reviewer breakdown.
+- You are tempted to (a) react to each recurrence as a fresh bug, (b) kill the loop on the first wedge, or (c) "just let it retry" — when the input is deterministic and cannot change between attempts.
+
+## Verified Workflow
+
+### Quick Reference
+
+```text
+# The wedge condition (distinct case that MUST NOT silently retry):
+verdict == NOGO  AND  durable_findings(review_output) == []   # no threads, no file:line
+
+# WRONG: default fail-back retries the identical input
+for attempt in (1, 2, final):        # 2 retries + final = 3 attempts
+    verdict, findings = run_pr_review(pr)   # deterministic -> same threadless NOGO
+    # nothing to address -> artifact-failure cap trips -> fail back to implementation
+    # implementation fail-back (2/2) re-adopts same PR -> exhausts -> TERMINAL stop
+
+# RIGHT: treat "NOGO + zero durable findings" as a DISTINCT case
+if verdict == NOGO and not durable_findings:
+    # (a) surface the raw verdict body as a SYNTHETIC finding, OR
+    # (b) classify as a review-ARTIFACT error and ESCALATE to a human
+    # Do NOT loop the deterministic fail-back.
+```
+
+```text
+# Wedge vs normal stop:
+normal poisoned-item stop  -> isolated, correct, may spend < full budget
+threadless-NOGO wedge      -> DETERMINISTIC: same input -> same NOGO -> ALWAYS burns full budget
+```
+
+### Detailed Steps
+
+**1. Recognize the wedge by its determinism, not its symptom.** The terminal "manual look needed" stop looks like any other poisoned-item stop. What makes THIS one a wedge is that the retry is deterministic: same input -> same threadless NOGO -> same exhaustion. Nothing changes between attempts, so the retry budget is spent achieving nothing. A normal poisoned-item stop is isolated and correct (an item that genuinely can't proceed); the wedge is a specific input class that ALWAYS burns the full budget.
+
+**2. Trace to the single root cause before filing.** In a queue-based pipeline, the `pr_review` stage can return a NOGO whose findings-parser yields no durable line-level findings (`_nogo_without_durable_artifact` at `pr_review.py:805`). The implementer then has nothing concrete to address, so the fail-back path re-runs the review deterministically (2 retries + final = 3 attempts). Each attempt produces the same threadless NOGO, tripping the artifact-failure cap and failing the item back to implementation. If implementation's own fail-back budget (2/2) also exhausts re-adopting the same PR, the item reaches the TERMINAL stop.
+
+**3. Cluster recurrences by root cause; count at run_end, don't file per-occurrence.** Over the observed run, 7 issues / 10 terminal stops all traced to `pr_review.py:805`. File ONE bug (#2079) with the aggregate occurrence data, not one per stop. Note the final count at run_end.
+
+**4. Confirm the blast radius is CLASS-scoped, not a global reviewer breakdown.** The wedge correlated specifically with AUDIT-FINDING issues; other issue classes passed review cleanly. ~15-21% of pr_review'd issues hit it (7 issues / 10 terminal stops over a 4.3h single-repo run). This is a targeted input-class failure, not the reviewer being broken everywhere.
+
+**5. Let the loop finish; the wedge is survivable.** Poisoned-item isolation bounded each wedge — the loop always continued to the next issue and stayed net-productive (29 PRs created). The stuck PRs' underlying implementation work was INTACT: each PR's own CI judged it independently, so only the review infra failed and no work was lost. Do NOT abort the loop on the first wedge — that would abandon good, independently-CI-judged work.
+
+**6. Fix the root cause: treat "NOGO + zero durable findings" as a DISTINCT case.** Either (a) surface the raw verdict body as a synthetic finding so the implementer has something concrete to act on, or (b) classify it as a review-artifact error and escalate to a human — rather than looping the deterministic fail-back. The load-bearing principle: **do NOT silently retry an input that cannot change.** Merged via PR #2105.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Let the loop retry | Default fail-back re-ran the same review 3x (2 retries + final) | Deterministic input -> identical threadless NOGO each attempt -> artifact-failure cap trips -> budget exhausted for nothing | A retry only helps if SOMETHING can change between attempts; a threadless NOGO is invariant. Do not silently retry an input that cannot change. |
+| Treat every terminal stop as a new bug | Reacted to each #2079 recurrence as a fresh signal | They were all the SAME root cause (`pr_review.py:805`, `_nogo_without_durable_artifact`) | Cluster by root cause before filing; note the final count at run_end, don't file per-occurrence. |
+| Kill the loop on first wedge | Considered aborting the whole run when the wedge first appeared | Would abandon 8 PRs of good, independently-CI-judged work whose implementation was intact | Poisoned-item isolation means a bounded wedge is survivable; let the loop finish and fix the root cause separately. |
+
+## Results & Parameters
+
+### The wedge condition and the two correct dispositions
+
+```text
+Condition:  verdict == NOGO  AND  durable_findings == []   (no threads, no file:line comments)
+Root cause: hephaestus/automation/pipeline/pr_review.py:805  (_nogo_without_durable_artifact)
+
+WRONG (default): loop the deterministic fail-back
+  pr_review fail-back: 2 retries + final = 3 attempts  -> same threadless NOGO each time
+  -> trips artifact-failure cap -> fails back to implementation
+  implementation fail-back: 2/2 -> re-adopts same PR -> exhausts -> TERMINAL "manual look needed"
+
+RIGHT (fix, PR #2105): treat as a DISTINCT case
+  (a) surface raw verdict body as a SYNTHETIC finding (implementer gets something concrete), OR
+  (b) classify as a review-ARTIFACT error and ESCALATE to a human
+  NEVER silently retry an input that cannot change.
+```
+
+### Blast-radius data (4.3h single-repo loop run)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Terminal stops hitting the wedge | 7 issues / 10 terminal stops | All same root cause (`pr_review.py:805`) |
+| Fraction of pr_review'd issues affected | ~15-21% | Class-scoped, NOT a global reviewer breakdown |
+| Correlated issue class | AUDIT-FINDING issues | Other issue classes passed review cleanly |
+| Net productivity | POSITIVE — 29 PRs created | Poisoned-item isolation bounded each wedge; loop always continued |
+| Stuck PRs' underlying work | INTACT | Each PR's own CI judged it independently; only the review infra failed, no work lost |
+
+### Retry budgets involved
+
+| Budget | Value | Behavior on the wedge |
+|--------|-------|-----------------------|
+| pr_review fail-back | 2 retries + final = 3 attempts | Each attempt deterministically reproduces the threadless NOGO; trips the artifact-failure cap |
+| implementation fail-back | 2 / 2 | Re-adopts the same PR; exhausts; reaches TERMINAL "manual look needed" stop |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Queue-based automation pipeline `pr_review` stage; 4.3h single-repo loop run surfaced 7 issues / 10 terminal stops all tracing to `pr_review.py:805` (`_nogo_without_durable_artifact`), correlated with AUDIT-FINDING issues; loop stayed net-productive (29 PRs) via poisoned-item isolation | Bug #2079 (full occurrence data); root-cause fix merged via PR #2105 |

--- a/skills/sampling-degeneration-seed-token-debugging.md
+++ b/skills/sampling-degeneration-seed-token-debugging.md
@@ -1,0 +1,141 @@
+---
+name: sampling-degeneration-seed-token-debugging
+description: "Debug seed-driven LLM sampling degeneration by stopping at the first bad token and inspecting the next-token distribution. Use when: (1) the same prompt, weights, backend, and generation config differ only by seed, (2) top-k/top-p/temperature changes alter garbled-output rates, (3) a logging top-N limit may have been confused with sampler support."
+category: debugging
+date: 2026-07-09
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - llm
+  - sampling
+  - seed
+  - logits
+  - top-k
+  - top-p
+  - degeneration
+  - xllm
+  - issue-257
+---
+
+# Sampling Degeneration Seed Token Debugging
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-09 |
+| **Objective** | Diagnose LLM garbled output when matched runs differ only by seed, and separate bad random draws from prompt, weight, tokenizer, backend, or deterministic-forward differences. |
+| **Outcome** | Successful locally. The useful pivot was asking why seed mattered: seed changes the random draw from the next-token distribution, not the prompt, weights, tokenizer, or deterministic forward pass. That moved the investigation from whole-trace comparison to the first bad sampled token in one trace. |
+| **Verification** | verified-local. Evidence came from redacted Inference360 issue #257 scripts, dense-model sweeps, direct XLLM checks, and manual review. ProjectMnemosyne CI validation is pending for this skill PR. |
+
+## When to Use
+
+- The same model, prompt, backend, tokenizer, and generation config produce readable output for one seed and garbled output for another.
+- A generation degenerates into repeated ellipsis, newline loops, prompt-framing leakage, or similar hard corruption after an apparently valid prefix.
+- You need to decide whether top-k, top-p, greedy, temperature, or stop-token behavior is changing the actual sampler support.
+- A trace-diff approach is producing too much noise and not explaining why a specific seed fails.
+- A script reports `top_k=N`, but there is any chance `N` is only the top-N dump/reporting limit instead of the sampler's support.
+
+## Verified Workflow
+
+Verified locally only through redacted Inference360 issue #257 scripts and manual review. Do not claim verified-ci until this skill PR's `validate` and `markdownlint` checks pass.
+
+### Quick Reference
+
+```bash
+# Capture a per-step trace for one failing seed.
+python <trace-script>.py \
+  --model <model-id> \
+  --prompt-file <REDACTED_PROMPT_FILE> \
+  --seed 116 \
+  --temperature 1 \
+  --top-k 20 \
+  --top-k-dump 50 \
+  --output <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl
+
+# Inspect the selected token rank and probability near the first hard-corruption step.
+python <analyze-trace-script>.py \
+  <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --window 80:100 \
+  --top-n 20
+
+# Replay the divergence step by forcing plausible alternatives.
+python <force-token-script>.py \
+  --trace <REDACTED_ARTIFACT_ROOT>/seed-116-trace.jsonl \
+  --force-step 90 \
+  --force-rank 1,2,3,4 \
+  --output <REDACTED_ARTIFACT_ROOT>/forced-alternatives.jsonl
+```
+
+### Detailed Steps
+
+1. **Ask why seed matters before comparing whole traces.** With the same prompt, weights, backend, tokenizer, and generation config, seed should only affect random sampling from the next-token distribution. It should not change the deterministic forward pass. This narrows the first question to: which sampled token draw sent the trace into a bad basin?
+2. **Collect per-step token evidence.** For each generated step, log the selected token id/text, selected rank, selected probability, logits or post-filter probabilities, top-N alternatives, active sampler config, stop/control-token flags, and the decoded prefix.
+3. **Stop at the first hard-corruption token.** Do not start by explaining every downstream token. Find the first selected token after which the continuation becomes repeated ellipsis/newline variants, prompt-framing leakage, or another stable corruption pattern.
+4. **Inspect selected rank and nearby alternatives.** A low-probability selected token can be a valid sampler draw even when rank 1 is overwhelmingly more likely. The key diagnostic is whether the selected token was inside the configured sampler support and whether higher-ranked alternatives preserve readable continuation.
+5. **Force plausible alternatives at the divergence step.** Replay from the same prefix while forcing rank-1, rank-2, rank-3, and the originally selected token. If the top alternatives stay readable and the original draw degenerates, the corruption is primarily a sampling-tail trajectory, not a whole-trace backend mismatch.
+6. **Sweep sampler support deliberately.** Compare greedy or top-k=1, small top-k, larger top-k, no top-k, and top-p thresholds such as 0.9, 0.95, 0.99, and 0.999. Keep dense-model and MoE results separate, and label partial MoE data as revalidation-needed.
+7. **Separate sampler controls from diagnostic dumps.** `--top-k` should control sampler support. A separate `--top-k-dump` or `--top-n-dump` should only limit the logged alternatives. Logs must print both actual sampler support and dump size.
+8. **Manually review labels.** Do not auto-label every newline or comma-adjacent ellipsis fragment as corruption. Repeated ellipsis bursts, newline loops, and prompt-framing leakage are the meaningful class. Numeric-array fragments such as `,...`, `...,`, `,…`, or `…,'` can be benign formatting artifacts and need context.
+9. **Treat stop/control-token artifacts separately.** If a suspicious case is caused by a special stop/control token or a harness stop condition, record it as an artifact unless the decoded continuation itself demonstrates model-output corruption.
+10. **Record verification honestly.** Local sweeps and manual review support `verified-local`. Only mark `verified-ci` when the skill PR's validation gates are observed green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Compare whole good/bad traces first | Diffed two generations that differed only by seed | The diff grew after divergence and obscured the causal draw | Ask what seed changes, then stop at the first bad sampled token in one failing trace |
+| Treat newline spam alone as corruption | Counted newline-heavy output as bad without reviewing decoded context | Some newline behavior was prompt or formatting related, not hard model degeneration | Label repeated ellipsis bursts, newline loops, and prompt-framing leakage; manually review ambiguous cases |
+| Use top-k dump count as sampler top-k | A script reported `top_k=N` from the logged top-N dump limit while actual `sampling_top_k` was infinite | The report implied a bounded sampler even when the sampler could draw from the full distribution | Use `--top-k` for sampler support and `--top-k-dump` only for diagnostic logging |
+| Assume low-probability draw means backend bug | Treated a very unlikely selected token as impossible | Sampling at temperature 1 can draw low-probability in-support tokens | Inspect rank/probability and replay forced alternatives before blaming logits computation |
+| Mistake stop-token artifacts for corruption | Counted special control or stop-token effects as bad model output | The harness boundary, not the model's decoded continuation, caused some suspicious cases | Track stop/control-token status and keep those cases out of true corruption counts |
+
+## Results & Parameters
+
+### Representative Local Finding
+
+A redacted 4B dense-model run with temperature explicitly set to 1, top-k=20, and seed 116 selected an ellipsis-family token around step 90. The selected token was rank 4 at about 0.01% probability while rank 1 was about 75%. After that draw, the next-token distribution flattened into ellipsis and newline variants and the text degenerated. Replaying the divergence while forcing rank-1, rank-2, or rank-3 alternatives kept the continuation readable.
+
+Direct XLLM sweeps showed greedy/top-k=1 removed the observed failures. Top-k=5, top-k=20, and no top-k still had failures. Top-p 0.9 and 0.95 mostly or entirely removed true ellipsis degeneration in the reviewed dense sweep.
+
+### Top-p Sweep Evidence
+
+The following are local issue #257 dense-model manual-review rates across 256 seeds per model where runs completed. Treat them as redacted local evidence, not ProjectMnemosyne CI evidence.
+
+| Sampler | 4B | 7B | 32B | 36B | Notes |
+|---------|----|----|-----|-----|-------|
+| top-p 0.9 | 0/256 | 0/256 | 0/256 | 0/256 | No manually reviewed true bad dense cases where runs completed |
+| top-p 0.95 | 0/256 | 2/256 suspicious | 0/256 | 0/256 | The 7B suspicious cases looked likely to be stop-token artifacts rather than true ellipsis degeneration |
+| top-p 0.99 | 1/256 | 2/256 | 2/256 | 0/256 | Low reviewed true bad rates |
+| top-p 0.999 | 3/256 | 5/256 | 14/256 | 20/256 | Higher reviewed true bad rates as the tail widened |
+
+MoE partial data from the same investigation is revalidation-needed and should not be generalized until dense and MoE runs complete under the same review protocol.
+
+### Config Contract
+
+Use separate flags for sampler behavior and diagnostic visibility:
+
+```text
+--top-k 20        # sampler support: only ranks inside top 20 are eligible
+--top-k-dump 50   # diagnostic dump: log up to 50 alternatives, does not affect sampling
+--top-p 0.95      # sampler support: nucleus threshold
+--temperature 1   # explicit temperature, not an implicit default
+```
+
+Sanity checks for trace/report scripts:
+
+- The emitted report field for sampler support must come from the actual sampling config, not the dump limit.
+- The logged top-N count may exceed sampler support if it is used only for diagnostics.
+- The trace should record selected rank after all active sampler filters.
+- The manual-review label should distinguish true degeneration from formatting fragments and stop/control-token artifacts.
+
+### Review Caveat
+
+Comma-adjacent ellipsis fragments in numeric arrays, including `,...`, `...,`, `,…`, and `…,'`, should not be auto-labeled as corruption. Review decoded context. Meaningful corruption is repeated ellipsis bursts, newline loops, or prompt-framing leakage that persists after the first bad draw.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| LLM360/Inference360 | Redacted issue #257 local scripts and manual review, 2026-07-09 | Dense-model traces and sweeps supported the first-bad-token workflow, forced-alternative replay, top-k/top-p findings, and the sampler-vs-dump caution. MoE partial data remains revalidation-needed. |


### PR DESCRIPTION
## Summary

New skill. Documents how a queue-based pipeline `pr_review` stage that returns a NOGO verdict carrying ZERO machine-extractable findings deterministically wedges the review->implement retry loop until the budget exhausts.

- Root cause: `hephaestus/automation/pipeline/pr_review.py:805` (`_nogo_without_durable_artifact`) — a NOGO with no durable line-level findings (no review threads, no file:line comments) leaves the implementer nothing concrete to address.
- The retry is DETERMINISTIC: same input -> same threadless NOGO -> the artifact-failure cap trips and both the pr_review (3-attempt) and implementation (2/2) fail-back budgets are burned for nothing, reaching a TERMINAL "manual look needed" stop.
- Distinct from a normal poisoned-item stop (isolated, correct): this specific input class ALWAYS burns the full budget because nothing can change between attempts.

## Verification Level

**verified-ci** — bug #2079 filed with occurrence data from a 4.3h single-repo loop run; the root-cause fix landed via PR #2105.

## Key Findings

**What Worked**:
- Tracing the cluster of terminal stops to a single root cause (`pr_review.py:805`) and filing ONE bug (#2079) with aggregate occurrence data instead of one per stop.
- Letting the loop finish: poisoned-item isolation bounded each wedge, so the run stayed net-productive (29 PRs created) and the stuck PRs' implementation work stayed intact (each PR's own CI judged it independently).
- Fix direction (PR #2105): treat "NOGO + zero durable findings" as a DISTINCT case — surface the raw verdict body as a synthetic finding, or classify it as a review-artifact error and escalate to a human. Never silently retry an input that cannot change.

**What Failed**:
- Letting the loop retry -> deterministic threadless NOGO reproduced each attempt, budget exhausted for nothing.
- Reacting to each recurrence as a new bug -> they were all the same root cause.
- Killing the loop on the first wedge -> would abandon good, independently-CI-judged work.

## Blast radius

~15-21% of pr_review'd issues hit it (7 issues / 10 terminal stops), correlated specifically with AUDIT-FINDING issues — a class-scoped failure, not a global reviewer breakdown.

## Test Plan

- [x] Validate with `python3 scripts/validate_plugins.py` (642/642 valid)
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords (threadless NOGO, retry wedge, durable finding)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>