### PR TITLE
chore(settings): swap hephaestus plugin -> Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,36 @@
     ]
   },
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
+  },
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

The `hephaestus@ProjectHephaestus` plugin ref in `.claude/settings.json` no longer resolves. The `hephaestus` plugin was carved out to `HomericIntelligence/Athena`, whose marketplace declares `name: "Athena"` with 23 per-skill plugins.

This PR migrates `.claude/settings.json`:

- Removes the stale `hephaestus@ProjectHephaestus` enabled-plugin key.
- Adds the 23 `<skill>@Athena` plugin keys (advise, brainstorm, code-review, create-reusable-utilities, finish-branch, git-worktrees, github-actions-python-cicd, learn, myrmidon-swarm, python-repo-modernization, repo-analyze, repo-analyze-full, repo-analyze-quick, repo-analyze-quick-full, repo-analyze-strict, repo-analyze-strict-full, review-pr-strict, skill-advisor, systematic-debugging, test-driven-development, tidy, verification, worktree-cleanup).
- Registers the Athena marketplace under `extraKnownMarketplaces` (git source `https://github.com/HomericIntelligence/Athena.git`).

## Preserved

- Existing `hooks.UserPromptSubmit` (learn-trigger) block, byte-for-byte.
- No other plugins or permission entries existed prior; nothing else changed.

Verified with jq: valid JSON, `hephaestus@ProjectHephaestus` absent, exactly 23 `@Athena` keys, `extraKnownMarketplaces.Athena` present, hooks intact.

Closes #3069
