### PR TITLE
feat: amend github-ruleset-review-count-governance for committed-vs-live drift (v1.2.0)

### DIFF
--- a/skills/github-ruleset-review-count-governance.history
+++ b/skills/github-ruleset-review-count-governance.history
@@ -1,0 +1,185 @@
+# github-ruleset-review-count-governance — History
+
+## v1.2.0 (2026-07-13)
+
+**Changed by:** HomericIntelligence/Odysseus committed-vs-live ruleset drift session; the misdiagnosis + live-verification method verified-ci; the sync + per-scope-guard fix shipped in PR #394, which MERGED (2026-07-13T02:02:20Z).
+**Verification:** verified-ci — live ruleset `homeric-main-baseline` (id 15556483, `source_type: Repository`) confirmed to require 0 approvals / 11 checks via `gh api`; PRs #388/#390 auto-merged mid-session with 0 reviews; the sync-to-live + per-scope CI-guard fix merged in PR #394 and main now shows count=0 / 11 checks.
+
+### What changed
+
+- Added a NEW diagnostic concern: never conclude a PR is "blocked waiting on
+  approval" from the COMMITTED `configs/github/*-ruleset*.json` — it drifts from
+  the live ruleset. Verify against `gh api repos/OWNER/REPO/rulesets/<id>`. In
+  this session the committed file said count=1 but the live enforcing ruleset
+  requires 0; PRs auto-merged with no review, disproving the "needs review"
+  conclusion. The real blocker was a GitHub Actions runner backlog
+  (`BLOCKED` + `MERGEABLE` + required checks pending = CI, not review).
+- Documented that the committed file drifts on MORE than the review count — it
+  was also stale on the required-check list (8 committed vs 11 live: missing
+  `test, install, release`).
+- Added the CI-guard gotcha: a `schema-validation` guard HARDCODED
+  `required_approving_review_count >= 1` for ALL ruleset files and blocked
+  syncing the repo-scoped file to the live count of 0; the fix relaxes it to a
+  per-scope expected-count map (repo=0, org=1) that still catches drift in both
+  directions.
+- Added the surgical-edit gotcha: a `json.dump(indent=2)` reformatted the whole
+  ruleset file (63-line churn) — reverted to a 1-line edit via
+  `git show HEAD~1:file > file` then Edit.
+- Added a new "Diagnose against the LIVE ruleset" workflow subsection with the
+  `gh api .../rulesets`, `.../rulesets/<id>`, `gh pr view --json ...`, and
+  `gh pr checks` command sequence; a v1.2.0 Results block; a Verified On row;
+  4 new "When to Use" triggers; and 5 new Failed Attempts rows.
+- Bumped date 2026-07-12 → 2026-07-13, version 1.1.0 → 1.2.0.
+
+### Why
+
+The v1.1.0 skill already handled setting the count to 0 for automation-authored
+repos, but it did not warn against reading the COMMITTED ruleset JSON to diagnose
+merge-blockage. That gap led to a repeated (twice) false "these PRs need approval"
+conclusion: the committed `repo-ruleset-active.json` was stale (count=1, 8 checks)
+while the live `homeric-main-baseline` ruleset required 0 approvals and 11 checks.
+The PRs auto-merged with zero reviews, proving the diagnosis wrong. The lasting
+lesson is a method — verify against the live ruleset, and treat
+`BLOCKED`+`MERGEABLE`+pending-checks as a CI backlog, not a policy gate — plus the
+concrete guard reconciliation (blanket `>=1` → per-scope map) needed to make the
+committed-to-live sync pass CI.
+
+### Previous version (v1.1.0) frontmatter snapshot
+
+```yaml
+---
+name: github-ruleset-review-count-governance
+description: "Use when: (1) auditing GitHub org or repo branch-protection ruleset JSON files for a zero-review governance gap (`required_approving_review_count: 0`), (2) fixing `required_approving_review_count` in canonical ruleset JSON files and the issue only names a subset of the files, (3) adding a CI regression guard to assert the review count cannot regress silently, (4) checking whether existing `bypass_actors` already mitigate the self-merge deadlock that requiring >=1 review creates, (5) leaving `enforcement` untouched and treating activation as a separate operational step, (6) green auto-merge-armed PRs will not merge because an automation authors PRs AS the operator and self-approval is forbidden — the count MUST be 0 on BOTH the classic branch protection and the repository ruleset layer."
+category: ci-cd
+date: 2026-07-12
+version: "1.1.0"
+user-invocable: false
+verification: verified-ci
+history: github-ruleset-review-count-governance.history
+tags:
+  - github-actions
+  - branch-protection
+  - ruleset
+  - governance
+  - review-count
+  - bypass-actors
+  - jq
+---
+```
+
+---
+
+## v1.1.0 (2026-07-12)
+
+**Changed by:** HomericIntelligence org-wide self-approval-deadlock remediation session (17 active repos, 3 PRs unblocked immediately)
+**Verification:** verified-ci — applied to all 17 active org repos; 3 green auto-merge-armed PRs merged the instant the gate dropped; `required_review_thread_resolution` preserved
+
+### What changed
+
+- Added a critical directional correction: the v1.0.0 recommendation to set the
+  count to `1` is correct ONLY when a second human approver exists. When an
+  automation authors PRs AS the operator (the same account that would approve),
+  the count MUST be `0` — GitHub structurally forbids self-approval
+  (`GraphQL: Cannot approve your own pull request`), so any nonzero value is a
+  PERMANENT deadlock for green, auto-merge-armed PRs.
+- Documented that the count lives on TWO independent layers — classic branch
+  protection AND repository rulesets — and BOTH must be flipped; fixing only one
+  leaves the gate live.
+- Added the org-wide detection sweep (read classic
+  `.required_approving_review_count` AND enumerate `rules/branches/main` for any
+  `pull_request` rule's count) and the safe ruleset-mutation recipe (fetch, jq
+  the single field, PUT the full modified body — never hand-reconstruct rules).
+- Added 3 new Failed Attempts rows (self-approve the PR; flip only the classic
+  layer; rely on the automation's `state:implementation-go` LABEL as an
+  approval).
+- Added a new "When to Use" trigger for the self-approval deadlock symptom.
+- Bumped verification from `verified-local` to `verified-ci` (org-wide apply
+  observed; 3 PRs merged).
+
+### Why
+
+The v1.0.0 skill treated `required_approving_review_count: 0` as a governance
+GAP to be closed (0 → 1). That is right for a repo with human reviewers, but the
+HomericIntelligence automation authors every PR as the operator (`mvillmow`) and
+there is no second GitHub account. Under that model a nonzero required-approval
+count is UNSATISFIABLE: `gh pr review --approve` returns "Cannot approve your own
+pull request", and the loop's `state:implementation-go` label is not a GitHub
+approving review. The fix that actually unblocked merges was the OPPOSITE of
+v1.0.0's default — set the count to `0` on both the classic protection and the
+ruleset layer, while preserving required STATUS CHECKS and
+`required_review_thread_resolution`. Three green PRs merged immediately.
+
+### Previous version (v1.0.0) snapshot
+
+```markdown
+---
+name: github-ruleset-review-count-governance
+description: "Use when: (1) auditing GitHub org or repo branch-protection ruleset JSON files for a zero-review governance gap (`required_approving_review_count: 0`), (2) fixing `required_approving_review_count` in canonical ruleset JSON files and the issue only names a subset of the files, (3) adding a CI regression guard to assert the review count cannot regress silently, (4) checking whether existing `bypass_actors` already mitigate the self-merge deadlock that requiring >=1 review creates, (5) leaving `enforcement` untouched and treating activation as a separate operational step."
+category: ci-cd
+date: 2026-06-19
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - github-actions
+  - branch-protection
+  - ruleset
+  - governance
+  - review-count
+  - bypass-actors
+  - jq
+---
+
+# GitHub Ruleset Required Approving Review Count Governance
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-19 |
+| **Objective** | Fix `required_approving_review_count: 0` in all canonical GitHub branch-protection ruleset JSON files (including `-active.json` variants the issue may not name), add a CI regression guard using a `first()`-wrapped jq assertion, verify existing `bypass_actors` mitigate deadlock, and leave `enforcement` untouched |
+| **Outcome** | All four canonical ruleset files updated to count=1; CI guard added to `_required.yml`; no bypass actor added (existing ones sufficient); PR #308 opened on HomericIntelligence/Odysseus |
+| **Verification** | verified-local — four jq checks + grep + JSON parse all pass locally; CI on Odysseus PR #308 pending |
+| **History** | n/a (initial version) |
+
+## When to Use
+
+- An issue reports `required_approving_review_count: 0` in one or two specific ruleset JSON files — check ALL canonical files (both base and `-active.json` variants) before scoping the fix.
+- An apply script selects the `-active.json` variant for enforcing mode; fixing only the base file leaves the gap live when the ruleset is activated.
+- You want a CI guard that asserts the review count cannot regress to zero silently (JSON-parse/lint validation alone does not check values).
+- You are about to add `bypass_actors` to prevent a self-merge deadlock — first inspect what bypass actors already exist.
+- A fix touches the `pull_request` rule but should NOT change `enforcement` (disabled/active/evaluate) — that is a separate rollout step.
+
+## Verified Workflow
+
+(Full v1.0.0 workflow: grep all ruleset files for the zero-review field, identify the enforcing -active.json variant, change 0 -> 1 in all four canonical files, inspect existing bypass_actors before adding one, add a first()-wrapped jq CI guard, leave enforcement untouched, run the four-check verification suite. See the v1.1.0 body for the retained + corrected workflow.)
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Fix only the two files named in the issue | Edit only base org/repo ruleset JSON | The -active.json variants also had 0 and are what the apply script deploys | Grep the whole config dir; the deploy path may use a file the issue never named |
+| Bare jq select without first() in CI guard | count=$(jq select .required_approving_review_count) | Multiple pull_request rules make jq emit multiple lines; bash test errors | Wrap with first() so the guard receives a single scalar |
+| Change enforcement while fixing review count | Activate ruleset in the same PR | Activation is a separate rollout step | Leave enforcement unchanged |
+| Add new bypass actor | Add admin bypass so authors can self-merge | Existing bypass actors already address it | Inspect existing bypass_actors first |
+| Change other PR rule flags | Set dismiss_stale_reviews_on_push while touching the file | Out of scope | Minimal-diff: change only the named field |
+
+## Results & Parameters
+
+Files fixed (HomericIntelligence/Odysseus, PR #308, issue #178): four canonical
+ruleset JSON files, 0 -> 1; first()-wrapped jq CI guard added to _required.yml;
+existing bypass actors (OrganizationAdmin id 1, Integration id 49699333,
+RepositoryRole id 5) left as-is.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| HomericIntelligence/Odysseus | Issue #178, PR #308 (2026-06-19) | Fixed all four canonical ruleset JSON files; verified-local only |
+```
+
+---
+
+## v1.0.0 (2026-06-19)
+
+**Initial version.**

