### PR TITLE
feat: migrate seven Athena workflow skills to standard knowledge

### DIFF
--- a/skills/code-review-before-merge-workflow.md
+++ b/skills/code-review-before-merge-workflow.md
@@ -1,0 +1,90 @@
+---
+name: code-review-before-merge-workflow
+description: "Review completed implementation work for correctness, regressions, maintainability, security, and test quality before merge. Use when: (1) a substantial change or complex fix is complete, (2) a branch is about to merge, (3) the author claims readiness and the claim needs independent technical review"
+category: tooling
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+tags: [code-review, workflow, evidence, merge-gate]
+---
+
+# Code Review Before Merge
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Standard workflow for reviewing completed implementation work before merge |
+| **Outcome** | Operational — migrated from the Athena `code-review` skill into standard knowledge |
+
+## When to Use
+
+- After a substantial change or complex fix, before merge.
+- When an author (human or agent) claims work is ready — review technical evidence, not the author's confidence.
+- When review feedback needs an independent recheck after fixes.
+
+## Verified Workflow
+
+### Quick Reference — resolve the review diff against the true base
+
+```bash
+# Discover the remote tracked by the current branch (fall back to origin)
+branch=$(git branch --show-current)
+remote=$(git config --get "branch.${branch}.remote" || echo origin)
+
+# Resolve the remote's default branch unambiguously
+default=$(git ls-remote --symref "$remote" HEAD | awk '/^ref:/ {sub("refs/heads/", "", $2); print $2}')
+
+# Fetch that exact base and diff from the merge-base
+git fetch "$remote" "$default"
+base=$(git merge-base HEAD "${remote}/${default}")
+git diff "${base}...HEAD" --stat
+git diff "${base}...HEAD"
+```
+
+Stop if the remote or default branch cannot be resolved unambiguously.
+
+### Detailed Steps
+
+1. Read the target repository's `AGENTS.md`, the requirements, and relevant plans or issues.
+2. Keep the target repository as the current working directory and produce the merge-base diff (quick reference above).
+3. Delegate to one independent reviewer when the host supports subagents; do not prescribe a vendor model. If delegation is unavailable, review sequentially in the current agent.
+4. Inspect correctness, requirement alignment, security boundaries, error handling, public API compatibility, tests, documentation, and unnecessary complexity. Apply KISS, YAGNI, TDD, DRY, SOLID, modularity, least-astonishment, durable-artifact, and behavior-test rules. Flag tests that pin prose or flaky implementation detail, and artifacts that create ongoing manual synchronization without a demonstrated product consumer.
+5. Run the repository-defined focused tests and quality gates. Never invent successful output.
+6. Rank findings as critical, important, or suggestion. Include a path and line, impact, evidence, and concrete remediation for each finding.
+7. Verify reviewer claims before changing code. Push back with evidence when a finding is incorrect.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Diff against local main | Reviewing `git diff main...HEAD` without fetching | Stale local base hides or fabricates changes | Always fetch the remote default branch and diff from the merge-base |
+| Trusting author confidence | Accepting "it works" from the implementer | Confidence is not evidence | Review runs the gates itself and ranks findings from observed behavior |
+
+## Results & Parameters
+
+### Expected Output
+
+A review report containing:
+
+- Scope and diff reviewed
+- Strengths
+- Critical findings
+- Important findings
+- Suggestions
+- Verification commands and results
+- Verdict: ready, ready after listed fixes, or not ready
+
+Do not post review comments or mutate GitHub state unless the user explicitly requests it.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Athena | Shipped as the `code-review` plugin skill; exercised across HomericIntelligence repositories | Migrated 2026-07-16 |
+
+## References
+
+- Athena development policy: `docs/policies/development.md` in HomericIntelligence/Athena
+- Related: [verification-evidence-audit.md](verification-evidence-audit.md), [finish-branch-delivery-workflow.md](finish-branch-delivery-workflow.md)

