### PR TITLE
fix: escape literal multiplication asterisks in sgd-momentum skill (MD037)

### DIFF
--- a/skills/sgd-momentum-initialization-convergence.md
+++ b/skills/sgd-momentum-initialization-convergence.md
@@ -56,7 +56,7 @@ SGD with Momentum:
 
 **Convergence pattern with momentum**:
 - First update: velocity = 0 * 0 + g₁ = g₁
-- Second update: velocity = 0.9 * g₁ + g₂ ≈ 0.9*g₁ + g₂ (can be > g₂ if g₁ and g₂ align)
+- Second update: velocity = 0.9 \* g₁ + g₂ ≈ 0.9\*g₁ + g₂ (can be > g₂ if g₁ and g₂ align)
 - Oscillation risk: If velocity becomes large, updates may overshoot the loss minimum
 
 ### Step 2: Initialize Velocity Buffers to Zero


### PR DESCRIPTION
## Summary

- Fixes a pre-existing `markdownlint` MD037 (no-space-in-emphasis) failure on `skills/sgd-momentum-initialization-convergence.md:59`
- The line used literal `*` as a multiplication sign (`0.9 * g₁ ... 0.9*g₁`); the spaced and unspaced asterisks on the same line formed an accidental emphasis-marker pair, which markdownlint flags as spaces-inside-emphasis
- Escaped both as `\*` to preserve the multiplication-sign meaning without tripping the emphasis heuristic
- This was unrelated to any specific PR — it was already broken on `main` and blocking the `markdownlint` gate on every open PR that touches `skills/**` (confirmed identical failure on #3072, #3073, #3074, #3075)

## Test Plan

- [x] `npx markdownlint-cli2 --config .markdownlint.yaml skills/sgd-momentum-initialization-convergence.md` → 0 errors (was 1)
- [ ] CI `markdownlint` check passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>