--- a/skills/github-ruleset-review-count-governance.md
+++ b/skills/github-ruleset-review-count-governance.md
@@ -1,11 +1,12 @@
 ---
 name: github-ruleset-review-count-governance
-description: "Use when: (1) auditing GitHub org or repo branch-protection ruleset JSON files for a zero-review governance gap (`required_approving_review_count: 0`), (2) fixing `required_approving_review_count` in canonical ruleset JSON files and the issue only names a subset of the files, (3) adding a CI regression guard to assert the review count cannot regress silently, (4) checking whether existing `bypass_actors` already mitigate the self-merge deadlock that requiring >=1 review creates, (5) leaving `enforcement` untouched and treating activation as a separate operational step."
+description: "Use when: (1) auditing GitHub org or repo branch-protection ruleset JSON files for a zero-review governance gap (`required_approving_review_count: 0`), (2) fixing `required_approving_review_count` in canonical ruleset JSON files and the issue only names a subset of the files, (3) adding a CI regression guard to assert the review count cannot regress silently, (4) checking whether existing `bypass_actors` already mitigate the self-merge deadlock that requiring >=1 review creates, (5) leaving `enforcement` untouched and treating activation as a separate operational step, (6) green auto-merge-armed PRs will not merge because an automation authors PRs AS the operator and self-approval is forbidden — the count MUST be 0 on BOTH the classic branch protection and the repository ruleset layer, (7) diagnosing whether a PR is 'blocked waiting on approval' — verify against the LIVE ruleset (`gh api repos/OWNER/REPO/rulesets/ID`), NOT the committed ruleset JSON, which can drift and cause a false 'needs review' misdiagnosis, (8) a CI schema-validation guard hardcodes `required_approving_review_count >= 1` for ALL ruleset files and fails when you sync a repo-scoped file to the live count of 0 — relax the guard to a per-scope expected-count map (repo=0, org=1)."
 category: ci-cd
