### PR TITLE
fix(skills): escape multiplication asterisks to clear markdownlint MD037

### DIFF
--- a/skills/sgd-momentum-initialization-convergence.md
+++ b/skills/sgd-momentum-initialization-convergence.md
@@ -56,7 +56,7 @@ SGD with Momentum:
 
 **Convergence pattern with momentum**:
 - First update: velocity = 0 * 0 + g₁ = g₁
-- Second update: velocity = 0.9 * g₁ + g₂ ≈ 0.9*g₁ + g₂ (can be > g₂ if g₁ and g₂ align)
+- Second update: velocity = 0.9 \* g₁ + g₂ ≈ 0.9\*g₁ + g₂ (can be > g₂ if g₁ and g₂ align)
 - Oscillation risk: If velocity becomes large, updates may overshoot the loss minimum
 
 ### Step 2: Initialize Velocity Buffers to Zero


### PR DESCRIPTION
## What
Escapes two multiplication asterisks on `skills/sgd-momentum-initialization-convergence.md:59`.

## Why
`markdownlint` is the **only** failing job on `main`'s Required Checks (the other 16 jobs — build, unit-tests, lint, schema-validation, etc. — all pass). The line

```
- Second update: velocity = 0.9 * g₁ + g₂ ≈ 0.9*g₁ + g₂ ...
```

has two literal `*` multiplication signs. markdownlint-cli2 pairs them into a spanning emphasis span with a leading space → **MD037/no-space-in-emphasis** at `59:34`. MD037 is not among the rules disabled in `.markdownlint.yaml`.

## Fix
Escape both asterisks (`\*`) so they are literal multiplication signs, not emphasis markers. Renders identically in GitHub/most viewers.

## Verification (local `markdownlint-cli2`)
- The file: **0 errors** (was 1).
- Repo-wide with the CI globs `**/*.md !.claude/**` (772 files): **0 errors**.

This clears the last red job → `main` Required Checks should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