--- a/skills/create-reusable-utilities-hephaestus-port.md
+++ b/skills/create-reusable-utilities-hephaestus-port.md
@@ -1,0 +1,75 @@
+---
+name: create-reusable-utilities-hephaestus-port
+description: "Port project-local utilities into the shared Hephaestus automation repository. Use when: (1) project-local automation has a demonstrated cross-project use case, (2) equivalent behavior may already exist in Hephaestus and must be extended instead of duplicated, (3) a typed reusable interface must be separated from source-repository policy"
+category: tooling
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+tags: [reuse, hephaestus, utilities, interface-design]
+---
+
+# Create Reusable Utilities (Hephaestus Port)
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Standard workflow for porting utilities with cross-project value into the shared Hephaestus automation repository |
+| **Outcome** | Operational — migrated from the Athena `create-reusable-utilities` skill into standard knowledge |
+
+## When to Use
+
+- Project-local automation has a demonstrated cross-project use case and belongs in the shared Hephaestus automation repository.
+- Do NOT use for one-off scripts with a single consumer — reuse must be demonstrated, not speculative.
+
+## Required repository and authority
+
+- Prepare Hephaestus at `$HOME/.agent_brain/automation` by following Athena's canonical dependency-resolution contract exactly (owner precedence, trust gates, checkout rules, revalidation). Report the exact repository, commit SHA, and trust basis. Any preparation or revalidation failure is blocking.
+- **External-write authority checkpoint:** a direct user request to port a utility authorizes the declared branch, edit, commit, push, and PR workflow. An indirect recommendation or invocation does not. Before creating mutable state, show the resolved repository/SHA/trust basis, proposed branch, owned files, validation, and PR target, then obtain explicit approval. Read-only overlap analysis never authorizes a later write.
+
+## Verified Workflow
+
+### Detailed Steps
+
+1. Read the source utility, its callers, tests, configuration, error behavior, and license.
+2. Search the resolved Hephaestus checkout for equivalent or overlapping behavior. Extend an existing abstraction instead of creating a duplicate.
+3. Separate reusable behavior from source-repository policy, paths, global state, and output.
+4. Design a typed programmatic interface first. Make filesystem, environment, clock, network, and process dependencies injectable where useful.
+5. Follow the resolved checkout's current package layout and repository instructions; never assume example paths from a prior version.
+6. Write failing behavior and error-path tests in the resolved repository before implementation.
+7. Add a thin CLI only when a real command-line consumer exists. Keep parsing and presentation out of the reusable core.
+8. Run Hephaestus's repository-defined validation and focused/full tests.
+9. Deliver the Hephaestus change through its signed, DCO-attested PR workflow. Do not edit or pin another repository as part of the same unapproved operation.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Copy-paste port | Moving the utility verbatim with source-repo paths and policy | The "reusable" code still encoded one repository's assumptions | Strip source-repository names, paths, and policy from the reusable interface |
+| Assuming prior layout | Using package paths remembered from an earlier Hephaestus version | Layout had changed; the port landed in a dead location | Read the resolved checkout's current layout every time |
+
+## Results & Parameters
+
+### Acceptance criteria
+
+- No source-repository names, paths, or policy remain in the reusable interface.
+- Existing behavior and failures are covered by tests.
+- Public types and errors are documented.
+- License and attribution are compatible and preserved.
+- The source repository migration is a separate, explicit follow-up after the shared change lands.
+
+### Expected Output
+
+Report the resolved Hephaestus repository/SHA, overlap analysis, interface decision, files changed, tests and gates run, compatibility/migration notes, and PR URL when authorized.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Athena | Shipped as the `create-reusable-utilities` plugin skill; exercised for Hephaestus ports | Migrated 2026-07-16 |
+
+## References
+
+- Athena dependency-resolution contract: `docs/dependency-resolution.md` in HomericIntelligence/Athena
+- Related: [finish-branch-delivery-workflow.md](finish-branch-delivery-workflow.md)