-date: 2026-06-19
-version: "1.0.0"
+date: 2026-07-13
+version: "1.2.0"
 user-invocable: false
-verification: verified-local
+verification: verified-ci
+history: github-ruleset-review-count-governance.history
 tags:
   - github-actions
   - branch-protection
@@ -22,11 +23,11 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-19 |
-| **Objective** | Fix `required_approving_review_count: 0` in all canonical GitHub branch-protection ruleset JSON files (including `-active.json` variants the issue may not name), add a CI regression guard using a `first()`-wrapped jq assertion, verify existing `bypass_actors` mitigate deadlock, and leave `enforcement` untouched |
-| **Outcome** | All four canonical ruleset files updated to count=1; CI guard added to `_required.yml`; no bypass actor added (existing ones sufficient); PR #308 opened on HomericIntelligence/Odysseus |
-| **Verification** | verified-local — four jq checks + grep + JSON parse all pass locally; CI on Odysseus PR #308 pending |
-| **History** | n/a (initial version) |
+| **Date** | 2026-07-13 |
+| **Objective** | Govern `required_approving_review_count` on GitHub `main` protection, and diagnose merge-blockage against the LIVE ruleset rather than the committed JSON. THREE concerns: (a) human-reviewed repos — close the zero-review gap (0 → 1) across ALL canonical ruleset JSON variants; (b) automation-authored repos — when an automation authors PRs AS the operator, the count MUST be `0` (nonzero is a permanent self-approval deadlock), flipped on BOTH the classic protection AND the ruleset layer; (c) NEVER conclude a PR is "blocked on review" from the committed ruleset JSON — the committed file drifts from the live ruleset; verify against `gh api .../rulesets/<id>` |
+| **Outcome** | v1.0.0: four Odysseus ruleset files set to count=1 + CI guard. v1.1.0: on the HomericIntelligence org (17 active repos) the count was set to `0` on `main` for every repo because the automation authors PRs as the operator; 3 green auto-merge-armed PRs merged the instant the gate dropped; `required_review_thread_resolution` preserved. v1.2.0: caught a twice-repeated MISDIAGNOSIS — PRs read as "blocked on approval" because the COMMITTED `repo-ruleset-active.json` said count=1, but the LIVE `homeric-main-baseline` ruleset (the ONLY ruleset on the repo, `source_type: Repository`) requires **0**; the real blocker was a GitHub Actions runner backlog. Synced the committed file to live (0 reviews, 11 checks) and relaxed the CI guard from a blanket `>=1` to a per-scope expected-count map (repo=0, org=1) (Odysseus PR #394, MERGED) |
+| **Verification** | verified-ci — v1.1.0 applied org-wide (3 PRs merged); v1.2.0 diagnosis proven (PRs #388/#390 auto-merged mid-session with 0 reviews; live ruleset count=0 confirmed via `gh api`); the sync + per-scope guard fix shipped in Odysseus PR #394 which MERGED (2026-07-13T02:02:20Z), main now shows count=0 / 11 checks |
+| **History** | [changelog](./github-ruleset-review-count-governance.history) |
 
 ## When to Use
 
@@ -35,10 +36,134 @@ tags:
 - You want a CI guard that asserts the review count cannot regress to zero silently (JSON-parse/lint validation alone does not check values).
 - You are about to add `bypass_actors` to prevent a self-merge deadlock — first inspect what bypass actors already exist.
 - A fix touches the `pull_request` rule but should NOT change `enforcement` (disabled/active/evaluate) — that is a separate rollout step.
+- **Green, auto-merge-armed PRs will NOT merge and `reviewDecision` is empty**, and `gh pr review --approve` fails with `GraphQL: Cannot approve your own pull request`. An automation authors PRs as the SAME account that would approve them (no second GitHub account). Then a nonzero `required_approving_review_count` is UNSATISFIABLE — set it to `0` on `main` (see the self-approval-deadlock regime below). This is the OPPOSITE of the 0 → 1 fix; apply it only when the automation-as-author model holds.
+- **You are about to conclude a PR is "blocked waiting on approval."** STOP and verify against the LIVE ruleset (`gh api repos/OWNER/REPO/rulesets/<id>`), NOT the committed `configs/github/*-ruleset*.json` — the committed file DRIFTS from live and reading it caused a repeated false "needs review" misdiagnosis (see "Diagnose against the live ruleset" below). `mergeStateStatus: BLOCKED` + `mergeable: MERGEABLE` + required checks still pending = waiting on **CI** (a runner backlog), NOT on a review gate.
+- **A CI `schema-validation` guard hardcodes `required_approving_review_count >= 1` for every ruleset file** and fails when you sync a repo-scoped file to the live count of `0`. Relax the guard from a blanket `>=1` to a per-scope expected-count map (repo=0, org=1) so drift is still caught in BOTH directions per scope.
 
 ## Verified Workflow
 
-> **Warning:** This skill is `verified-local`. Local verification commands all pass. CI on the Odysseus PR is pending at the time of writing. Do not treat this as `verified-ci` until the PR gate goes green.
+> **Two regimes.** Pick by who authors the PRs.
+>
+> - **Regime A — human-reviewed repos (v1.0.0):** `required_approving_review_count: 0` is a governance GAP. Close it (0 → 1) across ALL canonical ruleset JSON variants. This is the original workflow below.
+> - **Regime B — automation authors PRs AS the operator (v1.1.0):** the count MUST be `0`. GitHub structurally forbids self-approval, so ANY nonzero value is a permanent deadlock for green, auto-merge-armed PRs. Flip it to `0` on BOTH the classic protection AND the ruleset layer. See "Self-approval deadlock regime" below.
+>
+> The two regimes are mutually exclusive per repo. Never apply Regime A to a repo whose PRs are all authored by the single automation account.
+
+### Self-approval deadlock regime (automation authors PRs as the operator)
+
+**Symptom:** green, auto-merge-armed PRs will not merge; `reviewDecision` is empty;
+`gh pr review <n> --approve` returns `GraphQL: Cannot approve your own pull request`.
+
+**Root cause:** the automation runs as the operator, so every PR is authored by the
+same account that would approve it. There is no second GitHub account. The loop's own
+reviewer applies a `state:implementation-go` LABEL — that is NOT a GitHub approving
+review — so a nonzero `required_approving_review_count` is UNSATISFIABLE.
+
+**Fix — set the count to `0` on `main` on BOTH layers, preserving required STATUS
+CHECKS and `required_review_thread_resolution`:**
+
+```bash
+OWNER_REPO="OWNER/REPO"
+
+# --- Layer 1: classic branch protection ---
+# Read current values first so you can PRESERVE dismiss_stale / code-owner flags.
+gh api "repos/$OWNER_REPO/branches/main/protection/required_pull_request_reviews" \
+  --jq '{count:.required_approving_review_count, dismiss:.dismiss_stale_reviews, codeowners:.require_code_owner_reviews}'
+# Repos with NO classic protection return 404 — they simply have no gate to drop; skip.
+gh api -X PATCH "repos/$OWNER_REPO/branches/main/protection/required_pull_request_reviews" \
+  -F required_approving_review_count=0 \
+  -F dismiss_stale_reviews=<preserve> \
+  -F require_code_owner_reviews=<preserve>
+
+# --- Layer 2: repository ruleset ---
+# 2a. Find the ruleset that carries a pull_request rule on main.
+gh api "repos/$OWNER_REPO/rules/branches/main" \
+  --jq '.[] | select(.type=="pull_request") | {r?:.ruleset_id, count:.parameters.required_approving_review_count}'
+# 2b. Fetch the FULL ruleset body, set only the one field, PUT the whole thing back.
+#     NEVER hand-reconstruct the rules array — preserve every other rule verbatim.
+RS_ID=<id from 2a>
+gh api "repos/$OWNER_REPO/rulesets/$RS_ID" > /tmp/rs.json
+jq '(.rules[] | select(.type=="pull_request").parameters.required_approving_review_count) = 0' \
+  /tmp/rs.json > /tmp/rs.patched.json
+gh api -X PUT "repos/$OWNER_REPO/rulesets/$RS_ID" --input /tmp/rs.patched.json
+```
+
+**Detection sweep across an org:** for each repo, read the classic
+`.required_approving_review_count` AND enumerate `rules/branches/main` for any
+`pull_request` rule's `required_approving_review_count`. Repos with NO classic
+protection (404) have no classic gate to drop — still check their ruleset.
+
+### Diagnose against the LIVE ruleset, never the committed JSON (committed-vs-live drift)
+
+**Symptom:** you conclude "these armed PRs are blocked waiting on approval" because
+the COMMITTED `configs/github/repo-ruleset-active.json` says
+`required_approving_review_count: 1`. That conclusion is WRONG when the committed file
+has drifted from the live ruleset. In this session it was wrong TWICE — the live
+`homeric-main-baseline` ruleset (the ONLY ruleset enforced on the repo,
+`source_type: Repository`) actually requires **0** approvals; the PRs auto-merge on
+required STATUS CHECKS alone. Proof: PRs #388/#390 auto-merged mid-conversation with no
+review while I was still calling them "blocked."
+
+**The committed file drifts on MORE than the review count.** The same stale committed
+file also carried only 8 required checks while live had 11 (`+test, +install, +release`).
+Never trust the committed ruleset for any diagnostic claim — always read live.
+
+**Root-cause the REAL blocker.** `mergeStateStatus: BLOCKED` + `mergeable: MERGEABLE`
++ all required checks `queued`/`in_progress` (for 20-40 min) = a GitHub Actions **runner
+backlog**, NOT a policy gate. Do not "fix" a review gate that is not the blocker.
+
+```bash
+# 1. Which rulesets are LIVE on the repo, and which is the enforcing one?
+gh api repos/OWNER/REPO/rulesets --jq '.[] | {id, name, source_type, enforcement}'
+#    source_type: Repository  => this repo's own ruleset (the enforcing one here)
+
+# 2. What does the LIVE ruleset actually require for reviews? (NOT the committed JSON)
+gh api repos/OWNER/REPO/rulesets/<ID> \
+  --jq '.rules[] | select(.type=="pull_request") | .parameters
+        | {required_approving_review_count, required_review_thread_resolution}'
+#    => count 0 here: PRs merge on status checks alone, no human review needed
+
+# 3. Live required-check list (compare against the committed file — it drifts)
+gh api repos/OWNER/REPO/rulesets/<ID> \
+  --jq '[.rules[] | select(.type=="required_status_checks")
+         .parameters.required_status_checks[].context]'
+
+# 4. Is a specific PR REALLY blocked on review, or just on CI?
+gh pr view N --repo OWNER/REPO --json mergeable,mergeStateStatus,reviewDecision
+#    mergeable=MERGEABLE + mergeStateStatus=BLOCKED + reviewDecision empty + checks
+#    pending  =>  waiting on CI, not review
+gh pr checks N --repo OWNER/REPO
+#    look at REQUIRED contexts pending vs non-required (e.g. `Install (matrix)` is NOT
+#    required); a required context still queued is a runner backlog, not a policy block
+```
+
+**Fix the drift (Odysseus PR #394):** sync the committed `repo-ruleset*.json` to live via
+a field-by-field diff against `gh api .../rulesets/<id>` — set the review count to `0` and
+the required-check list to the live 11. Then relax the CI schema-validation guard: it
+HARDCODED `required_approving_review_count >= 1` for ALL ruleset files, so syncing the
+repo-scoped file to `0` FAILED that guard until the guard was changed to a per-scope
+expected-count map (repo=0, org=1) that still catches drift in BOTH directions.
+
+```yaml
+# _required.yml schema-validation guard — per-scope expected count, NOT a blanket >=1
+declare -A expected_min_reviews=(
+  [configs/github/org-ruleset.json]=1          # org policy: human review
+  [configs/github/org-ruleset-active.json]=1
+  [configs/github/repo-ruleset.json]=0         # repo: auto-merge on status checks
+  [configs/github/repo-ruleset-active.json]=0
+)
+for f in "${!expected_min_reviews[@]}"; do
+  count=$(jq 'first(.rules[] | select(.type=="pull_request")
+             | .parameters.required_approving_review_count)' "$f")
+  want=${expected_min_reviews[$f]}
+  [ "$count" != "$want" ] && { echo "ERROR: $f count=$count (expected $want)"; exit 1; }
+done
+```
+
+**Editing gotcha:** do NOT `json.dump(indent=2)` the whole ruleset file to change one field
+— it reformatted the entire file (a 63-line churn) and buried the one-field intent. Do a
+surgical edit: `git show HEAD~1:configs/github/repo-ruleset-active.json > <file>` to restore
+the original formatting, then a single-line Edit of just the count/check list.
 
 ### Quick Reference
 
@@ -134,6 +259,14 @@ for f in configs/github/*.json; do jq empty "$f" && echo "OK: $f"; done
 | Change `enforcement` field while fixing review count | Considered activating the ruleset as part of the same PR | Activation is a separate operational step with its own rollout runbook; bundling it expands scope and risk | Leave `enforcement` unchanged; activation is a distinct step |
 | Add new bypass actor to prevent self-merge deadlock | Considered adding a bypass for admin authors so they can self-merge after requiring >=1 review | Existing `pull_request`-mode bypass actors (OrganizationAdmin id 1, Integration id 49699333, RepositoryRole id 5) already address the deadlock | Inspect existing `bypass_actors` before adding any; a redundant actor is unnecessary and may confuse future audits |
 | Change other PR rule flags alongside review count | Considered setting `dismiss_stale_reviews_on_push: true` while touching the file | The issue's sole finding is `required_approving_review_count: 0`; other fields are out of scope | Minimal-diff principle: change only the field the issue names; other improvements go in separate PRs |
+| Approve the PRs to satisfy a nonzero gate (automation-authored repos) | `gh pr review <n> --approve` as the operator | `GraphQL: Cannot approve your own pull request` — the PRs are authored by the same account | GitHub structurally forbids self-approval; a nonzero required-approval count is a permanent deadlock when automation authors PRs as the operator — set the count to `0` instead |
+| Flip only the classic branch-protection layer | PATCH classic `required_approving_review_count=0` and stop | Some repos ALSO enforce approval via a repository ruleset's `pull_request` rule, so the gate stayed live | The count lives on TWO independent layers — enumerate `rules/branches/main` and flip the ruleset too |
+| Rely on the loop's `state:implementation-go` label as an approval | Assumed the automation's GO label satisfied the review gate | The label is not a GitHub approving review; the required-approval gate ignores it entirely | Distinguish the automation's GO label from a real GitHub approval; the branch-protection gate counts only real approvals |
+| Diagnosed PRs as "blocked waiting on approval" from the COMMITTED ruleset JSON | Read `configs/github/repo-ruleset-active.json` (count=1) and concluded a review was required — twice | The committed file had DRIFTED; the LIVE `homeric-main-baseline` ruleset (`source_type: Repository`, the only one enforced) requires **0** approvals; PRs #388/#390 auto-merged mid-conversation with no review | Never diagnose merge-blockage from the committed ruleset; read the LIVE ruleset via `gh api repos/OWNER/REPO/rulesets/<id>` before claiming a review gate exists |
+| Trusted the committed required-check list | Assumed the 8 checks in the committed file were the enforced set | Live ruleset had 11 (`+test, +install, +release`); the committed file was stale on the check list too | The committed ruleset JSON drifts on MORE than the review count; verify the required-check list against live as well |
+| Assumed BLOCKED meant a policy gate | Saw `mergeStateStatus: BLOCKED` and looked for a review/protection rule to fix | The blocker was a GitHub Actions runner BACKLOG — required checks `queued`/`in_progress` for 20-40 min; `mergeable: MERGEABLE` + checks pending = waiting on CI | `BLOCKED` + `MERGEABLE` + required checks pending = CI backlog, not review; check `gh pr checks N` for pending REQUIRED contexts before touching any ruleset |
+| Synced the committed repo file to live count=0 and expected CI to pass | Changed `required_approving_review_count` to 0 to match live | A CI `schema-validation` guard HARDCODED `>= 1` for ALL ruleset files and failed on the repo-scoped 0 | Relax the guard to a per-scope expected-count map (repo=0, org=1); a blanket `>=1` can't express that repo-scoped rulesets legitimately require 0 |
+| Reformatted the whole ruleset file to change one field | `json.dump(indent=2)` rewrote the entire file — a 63-line churn for a 1-field change | The diff buried the intent and expanded review surface | Surgical edit: `git show HEAD~1:file > file` to restore formatting, then a single-line Edit of just the changed field |
 
 ## Results & Parameters
 
@@ -192,11 +325,69 @@ count=1; [ "$count" -lt 1 ] && echo "FAIL" || echo "PASS"
   a self-PR the review requirement would block) NOT empirically tested against live GitHub.
 - Line numbers (`org:21`, `repo:17`) are checkout-relative and may drift.
 
+### v1.1.0 — Self-approval deadlock remediation (HomericIntelligence org)
+
+**Regime:** automation authors every PR AS the operator (`mvillmow`); no second GitHub account exists.
+
+**Applied:** set `required_approving_review_count: 0` on `main` for all 17 active org repos,
+across BOTH the classic branch-protection layer and the repository-ruleset layer. Required
+STATUS CHECKS and `required_review_thread_resolution: true` were PRESERVED — only the
+human-approval requirement was dropped, matching the automation-as-author model.
+
+**Immediate result:** 3 green, auto-merge-armed PRs merged the instant the gate dropped.
+
+```bash
+# Preserve thread-resolution; drop only the approval count. Ruleset PUT uses the
+# full fetched body with a single jq-patched field — never a reconstructed rules array.
+jq '(.rules[] | select(.type=="pull_request").parameters.required_approving_review_count) = 0' \
+  ruleset.json > ruleset.patched.json
+gh api -X PUT "repos/OWNER/REPO/rulesets/$RS_ID" --input ruleset.patched.json
+```
+
+### v1.2.0 — Committed-vs-live ruleset drift + false "needs review" misdiagnosis (Odysseus PR #394)
+
+**Misdiagnosis:** twice concluded armed PRs were "blocked waiting on approval" by reading
+the COMMITTED `configs/github/repo-ruleset-active.json` (`required_approving_review_count: 1`).
+
+**Ground truth (live):** the only ruleset enforced on HomericIntelligence/Odysseus is
+`homeric-main-baseline`, id `15556483`, `source_type: Repository`, `enforcement: active`.
+Its `pull_request` rule requires **0** approvals with `required_review_thread_resolution: true`,
+and its `required_status_checks` list has **11** contexts:
+
+```text
+lint, unit-tests, integration-tests, security/dependency-scan, security/secrets-scan,
+build, schema-validation, deps/version-sync, test, install, release
+```
+
+The committed file was stale on BOTH: count=1 (live 0) and 8 checks (live 11 — missing
+`test, install, release`). PRs #388/#390 auto-merged mid-session with zero reviews, proving
+review was never the gate. The actual merge delay was a GitHub Actions runner backlog.
+
+**Fix (PR #394, MERGED 2026-07-13T02:02:20Z):**
+- Synced committed `repo-ruleset*.json` to live via a field-by-field `gh api .../rulesets/<id>`
+  diff — set count to `0`, required-check list to the live 11. main now shows count=0 / 11 checks.
+- Changed the `_required.yml` `schema-validation` guard from a blanket
+  `required_approving_review_count >= 1` for all files to a per-scope expected-count map
+  (`org*=1`, `repo*=0`) so drift is still caught in BOTH directions per scope.
+- Reverted an accidental `json.dump(indent=2)` whole-file reformat (63-line churn) to a
+  surgical 1-line edit via `git show HEAD~1:file > file` then Edit.
+
+**Diagnostic commands that mattered:**
+
+```bash
+gh api repos/OWNER/REPO/rulesets --jq '.[] | {id,name,source_type,enforcement}'   # find the live enforcing ruleset
+gh api repos/OWNER/REPO/rulesets/<id> --jq '.rules[]|select(.type=="pull_request").parameters'
+gh pr view N --json mergeable,mergeStateStatus,reviewDecision   # MERGEABLE+BLOCKED+empty = CI, not review
+gh pr checks N                                                  # pending REQUIRED contexts vs non-required (e.g. `Install (matrix)`)
+```
+
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| HomericIntelligence/Odysseus | Issue #178, PR #308 (2026-06-19) | Fixed all four canonical ruleset JSON files; CI guard added; verified-local only — PR CI pending at skill creation time |
+| HomericIntelligence/Odysseus | Issue #178, PR #308 (2026-06-19) | Regime A: fixed all four canonical ruleset JSON files (0 → 1); CI guard added; verified-local at v1.0.0 |
+| HomericIntelligence org (17 active repos) | Self-approval deadlock remediation (2026-07-12) | Regime B: set count to `0` on `main` across classic protection + rulesets; 3 PRs merged immediately; thread-resolution preserved; verified-ci |
+| HomericIntelligence/Odysseus | Committed-vs-live drift + misdiagnosis, PR #394 (2026-07-13) | Live `homeric-main-baseline` (id 15556483, `source_type: Repository`) requires 0 approvals / 11 checks; committed file was stale (1 / 8); PRs #388/#390 auto-merged with no review; real blocker was a runner backlog. Synced committed JSON to live + relaxed the CI guard to a per-scope map (repo=0, org=1); PR #394 MERGED; main confirmed count=0 / 11 checks — verified-ci |
 
 ## References
 


### PR DESCRIPTION
Replaces #3065, whose head branch lives on the mvillmow/ProjectMnemosyne fork and could not be updated in place. Recreated on an upstream branch: rebased onto main after the marketplace removal (#3083), commits signed, scope reduced to the primary skill file(s); shared stacked files land separately in the recovery PR.

Supersedes #3065.