### PR TITLE
chore: align tree with its own pre-commit fixers (whitespace, EOF, ruff-format)

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -13,9 +13,7 @@ EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 SSN_RE = re.compile(r"(?<!\d)\d{3}[-. ]\d{2}[-. ]\d{4}(?!\d)")
 PHONE_RE = re.compile(r"(?<!\d)(?:\+?1[-. ]?)?(?:\(\d{3}\)|\d{3})[-. ]\d{3}[-. ]\d{4}(?!\d)")
 PHONE_CONTEXT_RE = re.compile(r"\b(?:phone|tel|mobile|cell|call|contact)\b", re.IGNORECASE)
-CARD_CANDIDATE_RE = re.compile(
-    r"(?<!\d)(?:\d{13,19}|\d{4}[- ]\d{4}[- ]\d{4}(?:[- ]\d{1,7})?)(?!\d)"
-)
+CARD_CANDIDATE_RE = re.compile(r"(?<!\d)(?:\d{13,19}|\d{4}[- ]\d{4}[- ]\d{4}(?:[- ]\d{1,7})?)(?!\d)")
 
 ALLOWED_EMAILS = {
     "git@github.com",
@@ -116,8 +114,7 @@ def main() -> int:
     print("PII-like patterns found:", file=sys.stderr)
     for finding in findings:
         print(
-            f"{finding.path}:{finding.line}:{finding.column}: "
-            f"{finding.kind}: {finding.value}",
+            f"{finding.path}:{finding.line}:{finding.column}: " f"{finding.kind}: {finding.value}",
             file=sys.stderr,
         )
     return 1

--- a/skills/automation-graphql-parameterisation-prevent-injection.md
+++ b/skills/automation-graphql-parameterisation-prevent-injection.md
@@ -85,29 +85,29 @@ query = 'query { repository(owner: $owner, name: $repo) { issue(number: $num) { 
 ```python
 def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, IssueState]:
     """Fetch issue states for a batch of issues in one aliased GraphQL call.
-    
+
     Args:
         batch: List of issue numbers to fetch (e.g. [615, 616, 617]).
         owner: Repository owner (e.g. 'HomericIntelligence').
         repo: Repository name (e.g. 'ProjectHephaestus').
-    
+
     Returns:
         dict mapping issue number -> IssueState.
     """
     if not batch:
         return {}
-    
+
     # Build alias fragment with variable references: n0: issue(number: $n0) { ... }
     fragments = [
         f"n{idx}: issue(number: $n{idx}) {{ number state }}"
         for idx in range(len(batch))
     ]
-    
+
     # Build the query template (no interpolation of batch data)
     query = (
         f"query {{'repository(owner: $owner, name: $repo) {{{' '.join(fragments)}}}}}"
     )
-    
+
     # Prepare -F variable flags: owner, repo, n0, n1, n2, ...
     flags = [
         "api", "graphql",
@@ -117,12 +117,12 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
     ]
     for idx, issue_num in enumerate(batch):
         flags.extend(["-F", f"n{idx}={int(issue_num)}"])
-    
+
     # Execute with all variables bound
     result = _gh_call(flags)
     data = json.loads(result.stdout)
     repo_data = data.get("data", {}).get("repository", {})
-    
+
     # Parse aliases back to issue numbers using the reverse mapping
     result_map = {}
     for idx, issue_num in enumerate(batch):
@@ -130,7 +130,7 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
         issue_data = repo_data.get(alias, {})
         state_str = issue_data.get("state", "UNKNOWN")
         result_map[issue_num] = IssueState(state_str)
-    
+
     return result_map
 ```
 
@@ -152,7 +152,7 @@ def _review_threads_for_review(owner: str, repo: str, pr_num: int, review_id: st
         }
       }
     }'''
-    
+
     flags = [
         "api", "graphql",
         "-f", f"query={query}",
@@ -160,15 +160,15 @@ def _review_threads_for_review(owner: str, repo: str, pr_num: int, review_id: st
         "-F", f"repo={repo}",
         "-F", f"prNum={int(pr_num)}",
     ]
-    
+
     result = _gh_call(flags)
     data = json.loads(result.stdout)
     threads = data.get("data", {}).get("repository", {}).get("pullRequest", {}).get("reviewThreads", {}).get("nodes", [])
-    
+
     # Filter to unresolved threads from the target review
     return [
         t for t in threads
-        if not t.get("isResolved") 
+        if not t.get("isResolved")
         and (t.get("comments", {}).get("nodes") or [{}])[0].get("pullRequestReview", {}).get("id") == review_id
     ]
 ```
@@ -214,9 +214,9 @@ def test_fetch_batch_states_single_issue(mocker):
         }
     })
     mocker.patch("hephaestus.automation.github_api._gh_call", return_value=mock_result)
-    
+
     result = _fetch_batch_states([615], "HomericIntelligence", "ProjectHephaestus")
-    
+
     assert result == {615: IssueState.OPEN}
     # Verify the call used parameterised variables
     call_args = _gh_call.call_args[0][0]
@@ -276,11 +276,11 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
     """Fetch issue states using parameterised GraphQL variables."""
     if not batch:
         return {}
-    
+
     # Sanitise owner/repo (defense-in-depth)
     if not OWNER_PATTERN.match(owner) or not REPO_PATTERN.match(repo):
         raise ValueError(f"Invalid repo: {owner}/{repo}")
-    
+
     # Build alias fragments with variable refs (NO data interpolation)
     fragments = [
         f"n{idx}: issue(number: $n{idx}) {{ number state }}"
@@ -293,22 +293,22 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
         }}
       }}
     """
-    
+
     # Prepare flags with parameterised variables
     flags = ["api", "graphql", "-f", f"query={query}", "-F", f"owner={owner}", "-F", f"repo={repo}"]
     for idx, num in enumerate(batch):
         flags.extend(["-F", f"n{idx}={int(num)}"])
-    
+
     result = _gh_call(flags)
     data = json.loads(result.stdout)
     repo_data = data.get("data", {}).get("repository", {})
-    
+
     result_map = {}
     for idx, num in enumerate(batch):
         issue_data = repo_data.get(f"n{idx}", {})
         state = IssueState(issue_data.get("state", "UNKNOWN"))
         result_map[num] = state
-    
+
     return result_map
 ```
 

--- a/skills/automation-loop-gating-removal.md
+++ b/skills/automation-loop-gating-removal.md
@@ -78,7 +78,7 @@ def test_process_repo_no_skip_without_gating():
 # BEFORE: env var injected with docstring justifying it
 def _phase_env(phase_name):
     """Populate environment with phase-specific variables.
-    
+
     HEPH_LOOP_INDEX and HEPH_TOTAL_LOOPS are gated to drive-green phase only
     because ci_driver.py skips if HEPH_LOOP_INDEX is not set (issue #689 workaround).
     """

--- a/skills/automation-loop-gating-removal.notes.md
+++ b/skills/automation-loop-gating-removal.notes.md
@@ -54,7 +54,7 @@ parser.add_argument(
 # hephaestus/automation/loop_runner.py (BEFORE)
 def _phase_env(phase_name: str) -> Dict[str, str]:
     """Populate environment with phase-specific variables.
-    
+
     HEPH_LOOP_INDEX and HEPH_TOTAL_LOOPS are gated to drive-green phase only
     because ci_driver.py skips if HEPH_LOOP_INDEX is not set (issue #689 workaround).
     See: hephaestus/automation/ci_driver.py:_maybe_skip_phase()
@@ -110,7 +110,7 @@ hephaestus-automation-loop \
 # tests/unit/automation/test_loop_runner.py (BEFORE)
 def test_process_repo_skips_issue_phases_when_no_issues():
     """When --issues not provided, plan/review phases are skipped.
-    
+
     This test verifies the gating behavior: ci_driver.py uses HEPH_LOOP_INDEX
     to decide whether to skip phases. When --issues omitted, loop_runner does
     not inject HEPH_LOOP_INDEX, so ci_driver skips phase.
@@ -118,7 +118,7 @@ def test_process_repo_skips_issue_phases_when_no_issues():
     cfg = LoopConfig(issues=[])  # Empty issues list
     with patch.object(loop_runner, "process_repo") as mock_process:
         run_loop(cfg)
-    
+
     # Verify phases were skipped
     for call in mock_process.call_args_list:
         assert "phase" not in call
@@ -132,14 +132,14 @@ def test_process_repo_skips_issue_phases_when_no_issues():
 # tests/unit/automation/test_loop_runner.py (AFTER)
 def test_process_repo_runs_phases_without_issues_flag():
     """Phases always run, regardless of --issues flag presence.
-    
+
     With HEPH_LOOP_INDEX gating removed, ci_driver.py no longer skips phases
     based on env vars. Phases run unconditionally.
     """
     cfg = LoopConfig(issues=[])  # Empty issues list
     with patch.object(loop_runner, "process_repo") as mock_process:
         run_loop(cfg)
-    
+
     # Verify phases ALWAYS run
     mock_process.assert_called()
 ```

--- a/skills/automation-prefix-match-plan-detection.md
+++ b/skills/automation-prefix-match-plan-detection.md
@@ -47,7 +47,7 @@ from hephaestus.automation.planner_state import PLAN_COMMENT_MARKER
 
 def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None]:
     """Fetch plan and review comment from comments.
-    
+
     Return: (plan_text, review_comment) or (None, None) if no plan found.
     """
     for comment in comments:
@@ -154,7 +154,7 @@ def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None
 
 def test_has_plan_prefix_match():
     """Regression: Plan Review comments quoting the plan should NOT count as having a plan.
-    
+
     Issue #715: substring-match was broken because Review comments contain 'The plan:' text.
     """
     # Plan comment (starts with marker)
@@ -162,13 +162,13 @@ def test_has_plan_prefix_match():
         "body": "## Plan\n\n1. Implement foo\n2. Test bar"
     }
     assert _has_plan([plan_comment]) is True
-    
+
     # Review comment (contains word 'plan' but doesn't start with marker) — MUST be False
     review_comment = {
         "body": "## Review:\n\nThe plan is good, implementation is correct."
     }
     assert _has_plan([review_comment]) is False
-    
+
     # Both comments: only plan comment counts
     assert _has_plan([plan_comment, review_comment]) is True
 ```

--- a/skills/automation-prefix-match-plan-detection.notes.md
+++ b/skills/automation-prefix-match-plan-detection.notes.md
@@ -75,7 +75,7 @@ def test_has_plan_prefix_match():
     """Regression: Plan Review comments quoting the plan should NOT count as having a plan."""
     plan_comment = {"body": "## Plan\n\n1. Implement foo\n2. Test bar"}
     assert _has_plan([plan_comment]) is True
-    
+
     review_comment = {"body": "## Review:\n\nThe plan is good, implementation is correct."}
     assert _has_plan([review_comment]) is False  # Critical: Review ≠ Plan
 ```

--- a/skills/cifar10-one-hot-label-encoding.md
+++ b/skills/cifar10-one-hot-label-encoding.md
@@ -76,31 +76,31 @@ fn one_hot_encode(
 ) -> Tensor[DType.float32]:
     """
     Convert integer labels to one-hot encoded format.
-    
+
     Args:
         labels: Shape (B,) with values in [0, num_classes)
         num_classes: Number of classes (10 for CIFAR-10)
-    
+
     Returns:
         Shape (B, num_classes) with one 1.0 per row, rest 0.0
     """
     var batch_size = labels.shape[0]
-    
+
     # Create zero tensor (B, num_classes)
     var one_hot = zeros[DType.float32](batch_size, num_classes)
-    
+
     # Set one_hot[i, labels[i]] = 1.0
     for i in range(batch_size):
         var class_idx = int(labels[i])
-        
+
         # Bounds check (safety)
         if class_idx < 0 or class_idx >= num_classes:
             raise ValueError(
                 f"Label {class_idx} out of range [0, {num_classes})"
             )
-        
+
         one_hot[i, class_idx] = Float32(1.0)
-    
+
     return one_hot
 ```
 
@@ -111,7 +111,7 @@ struct CIFAR10Batch:
     var images: Tensor[DType.float32]  # Shape: (B, 3, 32, 32)
     var labels_raw: Tensor[DType.uint8]  # Shape: (B,) with values 0-9
     var labels_onehot: Tensor[DType.float32]  # Shape: (B, 10)
-    
+
     fn __init__(
         out self,
         images: Tensor[DType.float32],
@@ -126,7 +126,7 @@ fn load_cifar10_batch(batch_file: String) -> CIFAR10Batch:
     """Load batch and convert labels to one-hot format"""
     var images = load_images(batch_file)  # (B, 3, 32, 32) float32
     var labels_raw = load_labels(batch_file)  # (B,) uint8
-    
+
     return CIFAR10Batch(images, labels_raw)
 
 fn train_epoch(
@@ -134,17 +134,17 @@ fn train_epoch(
     batch_file: String,
 ) -> Float32:
     """Training epoch with proper label encoding"""
-    
+
     var batch = load_cifar10_batch(batch_file)
-    
+
     # Forward pass
     var logits = model.forward(batch.images)  # (B, 10)
-    
+
     # Cross-entropy expects:
     # - logits: (B, 10) raw predictions
     # - labels: (B, 10) one-hot encoded targets
     var loss = cross_entropy(logits, batch.labels_onehot)
-    
+
     return loss[0, 0]
 ```
 
@@ -157,47 +157,47 @@ fn verify_one_hot_encoding(
     num_classes: Int = 10,
 ) -> Bool:
     """Validate one-hot encoding properties"""
-    
+
     var batch_size = labels.shape[0]
-    
+
     # Check shape
     if one_hot.shape[0] != batch_size or one_hot.shape[1] != num_classes:
         print(f"ERROR: Shape mismatch. Expected ({batch_size}, {num_classes}), got {one_hot.shape}")
         return False
-    
+
     # Check each row
     for i in range(batch_size):
         var row_sum = Float32(0.0)
         var one_count = 0
         var class_idx = int(labels[i])
-        
+
         for j in range(num_classes):
             var val = one_hot[i, j]
-            
+
             // Each value should be 0.0 or 1.0
             if val != 0.0 and val != 1.0:
                 print(f"ERROR: one_hot[{i}, {j}] = {val}, expected 0.0 or 1.0")
                 return False
-            
+
             if val == 1.0:
                 one_count += 1
             row_sum += val
-        
+
         // Each row should sum to exactly 1.0
         if abs(row_sum - 1.0) > 1e-6:
             print(f"ERROR: Row {i} sums to {row_sum}, expected 1.0")
             return False
-        
+
         // Exactly one 1.0 per row
         if one_count != 1:
             print(f"ERROR: Row {i} has {one_count} ones, expected 1")
             return False
-        
+
         // The 1.0 should be at position labels[i]
         if abs(one_hot[i, class_idx] - 1.0) > 1e-6:
             print(f"ERROR: one_hot[{i}, {class_idx}] should be 1.0, got {one_hot[i, class_idx]}")
             return False
-    
+
     return True
 ```
 
@@ -210,33 +210,33 @@ fn process_cifar10_epoch(
     num_batches: Int,
 ) -> List[Float32]:
     """Process multiple batches with proper label encoding"""
-    
+
     var losses = List[Float32]()
-    
+
     for batch_idx in range(num_batches):
         // Load batch (images + raw integer labels)
         var batch = batch_iterator.next()
-        
+
         var images = batch.images  // (B, 3, 32, 32)
         var labels_raw = batch.labels_raw  // (B,) with uint8 values
-        
+
         // Encode labels to one-hot
         var labels_onehot = one_hot_encode(labels_raw, num_classes=10)
-        
+
         // Forward pass
         var logits = model.forward(images)  // (B, 10)
-        
+
         // Compute loss with one-hot encoded labels
         var loss = cross_entropy(logits, labels_onehot)
         losses.append(loss[0, 0])
-        
+
         // Backward pass
         var grad_out = grad_cross_entropy(logits, labels_onehot)
         var gradients = model.backward(grad_out)
-        
+
         // Update parameters
         update_step(model, gradients, lr=0.01)
-    
+
     return losses
 ```
 
@@ -245,16 +245,16 @@ fn process_cifar10_epoch(
 ```mojo
 fn test_one_hot_encoding() -> None:
     """Test one-hot encoding implementation"""
-    
+
     // Test 1: Single sample
     var labels1 = Tensor[DType.uint8](1)
     labels1[0] = 5
     var one_hot1 = one_hot_encode(labels1, num_classes=10)
-    
+
     assert_true(one_hot1.shape == (1, 10), "Shape should be (1, 10)")
     assert_true(one_hot1[0, 5] == 1.0, "Position 5 should be 1.0")
     assert_true(one_hot1[0, 0] == 0.0, "Other positions should be 0.0")
-    
+
     // Test 2: Multiple samples
     var labels2 = Tensor[DType.uint8](4)
     labels2[0] = 0
@@ -262,20 +262,20 @@ fn test_one_hot_encoding() -> None:
     labels2[2] = 5
     labels2[3] = 9
     var one_hot2 = one_hot_encode(labels2, num_classes=10)
-    
+
     assert_true(one_hot2.shape == (4, 10), "Shape should be (4, 10)")
     assert_true(one_hot2[0, 0] == 1.0, "Row 0, class 0 should be 1.0")
     assert_true(one_hot2[1, 1] == 1.0, "Row 1, class 1 should be 1.0")
     assert_true(one_hot2[2, 5] == 1.0, "Row 2, class 5 should be 1.0")
     assert_true(one_hot2[3, 9] == 1.0, "Row 3, class 9 should be 1.0")
-    
+
     // Test 3: Row sums
     for i in range(4):
         var row_sum = Float32(0.0)
         for j in range(10):
             row_sum += one_hot2[i, j]
         assert_true(abs(row_sum - 1.0) < 1e-6, "Each row should sum to 1.0")
-    
+
     print("✓ All one-hot encoding tests passed")
 ```
 
@@ -351,7 +351,7 @@ var loss = cross_entropy(logits, soft_labels)
 
 ```mojo
 // Input: labels = [0, 1, 5, 3] (shape: (4,))
-// Output: one_hot = 
+// Output: one_hot =
 // [1, 0, 0, 0, 0, 0, 0, 0, 0, 0]  // Class 0
 // [0, 1, 0, 0, 0, 0, 0, 0, 0, 0]  // Class 1
 // [0, 0, 0, 0, 0, 1, 0, 0, 0, 0]  // Class 5
@@ -365,7 +365,7 @@ Each sample has exactly one 1.0 (at the true class index) and nine 0.0s.
 ```
 Cross-entropy(logits, labels_onehot) =
   -sum over all i,j: labels_onehot[i,j] * log(softmax(logits[i,j]))
-  
+
 With one-hot labels, this simplifies to:
   -log(softmax(logits[i, true_class[i]]))
 ```
@@ -378,17 +378,17 @@ The loss only depends on the predicted probability of the true class.
 1. Load CIFAR-10 batch
    images: (B, 3, 32, 32) float32
    labels_raw: (B,) uint8 with values [0-9]
-   
+
 2. Encode labels
    labels_onehot = one_hot_encode(labels_raw, 10)
    Result: (B, 10) float32
-   
+
 3. Forward pass
    logits = model.forward(images)  // (B, 10)
-   
+
 4. Compute loss
    loss = cross_entropy(logits, labels_onehot)
-   
+
 5. Backward pass
    grad_out = grad_cross_entropy(logits, labels_onehot)
    gradients = model.backward(grad_out)

--- a/skills/depthwise-separable-forward-backward.md
+++ b/skills/depthwise-separable-forward-backward.md
@@ -70,7 +70,7 @@ fn depthwise_block_forward(
     bn2: BatchNorm2d,
 ) -> Tensor[DType.float32]:
     """Forward pass: depthwise → BN → ReLU → pointwise → BN → ReLU"""
-    
+
     # Depthwise convolution: (B, C, H, W) → (B, C, H', W')
     var dw_out = depthwise_conv2d(
         input,
@@ -78,22 +78,22 @@ fn depthwise_block_forward(
         stride=1,
         padding=1
     )
-    
+
     # Batch norm: normalize per-channel statistics
     var bn1_out = bn1.forward(dw_out)
-    
+
     # ReLU activation
     var relu1_out = relu(bn1_out)
-    
+
     # Pointwise (1x1) convolution: (B, C, H', W') → (B, C_out, H', W')
     var pw_out = conv2d(relu1_out, pw_weight, stride=1, padding=0)
-    
+
     # Second batch norm
     var bn2_out = bn2.forward(pw_out)
-    
+
     # Second ReLU
     var relu2_out = relu(bn2_out)
-    
+
     return relu2_out
 ```
 
@@ -123,27 +123,27 @@ fn depthwise_block_backward(
     pw_weight: Tensor[DType.float32],
 ) -> Tuple[Tensor[DType.float32], Tensor[DType.float32], Tensor[DType.float32]]:
     """Backward pass in reverse order. Returns (grad_input, grad_dw, grad_pw)"""
-    
+
     # 1. ReLU2 backward
     var grad_relu2 = grad_out * (relu2_out > 0).cast[DType.float32]()
-    
+
     # 2. BN2 backward (using cached BN2 output)
     var grad_bn2 = bn2.backward(grad_relu2, bn2_out)
-    
+
     # 3. Pointwise conv backward
     var grad_pw_out = conv2d_backward_data(grad_bn2, pw_weight)
     var grad_pw_weight = conv2d_backward_weight(relu1_out, grad_bn2)
-    
+
     # 4. ReLU1 backward
     var grad_relu1 = grad_pw_out * (relu1_out > 0).cast[DType.float32]()
-    
+
     # 5. BN1 backward (using cached BN1 output)
     var grad_bn1 = bn1.backward(grad_relu1, bn1_out)
-    
+
     # 6. Depthwise conv backward
     var grad_input = depthwise_conv2d_backward_data(grad_bn1, dw_weight)
     var grad_dw_weight = depthwise_conv2d_backward_weight(input, grad_bn1)
-    
+
     return (grad_input, grad_dw_weight, grad_pw_weight)
 ```
 
@@ -159,36 +159,36 @@ fn verify_depthwise_gradients(
     epsilon: Float32 = 1e-5,
 ) -> Bool:
     """Verify analytical gradients match numerical gradients"""
-    
+
     # Forward pass
     var output = depthwise_block_forward(input, dw_weight, pw_weight)
     var loss = output.sum()  # Scalar loss
-    
+
     # Backward pass (analytical)
     var grad_input, var grad_dw, var grad_pw = depthwise_block_backward(...)
-    
+
     # Numerical gradient for dw_weight[i,j,k,l]
     for i in range(dw_weight.shape[0]):
         for j in range(dw_weight.shape[1]):
             var original = dw_weight[i,j,k,l]
-            
+
             # Forward difference
             dw_weight[i,j,k,l] = original + epsilon
             var loss_plus = depthwise_block_forward(...).sum()
-            
+
             dw_weight[i,j,k,l] = original - epsilon
             var loss_minus = depthwise_block_forward(...).sum()
-            
+
             var numerical_grad = (loss_plus - loss_minus) / (2 * epsilon)
             var analytical_grad = grad_dw[i,j,k,l]
-            
+
             # Relative error should be < 1e-4
             var rel_error = abs(numerical_grad - analytical_grad) / (abs(analytical_grad) + 1e-8)
             if rel_error > 1e-4:
                 return False
-            
+
             dw_weight[i,j,k,l] = original
-    
+
     return True
 ```
 
@@ -203,9 +203,9 @@ fn train_step(
     lr: Float32,
 ) -> Float32:
     """Single training step with caching for backward pass"""
-    
+
     var input, var labels = batch
-    
+
     # Forward pass - cache intermediate outputs
     var dw_out = depthwise_conv2d(input, model.dw_weight, ...)
     var bn1_out = model.bn1.forward(dw_out)
@@ -213,20 +213,20 @@ fn train_step(
     var pw_out = conv2d(relu1_out, model.pw_weight, ...)
     var bn2_out = model.bn2.forward(pw_out)
     var logits = relu(bn2_out)
-    
+
     # Loss computation
     var loss = cross_entropy(logits, labels)
-    
+
     # Backward pass with cached tensors
     var grad_out = grad_cross_entropy(logits, labels)
     var grad_input, var grad_dw, var grad_pw = depthwise_block_backward(
         grad_out, input, dw_out, bn1_out, relu1_out, pw_out, bn2_out, ...
     )
-    
+
     # Parameter updates
     model.dw_weight -= lr * grad_dw
     model.pw_weight -= lr * grad_pw
-    
+
     return loss[0, 0]
 ```
 
@@ -239,7 +239,7 @@ fn train_step(
 ```mojo
 struct DepthwiseBlock:
     var depthwise: Conv2d  # Wrapper around depthwise_conv2d
-    
+
 fn forward(self, x: Tensor) -> Tensor:
     return self.depthwise.forward(x)  # Calls conv2d, not depthwise
 ```
@@ -307,7 +307,7 @@ fn forward_with_cache(...) -> Tuple[Tensor, ForwardCache]:
     var bn1_out = bn1.forward(dw_out)
     var relu1_out = relu(bn1_out)
     # ... more computations
-    
+
     var cache = ForwardCache(dw_out, bn1_out, relu1_out, pw_out, bn2_out)
     return (final_output, cache)
 

--- a/skills/exception-discriminator-enums-state-machine-pola.md
+++ b/skills/exception-discriminator-enums-state-machine-pola.md
@@ -51,7 +51,7 @@ class CircuitBreakerOpenReason(str, Enum):
 # Step 2: Add reason field with semantic default
 class CircuitBreakerOpenError(Exception):
     """Raised when circuit breaker is open."""
-    
+
     def __init__(
         self,
         message: str,
@@ -96,7 +96,7 @@ except CircuitBreakerOpenError as exc:
 1. **Define the discriminator enum** with `(str, Enum)` mixin (not `enum.StrEnum` for Python 3.10 compatibility):
    ```python
    from enum import Enum
-   
+
    class YourStateReason(str, Enum):
        """Reason for exception."""
        REASON_A = "reason_a"
@@ -130,7 +130,7 @@ except CircuitBreakerOpenError as exc:
    ```python
    # GOOD: Explicit reason at every raise site
    raise YourException(msg, reason=YourStateReason.REASON_A)
-   
+
    # BAD: Relying on default for some cases, explicit for others
    raise YourException(msg)  # What's the reason? Ambiguous!
    raise YourException(msg, reason=YourStateReason.REASON_B)
@@ -141,7 +141,7 @@ except CircuitBreakerOpenError as exc:
    # OLD: Only check message
    with pytest.raises(CircuitBreakerOpenError, match="Circuit breaker open"):
        breaker.call(fn)
-   
+
    # NEW: Assert both message and reason
    with pytest.raises(CircuitBreakerOpenError) as exc_info:
        breaker.call(fn)
@@ -157,25 +157,25 @@ except CircuitBreakerOpenError as exc:
    def test_half_open_exhaustion_vs_recovery_timeout():
        """Verify both reason codes are reachable in concurrent scenarios."""
        barrier = threading.Event()
-       
+
        # Hold first probe in-flight while second call hits slot exhaustion
        def slow_probe():
            barrier.set()  # Signal that we're in-flight
            time.sleep(0.5)  # Block for a bit
            return True
-       
+
        # Transition to HALF_OPEN, start probe
        breaker.state = CircuitBreakerState.HALF_OPEN
        breaker.max_calls = 1
        t = threading.Thread(target=lambda: breaker.call(slow_probe))
        t.start()
        barrier.wait()  # Wait for probe to be in-flight
-       
+
        # Second call hits slot exhaustion
        with pytest.raises(CircuitBreakerOpenError) as exc_info:
            breaker.call(lambda: None)
        assert exc_info.value.reason == CircuitBreakerOpenReason.HALF_OPEN_EXHAUSTED
-       
+
        t.join()
    ```
 
@@ -223,10 +223,10 @@ from enum import Enum
 
 class CircuitBreakerOpenReason(str, Enum):
     """Reason why circuit breaker is open.
-    
+
     RECOVERY_TIMEOUT: Circuit is in OPEN state, waiting for recovery timeout before
         transitioning to HALF_OPEN. time_until_recovery indicates seconds remaining.
-    
+
     HALF_OPEN_EXHAUSTED: Circuit is in HALF_OPEN state, but all max_calls slots are
         in-flight with probe attempts. Retry after probes complete (typically < 1s).
     """
@@ -239,12 +239,12 @@ class CircuitBreakerOpenReason(str, Enum):
 ```python
 class CircuitBreakerOpenError(Exception):
     """Raised when circuit breaker is in OPEN or HALF_OPEN state.
-    
+
     Attributes:
         time_until_recovery: Seconds to wait before retrying (OPEN state) or 0.0 (HALF_OPEN).
         reason: CircuitBreakerOpenReason discriminator — RECOVERY_TIMEOUT or HALF_OPEN_EXHAUSTED.
     """
-    
+
     def __init__(
         self,
         message: str,

--- a/skills/exception-discriminator-enums-state-machine-pola.notes.md
+++ b/skills/exception-discriminator-enums-state-machine-pola.notes.md
@@ -85,19 +85,19 @@ The reason assertion exposed that `test_half_open_max_calls_exceeded` was ambigu
 ```python
 def test_half_open_exhaustion():
     barrier = threading.Event()
-    
+
     def slow_probe():
         barrier.set()  # Signal we're in-flight
         time.sleep(0.5)
         return True
-    
+
     # Hold probe in-flight while second call hits exhaustion
     breaker.state = CircuitBreakerState.HALF_OPEN
     breaker.max_calls = 1
     t = threading.Thread(target=lambda: breaker.call(slow_probe))
     t.start()
     barrier.wait()  # Wait for probe to be in-flight
-    
+
     # Now second call should hit slot exhaustion
     with pytest.raises(CircuitBreakerOpenError) as exc_info:
         breaker.call(lambda: None)

--- a/skills/github-graphql-batch-query-optimization.md
+++ b/skills/github-graphql-batch-query-optimization.md
@@ -137,7 +137,7 @@ def get_prs_stats(owner: str, repo: str, state: str = "all") -> PRsStats:
            "hephaestus.github.github_api._gh_call",
            return_value=MockResult(json.dumps(graphql_response))
        )
-       
+
        result = get_prs_stats("owner", "repo")
        assert result.total_count == 100
        assert result.merged_count == 50

--- a/skills/hephaestus-env-var-fallback-path-resolution.md
+++ b/skills/hephaestus-env-var-fallback-path-resolution.md
@@ -62,10 +62,10 @@ from pathlib import Path
 
 def repo_root() -> Path:
     """Resolve repository root with env-var override + walk-up fallback.
-    
+
     Returns:
         Path to repository root (hephaestus/__init__.py is one level below)
-    
+
     Raises:
         RuntimeError: If repository root cannot be located
     """
@@ -75,14 +75,14 @@ def repo_root() -> Path:
         if (root / 'hephaestus' / '__init__.py').exists():
             return root
         raise RuntimeError(f"HEPHAESTUS_REPO_ROOT={env_path} does not contain hephaestus/__init__.py")
-    
+
     # 2. Walk up from __file__ until pyproject.toml marker is found
     current = Path(__file__).parent
     for _ in range(10):  # Limit iterations to prevent infinite loops
         if (current / 'pyproject.toml').exists():
             return current
         current = current.parent
-    
+
     # 3. Fail explicitly
     raise RuntimeError(
         "Could not locate repository root. "
@@ -91,10 +91,10 @@ def repo_root() -> Path:
 
 def scripts_dir() -> Path:
     """Resolve scripts directory with env-var override + repo_root fallback.
-    
+
     Returns:
         Path to scripts/ directory
-    
+
     Raises:
         RuntimeError: If scripts directory cannot be located
     """
@@ -104,12 +104,12 @@ def scripts_dir() -> Path:
         if scripts.exists() and scripts.is_dir():
             return scripts
         raise RuntimeError(f"HEPHAESTUS_SCRIPTS_DIR={env_path} does not exist or is not a directory")
-    
+
     # 2. Derive from repo_root
     scripts = repo_root() / 'scripts'
     if scripts.exists() and scripts.is_dir():
         return scripts
-    
+
     # 3. Fail explicitly
     raise RuntimeError(f"Scripts directory not found at {scripts}")
 

--- a/skills/hephaestus-env-var-fallback-path-resolution.notes.md
+++ b/skills/hephaestus-env-var-fallback-path-resolution.notes.md
@@ -34,7 +34,7 @@ This brittle fragmentation is the **core problem** — any directory structure c
 ```python
 def repo_root() -> Path:
     """Env override → pyproject.toml walk-up → RuntimeError"""
-    
+
 def scripts_dir() -> Path:
     """Env override → repo_root derivation → RuntimeError"""
 

--- a/skills/logging-contextvars-ambient-state.md
+++ b/skills/logging-contextvars-ambient-state.md
@@ -53,7 +53,7 @@ _correlation_id_var = contextvars.ContextVar(
 # 2. Accessor function to read current value
 def get_current_correlation_id() -> str | None:
     """Get the current correlation ID from context.
-    
+
     Returns:
         The correlation ID if set, None otherwise.
     """
@@ -62,10 +62,10 @@ def get_current_correlation_id() -> str | None:
 # 3. Setter function to set value
 def set_correlation_id(correlation_id: str | None) -> contextvars.Token:
     """Set the correlation ID in context.
-    
+
     Args:
         correlation_id: The correlation ID to set.
-    
+
     Returns:
         Token that can be used to reset context later.
     """
@@ -74,7 +74,7 @@ def set_correlation_id(correlation_id: str | None) -> contextvars.Token:
 # 4. Context manager for scoped binding
 def correlation_id_scope(correlation_id: str | None):
     """Context manager to temporarily set correlation ID.
-    
+
     Usage:
         with correlation_id_scope("req-123"):
             # Inside this block, get_current_correlation_id() == "req-123"
@@ -82,7 +82,7 @@ def correlation_id_scope(correlation_id: str | None):
         # After exiting, context is restored
     """
     from contextlib import contextmanager
-    
+
     @contextmanager
     def _scope():
         token = set_correlation_id(correlation_id)
@@ -90,17 +90,17 @@ def correlation_id_scope(correlation_id: str | None):
             yield
         finally:
             _correlation_id_var.reset(token)
-    
+
     return _scope()
 
 # 5. Use in subprocesses (inject into environment)
 def run_subprocess(cmd: list[str]) -> str:
     """Run subprocess, injecting correlation ID into environment."""
     env = os.environ.copy()
-    
+
     if cid := get_current_correlation_id():
         env['GH_TRACE_ID'] = cid
-    
+
     result = subprocess.run(cmd, env=env, capture_output=True, text=True)
     return result.stdout
 ```
@@ -110,7 +110,7 @@ def run_subprocess(cmd: list[str]) -> str:
 1. **Define ContextVar at module level** (typically in a logging utilities module):
    ```python
    import contextvars
-   
+
    _correlation_id_var = contextvars.ContextVar('correlation_id', default=None)
    ```
    - Name is arbitrary (used for debugging)
@@ -190,10 +190,10 @@ _correlation_id_var = contextvars.ContextVar('correlation_id', default=None)
 
 def get_current_correlation_id() -> Optional[str]:
     """Get the current correlation ID from context.
-    
+
     Returns:
         The correlation ID if set, None otherwise.
-    
+
     Example:
         >>> set_correlation_id("req-abc123")
         >>> get_current_correlation_id()
@@ -203,13 +203,13 @@ def get_current_correlation_id() -> Optional[str]:
 
 def set_correlation_id(correlation_id: Optional[str]) -> contextvars.Token:
     """Set the correlation ID in context.
-    
+
     Args:
         correlation_id: The correlation ID to set (None to clear).
-    
+
     Returns:
         Token that can be used to reset context later.
-    
+
     Example:
         >>> token = set_correlation_id("req-xyz")
         >>> get_current_correlation_id()
@@ -222,15 +222,15 @@ def set_correlation_id(correlation_id: Optional[str]) -> contextvars.Token:
 @contextmanager
 def correlation_id_scope(correlation_id: Optional[str]):
     """Context manager to temporarily set correlation ID.
-    
+
     Automatically restores the previous value on exit.
-    
+
     Args:
         correlation_id: The correlation ID to set.
-    
+
     Yields:
         None.
-    
+
     Example:
         >>> with correlation_id_scope("req-scope-123"):
         ...     print(get_current_correlation_id())  # "req-scope-123"
@@ -252,25 +252,25 @@ import subprocess
 
 def run_subprocess(cmd: list[str], **kwargs) -> str:
     """Run subprocess, injecting correlation ID into environment.
-    
+
     Args:
         cmd: List of command arguments.
         **kwargs: Additional arguments to subprocess.run().
-    
+
     Returns:
         stdout from the subprocess.
-    
+
     Raises:
         subprocess.CalledProcessError: If subprocess returns non-zero.
     """
     env = kwargs.pop('env', None) or os.environ.copy()
-    
+
     # Inject correlation ID into subprocess environment
     from hephaestus.logging.utils import get_current_correlation_id
-    
+
     if cid := get_current_correlation_id():
         env['GH_TRACE_ID'] = cid
-    
+
     result = subprocess.run(
         cmd,
         env=env,
@@ -317,11 +317,11 @@ def test_thread_isolation():
     """Each thread has isolated correlation ID."""
     import threading
     results = {}
-    
+
     def thread_func(cid):
         set_correlation_id(cid)
         results[threading.current_thread().name] = get_current_correlation_id()
-    
+
     set_correlation_id("main")
     t1 = threading.Thread(target=thread_func, args=("thread-1",), name="T1")
     t2 = threading.Thread(target=thread_func, args=("thread-2",), name="T2")
@@ -329,7 +329,7 @@ def test_thread_isolation():
     t2.start()
     t1.join()
     t2.join()
-    
+
     # Main thread was not affected by thread spawns
     assert get_current_correlation_id() == "main"
     # Each thread had its own value
@@ -339,20 +339,20 @@ def test_thread_isolation():
 def test_subprocess_receives_env_var():
     """Subprocess inherits correlation ID via environment."""
     import subprocess
-    
+
     set_correlation_id("req-subprocess-test")
-    
+
     env = os.environ.copy()
     if cid := get_current_correlation_id():
         env['GH_TRACE_ID'] = cid
-    
+
     result = subprocess.run(
         ["sh", "-c", "echo $GH_TRACE_ID"],
         env=env,
         capture_output=True,
         text=True,
     )
-    
+
     assert "req-subprocess-test" in result.stdout
 ```
 

--- a/skills/logging-subprocess-context-tracking.md
+++ b/skills/logging-subprocess-context-tracking.md
@@ -46,13 +46,13 @@ tags:
 # In subprocess runner function
 def run_git_cmd(cmd: list[str], cwd: str | None = None) -> str:
     """Run git command in optional working directory."""
-    
+
     # Conditional log formatting
     if cwd is not None:
         logger.info(f"Running: {' '.join(cmd)} (cwd={cwd})")
     else:
         logger.info(f"Running: {' '.join(cmd)}")
-    
+
     result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
     return result.stdout
 ```
@@ -71,11 +71,11 @@ Locate the function that invokes subprocess calls. Examples:
 ```python
 def run_git_cmd(cmd: list[str], cwd: str | None = None) -> str:
     """Run git command in optional working directory.
-    
+
     Args:
         cmd: Command and arguments as list of strings
         cwd: Working directory for command execution (None = current directory)
-    
+
     Returns:
         stdout from the command
     """
@@ -92,7 +92,7 @@ def run_git_cmd(cmd: list[str], cwd: str | None = None) -> str:
         logger.info(f"Running git command: {' '.join(cmd)} (cwd={cwd})")
     else:
         logger.info(f"Running git command: {' '.join(cmd)}")
-    
+
     result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=True)
     return result.stdout
 ```
@@ -109,7 +109,7 @@ def test_run_git_cmd_with_cwd_logs_context():
     """Test that cwd context is logged when provided."""
     with patch("hephaestus.github.pr_merge.logger") as mock_logger:
         run_git_cmd(["git", "status"], cwd="/tmp/test_repo")
-        
+
         # Verify the logger call includes the cwd context
         call_args = mock_logger.info.call_args
         assert call_args is not None
@@ -120,7 +120,7 @@ def test_run_git_cmd_without_cwd_no_context():
     """Test that cwd is omitted from log when not provided."""
     with patch("hephaestus.github.pr_merge.logger") as mock_logger:
         run_git_cmd(["git", "status"])
-        
+
         # Verify the logger call does NOT include cwd context
         call_args = mock_logger.info.call_args
         assert call_args is not None
@@ -177,13 +177,13 @@ def test_subprocess_runner_with_cwd():
     """Test that working directory context is logged."""
     with patch("module_name.logger") as mock_logger:
         result = run_git_cmd(["git", "log", "--oneline"], cwd="/home/user/repo")
-        
+
         # Verify logger.info was called
         assert mock_logger.info.called
-        
+
         # Extract the logged message (first positional argument)
         logged_msg = mock_logger.info.call_args[0][0]
-        
+
         # Assertions on the message content
         assert "git log --oneline" in logged_msg or isinstance(logged_msg, str)
         assert "(cwd=/home/user/repo)" in logged_msg

--- a/skills/mojo-tensor-ownership-training-loops.md
+++ b/skills/mojo-tensor-ownership-training-loops.md
@@ -73,26 +73,26 @@ fn train_step(
     lr: Float32,
 ) -> Tuple[Float32, Float32]:
     """Training step with separate batches for gradient and forward"""
-    
+
     # First batch for gradient computation
     var batch1 = batch_loader.load_batch()  # Fresh batch object
     var input1 = batch1[0]  # Extract input (ownership moves)
     var labels1 = batch1[1]  # Extract labels (ownership moves)
-    
+
     # compute_gradients takes ownership of input1 and labels1
     var loss1 = compute_gradients(model, input1, labels1, lr)
     // input1 and labels1 are now destroyed
-    
+
     # Second batch for forward pass (SEPARATE batch object)
     var batch2 = batch_loader.load_batch()  # Fresh batch object
     var input2 = batch2[0]  # Extract input (ownership moves to input2)
     var labels2 = batch2[1]  # Extract labels (ownership moves to labels2)
-    
+
     # model.forward takes ownership of input2 (not input1)
     var logits = model.forward(input2)  // Safe - input2 is fresh
-    
+
     var loss2 = cross_entropy(logits, labels2)
-    
+
     return (loss1, loss2[0, 0])
 ```
 
@@ -106,11 +106,11 @@ fn train_epoch(
     batch: Tensor,
 ) -> Float32:
     """Multiple operations on same batch using references"""
-    
+
     # Option 1: Borrow with & (read-only reference)
     var loss1 = compute_loss(model, batch &)  # & borrows, no move
     var loss2 = compute_loss_alt(model, batch &)  # Can borrow multiple times
-    
+
     return loss1 + loss2
 ```
 
@@ -125,20 +125,20 @@ struct BatchLoader:
     var input_path: String
     var label_path: String
     var batch_size: Int
-    
+
     fn load_batch(self) -> Tuple[Tensor, Tensor]:
         """Load fresh batch - each call creates new tensors"""
         var input_data = read_file(self.input_path)
         var label_data = read_file(self.label_path)
-        
+
         var input_tensor = Tensor[DType.float32](
             self.batch_size,
             input_data.shape[1]
         )
         var label_tensor = Tensor[DType.uint8](self.batch_size)
-        
+
         # ... populate tensors from files
-        
+
         return (input_tensor, label_tensor)
 
 fn train_epoch(model: Model, batch_loader: BatchLoader) -> None:
@@ -147,7 +147,7 @@ fn train_epoch(model: Model, batch_loader: BatchLoader) -> None:
         var batch = batch_loader.load_batch()
         var input = batch[0]
         var labels = batch[1]
-        
+
         _ = compute_gradients(model, input, labels, lr)
         // input, labels destroyed after compute_gradients
 ```
@@ -162,19 +162,19 @@ fn verify_post_training(
     validation_batch: Tuple[Tensor, Tensor],
 ) -> Float32:
     """Forward pass after training complete"""
-    
+
     # Create separate batch for validation
     var eval_batch = load_eval_batch()  # Fresh batch
     var eval_input = eval_batch[0]
     var eval_labels = eval_batch[1]
-    
+
     # Forward pass (may take input by value)
     var logits = model.forward(eval_input)  // input moved
-    
+
     # Compute metrics
     var loss = cross_entropy(logits, eval_labels)
     var accuracy = compute_accuracy(logits, eval_labels)
-    
+
     return loss[0, 0]
 ```
 
@@ -252,7 +252,7 @@ fn full_training_with_verification(
     batch_loader: BatchLoader,
 ) -> Tuple[Float32, Float32]:
     """Training complete with post-training forward pass"""
-    
+
     # Phase 1: Training (consuming batches)
     for epoch in range(num_epochs):
         for step in range(steps_per_epoch):
@@ -260,15 +260,15 @@ fn full_training_with_verification(
             var train_input = train_batch[0]
             var train_labels = train_batch[1]
             _ = compute_gradients(model, train_input, train_labels, lr)
-    
+
     # Phase 2: Post-training verification (SEPARATE batch)
     var eval_batch = batch_loader.load_batch()  // New batch object
     var eval_input = eval_batch[0]
     var eval_labels = eval_batch[1]
-    
+
     var logits = model.forward(eval_input)  // Safe - eval_input is fresh
     var loss = cross_entropy(logits, eval_labels)
-    
+
     return (training_loss, loss[0, 0])
 ```
 

--- a/skills/optional-scoped-discovery-pola-gate.md
+++ b/skills/optional-scoped-discovery-pola-gate.md
@@ -238,11 +238,11 @@ from typing import Optional, List
 
 def setup_cli():
     """Setup a POLA-compliant CLI with optional discovery flags."""
-    
+
     parser = argparse.ArgumentParser(
         description="Drive PRs green via issue-driven or PR-driven discovery."
     )
-    
+
     # Optional issues: gate to issue-driven if provided, PR-driven if absent
     parser.add_argument(
         "--issues",
@@ -252,7 +252,7 @@ def setup_cli():
         dest="issues",
         help="Discover work from specific issues. Omit for auto-discovery from all PRs.",
     )
-    
+
     # Optional org: gate to org-scoped or global discovery
     parser.add_argument(
         "--org",
@@ -261,7 +261,7 @@ def setup_cli():
         dest="org",
         help="Org name to drive. Omit for auto-detect from git remote.",
     )
-    
+
     return parser
 
 
@@ -270,18 +270,18 @@ def discover_work(
     args_org: Optional[str],
 ) -> dict[int, int]:
     """Discover work based on POLA-gated flags.
-    
+
     Args:
         args_issues: Issues to discover (or None if flag not provided)
         args_org: Org name to discover (or None if flag not provided)
-    
+
     Returns:
         dict[int, int]: Discovered {issue_num: pr_num} pairs
     """
-    
+
     # First gate: org scope
     org = args_org if args_org is not None else _auto_detect_org()
-    
+
     # Second gate: discovery mode
     if args_issues is not None:
         # Operator provided --issues (even if empty)
@@ -295,7 +295,7 @@ def discover_work(
         # Operator did NOT provide --issues
         # Go wide: discover from all failing PRs
         discovered = _discover_from_all_prs(org=org)
-    
+
     return discovered
 ```
 
@@ -307,22 +307,22 @@ import pytest
 
 class TestPolaDiscoveryGate:
     """Validate that flag presence gates discovery scope."""
-    
+
     def test_issues_flag_gates_to_issue_driven(self):
         """--issues provided → issue-driven discovery, not PR-driven."""
         # Arrange
         mock_discovered_issues = {1: 100, 2: 200}
         mock_discover_from_issues = lambda issues, **kw: mock_discovered_issues
-        
+
         # Act
         result = discover_work(
             args_issues=[1, 2],  # Flag provided with values
             args_org=None,
         )
-        
+
         # Assert: should not call _discover_from_all_prs
         assert result == mock_discovered_issues
-    
+
     def test_issues_flag_empty_stays_issue_driven(self):
         """--issues with no values → still issue-driven (empty result)."""
         # Arrange
@@ -331,25 +331,25 @@ class TestPolaDiscoveryGate:
             args_issues=[],  # Flag present, no values
             args_org=None,
         )
-        
+
         # Assert: should stay in issue-driven mode, return empty (no work)
         assert result == {}
-    
+
     def test_no_issues_flag_gates_to_pr_driven(self):
         """Omit --issues → PR-driven auto-discovery."""
         # Arrange
         mock_discovered_prs = {300: 300, 301: 301}
-        
+
         # Act: flag NOT provided (None)
         result = discover_work(
             args_issues=None,  # Flag not provided
             args_org=None,
         )
-        
+
         # Assert: should call _discover_from_all_prs, not _discover_from_issues
         # Result should include PRs, not issues
         assert result == mock_discovered_prs
-    
+
     def test_org_flag_gates_to_scoped_discovery(self):
         """--org provided → org-scoped discovery."""
         # Act
@@ -357,7 +357,7 @@ class TestPolaDiscoveryGate:
             args_issues=None,  # Auto-discover PRs
             args_org="homeric-intelligence",  # Scoped to org
         )
-        
+
         # Assert: discovery function should receive the org
         # (Verified via mock.assert_called_with)
         # ...

--- a/skills/parallel-agent-myrmidon-swarm-orchestration.history
+++ b/skills/parallel-agent-myrmidon-swarm-orchestration.history
@@ -783,4 +783,3 @@ user-invocable: false
 
 
 ---
-

--- a/skills/prompt-string-syntax-raw-vs-plain.md
+++ b/skills/prompt-string-syntax-raw-vs-plain.md
@@ -179,7 +179,7 @@ def test_directive_in_implementation_prompt():
 # ✅ CLEAR: Explains why test is incomplete
 def test_directive_in_implementation_prompt():
     """Validate terse directive in implementation agent prompt.
-    
+
     Note: Requires get_comment_difficulty_prompt() helper, planned for future
     refinement. Currently implementation prompt does not use comment difficulty
     scoring, so this test is deferred.

--- a/skills/prompt-string-syntax-raw-vs-plain.notes.md
+++ b/skills/prompt-string-syntax-raw-vs-plain.notes.md
@@ -115,7 +115,7 @@ unclear whether the gap is intentional (deferred) or accidental (forgotten).
 ```python
 def test_directive_in_implementation_prompt():
     """Validate terse directive in implementation agent prompt.
-    
+
     Note: Requires get_comment_difficulty_prompt() helper, planned for future
     refinement. Currently implementation prompt does not use comment difficulty
     scoring, so this test is deferred.

--- a/skills/pydantic-frozen-models-testing-pattern.md
+++ b/skills/pydantic-frozen-models-testing-pattern.md
@@ -41,15 +41,15 @@ from pydantic import model_validator
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(frozen=True)
-    
+
     hermes_port: int = 8080
     hermes_public_url: str | None = None
-    
+
     @model_validator(mode="before")
     @classmethod
     def _set_public_url_default(cls, data: object) -> object:
         """Default ``hermes_public_url`` from ``hermes_port`` when unset.
-        
+
         Operates on raw input dict before instance construction (freezing).
         """
         if not isinstance(data, dict):
@@ -69,10 +69,10 @@ class Settings(BaseSettings):
 ```python
 def test_webhook_with_custom_key(monkeypatch: pytest.MonkeyPatch) -> None:
     from hermes.config import get_settings
-    
+
     monkeypatch.setenv("WEBHOOK_SECRET", "my-custom-secret-xxxxx")
     get_settings.cache_clear()  # Force re-instantiation from env vars
-    
+
     settings = get_settings()
     assert settings.webhook_secret == "my-custom-secret-xxxxx"
     # ... rest of test
@@ -90,13 +90,13 @@ class TestDeadLettersGetAuth:
         """Helper to construct a test client with custom DEAD_LETTER_API_KEY."""
         from hermes.config import get_settings
         from hermes.server import app
-        
+
         monkeypatch.setenv("DEAD_LETTER_API_KEY", key)
         get_settings.cache_clear()
-        
+
         # ... set up mock publisher, etc.
         return TestClient(app)
-    
+
     def test_correct_key_returns_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
         client = self._build_client(key="correct-key", monkeypatch=monkeypatch)
         resp = client.get("/dead-letters", headers={"X-Dead-Letter-Key": "correct-key"})
@@ -160,7 +160,7 @@ def reset_settings() -> Generator[None, None, None]:
     a fresh ``Settings()`` with explicit kwargs.
     """
     from hermes.server import app
-    
+
     get_settings.cache_clear()
     app.dependency_overrides.clear()
     yield
@@ -184,7 +184,7 @@ class TestDeadLettersGetAuth:
     def _build_client(self, *, key: str) -> TestClient:
         get_settings().dead_letter_api_key = key  # <-- Raises ValidationError
         return TestClient(app)
-    
+
     def teardown_method(self) -> None:
         get_settings().dead_letter_api_key = ""  # <-- Also raises
 
@@ -194,11 +194,11 @@ class TestDeadLettersGetAuth:
         monkeypatch.setenv("DEAD_LETTER_API_KEY", key)
         get_settings.cache_clear()
         return TestClient(app)
-    
+
     def test_correct_key_returns_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
         client = self._build_client(key="valid-key", monkeypatch=monkeypatch)
         assert client.get("/dead-letters", headers={"X-Dead-Letter-Key": "valid-key"}).status_code == 200
-    
+
     # No teardown_method needed — reset_settings fixture handles cleanup
 ```
 
@@ -210,22 +210,22 @@ Verify that the frozen model actually prevents mutations (regression guard):
 class TestSettingsImmutable:
     def test_settings_is_frozen_direct_mutation_raises(self) -> None:
         from hermes.config import Settings
-        
+
         s = Settings(_env_file=None)
         with pytest.raises(ValidationError):
             s.nats_url = "nats://mutated:4222"  # type: ignore[misc]
-    
+
     def test_settings_is_frozen_via_get_settings(self) -> None:
         from hermes.config import get_settings
-        
+
         get_settings.cache_clear()
         s = get_settings()
         with pytest.raises(ValidationError):
             s.hermes_port = 9999  # type: ignore[misc]
-    
+
     def test_public_url_default_still_applies_under_frozen(self) -> None:
         from hermes.config import Settings
-        
+
         s = Settings(hermes_port=8123, _env_file=None)
         assert s.hermes_public_url == "http://localhost:8123"
 ```
@@ -283,5 +283,5 @@ model_config = SettingsConfigDict(
 
 ---
 
-**Last Updated:** 2026-06-04  
+**Last Updated:** 2026-06-04
 **Author:** Claude Haiku 4.5

--- a/skills/pydantic-frozen-models-testing-pattern.notes.md
+++ b/skills/pydantic-frozen-models-testing-pattern.notes.md
@@ -108,7 +108,7 @@ class TestDeadLettersGetAuth:
         client = self._build_client(key=_DEAD_LETTER_KEY, monkeypatch=monkeypatch)
         resp = client.get("/dead-letters", headers={"X-Dead-Letter-Key": _DEAD_LETTER_KEY})
         assert resp.status_code == 200
-    
+
     # No teardown_method — reset_settings fixture handles cleanup
 ```
 
@@ -311,10 +311,10 @@ s = get_settings()  # Fresh instance with new value
 
 ## Test Results
 
-**Commit:** b7191ad  
-**Total Tests:** 544  
-**Pass Rate:** 100% (544/544 pass)  
-**Coverage:** 97.60%  
+**Commit:** b7191ad
+**Total Tests:** 544
+**Pass Rate:** 100% (544/544 pass)
+**Coverage:** 97.60%
 **Duration:** ~30 seconds (full suite)
 
 ### Test Breakdown
@@ -345,7 +345,7 @@ All tests pass with no regressions. The monkeypatch+cache_clear pattern correctl
 
 ---
 
-**Skill File:** pydantic-frozen-models-testing-pattern.md  
-**Notes File:** pydantic-frozen-models-testing-pattern.notes.md  
-**Version:** 1.0.0  
+**Skill File:** pydantic-frozen-models-testing-pattern.md
+**Notes File:** pydantic-frozen-models-testing-pattern.notes.md
+**Version:** 1.0.0
 **Last Updated:** 2026-06-04

--- a/skills/resilience-circuit-breaker-error-translation.md
+++ b/skills/resilience-circuit-breaker-error-translation.md
@@ -54,7 +54,7 @@ _GH_BREAKER = CircuitBreaker(
 # 3. Wrap the call and translate errors
 def _gh_call(cmd, json_output=False, timeout_ms=None):
     """Execute GitHub CLI command with circuit breaker protection.
-    
+
     Raises:
         CircuitBreakerOpenError → GitHubUnavailableError
         subprocess.CalledProcessError → re-raised unchanged
@@ -121,7 +121,7 @@ def _gh_call(cmd, json_output=False, timeout_ms=None):
        _gh_call([...])
    except RuntimeError:  # GitHubUnavailableError is a RuntimeError
        log_error("GitHub is down")
-   
+
    # New code can catch the specific exception:
    try:
        _gh_call([...])
@@ -174,15 +174,15 @@ class GitHubUnavailableError(RuntimeError):
 
 def _gh_call(cmd, json_output=False, timeout_ms=None):
     """Execute GitHub CLI command with circuit breaker protection.
-    
+
     Args:
         cmd: List of CLI arguments (e.g., ["pr", "view", "123"])
         json_output: If True, parse response as JSON
         timeout_ms: Optional timeout in milliseconds
-    
+
     Returns:
         Command output (str) or parsed JSON (dict/list)
-    
+
     Raises:
         GitHubUnavailableError: When GitHub API is unavailable
         subprocess.CalledProcessError: When command returns non-zero

--- a/skills/sgd-momentum-initialization-convergence.md
+++ b/skills/sgd-momentum-initialization-convergence.md
@@ -68,12 +68,12 @@ struct SGDMomentumOptimizer:
     var lr: Float32
     var momentum: Float32
     var velocities: List[Tensor[DType.float32]]  # One buffer per parameter
-    
+
     fn __init__(out self, lr: Float32 = 0.01, momentum: Float32 = 0.9):
         self.lr = lr
         self.momentum = momentum
         self.velocities = List[Tensor[DType.float32]]()
-    
+
     fn initialize_velocities(
         mut self,
         param_shapes: List[Tuple[Int, ...]],
@@ -88,14 +88,14 @@ struct SGDMomentumOptimizer:
 fn create_optimizer(model: MobileNetV1) -> SGDMomentumOptimizer:
     """Create optimizer and initialize velocity buffers"""
     var optimizer = SGDMomentumOptimizer(lr=0.01, momentum=0.9)
-    
+
     # Collect all parameter shapes
     var param_shapes = List[Tuple[Int, ...]]()
     param_shapes.append(model.dw_weight.shape)
     param_shapes.append(model.pw_weight.shape)
     param_shapes.append(model.bn1.gamma.shape)
     param_shapes.append(model.bn1.beta.shape)
-    
+
     optimizer.initialize_velocities(param_shapes)
     return optimizer
 ```
@@ -126,7 +126,7 @@ fn update_parameters(
     gradients: List[Tensor[DType.float32]],
 ) -> None:
     """Apply momentum-based parameter updates"""
-    
+
     for i in range(gradients.size()):
         # velocity[i] = momentum * velocity[i] + gradient[i]
         var new_velocity = (
@@ -134,11 +134,11 @@ fn update_parameters(
             gradients[i]
         )
         self.velocities[i] = new_velocity
-        
+
         # param -= lr * velocity
         # (This is equivalent to: param -= lr * (momentum * old_velocity + gradient))
         var parameter_update = self.lr * new_velocity
-        
+
         # Update parameters (pseudo-code - actual indexing depends on model structure)
         if i == 0:
             model.dw_weight -= parameter_update
@@ -158,35 +158,35 @@ fn test_convergence_with_fixed_batch(
     num_iterations: Int = 3,
 ) -> List[Float32]:
     """Train on same batch multiple times and verify loss decreases"""
-    
+
     var input, var labels = batch
     var losses = List[Float32]()
-    
+
     # Initialize optimizer with momentum
     var optimizer = create_optimizer(model)
     optimizer.momentum = Float32(0.0)  # Start with pure SGD
-    
+
     for iteration in range(num_iterations):
         # Forward pass
         var logits = model.forward(input)
         var loss = cross_entropy(logits, labels)
         var loss_scalar = loss[0, 0]
         losses.append(loss_scalar)
-        
+
         # Backward pass
         var grad_out = grad_cross_entropy(logits, labels)
         var gradients = model.backward(grad_out)
-        
+
         # Update parameters with momentum
         optimizer.update_parameters(model, gradients)
-        
+
         # Verify convergence: loss should strictly decrease
         if iteration > 0:
             if losses[iteration] >= losses[iteration - 1]:
                 print("WARNING: Loss did not decrease!")
                 print("  Iteration {iteration}: loss = {losses[iteration]}")
                 print("  Previous: {losses[iteration-1]}")
-    
+
     return losses
 ```
 
@@ -200,15 +200,15 @@ fn compare_momentum_values(
     batch: Tuple[Tensor, Tensor],
 ) -> Dict[Float32, List[Float32]]:
     """Compare convergence with different momentum coefficients"""
-    
+
     var results = Dict[Float32, List[Float32]]()
     var momentum_values = [0.0, 0.1, 0.3, 0.9]
-    
+
     for momentum_beta in momentum_values:
         var model = clone_model(model_template)
         var losses = test_convergence_with_fixed_batch(model, batch, momentum=momentum_beta)
         results[momentum_beta] = losses
-    
+
     # Print results
     print("Convergence Results:")
     print("Momentum | Loss@Iter0 | Loss@Iter1 | Loss@Iter2 | Converges?")
@@ -216,7 +216,7 @@ fn compare_momentum_values(
         var losses = results[momentum_beta]
         var converges = "✓" if losses[1] < losses[0] else "✗"
         print(f"{momentum_beta}       | {losses[0]:.6f} | {losses[1]:.6f} | {losses[2]:.6f} | {converges}")
-    
+
     return results
 ```
 
@@ -230,11 +230,11 @@ fn compare_momentum_values(
 fn test_training():
     var model = MobileNetV1()  # Random initialization
     var optimizer = SGDMomentumOptimizer(lr=0.01, momentum=0.9)
-    
+
     var batch = load_batch()
     var loss1 = compute_loss(model.forward(batch[0]), batch[1])
     update_step(model, optimizer)
-    
+
     var loss2 = compute_loss(model.forward(batch[0]), batch[1])
     assert_true(loss2 < loss1, "Loss should decrease")  // FAILS!
 ```
@@ -255,7 +255,7 @@ fn test_training():
 ```mojo
 struct SGDMomentumOptimizer:
     var velocities: List[Tensor]  // Never initialized!
-    
+
     fn update(mut self, model: mut Model, gradients: List[Tensor]):
         for i in range(gradients.size()):
             self.velocities[i] = self.momentum * self.velocities[i] + gradients[i]

--- a/skills/silent-boundary-observability-exception-classification.md
+++ b/skills/silent-boundary-observability-exception-classification.md
@@ -205,7 +205,7 @@ def test_follow_up_expected_failure_logs_warning(caplog):
     with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "cmd")):
         with caplog.at_level("WARNING"):
             run_follow_up_issues(...)
-    
+
     assert "expected failure type" in caplog.text
     assert caplog.records[0].levelname == "WARNING"
     assert caplog.records[0].exception_type == "CalledProcessError"
@@ -215,7 +215,7 @@ def test_follow_up_unexpected_failure_logs_error(caplog):
     with patch("some.function", side_effect=AttributeError("bad attr")):
         with caplog.at_level("ERROR"):
             run_follow_up_issues(...)
-    
+
     assert "unexpected exception type" in caplog.text
     assert caplog.records[0].levelname == "ERROR"
     assert caplog.records[0].exception_type == "AttributeError"
@@ -224,7 +224,7 @@ def test_follow_up_always_returns_none(caplog):
     """Even on exception, must return None (fail-safe contract)."""
     with patch("subprocess.run", side_effect=RuntimeError("boom")):
         result = run_follow_up_issues(...)
-    
+
     assert result is None
 ```
 
@@ -316,7 +316,7 @@ def run_follow_up_issues(
     github: GitHub,
 ) -> None:
     """Generate and create follow-up issues for completed tasks.
-    
+
     Returns None on any error — this is a fail-safe operation designed
     to never block the automation loop.
     """

--- a/skills/skill-teaching-stale-practices-contradicting-canonical-docs.md
+++ b/skills/skill-teaching-stale-practices-contradicting-canonical-docs.md
@@ -100,11 +100,11 @@ pre-commit run markdownlint-cli2 --files skills/github-actions-python-cicd/SKILL
    # Check ENTIRE directory for stale tokens (critical — catches hidden files)
    ! grep -rnE 'flake8|black|requirements.txt|setup.py|src/' skills/github-actions-python-cicd/
    # Exit 0 ✓ (no stale tokens found)
-   
+
    # Positive match: confirm correct version/pattern is present
    grep -n 'ruff check' skills/github-actions-python-cicd/SKILL.md
    grep -n 'python-version.*3\.1[0-3]' skills/github-actions-python-cicd/SKILL.md
-   
+
    # Format gate
    pre-commit run markdownlint-cli2 --files skills/github-actions-python-cicd/SKILL.md
    ```

--- a/skills/test-state-machine-docstring-accuracy.md
+++ b/skills/test-state-machine-docstring-accuracy.md
@@ -71,7 +71,7 @@ def on_enter(self, machine_state):
     # Line 176: guard fires FIRST
     if self.is_plan_go(machine_state):
         return ADVANCE  # Early exit; rest of function never executes
-    
+
     # Line 206: swap logic (unreachable when is_plan_go=True)
     self._swap_plan(machine_state)
 ```
@@ -109,7 +109,7 @@ def on_enter(self, machine_state):
     # Line 176: is_plan_go guard fires first
     if self.is_plan_go(machine_state):
         return ADVANCE  # Short-circuit; lines below never execute
-    
+
     # Line 206: swap logic unreachable when is_plan_go=True
     # (only executes if is_plan_go=False, which is the opposite test case)
     self._swap_plan(machine_state)
@@ -133,7 +133,7 @@ pixi run pytest tests/unit/automation/planning/test_state_machine.py -v
 # WRONG: Claims test verifies swap + defense, but only guards prevent swap
 def test_replan_entry_with_stale_go_swaps_atomically(self):
     """Defense-in-depth protection for the swap logic.
-    
+
     The is_plan_go guard defends against incorrect state transitions,
     and the swap logic provides additional protection.
     """
@@ -193,7 +193,7 @@ test_plan_go_on_entry_fast_forwards_without_swap
 ```python
 def test_<name>(self):
     """The <guard_name> guard fires first and returns <early_exit_result>; <later_path> never reached.
-    
+
     Test verifies:
     - Guard condition: <condition>
     - Early exit: <action>

--- a/skills/testing-integration-fake-binary-on-path.md
+++ b/skills/testing-integration-fake-binary-on-path.md
@@ -48,17 +48,17 @@ from pathlib import Path
 @pytest.fixture(autouse=True)
 def _fake_binary_on_path(tmp_path, monkeypatch):
     """Create fake gh binary that outputs environment variables.
-    
+
     Subprocess will find this fake instead of the real gh command.
     """
     fake_bin_dir = tmp_path / "bin"
     fake_bin_dir.mkdir()
-    
+
     # Create fake gh that outputs environment
     fake_gh = fake_bin_dir / "gh"
     fake_gh.write_text("#!/bin/sh\nenv | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'\n")
     fake_gh.chmod(0o755)  # ← CRITICAL: must set execute bit
-    
+
     # Prepend to PATH (so fake is found first)
     original_path = os.environ.get("PATH", "")
     monkeypatch.setenv("PATH", str(fake_bin_dir) + ":" + original_path)
@@ -66,17 +66,17 @@ def _fake_binary_on_path(tmp_path, monkeypatch):
 def test_gh_trace_id_propagated_to_subprocess(monkeypatch, _fake_binary_on_path):
     """Integration test: subprocess receives GH_TRACE_ID from context."""
     from hephaestus.logging.utils import set_correlation_id
-    
+
     # Set correlation ID in context
     set_correlation_id("req-integration-test-123")
-    
+
     # Call subprocess (will find fake gh from fixture)
     result = subprocess.run(
         ["gh", "pr", "view", "123"],
         capture_output=True,
         text=True,
     )
-    
+
     # Verify fake gh received the env var
     assert "req-integration-test-123" in result.stdout
 ```
@@ -203,18 +203,18 @@ from pathlib import Path
 @pytest.fixture(autouse=True)
 def _fake_binary_on_path(tmp_path, monkeypatch):
     """Create fake gh binary that echoes environment variables.
-    
+
     This fixture provides a fake gh command that will be found before
     the real gh in PATH. Used to test environment variable propagation
     to subprocesses without requiring a real GitHub CLI installation.
-    
+
     Args:
         tmp_path: pytest fixture providing temporary directory
         monkeypatch: pytest fixture for environment modification
     """
     fake_bin_dir = tmp_path / "bin"
     fake_bin_dir.mkdir()
-    
+
     # Create fake gh script that outputs environment
     fake_gh = fake_bin_dir / "gh"
     fake_gh.write_text(
@@ -223,82 +223,82 @@ def _fake_binary_on_path(tmp_path, monkeypatch):
         "echo 'GH_TRACE_ID='$GH_TRACE_ID\n"
         "echo 'CUSTOM_CONFIG='$CUSTOM_CONFIG\n"
     )
-    
+
     # Set executable permission (CRITICAL!)
     fake_gh.chmod(0o755)
-    
+
     # Prepend fake bin dir to PATH
     original_path = os.environ.get("PATH", "")
     monkeypatch.setenv("PATH", str(fake_bin_dir) + ":" + original_path)
-    
+
     return fake_bin_dir
 
 
 class TestGHTraceIDPropagation:
     """Integration tests for environment variable propagation to subprocesses."""
-    
+
     def test_subprocess_receives_gh_trace_id_from_context(self, monkeypatch, _fake_binary_on_path):
         """Subprocess receives GH_TRACE_ID when set in context."""
         from hephaestus.logging.utils import set_correlation_id
-        
+
         # Set correlation ID in context
         set_correlation_id("req-trace-12345")
-        
+
         # Import and call run_subprocess (which injects correlation ID into env)
         from hephaestus.utils.helpers import run_subprocess
-        
+
         result = run_subprocess(["gh", "pr", "view", "123"])
-        
+
         # Verify fake gh received the env var
         assert "GH_TRACE_ID=req-trace-12345" in result
-    
+
     def test_subprocess_no_trace_id_when_not_set(self, monkeypatch, _fake_binary_on_path):
         """Subprocess does not receive GH_TRACE_ID when not set in context."""
         from hephaestus.logging.utils import set_correlation_id
-        
+
         # Explicitly set to None (no context)
         set_correlation_id(None)
-        
+
         from hephaestus.utils.helpers import run_subprocess
-        
+
         result = run_subprocess(["gh", "pr", "view", "123"])
-        
+
         # Verify fake gh did NOT receive the env var
         # (output will be empty for GH_TRACE_ID or the variable undefined)
         assert "GH_TRACE_ID=" not in result or result.count("GH_TRACE_ID=") == 1
-    
+
     def test_subprocess_receives_custom_env_var(self, monkeypatch, _fake_binary_on_path):
         """Test custom environment variable propagation pattern."""
         import os
-        
+
         env = os.environ.copy()
         env['CUSTOM_CONFIG'] = 'test-value-789'
-        
+
         result = subprocess.run(
             ["gh", "pr", "view", "456"],
             env=env,
             capture_output=True,
             text=True,
         )
-        
+
         assert "CUSTOM_CONFIG=test-value-789" in result.stdout
 
 
 @pytest.mark.skip_on_ci
 class TestGHTraceIDPropagationWithRealGH:
     """Tests that use the real gh command (skip in CI)."""
-    
+
     def test_real_gh_availability(self):
         """Verify real gh is available in the current environment."""
         result = subprocess.run(["which", "gh"], capture_output=True, text=True)
         assert result.returncode == 0, "Real gh not found in PATH"
-    
+
     def test_real_gh_with_trace_id(self):
         """Integration test with real gh (if available)."""
         from hephaestus.logging.utils import set_correlation_id
-        
+
         set_correlation_id("req-real-gh-test")
-        
+
         # This test requires real gh; only runs when explicitly enabled
         # Example: pytest -m real_gh tests/integration/test_gh_trace_id_propagation.py
         result = subprocess.run(
@@ -333,25 +333,25 @@ GH_TRACE_ID=req-123...  # ← Fake binary output
 
 def run_subprocess(cmd: list[str], **kwargs) -> str:
     """Run subprocess, injecting correlation ID into environment.
-    
+
     Args:
         cmd: Command to run (e.g., ["gh", "pr", "view", "123"])
         **kwargs: Additional arguments to subprocess.run()
-    
+
     Returns:
         stdout from the subprocess
-    
+
     Raises:
         subprocess.CalledProcessError: If subprocess returns non-zero
     """
     env = kwargs.pop('env', None) or os.environ.copy()
-    
+
     # Inject correlation ID into environment
     from hephaestus.logging.utils import get_current_correlation_id
-    
+
     if cid := get_current_correlation_id():
         env['GH_TRACE_ID'] = cid
-    
+
     result = subprocess.run(
         cmd,
         env=env,

--- a/tests/test_skill_consolidation_integrity.py
+++ b/tests/test_skill_consolidation_integrity.py
@@ -101,6 +101,4 @@ def test_skill_files_only_keep_canonical_consolidation_targets():
         assert fm.get("version") == consolidation["version"]
 
         for absorbed in consolidation["absorbed"]:
-            assert not (SKILLS_DIR / f"{absorbed}.md").exists(), (
-                f"absorbed skill still present: {absorbed}"
-            )
+            assert not (SKILLS_DIR / f"{absorbed}.md").exists(), f"absorbed skill still present: {absorbed}"


### PR DESCRIPTION
CI does not run the repo's pinned pre-commit fixers, so drift accumulated on main. The local pre-push hook chain runs them over every push range, which currently blocks any push whose range includes one of these 29 files. This sweeps the whole tree once: trailing-whitespace, end-of-file-fixer, and ruff-format (v0.8.6, line-length 120). Zero behavior change; validate_plugins 645/645, pytest 210 passed, markdownlint clean, mypy clean.