--- a/skills/finish-branch-delivery-workflow.md
+++ b/skills/finish-branch-delivery-workflow.md
@@ -1,0 +1,73 @@
+---
+name: finish-branch-delivery-workflow
+description: "Finish a development branch with repository-defined validation, signed DCO Conventional Commits, and explicit delivery choices. Use when: (1) implementation on a feature branch is complete, (2) a branch is ready for PR creation or preservation, (3) commit hygiene must be verified before delivery"
+category: tooling
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+tags: [git, branch, delivery, pull-request, dco]
+---
+
+# Finish a Development Branch
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Standard workflow for finishing a feature branch: validate, verify commit hygiene, and deliver with explicit authority |
+| **Outcome** | Operational — migrated from the Athena `finish-branch` skill into standard knowledge |
+
+## When to Use
+
+- Implementation on a branch is complete and verification has already passed (run the verification evidence audit first; do not proceed while relevant repository-defined checks fail).
+
+## Verified Workflow
+
+### Detailed Steps
+
+1. Read the target repository's `AGENTS.md` and development policy.
+2. Prepare Hephaestus at `$HOME/.agent_brain/automation` under Athena's canonical dependency-resolution contract. Report repository, SHA, and trust basis; any preparation or revalidation failure is blocking.
+3. Discover the default branch and repository-defined validation commands from the target's task runner, manifests, and required workflow. Do not substitute Hephaestus-specific commands.
+4. Run the relevant tests, validation, formatting, linting, and build/package checks. Report exact commands and results.
+5. Review `git log <base>..HEAD` and both the merge-base and current-base diffs.
+6. Verify every commit is cryptographically signed, has a DCO `Signed-off-by` trailer, and follows Conventional Commits. Fix violations before offering delivery.
+7. Present three choices: create/update a pull request, preserve the branch and worktree, or request a separate read-only worktree-cleanup audit. Do not represent a cleanup request as removal authority.
+8. For a PR, push only the feature branch and create a body containing `Closes #N` when a tracking issue exists. Do not enable auto-merge or merge without explicit user authority.
+9. Never remove a worktree directly. Route each candidate through the worktree-cleanup audit, which requires a fresh audit and separate explicit approval for the exact path and audited HEAD.
+
+### Merge-method helper
+
+Use the resolved Hephaestus checkout's current merge-method helper when the target repository does not provide its own. Never use an unrelated executable from `PATH` or guess an organization-wide merge method.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Direct merge to default | Merging locally to the protected default branch | Bypasses required checks and review | Always deliver through a PR against the protected branch |
+| Cleanup as side effect | Removing worktrees while finishing the branch | Deleted work the user had not authorized losing | Worktree removal always goes through a separate audited approval |
+
+## Results & Parameters
+
+### Never
+
+- Merge directly to the protected default branch.
+- Skip hooks, fabricate successful checks, or force-push without explicit authority.
+- Delete a branch or worktree without the required confirmation.
+- Claim completion while CI is absent, stale, skipped incorrectly, or failing.
+
+### Expected Output
+
+Exact validation commands and results, commit-hygiene status, and the user's chosen delivery action (PR created/updated, branch preserved, or cleanup audit requested).
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Athena | Shipped as the `finish-branch` plugin skill; exercised across HomericIntelligence repositories | Migrated 2026-07-16 |
+
+## References
+
+- Athena dependency-resolution contract: `docs/dependency-resolution.md` in HomericIntelligence/Athena
+- Related: [verification-evidence-audit.md](verification-evidence-audit.md), [code-review-before-merge-workflow.md](code-review-before-merge-workflow.md)
+- Adapted from [obra/superpowers](https://github.com/obra/superpowers) under the MIT License. Copyright (c) 2025 Jesse Vincent.

--- a/skills/github-actions-python-required-checks.md
+++ b/skills/github-actions-python-required-checks.md
@@ -1,0 +1,79 @@
+---
+name: github-actions-python-required-checks
+description: "Create or repair required GitHub Actions checks and tag releases for a Python repository using Hephaestus as the control-pattern reference. Use when: (1) a Python repo needs a required merge gate, (2) CI must be brought up to fail-closed policy, (3) a tag-only release workflow is needed"
+category: ci-cd
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+tags: [github-actions, python, ci, required-checks, release]
+---
+
+# GitHub Actions for Python Repositories
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Standard workflow for setting up fail-closed required checks and tag-only releases in Python repositories |
+| **Outcome** | Operational — migrated from the Athena `github-actions-python-cicd` skill into standard knowledge |
+
+## When to Use
+
+- Creating or repairing required checks in a Python repository.
+- Setting up a tag-only release workflow.
+- The target repository remains authoritative for its languages, package layout, commands, and release channel.
+
+## Required reference
+
+Prepare Hephaestus at `$HOME/.agent_brain/automation` by following Athena's canonical dependency-resolution contract exactly. Report repository, SHA, and trust basis; any preparation or revalidation failure is blocking. Read the resolved checkout's current `_required.yml`, release workflow, `.github/CODEOWNERS`, and local policies. Treat them as control-pattern guidance, not copy-ready package commands.
+
+## Verified Workflow
+
+### Discover the target contract
+
+Read `AGENTS.md`, manifests, lockfiles, task runners, existing workflows, supported Python classifiers, test layout, release documentation, GitHub Actions settings, and rulesets. Determine:
+
+- Bootstrap and locked-install command.
+- Formatting, lint, typing, unit/integration, build, install-smoke, and security commands.
+- Supported runners/Python matrix.
+- Artifact and publication channel.
+- Required PR policy and branch-protection contexts.
+
+Ask when these sources conflict; never substitute Hephaestus package paths.
+
+### Required workflow design
+
+1. Use `.github/workflows/_required.yml` as the canonical merge gate.
+2. Pin third-party Actions to immutable commits with readable version comments.
+3. Set least-privilege permissions, timeouts, and concurrency cancellation.
+4. Fail closed: no `continue-on-error`, swallowed exit codes, or advisory replacement for a gate.
+5. Separate meaningful jobs such as lint, tests, build/package, install smoke, dependency/security scans, workflow schema, version/lock sync, and PR policy.
+6. Fan every gating job into `required-checks-gate` with `if: always()` and explicit result checks.
+7. Use a tag-only release workflow that reruns the release contract and publishes only validated artifacts.
+8. Put `CODEOWNERS` at `.github/CODEOWNERS` and cover workflows, package metadata, source, tests, scripts, and policy files.
+9. Verify workflows against the GitHub schema and inspect live Actions/ruleset configuration.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Copying reference commands | Reusing Hephaestus package commands in the target repo | Package names, layouts, and runners differed | The reference provides control patterns; the target defines every command |
+| Advisory gates | `continue-on-error: true` on flaky jobs | The merge gate stopped gating | Fail closed; fix or quarantine flakes explicitly |
+
+## Results & Parameters
+
+### Expected Output
+
+Report the resolved reference SHA, discovered target contract, jobs and contexts created, pin and permission choices, commands run, live settings still requiring operator action, and rollback.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Athena | Shipped as the `github-actions-python-cicd` plugin skill; applied across HomericIntelligence Python repositories | Migrated 2026-07-16 |
+
+## References
+
+- Athena dependency-resolution contract: `docs/dependency-resolution.md` in HomericIntelligence/Athena
+- Related: [python-repo-modernization-workflow.md](python-repo-modernization-workflow.md)

--- a/skills/python-repo-modernization-workflow.md
+++ b/skills/python-repo-modernization-workflow.md
@@ -1,0 +1,73 @@
+---
+name: python-repo-modernization-workflow
+description: "Modernize a Python repository with mixed legacy and modern practices, following the target's product requirements. Use when: (1) a Python repo mixes legacy and modern tooling, (2) packaging/typing/CI need alignment without breaking public behavior, (3) release artifacts must be verified outside the checkout"
+category: tooling
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+tags: [python, modernization, packaging, typing, migration]
+---
+
+# Python Repository Modernization
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Standard workflow for modernizing a Python repository without breaking public behavior |
+| **Outcome** | Operational — migrated from the Athena `python-repo-modernization` skill into standard knowledge |
+
+## When to Use
+
+- A Python repository has mixed legacy and modern practices. Modernization follows the target's product requirements; it is not a mechanical conversion to one package layout.
+
+## Required reference
+
+Prepare Hephaestus at `$HOME/.agent_brain/automation` by following Athena's canonical dependency-resolution contract exactly. Report repository, SHA, and trust basis; any preparation or revalidation failure is blocking. Use the resolved checkout to study current policy, typing, testing, CI, security, and release patterns. Substitute the target repository's package name, source layout, commands, and publication model everywhere.
+
+## Verified Workflow
+
+### Detailed Steps
+
+1. Establish a green or honestly documented baseline: imports, tests, coverage, lint, typing, build, installed-artifact smoke test, dependency audit, and workflow state.
+2. Read public API and compatibility requirements before moving modules or removing shims.
+3. Fix correctness and circular-import issues with regression tests first.
+4. Select flat or `src/` layout based on the target's import and packaging needs; do not impose the reference layout.
+5. Align tests with behavioral boundaries. Require focused unit/error tests and integration or installed-artifact tests where they catch distinct failures.
+6. Centralize tool configuration and commit the authoritative dependency lock.
+7. Add typed-package metadata only when the package ships inline types.
+8. Add fail-fast pre-commit and required GitHub checks (see the GitHub Actions for Python knowledge entry).
+9. Build the actual release artifacts, inspect contents, install them outside the checkout, and verify public imports/commands.
+10. Document supported versions, installation, upgrades, compatibility, release, and rollback.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Layout-first conversion | Imposing `src/` layout because the reference used it | Broke the target's import contract | Choose layout from the target's import and packaging needs |
+| Coverage gaming | Excluding hard modules to keep the coverage number | Hid untested correctness risks | Never lower coverage merely to pass; justify exclusions with tests |
+
+## Results & Parameters
+
+### Guardrails
+
+- Preserve public behavior unless a breaking change and migration are explicitly approved.
+- Do not hide failing tests, lower coverage merely to pass, or exclude hard modules without tested justification.
+- Do not mix environment managers over one site-packages tree.
+- Never claim PyPI or another registry publication without a real authenticated publish result.
+
+### Expected Output
+
+Return the resolved reference SHA, baseline, modernization decisions, compatibility impact, files changed, exact gate results, artifact inspection/install evidence, and remaining release actions.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Athena | Shipped as the `python-repo-modernization` plugin skill; applied across HomericIntelligence Python repositories | Migrated 2026-07-16 |
+
+## References
+
+- Athena dependency-resolution contract: `docs/dependency-resolution.md` in HomericIntelligence/Athena
+- Related: [github-actions-python-required-checks.md](github-actions-python-required-checks.md)

--- a/skills/skill-advisor-task-routing.md
+++ b/skills/skill-advisor-task-routing.md
@@ -1,0 +1,102 @@
+---
+name: skill-advisor-task-routing
+description: "Route a task to the appropriate procedural skill before starting substantive work. Use when: (1) beginning any non-trivial task, (2) unsure whether a process, execution, or completion skill applies, (3) tempted to skip workflow checks because the task 'seems simple'"
+category: tooling
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+tags: [workflow, routing, process, skills]
+---
+
+# Skill Advisor: Task Routing
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Decision tree for routing a task to the right procedural skill before work begins |
+| **Outcome** | Operational — migrated from the Athena `skill-advisor` skill into standard knowledge |
+
+## When to Use
+
+**Core principle:** check for a relevant skill BEFORE beginning any substantive work. If there is even a 1% chance a skill applies, invoke it.
+
+Knowledge first, then process: search the knowledge backend (advise) for prior lessons before routing to a procedural skill. Failure to prepare the required knowledge backend is blocking.
+
+## Verified Workflow
+
+### Decision Tree
+
+```text
+What are you about to do?
+│
+├─ Implementing a new feature or fixing a bug?
+│   └─ → test-driven-development (BEFORE writing any code)
+│
+├─ Debugging an unexpected failure, bug, or error?
+│   └─ → systematic-debugging (BEFORE proposing fixes)
+│
+├─ About to claim work is "done", "passing", or "fixed"?
+│   └─ → verification evidence audit (BEFORE making any success claims)
+│
+├─ Starting a complex or ambiguous feature from scratch?
+│   └─ → brainstorm (BEFORE writing any code or plan)
+│
+├─ Needing an isolated workspace for a new branch?
+│   └─ → git-worktrees
+│       (skip if using myrmidon-swarm — it handles isolation automatically)
+│
+├─ Implementation complete, ready to merge or create PR?
+│   └─ → finish-branch delivery workflow (AFTER verification)
+│
+├─ Completed a major task and want quality assurance?
+│   └─ → code-review before merge (uses an independent reviewer when available)
+│
+└─ Received code review feedback to act on?
+    └─ → evaluate each comment with evidence, then request an independent recheck
+```
+
+### Skill Priority
+
+When multiple skills could apply:
+
+1. **Process skills first** (brainstorm, systematic-debugging) — determine HOW to approach
+2. **Execution skills second** (test-driven-development, git-worktrees) — guide execution
+3. **Completion skills last** (verification, finish-branch, code-review) — gate closure
+
+Example: "Fix this bug" → systematic-debugging first, then test-driven-development for the fix.
+
+Example: "Build new feature" → brainstorm first, then test-driven-development for implementation.
+
+### When to Skip
+
+- You are a subagent dispatched by an orchestrator with a specific task — follow your task prompt directly.
+- You were explicitly told "just do X" without workflow overhead.
+- The task is truly trivial (typo fix, single-line rename).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| "Just a simple question" | Skipping the check for questions | Questions become tasks | Check anyway |
+| "I already know the approach" | Working from memory of a skill | Skills evolve | Check the current version |
+| "Skill is overkill" | Ad-hoc approach to a "simple" task | Simple things become complex | Use the skill |
+| "I'll check after exploring" | Exploring first, routing later | Skills tell you HOW to explore | Check first |
+
+## Results & Parameters
+
+### Expected Output
+
+The selected skill (or explicit skip justification) stated before substantive work begins.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Athena | Shipped as the `skill-advisor` plugin skill; exercised across HomericIntelligence repositories | Migrated 2026-07-16 |
+
+## References
+
+- Related: [advise-before-planning.md](advise-before-planning.md), [verification-evidence-audit.md](verification-evidence-audit.md), [finish-branch-delivery-workflow.md](finish-branch-delivery-workflow.md)
+- Adapted from [obra/superpowers](https://github.com/obra/superpowers) under the MIT License. Copyright (c) 2025 Jesse Vincent.

--- a/skills/verification-evidence-audit.md
+++ b/skills/verification-evidence-audit.md
@@ -1,0 +1,93 @@
+---
+name: verification-evidence-audit
+description: "Verify completion, fix, passing-check, metric, CI, or benchmark claims with fresh runnable evidence. Use when: (1) about to claim work is complete/fixed/passing/ready, (2) a measured value, CI result, benchmark, or training loss is posted, (3) a success claim cites a committed file or badge instead of a live gate"
+category: testing
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+tags: [verification, evidence, ci, claims, integrity]
+---
+
+# Verification: Evidence Audit for Claims
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Determine whether a completion or measurement claim is backed by runnable evidence |
+| **Outcome** | Operational — migrated from the Athena `verification` skill into standard knowledge |
+
+## When to Use
+
+- Before any claim that work is complete, fixed, passing, or ready.
+- Whenever a measured value, CI result, benchmark, training loss, or successful-run claim is posted.
+- For a completion claim, discover and freshly run the repository-defined relevant validation; a prior run, badge, or implementation diff is not evidence of the current state.
+- The audit does not automatically reproduce an expensive or side-effecting run; it queries current read-only evidence and may re-execute safe, bounded verification commands.
+
+## Inputs
+
+1. **The claim.** A sentence like "the build passed in 4m12s" or "epoch 1 loss = 0.4123". Quoted verbatim.
+2. **The evidence pointer.** A path, a URL, or a CI run id. If absent, ask before proceeding.
+
+## Verified Workflow
+
+### Detailed Steps
+
+1. **Classify the claim type.**
+   - **Completion/fix claim**: evidence is fresh output from the repository-defined relevant tests, validation, lint, type, build, or package commands at the claimed revision.
+   - **CI gate result** ("all checks pass"): evidence is the `gh pr checks` JSON, not a PR body line.
+   - **Measured metric / benchmark**: evidence is a CI-produced artifact or an independently-reproduced log; a file committed into a PR does NOT count.
+   - **Training/optimization result**: accepted evidence is a CI-produced artifact or a detached-execution run record bound to the reviewed revision.
+   - **Operational status** ("the daemon is running"): `systemctl status` or `podman ps` output.
+2. **Locate the evidence.** Use read-only file inspection for workspace evidence. Run read-only commands such as `gh pr checks`, `systemctl status`, or `podman ps` directly when the host grants Bash. Quote user-provided identifiers, reject values beginning with `-`, and prefer structured output. Delegate an independent or long-running check when the host grants subagents. If neither execution nor delegation is available, return `CONDITIONAL` or `NO-GO` with the exact command the caller must run; never present an unexecuted command as evidence. Any command with side effects, credentials beyond read access, or material cost requires explicit user authority.
+3. **Apply the evidence audit table.**
+
+   | Claim type | Accepted evidence | Default verdict |
+   | ------------ | ------------------- | ----------------- |
+   | CI gate result | `gh pr checks <pr> --json name,state` showing the named gate in SUCCESS state | Run `gh pr checks`; report gate state verbatim |
+   | Measured metric in PR body | (a) CI-produced artifact URL, OR (b) re-executed run output | NO-GO unless either is present |
+   | Committed `epoch*.log` file in PR | n/a | **NEVER** independent evidence |
+   | Training result on slow path | detached-execution run record | NO-GO unless a follow-up evidence-collection task has landed |
+
+4. **Report** using the output contract below. **Do not soften the verdict.** A NO-GO with a clear "here is what would change it" answer is the right outcome for a fabricated claim.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Repo audit for claims | Running a whole-repository review to verify one claim | Repo audits check repositories, not individual claims | Use this per-claim audit instead |
+| Emoji as evidence | Accepting a "✓" in a comment | Anyone can type a checkmark | Only runnable/queryable channels count |
+| Re-reading the claim | Re-reading the same PR body line to "find" evidence | The claim is not its own evidence | Query the live gate state or re-run the safe command |
+| Trusting the author | "Looks good, it's from a trusted author" | Evidentiary channel matters, not source reputation | Audit the channel every time |
+
+## Results & Parameters
+
+### Output contract
+
+```markdown
+## Verification verdict for <one-line claim>
+
+| Field | Value |
+|-------|-------|
+| Claim | <verbatim claim text> |
+| Class | CI gate / measured metric / training result / operational |
+| Evidence cited | <path, URL, or PR #N> |
+| Evidence channel | CI-produced artifact / re-executed run / committed file (NOT EVIDENCE) / none |
+| Verdict | GO / CONDITIONAL / NO-GO |
+| Action | <one-line "what would change the verdict"> |
+| Policy reference | evidence-integrity policy |
+```
+
+Then a short paragraph (≤ 4 lines) explaining the verdict.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Athena | Shipped as the `verification` plugin skill; exercised across HomericIntelligence repositories | Migrated 2026-07-16 |
+
+## References
+
+- Athena evidence-integrity policy: `docs/policies/evidence-integrity.md` in HomericIntelligence/Athena
+- Related: [finish-branch-delivery-workflow.md](finish-branch-delivery-workflow.md), [code-review-before-merge-workflow.md](code-review-before-merge-workflow.md)


### PR DESCRIPTION
Migrates the content of seven Athena plugin skills into standard knowledge entries so they live in the knowledge corpus instead of the plugin catalog:

- `code-review-before-merge-workflow`
- `create-reusable-utilities-hephaestus-port`
- `finish-branch-delivery-workflow`
- `github-actions-python-required-checks`
- `python-repo-modernization-workflow`
- `skill-advisor-task-routing`
- `verification-evidence-audit`

Workflows, guardrails, output contracts, and obra/superpowers MIT attribution are preserved. `scripts/validate_plugins.py` passes 661/661. The corresponding skill removal from Athena is HomericIntelligence/Athena (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)