### PR TITLE
ci: prepare Mnemosyne merge queue policy

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,15 @@ docs: update migration status - 100% complete
    - Category is valid.
 6. Once CI passes and the PR is approved, it will be merged.
 
+### Merge queue readiness
+
+The required-check workflow supports GitHub merge groups, but queue activation
+is a separate Odysseus-owned operation. See
+[`docs/ci/merge-queue.md`](docs/ci/merge-queue.md) for the policy artifact,
+trigger boundaries, and post-merge evidence required by issue #3115. Until that
+evidence is recorded, enabling auto-merge does not prove a pull request entered
+the queue.
+
 ## Validation
 
 All PRs are validated by CI. Run validation locally before submitting:

--- a/configs/github/merge-queue-policy.json
+++ b/configs/github/merge-queue-policy.json
@@ -1,0 +1,48 @@
+{
+  "repository": "HomericIntelligence/Mnemosyne",
+  "target_branch": "main",
+  "activation_authority": "HomericIntelligence/Odysseus#386",
+  "readiness_issue": "HomericIntelligence/Mnemosyne#3115",
+  "required_contexts": [
+    "build",
+    "deps/version-sync",
+    "integration-tests",
+    "lint",
+    "pixi-check",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "symlink-check",
+    "test",
+    "unit-tests"
+  ],
+  "required_contexts_by_ruleset": {
+    "homeric-main-baseline": [
+      "build",
+      "deps/version-sync",
+      "integration-tests",
+      "lint",
+      "schema-validation",
+      "security/dependency-scan",
+      "security/secrets-scan",
+      "test",
+      "unit-tests"
+    ],
+    "homeric-main-extras": [
+      "pixi-check",
+      "symlink-check"
+    ]
+  },
+  "merge_queue_rule": {
+    "type": "merge_queue",
+    "parameters": {
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }
+  }
+}

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -1,0 +1,48 @@
+# Merge queue readiness
+
+Mnemosyne's required-check workflow is prepared for a staged GitHub merge
+queue rollout on `main`. This repository does not activate or modify the live
+queue. [Odysseus issue #386](https://github.com/HomericIntelligence/Odysseus/issues/386)
+and its repository-owned tooling are the sole authority for future activation.
+
+## Readiness contract
+
+[`configs/github/merge-queue-policy.json`](../../configs/github/merge-queue-policy.json)
+is the machine-readable source of truth for the approved queue rule and the
+required contexts observed before this readiness change. The context list is
+also grouped by its live repository ruleset so the two-rule source is explicit:
+
+- `homeric-main-baseline` (`17852368`) supplies nine required contexts.
+- `homeric-main-extras` (`18221133`) supplies `pixi-check` and `symlink-check`.
+
+The aggregate list contains 11 unique required contexts. Inspect the contract
+without copying it into another policy source:
+
+```bash
+jq '.required_contexts_by_ruleset, .merge_queue_rule' \
+  configs/github/merge-queue-policy.json
+```
+
+`.github/workflows/_required.yml` emits those contexts for `push` and
+`pull_request` events on `main`, and for `merge_group` `checks_requested`
+events. The advisory `validate-plugins.yml` workflow keeps its existing
+triggers. The release publisher remains tag-only and retains write permission
+only for publishing releases.
+
+## Staged activation
+
+Merging the readiness pull request does not enable the queue. After it lands,
+the Odysseus operator must:
+
+1. Re-read both live Mnemosyne rulesets and verify the 11 required contexts
+   still equal the policy artifact.
+2. Use the Odysseus merge-queue rollout tool to add the approved rule without
+   changing existing conditions, enforcement, required contexts, permissions,
+   or unrelated protection rules.
+3. Queue a designated smoke pull request and verify that its exact
+   `merge_group` run emits every required context once and successfully.
+4. Record the live ruleset response, workflow run, and queued merge result in
+   [Mnemosyne issue #3115](https://github.com/HomericIntelligence/Mnemosyne/issues/3115).
+
+Issue #3115 stays open until activation and queued-smoke evidence are recorded.
+No ruleset or branch-protection mutation belongs in this readiness change.

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -1,0 +1,138 @@
+"""Behavioral regression tests for staged GitHub merge-queue readiness."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+REQUIRED_WORKFLOW = WORKFLOWS_DIR / "_required.yml"
+VALIDATE_WORKFLOW = WORKFLOWS_DIR / "validate-plugins.yml"
+RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
+MERGE_QUEUE_POLICY = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
+
+EXPECTED_REQUIRED_CONTEXTS_BY_RULESET = {
+    "homeric-main-baseline": [
+        "build",
+        "deps/version-sync",
+        "integration-tests",
+        "lint",
+        "schema-validation",
+        "security/dependency-scan",
+        "security/secrets-scan",
+        "test",
+        "unit-tests",
+    ],
+    "homeric-main-extras": [
+        "pixi-check",
+        "symlink-check",
+    ],
+}
+EXPECTED_REQUIRED_CONTEXTS = sorted(
+    context for contexts in EXPECTED_REQUIRED_CONTEXTS_BY_RULESET.values() for context in contexts
+)
+EXPECTED_MERGE_QUEUE_RULE = {
+    "type": "merge_queue",
+    "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5,
+    },
+}
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    workflow = yaml.safe_load(path.read_text())
+    assert isinstance(workflow, dict), f"{path} must contain a workflow mapping"
+    return workflow
+
+
+def _on_block(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the Actions trigger block despite PyYAML 1.1 coercing `on`."""
+    on_block = workflow.get(True, workflow.get("on"))
+    assert isinstance(on_block, dict), "workflow `on` block must be a mapping"
+    return on_block
+
+
+def _load_policy() -> dict[str, Any]:
+    policy = json.loads(MERGE_QUEUE_POLICY.read_text())
+    assert isinstance(policy, dict), "merge-queue policy must be a JSON object"
+    return policy
+
+
+def test_policy_pins_exact_live_required_contexts_by_ruleset() -> None:
+    policy = _load_policy()
+
+    assert policy["required_contexts_by_ruleset"] == EXPECTED_REQUIRED_CONTEXTS_BY_RULESET
+    assert policy["required_contexts"] == EXPECTED_REQUIRED_CONTEXTS
+
+
+def test_policy_contexts_are_exact_union_of_ruleset_contexts() -> None:
+    policy = _load_policy()
+    contexts_by_ruleset = policy["required_contexts_by_ruleset"]
+    derived_contexts = sorted(context for contexts in contexts_by_ruleset.values() for context in contexts)
+
+    assert policy["required_contexts"] == derived_contexts
+    assert len(derived_contexts) == len(set(derived_contexts))
+
+
+def test_policy_pins_exact_approved_queue_rule() -> None:
+    assert _load_policy()["merge_queue_rule"] == EXPECTED_MERGE_QUEUE_RULE
+
+
+def test_only_required_workflow_adds_exact_merge_group_trigger() -> None:
+    required_on = _on_block(_load_workflow(REQUIRED_WORKFLOW))
+    validate_on = _on_block(_load_workflow(VALIDATE_WORKFLOW))
+
+    assert required_on == {
+        "pull_request": {"branches": ["main"]},
+        "push": {"branches": ["main"]},
+        "merge_group": {"types": ["checks_requested"]},
+    }
+    assert validate_on == {
+        "pull_request": None,
+        "push": {"branches": ["main"]},
+        "workflow_dispatch": None,
+    }
+
+
+def test_required_workflow_emits_every_policy_context_exactly_once() -> None:
+    jobs = _load_workflow(REQUIRED_WORKFLOW)["jobs"]
+    emitted_names = [job.get("name", job_id) for job_id, job in jobs.items() if isinstance(job, dict)]
+    policy_contexts = _load_policy()["required_contexts"]
+    emitted_policy_contexts = [name for name in emitted_names if name in policy_contexts]
+
+    assert sorted(emitted_policy_contexts) == policy_contexts
+    assert len(emitted_policy_contexts) == len(set(emitted_policy_contexts))
+
+
+def test_workflows_keep_existing_least_privilege_permissions() -> None:
+    required_workflow = _load_workflow(REQUIRED_WORKFLOW)
+    validate_workflow = _load_workflow(VALIDATE_WORKFLOW)
+    release_workflow = _load_workflow(RELEASE_WORKFLOW)
+
+    assert required_workflow["permissions"] == {"contents": "read"}
+    assert validate_workflow["permissions"] == {"contents": "read"}
+    assert release_workflow["permissions"] == {"contents": "write"}
+
+
+def test_required_secrets_scan_still_blocks_detected_secrets() -> None:
+    workflow = _load_workflow(REQUIRED_WORKFLOW)
+    job = workflow["jobs"]["security-secrets-scan"]
+    scan = next(step for step in job["steps"] if step.get("name") == "Run Gitleaks")
+    upload = next(step for step in job["steps"] if step.get("name") == "Upload Gitleaks SARIF")
+
+    assert "--exit-code 0" not in scan["run"]
+    assert upload["if"] == "always() && hashFiles('gitleaks.sarif') != ''"
+
+
+def test_release_publisher_remains_tag_only() -> None:
+    on_block = _on_block(_load_workflow(RELEASE_WORKFLOW))
+
+    assert on_block == {"push": {"tags": ["v*"]}}

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -47,13 +47,13 @@ EXPECTED_MERGE_QUEUE_RULE = {
 }
 
 
-def _load_workflow(path: Path) -> dict[str, Any]:
+def _load_workflow(path: Path) -> dict[Any, Any]:
     workflow = yaml.safe_load(path.read_text())
     assert isinstance(workflow, dict), f"{path} must contain a workflow mapping"
     return workflow
 
 
-def _on_block(workflow: dict[str, Any]) -> dict[str, Any]:
+def _on_block(workflow: dict[Any, Any]) -> dict[Any, Any]:
     """Return the Actions trigger block despite PyYAML 1.1 coercing `on`."""
     on_block = workflow.get(True, workflow.get("on"))
     assert isinstance(on_block, dict), "workflow `on` block must be a mapping"


### PR DESCRIPTION
## Summary

- enable only the `Required Checks` workflow for `merge_group` /
  `checks_requested` while preserving its exact `push.main` and
  `pull_request.main` triggers
- add a machine-readable policy for the approved queue parameters and all 11
  required contexts across Mnemosyne's two active repository rulesets
- add behavior-focused regressions for trigger boundaries, exact context
  emission, permissions, security scanning, and the tag-only release publisher
- document that Odysseus is the sole future activation authority

## Staged rollout

This PR does not mutate live rulesets or branch protection. Queue activation
and a representative queued smoke remain post-merge Odysseus operations, and
issue #3115 stays open until that evidence is recorded.

Live baseline inspected on 2026-07-17:

- `homeric-main-baseline` (ruleset `17852368`): 9 required contexts
- `homeric-main-extras` (ruleset `18221133`): `pixi-check` and `symlink-check`
- no pre-existing `merge_queue` rule

## Verification

- TDD RED: `pixi run pytest tests/test_merge_queue.py -q` — 5 failed, 2 passed
  for the intended missing policy/trigger
- focused final: same command — 8 passed
- `pixi run check` — 654/654 skills valid; release contract valid; 215 passed,
  3 skipped; 77% coverage
- Ruff check and changed-test format check — passed
- mypy 2.2.0 on `scripts/` under Python 3.12 — no issues in 7 source files
- yamllint and GitHub workflow JSON Schema validation — passed
- changed-file pre-commit — all hooks passed
- markdownlint-cli2 0.20.0 — 0 errors on changed Markdown
- wheel and sdist build, `twine check`, and installed-wheel Python 3.12 import
  smoke — passed
- `git diff --cached --check` — passed before commit
- signed commit and DCO trailer verified locally

Local package-task note: `pixi run package` cannot start because the committed
Pixi environment does not include the `build` module. The CI-equivalent
disposable Python 3.12 build/twine/install path passed; this PR does not expand
into dependency-manifest cleanup.

Refs #3115

Umbrella rollout: https://github.com/HomericIntelligence/Odysseus/issues/386
