### PR TITLE
feat: amend logical-model-family-rename skill — execute deferred package rename (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10210,8 +10210,8 @@
     },
     {
       "name": "logical-model-family-rename-with-storage-exceptions",
-      "description": "Rename repository logical model-family surfaces without breaking physical checkpoint or benchmark storage paths. Use when: (1) replacing old model-family names in manifests, docs, tests, scripts, and routes, (2) preserving real external paths that still contain the old name, (3) adding a guard that blocks old logical names while allowing storage references.",
-      "version": "1.0.1",
+      "description": "Rename logical reference surfaces (model-family names, or org/repo names when dropping a prefix) without breaking physical storage paths or package identity, AND execute the deferred breaking package rename correctly. Use when: (1) replacing old names in manifests, docs, tests, scripts, routes, and repo/URL references, (2) preserving real external paths or package names that still contain the old name, (3) splitting a safe reference-only sweep now from a breaking package/source rename deferred to a tracked issue, (4) adding a guard that blocks old logical names while allowing storage references, (5) a rename PR fails coverage/build because refs were renamed but package DIRECTORIES were not git mv'd, (6) completing a projectX->X package rename (git mv dirs + fix post-branch-merged files), (7) rebasing a stale whole-tree rename onto current main.",
+      "version": "1.2.0",
       "source": "./skills/logical-model-family-rename-with-storage-exceptions.md",
       "category": "tooling",
       "tags": [
@@ -10220,7 +10220,16 @@
         "manifests",
         "h200-slurm",
         "storage-exceptions",
-        "ruff"
+        "ruff",
+        "repo-rename",
+        "url-sweep",
+        "package-rename",
+        "deferred-breaking-change",
+        "git-mv",
+        "whole-tree-rename",
+        "rebase",
+        "coverage-validator",
+        "mojo"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10150,8 +10150,8 @@
     },
     {
       "name": "logical-model-family-rename-with-storage-exceptions",
-      "description": "Rename repository logical model-family surfaces without breaking physical checkpoint or benchmark storage paths. Use when: (1) replacing old model-family names in manifests, docs, tests, scripts, and routes, (2) preserving real external paths that still contain the old name, (3) adding a guard that blocks old logical names while allowing storage references.",
-      "version": "1.0.1",
+      "description": "Rename logical reference surfaces (model-family names, or org/repo names when dropping a prefix) without breaking physical storage paths or package identity, AND execute the deferred breaking package rename correctly. Use when: (1) replacing old names in manifests, docs, tests, scripts, routes, and repo/URL references, (2) preserving real external paths or package names that still contain the old name, (3) splitting a safe reference-only sweep now from a breaking package/source rename deferred to a tracked issue, (4) adding a guard that blocks old logical names while allowing storage references, (5) a rename PR fails coverage/build because refs were renamed but package DIRECTORIES were not git mv'd, (6) completing a projectX->X package rename (git mv dirs + fix post-branch-merged files), (7) rebasing a stale whole-tree rename onto current main.",
+      "version": "1.2.0",
       "source": "./skills/logical-model-family-rename-with-storage-exceptions.md",
       "category": "tooling",
       "tags": [
@@ -10160,7 +10160,16 @@
         "manifests",
         "h200-slurm",
         "storage-exceptions",
-        "ruff"
+        "ruff",
+        "repo-rename",
+        "url-sweep",
+        "package-rename",
+        "deferred-breaking-change",
+        "git-mv",
+        "whole-tree-rename",
+        "rebase",
+        "coverage-validator",
+        "mojo"
       ]
     },
     {

--- a/skills/logical-model-family-rename-with-storage-exceptions.history
+++ b/skills/logical-model-family-rename-with-storage-exceptions.history
@@ -3,6 +3,20 @@
 
 # History: logical-model-family-rename-with-storage-exceptions
 
+## v1.2.0 (2026-07-12)
+
+- **Changed by:** HomericIntelligence/Odyssey — EXECUTING the deferred breaking package rename `projectodyssey`->`odyssey`, PR #5584 (MERGED)
+- **Verification:** verified-ci
+- **What changed:**
+  - Bumped `version` 1.1.0 -> 1.2.0 and `date` 2026-07-11 -> 2026-07-12.
+  - Extended the skill from "defer the breaking package rename to an issue" (v1.1.0) to also cover **executing** that deferred rename: this session ran PR #5584, the atomic PR issue #5579 tracked.
+  - Extended the description with triggers (5) a rename PR fails coverage/build because refs were renamed but dirs were not `git mv`'d, (6) completing a projectX->X package rename, (7) rebasing a stale whole-tree rename. Added tags: git-mv, whole-tree-rename, rebase, coverage-validator, mojo.
+  - Added an Overview "Also verified on" clause + 3 When-to-Use triggers for the half-done-rename symptom, executing the deferred rename, and rebasing a stale whole-tree rename.
+  - Added Verified Workflow subsection **"Execute the Deferred Breaking Package Rename (git mv the DIRS, then rebase)"** with a `### Quick Reference` (git mv the 3 package dirs + `git status` R-check + `git grep`/`find` completeness verify + mojo build verify + `validate_test_coverage.py`) and a **rebase conflict-resolution recipe** (content conflict -> take main's newer content via `--ours` then re-sed; `CONFLICT (file location)` -> `git mv` into renamed tree + sed imports; re-`git grep` for post-branch merges).
+  - Added 4 Failed Attempts rows: renamed refs only not dirs (mojo.toml -> missing dir, "267 uncovered"); whole-file reformat churn; rebased blind; assumed passed-rebase == complete.
+  - Added an "Execute-the-Package-Rename Completion Checklist" Results block and a Verified On row for PR #5584 (MERGED).
+- **Why:** v1.1.0 deferred the breaking `projectodyssey` package rename to `state:needs-plan` issue #5579. This session executed it. Key learning: a "rename X->Y" PR that rewrites every *reference* but never `git mv`s the actual package DIRECTORIES is half-done — the manifest points at a nonexistent dir and the coverage validator sees old-path files as uncovered (symptom: `Validate Test Coverage` "❌ Found 267 uncovered test file(s)"). Completing it = move the dirs + fix refs in files merged post-branch + rebase the stale whole-tree rename. A whole-tree rename is atomic and stales on every merge; verify with `git grep` == 0 AND a build AND the coverage validator, not just "references look renamed."
+
 ## v1.1.0 (2026-07-11)
 
 - **Changed by:** HomericIntelligence/Odyssey repo rename — URL sweep PR #5580 + package-rename issue #5579

--- a/skills/logical-model-family-rename-with-storage-exceptions.md
+++ b/skills/logical-model-family-rename-with-storage-exceptions.md
@@ -1,12 +1,12 @@
 ---
 name: logical-model-family-rename-with-storage-exceptions
-description: "Rename logical reference surfaces (model-family names, or org/repo names when dropping a prefix) without breaking physical storage paths or package identity. Use when: (1) replacing old names in manifests, docs, tests, scripts, routes, and repo/URL references, (2) preserving real external paths or package names that still contain the old name, (3) splitting a safe reference-only sweep now from a breaking package/source rename deferred to a tracked issue, (4) adding a guard that blocks old logical names while allowing storage references."
+description: "Rename logical reference surfaces (model-family names, or org/repo names when dropping a prefix) without breaking physical storage paths or package identity, AND execute the deferred breaking package rename correctly. Use when: (1) replacing old names in manifests, docs, tests, scripts, routes, and repo/URL references, (2) preserving real external paths or package names that still contain the old name, (3) splitting a safe reference-only sweep now from a breaking package/source rename deferred to a tracked issue, (4) adding a guard that blocks old logical names while allowing storage references, (5) a rename PR fails coverage/build because refs were renamed but package DIRECTORIES were not git mv'd, (6) completing a projectX->X package rename (git mv dirs + fix post-branch-merged files), (7) rebasing a stale whole-tree rename onto current main."
 category: tooling
-date: 2026-07-11
-version: "1.1.0"
+date: 2026-07-12
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
-tags: [model-family, rename, manifests, h200-slurm, storage-exceptions, ruff, repo-rename, url-sweep, package-rename, deferred-breaking-change]
+tags: [model-family, rename, manifests, h200-slurm, storage-exceptions, ruff, repo-rename, url-sweep, package-rename, deferred-breaking-change, git-mv, whole-tree-rename, rebase, coverage-validator, mojo]
 ---
 
 # Logical Model Family Rename With Storage Exceptions
@@ -19,7 +19,7 @@ tags: [model-family, rename, manifests, h200-slurm, storage-exceptions, ruff, re
 | **Objective** | Rename logical reference surfaces (a model-family name, or an org/repo name when dropping a prefix) from an old name to a new name while preserving real physical storage paths and package identity that still contain the old name. |
 | **Outcome** | Successful. Logical identifiers, reference/URL surfaces, and tracked filenames moved to the new name; stale logical names were guarded by tests; physical storage paths and package/source identity were intentionally preserved or deferred to a tracked breaking-change issue; source-repository CI passed. |
 | **Verification** | verified-ci |
-| **Also verified on** | HomericIntelligence/Odyssey (formerly ProjectOdyssey) org/repo rename: safe URL sweep PR #5580 (docs-only, 105 files) passed CI; breaking package rename deferred to issue #5579. |
+| **Also verified on** | HomericIntelligence/Odyssey (formerly ProjectOdyssey) org/repo rename: safe URL sweep PR #5580 (docs-only, 105 files) passed CI; breaking package rename deferred to issue #5579. The **deferred breaking package rename was then EXECUTED** in PR #5584 (`projectodyssey`->`odyssey`): `git mv` the 3 package dirs, fix post-branch-merged refs, rebase the stale whole-tree rename — previously-failing coverage/build checks passed and PR #5584 MERGED. |
 
 ## When to Use
 
@@ -29,6 +29,9 @@ tags: [model-family, rename, manifests, h200-slurm, storage-exceptions, ruff, re
 - Old logical names must disappear, but real external storage or a published package name still uses old-name segments.
 - A bulk rename has started to mutate protected paths, package-identity fields, workflow files, or generated placeholder tokens.
 - Ruff reformats a stale-token guard in a way that defeats the guard.
+- **A "rename package X->Y" PR fails CI coverage or build** because it rewrote every text *reference* but never `git mv`'d the actual package *directories* — the manifest points at a nonexistent dir and the coverage validator sees the old-path files as "uncovered."
+- **You are now executing the previously-deferred breaking package rename** (the atomic PR the issue tracked): move the source/test/python package dirs and fix references in files that merged AFTER the branch was cut.
+- **You must rebase a stale whole-tree rename** onto current main: the branch is N commits behind, other work merged inside a renamed dir, and `git rebase` produces content conflicts plus `CONFLICT (file location)` for files added on main inside the renamed tree.
 
 ## Verified Workflow
 
@@ -114,6 +117,65 @@ When an org renames a repo by dropping a prefix (`HomericIntelligence/ProjectOdy
 
 5. **Companion repos:** for package-producing siblings (e.g. Hephaestus) whose rename affects a published package or plugin, file a parallel package-rename issue on each rather than sweeping their source inline.
 
+### Execute the Deferred Breaking Package Rename (git mv the DIRS, then rebase)
+
+This is the atomic PR the deferred issue tracked. A rename PR that rewrites every *reference*
+(`mojo.toml` already maps `odyssey = "src/odyssey"`, configs say `odyssey`, `check_coverage.py`
+uses `src/odyssey/`) but **never `git mv`s the actual package directories** is half-done and
+breaks the build + coverage: the manifest points at a nonexistent `src/odyssey`, and the coverage
+validator looks under the renamed path while the code still lives at the old path. Symptom seen:
+`precommit-benchmark` -> `Validate Test Coverage` -> "❌ Found 267 uncovered test file(s)" all
+under `tests/projectodyssey/...`, plus a ruff-format failure.
+
+**A whole-tree rename PR is ATOMIC and goes stale the instant any other PR merges.** It must
+merge before any new PR lands, or you must re-rebase. Complete it in a window with an empty merge
+queue. Verify with `git grep -l <oldname>` == 0 AND a build AND the coverage/manifest validator —
+not just "references look renamed."
+
+#### Quick Reference
+
+```bash
+OLD=projectodyssey; NEW=odyssey
+
+# 1. git mv the ACTUAL package directories (this is the step the half-done PR skipped).
+git mv src/${OLD}     src/${NEW}
+git mv tests/${OLD}   tests/${NEW}
+git mv python/${OLD}  python/${NEW}
+# Confirm git detected RENAMES (R), not delete+add:
+git status --short | awk '{print $1}' | sort | uniq -c   # expect R's, not D+A
+
+# 2. Fix flagged Python files (avoid a whole-file reformat diff — run the repo's formatter).
+pixi run ruff format .
+
+# 3. VERIFY completeness — BOTH must be empty/none:
+git grep -l 'projectodyssey\|ProjectOdyssey'      # must print nothing (rc 1)
+find . -type d -name '*projectodyssey*'           # must print nothing
+
+# 4. VERIFY it BUILDS from the NEW path (imports must resolve there):
+pixi run mojo build -I src tests/${NEW}/base/test_base_imports.mojo -o /tmp/x -Xlinker -lm
+/tmp/x                                             # binary runs
+
+# 5. VERIFY the coverage/manifest validator the CI job runs:
+python3 scripts/validate_test_coverage.py          # rc 0
+```
+
+#### Rebasing the stale whole-tree rename (the critical part)
+
+The branch was 16 commits behind main; other work had merged into `src/projectodyssey/**`
+AFTER the branch was cut. `git rebase origin/main` produces two distinct conflict classes:
+
+- **(a) Content conflicts** in files both sides touched. Resolve by taking **main's newer
+  content** (`git checkout --ours <file>` during the rebase — during a rebase, "ours" is the
+  branch being rebased onto, i.e. main's HEAD), then re-apply the rename to that newer content:
+  `sed -i 's/projectodyssey/odyssey/g' <file>`.
+- **(b) `CONFLICT (file location)`** for files ADDED on main *inside a renamed dir*. Git literally
+  tells you the file "should perhaps be moved to `tests/odyssey/...`". Resolve by moving those new
+  files into the renamed tree (`git mv`) and `sed` their imports to the new package name.
+
+After the rebase completes, **re-run `git grep -l 'projectodyssey\|ProjectOdyssey'`** — this
+session it surfaced 7 more files (new `*_autograd.mojo` example entrypoints that merged
+post-branch) still carrying old refs. `sed` those too, then re-verify build + validator.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -125,6 +187,10 @@ When an org renames a repo by dropping a prefix (`HomericIntelligence/ProjectOdy
 | Assumed repo rename == package rename | Planned to rewrite the `projectodyssey` Mojo package and all ~546 imports inline in the repo-rename PR | Renaming a repo does not rename its package; conflating them makes a massive breaking change that leaves the tree half-renamed | Defer the package/source rename to its own atomic PR tracked by a `state:needs-plan` issue; the reference sweep and the package rename are different classes of change. |
 | Global `\bProjectOdyssey\b` sweep | Substituted the bare word everywhere | Risked hitting `pixi.toml`/`pyproject.toml` `name = "ProjectOdyssey"` and workflow `version('ProjectOdyssey')` — package identity, not references | Scope sed to the URL form (`github.com/Org/ProjectRepo`) plus repo-name prose; exclude `name=` fields, `.github/workflows`, and `.mojo`. |
 | Edited workflow files in the sweep | Included `.github/workflows/` in the URL substitution | Workflow edits are human-review-gated per repo AGENTS.md, and they often carry the deferred package name anyway | Exclude `.github/workflows` from the sweep; verify `git diff --name-only \| grep '.github/workflows'` is empty. |
+| Renamed references only, not the dirs | Rewrote every `projectodyssey`->`odyssey` reference (`mojo.toml` mapped `odyssey = "src/odyssey"`, configs, `check_coverage.py`) but never `git mv`'d `src/`, `tests/`, `python/` package dirs | `mojo.toml` pointed at a non-existent `src/odyssey`; the coverage validator looked under the renamed path but code was at the old path -> "❌ Found 267 uncovered test file(s)" + build failure | A rename is only half-done until the DIRECTORIES move. `git mv` the package dirs; verify with `git grep -l <old>` == 0 AND `find -type d -name '*<old>*'` == none AND a build AND the coverage validator, not just "references look renamed." |
+| Whole-file reformat churn | Let the formatter rewrite whole files (json.dump-style) so the rename diff drowned in reformatting noise | Massive unrelated churn makes the rename PR unreviewable and can hide real changes | Run the repo's own formatter (`pixi run ruff format .`) so only the genuinely-flagged files change; keep the rename diff focused on moves + import lines. |
+| Rebased the stale whole-tree rename blind | Ran `git rebase origin/main` on a 16-commits-behind whole-tree rename and tried to auto-resolve | Two conflict classes appeared: content conflicts (files both sides touched) and `CONFLICT (file location)` for files ADDED on main inside a renamed dir; naive resolution dropped main's newer work or left files at the old path | Take main's newer content (`--ours` during rebase) then re-`sed` the rename onto it; `git mv` the file-location conflicts into the renamed tree + sed imports; then re-`git grep` (7 more `*_autograd.mojo` files that merged post-branch still had old refs). |
+| Assumed a passed rebase == complete rename | Called the rename done once `git rebase` finished cleanly | Files that merged onto main AFTER the branch was cut carried old refs the branch never touched | A whole-tree rename is atomic and stales on every merge; after rebase, re-run `git grep -l <old>` and expect new hits from post-branch merges. Merge it in an empty-merge-queue window or re-rebase. |
 
 ## Results & Parameters
 
@@ -196,6 +262,27 @@ ALLOWED_PHYSICAL_PATH_FRAGMENTS = (
 
 The test should scan logical repo surfaces and fail on stale logical tokens unless the match is inside a known physical storage fragment.
 
+### Execute-the-Package-Rename Completion Checklist
+
+```yaml
+move_the_dirs:            # the step a half-done rename skips
+  - git mv src/<old>    src/<new>
+  - git mv tests/<old>  tests/<new>
+  - git mv python/<old> python/<new>
+  - "git status --short must show R (rename), not D+A"
+completeness_verify:      # ALL must be clean before calling it done
+  - "git grep -l '<old>\\|<OldCamel>'   -> empty (rc 1)"
+  - "find . -type d -name '*<old>*'      -> none"
+  - "mojo build -I src tests/<new>/base/test_base_imports.mojo -> binary runs"
+  - "python3 scripts/validate_test_coverage.py -> rc 0"
+rebase_stale_whole_tree_rename:
+  - "content conflict (both sides touched): take main's newer content (--ours during rebase) then sed the rename onto it"
+  - "CONFLICT (file location) (file added on main inside renamed dir): git mv it into the renamed tree + sed imports"
+  - "AFTER rebase: re-run git grep; expect NEW hits from files merged post-branch (this session: 7 *_autograd.mojo entrypoints)"
+merge_window:
+  - "atomic: stales on every merge into a renamed dir; merge in an empty-merge-queue window or re-rebase"
+```
+
 ### Verification Evidence
 
 ```text
@@ -213,3 +300,4 @@ verification: verified-ci
 |---------|---------|---------|
 | LLM360/Inference360 | Logical model-family rename across H200 Slurm manifests, docs, scripts, examples, and tests | Verified with clean diff whitespace check, no stale tracked filenames, stale logical-name grep guard, full local validation, and passing CI. |
 | HomericIntelligence/Odyssey (formerly ProjectOdyssey) | Org/repo rename dropping the `Project` prefix: safe URL/reference sweep separated from the breaking package rename | URL sweep PR #5580 (docs-only, 105 files, 445-for-445 substitution) passed CI; `.mojo`/`.github/workflows`/`name=` fields excluded and verified empty; breaking Mojo-package (`projectodyssey`, ~546 imports) + `name`/`version` rename deferred to `state:needs-plan` issue #5579; companion package-repo (Hephaestus) got its own parallel package-rename issue. |
+| HomericIntelligence/Odyssey (Mojo repo) | **Executing** the deferred breaking package rename `projectodyssey`->`odyssey` in PR #5584 | The PR had renamed all *references* but never moved the dirs -> `precommit-benchmark` / `Validate Test Coverage` failed with "❌ Found 267 uncovered test file(s)" under `tests/projectodyssey/...` + a ruff-format failure. Fix: `git mv src/tests/python projectodyssey->odyssey` dirs (git detected renames), `pixi run ruff format .`, verify `git grep -l projectodyssey` == 0 + `find -type d -name '*projectodyssey*'` == none + `mojo build` from new path + `validate_test_coverage.py` rc 0. Then rebased the 16-commits-behind whole-tree rename: content conflicts resolved to main's newer content + re-sed; `CONFLICT (file location)` files `git mv`'d into the renamed tree; post-rebase `git grep` surfaced 7 new `*_autograd.mojo` entrypoints that merged post-branch. Previously-failing checks passed; **PR #5584 MERGED** (`gh pr view 5584 --json state` -> MERGED; `src/odyssey` on main, `src/projectodyssey` gone). |


### PR DESCRIPTION
## Summary

Amends the **`logical-model-family-rename-with-storage-exceptions`** skill (v1.1.0 → **v1.2.0**) to cover **executing** the deferred breaking package rename — the atomic PR that v1.1.0 told you to defer to a tracked issue.

v1.1.0 taught: on an org/repo rename dropping a prefix, sweep references now and *defer* the breaking package/source rename to a `state:needs-plan` issue (#5579). This amendment continues that storyline: how to actually **execute** that deferred rename correctly.

## The learning

A "rename package X→Y" PR that rewrites every text *reference* but never `git mv`s the actual package **directories** is half-done and breaks the build + coverage: the manifest points at a nonexistent dir, and validators see the old-path files as "uncovered." Completing such a rename = move the dirs + fix references in files that merged AFTER the branch was cut + rebase onto current main.

## Verified on (verified-ci)

HomericIntelligence/Odyssey PR **#5584** (`projectodyssey`→`odyssey`, **MERGED**), executing deferred issue #5579:
- Symptom: `precommit-benchmark` → `Validate Test Coverage` → "❌ Found 267 uncovered test file(s)" under `tests/projectodyssey/...` + a ruff-format failure.
- Fix: `git mv` the 3 package dirs (src/tests/python), `ruff format`, verify `git grep -l projectodyssey`==0 + `find -type d -name '*projectodyssey*'`==none + a `mojo build` from the new path + `validate_test_coverage.py` rc 0.
- Rebased the 16-commits-behind whole-tree rename: content conflicts → take main's newer content (`--ours`) then re-`sed`; `CONFLICT (file location)` → `git mv` into the renamed tree + sed imports; post-rebase `git grep` surfaced 7 more `*_autograd.mojo` entrypoints merged post-branch.
- Confirmed: `gh pr view 5584 --json state` → MERGED; `src/odyssey` on main, `src/projectodyssey` gone.

## Changes

- Description + tags extended (git-mv, whole-tree-rename, rebase, coverage-validator, mojo).
- 3 new When-to-Use triggers; new **"Execute the Deferred Breaking Package Rename"** Verified Workflow subsection with a `### Quick Reference` (git mv dirs + git grep/find/build/coverage verify) and a **rebase conflict-resolution recipe**.
- 4 new Failed Attempts rows (renamed refs not dirs → 267 uncovered; whole-file reformat churn; rebased blind; passed-rebase ≠ complete).
- Completion-checklist Results block + Verified On row for PR #5584.
- `.claude-plugin/marketplace.json` entry for this skill updated (description/version/tags only).

## Verification

```
python3 scripts/validate_plugins.py → Valid: 640/640
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)