### PR TITLE
docs: point command users to Athena

### DIFF
--- a/plugins/tooling/mnemosyne/.claude-plugin/plugin.json
+++ b/plugins/tooling/mnemosyne/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mnemosyne",
   "version": "2.0.0",
-  "description": "Skills registry for the HomericIntelligence ecosystem. Provides documentation-patterns and validation-workflow skills for skill authoring. Commands have moved to the hephaestus plugin in ProjectHephaestus.",
+  "description": "Skills registry for the HomericIntelligence ecosystem. Provides documentation-patterns and validation-workflow skills for skill authoring. Commands are provided by the Athena plugin.",
   "author": {
     "name": "ML Odyssey Team"
   },


### PR DESCRIPTION
## Summary

- Replace the stale Hephaestus-plugin handoff in the Mnemosyne manifest with the Athena plugin.

## Why

Mnemosyne is the skills and memory store; Athena is the supported plugin that provides its commands.

## Validation

- Parsed the plugin manifest as JSON.
- Confirmed the manifest no longer contains a Hephaestus or ProjectHephaestus reference.
- Ran `git diff --check`.
