### PR TITLE
feat(skills): state:skip mass-mislabel forensics + three verified fix amendments

### DIFF
--- a/skills/automation-ambient-cwd-repo-resolution-breaker-cascade.history
+++ b/skills/automation-ambient-cwd-repo-resolution-breaker-cascade.history
@@ -1,0 +1,26 @@
+# automation-ambient-cwd-repo-resolution-breaker-cascade — History
+
+## v1.1.0 (2026-07-17)
+
+**Changed by:** Session triaging an org-wide `state:skip` mass-mislabel that turned out to be this
+entry's predicted "silent-corruption twin", realized on the label-WRITE path.
+**Verification:** verified-ci (Hephaestus PR #2248 merged with CI green; the restarted loop tags
+epics on the correct repo).
+
+### What changed
+
+- Key Insight 3 upgraded from prediction to verified occurrence: epic `state:skip` writes via
+  `gh issue edit` with no `--repo` landed on the cwd repo's colliding issue numbers
+  (Proteus#81/Telemachy#92/Hermes#316,#545 → Hephaestus#81/#92/#316/#545), all clean 200s.
+- Documented the fix (Hephaestus PR #2248): thread `(owner, name)` through the label helpers and
+  key the label cache by the explicit slug — the PR #2047 pattern applied to writes.
+- Added a When-to-Use trigger for wrong-repo labels/comments/state with no error anywhere.
+- Linked [[github-label-mass-mislabel-forensics]] for the timeline-based triage workflow.
+- Bumped 1.0.0 → 1.1.0.
+
+### Why
+
+v1.0.0 warned that the number-collision half of ambient-cwd resolution "will not appear in any
+error grep" but had only observed the read-side 404 cascade. The write-side twin then occurred in
+production exactly as predicted; recording the verified instance, its evidence trail, and its fix
+turns the warning into a diagnosable, fixable pattern.

--- a/skills/automation-ambient-cwd-repo-resolution-breaker-cascade.md
+++ b/skills/automation-ambient-cwd-repo-resolution-breaker-cascade.md
@@ -1,9 +1,10 @@
 ---
 name: automation-ambient-cwd-repo-resolution-breaker-cascade
-description: "Diagnose why a handful of wrong-repo 404s silently opens a SHARED circuit breaker and poisons an ENTIRE multi-repo automation run. Use when: (1) a multi-repo loop aborts with hundreds of 'poisoned' items, CircuitBreakerOpenError, or 'FAIL:poisoned' and near-zero useful work, (2) you see 'Could not resolve to an Issue with the number of N' 404s in a cross-repo run, (3) a caught/swallowed exception still trips a breaker ('WARNING: ...using cache' next to 'ERROR: Non-transient error'), (4) a GitHub helper takes a bare issue NUMBER with no owning repo, (5) triaging a multi-repo abort and deciding how many DISTINCT root-cause bugs to file."
+description: "Diagnose why a handful of wrong-repo 404s silently opens a SHARED circuit breaker and poisons an ENTIRE multi-repo automation run. Use when: (1) a multi-repo loop aborts with hundreds of 'poisoned' items, CircuitBreakerOpenError, or 'FAIL:poisoned' and near-zero useful work, (2) you see 'Could not resolve to an Issue with the number of N' 404s in a cross-repo run, (3) a caught/swallowed exception still trips a breaker ('WARNING: ...using cache' next to 'ERROR: Non-transient error'), (4) a GitHub helper takes a bare issue NUMBER with no owning repo, (5) triaging a multi-repo abort and deciding how many DISTINCT root-cause bugs to file, (6) labels/comments/state appear on the WRONG repo's issues with no error anywhere — the silent WRITE twin (verified: epic state:skip tags landed on the cwd repo's colliding issue numbers)."
 category: debugging
-date: 2026-07-10
-version: "1.0.0"
+date: 2026-07-17
+version: "1.1.0"
+history: automation-ambient-cwd-repo-resolution-breaker-cascade.history
 user-invocable: false
 verification: verified-ci
 tags:
@@ -69,9 +70,21 @@ The `WARNING ... (using cache)` proves the CALLER recovered. It does **not** pro
 
 Treat any function signature that takes a bare `issue: int` (or `issue_number`) and then calls GitHub as **suspect**. Without an explicit `(owner, name)` it will resolve against whatever the ambient CWD happens to be — correct in a single-repo tool, catastrophic in a multi-repo loop.
 
-### 3. The silent-corruption twin (WORSE than the 404s)
+### 3. The silent-corruption twin (WORSE than the 404s) — now VERIFIED on the write side
 
 Where issue numbers **collide** across repos there is no 404 at all — so no error, no log line, no breaker trip. The loop silently reads/acts on an unrelated object in the wrong repo.
+
+**Verified occurrence (2026-07-16/17, fixed in Hephaestus PR #2248):** the epic skip-tag chokepoint
+(`github_api.skip_epics` → `gh_issue_add_labels`) built `gh issue edit N --add-label state:skip`
+with no `--repo` selector. In the multi-repo parent process (cwd = the launch checkout), other
+repos' epic numbers were written onto the cwd repo: Proteus#81 / Telemachy#92 / Hermes#316,#545
+tagged Hephaestus#81/#92/#316/#545 — every write a clean 200. Because `state:skip` overrides all
+planning, the mislabeled issues silently vanished from the loop. Label timelines
+(`gh api repos/O/R/issues/N/timeline`) were the only evidence trail; see
+[[github-label-mass-mislabel-forensics]] for the triage workflow. The fix threads an optional
+`(owner, name)` through `gh_issue_add_labels` / `gh_list_labels` / `gh_create_label` / `skip_epics`
+(appending `--repo owner/name` and keying the label cache by the explicit slug) — the same
+thread-the-owning-repo pattern as PR #2047, applied to the WRITE path.
 
 - Example: `ProjectAgamemnon#188` is a real issue; `ProjectHephaestus#188` also exists — as a merged PR. An ambient-CWD lookup for "188" while CWD=Hephaestus returns the wrong object with a 200.
 

--- a/skills/automation-loop-exclude-epic-roadmap-issues.history
+++ b/skills/automation-loop-exclude-epic-roadmap-issues.history
@@ -1,0 +1,27 @@
+# automation-loop-exclude-epic-roadmap-issues — History
+
+## v1.1.0 (2026-07-17)
+
+**Changed by:** Session triaging an org-wide `state:skip` mass-mislabel: the entry's own
+anywhere-in-title detection rule skip-parked Hephaestus issue #2245 — a bug report whose title
+mentioned "epic labels" mid-sentence — live, during the investigation.
+**Verification:** verified-ci (Hephaestus PR #2253 merged with CI green; regression tests pin the
+mid-title mention and the hyphenated leading marker).
+
+### What changed
+
+- Corrected the detection rule: the title signal matches `epic`/`roadmap` as a standalone token
+  only within the first ~3 title words (`_EPIC_TITLE_LEADING_TOKENS`), never anywhere in the title.
+- Updated the inline `is_epic` snippet to the leading-tokens form and noted that hyphens do NOT
+  block the token regex ("roadmap-exclusion" matches).
+- Added a Failed Attempts row for the anywhere-in-title false positive with the live incident.
+- Added a When-to-Use trigger for "issue ABOUT epic handling got excluded/skip-parked".
+- Bumped 1.0.0 → 1.1.0; verification verified-local → verified-ci.
+
+### Why
+
+The v1.0.0 rule ("epic/roadmap substring in title") was written when zero labelled epics existed
+and recall mattered most. In production it false-positived on issues that merely mention epics —
+including the bug report tracking the mislabeling investigation itself — and each false positive
+is durably tagged `state:skip`, silently removing the issue from all future planning. Tracking
+issues lead with the marker, so precision costs no known recall.

--- a/skills/automation-loop-exclude-epic-roadmap-issues.md
+++ b/skills/automation-loop-exclude-epic-roadmap-issues.md
@@ -1,11 +1,12 @@
 ---
 name: automation-loop-exclude-epic-roadmap-issues
-description: "An automation/planning loop that auto-discovers GitHub issues MUST exclude epic/roadmap TRACKING issues (checklists of child work, not code tasks) or it will plan+implement them and produce a wrong code PR. Detect an epic via an `epic`/`roadmap` LABEL (case-insensitive) OR an `epic`/`roadmap` substring in the TITLE — native GitHub issue types are NOT reachable from the installed gh CLI. Filter at BOTH the loop discovery chokepoint and the standalone planner, tag excluded epics `state:skip` idempotently, and keep the write OUT of the pure 'return [] on failure / never raise' discovery function. Use when: (1) an auto-discovery loop plans an epic/roadmap tracking issue as if it were code, (2) designing an issue-type filter and reaching for `gh issue list --json issueType`, (3) a label convention exists but is not consistently applied, (4) you need to exclude tracking issues from convergence/open-issue gates too."
+description: "An automation/planning loop that auto-discovers GitHub issues MUST exclude epic/roadmap TRACKING issues (checklists of child work, not code tasks) or it will plan+implement them and produce a wrong code PR. Detect an epic via an `epic`/`roadmap` LABEL (case-insensitive) OR an `epic`/`roadmap` token in the LEADING title words ONLY (first ~3) — an anywhere-in-title match skip-parks bug reports that merely MENTION epics (verified false positive). Native GitHub issue types are NOT reachable from the installed gh CLI. Filter at BOTH the loop discovery chokepoint and the standalone planner, tag excluded epics `state:skip` idempotently, and keep the write OUT of the pure 'return [] on failure / never raise' discovery function. Use when: (1) an auto-discovery loop plans an epic/roadmap tracking issue as if it were code, (2) designing an issue-type filter and reaching for `gh issue list --json issueType`, (3) a label convention exists but is not consistently applied, (4) you need to exclude tracking issues from convergence/open-issue gates too, (5) an issue ABOUT epic handling was excluded from planning and tagged state:skip."
 category: tooling
-date: 2026-06-29
-version: "1.0.0"
+date: 2026-07-17
+version: "1.1.0"
 user-invocable: false
-verification: verified-local
+verification: verified-ci
+history: automation-loop-exclude-epic-roadmap-issues.history
 tags: [epic, roadmap, tracking-issue, automation-loop, issue-discovery, gh-cli, state-skip, partition, label-and-title-signal, planner-filter, dry-chokepoints, pure-function-contract]
 ---
 
@@ -35,6 +36,8 @@ discovery time and exclude them from every path that feeds the planner.
 - A repo has an `epic`/`roadmap` label convention but it is NOT consistently applied (so label-only detection misses issues).
 - You need tracking issues excluded from convergence / open-issue-count gates as well as from planning.
 - A loop supports both auto-discovery AND an explicit `--issues` override (both paths must filter).
+- An issue whose title merely MENTIONS epics (a bug report about epic handling, an audit finding) was
+  excluded from planning and durably tagged `state:skip` — the anywhere-in-title false positive.
 
 ## Verified Workflow
 
@@ -46,17 +49,26 @@ gh issue list --json issueType   # -> "Unknown JSON field: issueType" on the ins
 # => label + title are the ONLY available signals.
 
 # 2. Detection signal (case-insensitive):
-#    epic iff  ('epic' or 'roadmap' in labels)  OR  ('epic' or 'roadmap' substring in title)
+#    epic iff  ('epic' or 'roadmap' in labels)
+#          OR  ('epic'/'roadmap' as a standalone token in the first ~3 title words)
+#    NEVER match anywhere in the title: a bug report titled "...tags state:skip
+#    epic labels on the wrong repo" was excluded and skip-parked by the
+#    anywhere-match (Hephaestus #2245, fixed in PR #2253).
 ```
 
 ```python
 # Pure helper in the label-vocabulary module (hephaestus/automation/state_labels.py):
+_EPIC_TITLE_LEADING_TOKENS = 3  # tracking issues LEAD with the marker
+
 def is_epic(labels: Iterable[str], title: str) -> bool:
     lowered = {label.lower() for label in labels}
     if {"epic", "roadmap"} & lowered:
         return True
-    title_l = title.lower()
-    return "epic" in title_l or "roadmap" in title_l
+    leading = " ".join(title.lower().split()[:_EPIC_TITLE_LEADING_TOKENS])
+    return any(
+        re.search(rf"(?<![a-z0-9_]){marker}(?![a-z0-9_])", leading)
+        for marker in ("epic", "roadmap")
+    )
 
 def partition_epics(issues_meta):  # -> (kept, epics)
     kept, epics = [], []
@@ -101,6 +113,7 @@ def partition_epics(issues_meta):  # -> (kept, epics)
 | Native issue type | `gh issue list --json issueType` to filter by GitHub issue type | Installed gh returns `Unknown JSON field: issueType` — native types are not exposed by the CLI | Fall back to label + title detection; verify gh field availability BEFORE designing any issue-type filter |
 | Label-only detection | Detect epics solely by the `epic`/`roadmap` label | Convention not consistently applied — at the time, 94 open issues and ZERO carried the label | Add a title-substring fallback (`epic`/`roadmap` in the title, case-insensitive) |
 | Tag inside pure discovery | Write `state:skip` from inside `_list_open_issue_numbers` | Violates that function's "return `[]` on failure / never raise" contract — a failed label write would break discovery | Keep writes OUT of pure discovery; do best-effort tagging in the caller, wrapped in try/except |
+| Anywhere-in-title match | Match `epic`/`roadmap` as a standalone token ANYWHERE in the title | A bug report titled "Multi-repo loop tags state:skip epic labels on the wrong repo" (#2245) was excluded from planning and durably skip-parked; any issue ABOUT epic handling triggers it. Hyphens do not block the token regex, so "roadmap-exclusion" also matches | Tracking issues LEAD with the marker ("Epic: ...", "Q3 Roadmap tracking"); match only within the first ~3 whitespace tokens (Hephaestus PR #2253, verified-ci) |
 
 ## Results & Parameters
 

--- a/skills/github-label-mass-mislabel-forensics.md
+++ b/skills/github-label-mass-mislabel-forensics.md
@@ -1,0 +1,110 @@
+---
+name: github-label-mass-mislabel-forensics
+description: "Triage an org-wide GitHub label mass-mislabel (e.g. dozens of issues suddenly carrying an automation state label like state:skip) by histogramming label timeline events, separating the DISTINCT tagging mechanisms by timestamp cluster, bulk-removing first (timelines preserve provenance), and using the still-running automation as a live probe of which code path re-tags. Use when: (1) many issues across repos carry a label nobody remembers applying, (2) you must decide whether a bulk label removal destroys evidence (it does not — labeled/unlabeled events persist), (3) a label reappears minutes after removal and you need to identify WHICH code path re-applied it, (4) label writes appear on the WRONG repo's issue numbers, (5) sizing an org-wide sweep (gh repo list --limit, pagination, PRs-are-issues)."
+category: debugging
+date: 2026-07-17
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - github-labels
+  - state-skip
+  - mass-mislabel
+  - forensics
+  - label-timeline
+  - bulk-removal
+  - automation-loop
+  - triage
+  - gh-cli
+  - org-wide-sweep
+---
+
+# GitHub Label Mass-Mislabel Forensics
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-17 |
+| **Objective** | Explain and clean up 142 `state:skip` labels spread over 14 HomericIntelligence repos, then identify every distinct mechanism that applied them |
+| **Outcome** | All 142 removed (0 failures); three DISTINCT mechanisms identified from timeline clusters and live re-tagging: (1) merge-attempt budget default 1 → 76 labels in one overnight run, (2) cross-repo ambient-cwd label writes, (3) epic-title heuristic false positive. Each became its own issue + fixed PR (Hephaestus #2249, #2248, #2253) |
+| **Verification** | verified-local — the forensic workflow itself; the three fixes it produced are each verified-ci in Hephaestus |
+
+## When to Use
+
+- Dozens/hundreds of issues carry an automation-owned label (`state:skip`, `state:*`) nobody
+  remembers applying, possibly across many repos.
+- You are asked to bulk-remove labels FIRST and investigate after — and need to know what evidence
+  survives removal.
+- A removed label reappears minutes later and you must attribute the re-tag to a specific code path.
+- Labels appear on issue numbers that correspond to a DIFFERENT repo's issues (the ambient-cwd
+  write bug — see [[automation-ambient-cwd-repo-resolution-breaker-cascade]]).
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Org-wide sweep of label carriers. PRs ARE issues on this endpoint — split them.
+for repo in $(gh repo list ORG --limit 1000 --no-archived --json name --jq '.[].name'); do
+  gh api "repos/ORG/$repo/issues?labels=state%3Askip&state=all&per_page=100" --paginate \
+    --jq '.[] | select(.pull_request | not) | .number'
+done
+
+# 2. Bulk-remove is SAFE for forensics: labeled/unlabeled timeline events persist.
+gh api -X DELETE "repos/ORG/REPO/issues/N/labels/state%3Askip"
+
+# 3. Histogram WHO/WHEN from timelines (the core forensic move):
+gh api "repos/ORG/REPO/issues/N/timeline?per_page=100" --paginate \
+  --jq '.[] | select(.event=="labeled" and .label.name=="state:skip") | "\(.actor.login) \(.created_at)"'
+# Bucket created_at by hour across all carriers; each timestamp CLUSTER is one mechanism/run.
+```
+
+### Detailed Steps
+
+1. **Sweep the whole org, not one repo.** `gh repo list --limit 1000` (the default 30 / a low limit
+   silently truncates); the `issues?labels=` endpoint returns PRs too — filter `.pull_request | not`
+   and record labeled PRs separately.
+2. **Remove first if asked; evidence survives.** GitHub label timelines keep `labeled`/`unlabeled`
+   events (actor + timestamp) after removal, so bulk cleanup does not destroy provenance. Automation
+   running under the operator's token shows the OPERATOR as actor — timestamps (e.g. 02:00 clusters),
+   not actors, distinguish automation from humans.
+3. **Histogram timestamps and count clusters.** Each tight cluster (minutes-wide, many issues) is one
+   run of one mechanism. In the verified case: 53 labels at 02:0x + 23 at 06:00 on one date = one
+   overnight run whose merge budget (default 1) skip-parked every issue that failed once.
+4. **Use the running automation as a live probe.** After removal, watch what gets re-tagged within
+   the next loop iteration. Re-tags on the CORRECT repos' epics are by-design; re-tags on colliding
+   issue numbers of the launch-directory repo exposed the ambient-cwd write bug the moment they
+   reappeared. Diff "what returned" against "what should return".
+5. **Attribute each cluster to a code path before fixing.** Grep the automation for every site that
+   applies the label (`add_labels.*STATE_SKIP`); map each cluster to one site (budget exhaustion,
+   epic tagging, review exhaustion...). File ONE issue per distinct root-cause signature, not per
+   symptom — the 142 labels reduced to three defects.
+6. **Beware self-referential false positives.** An issue FILED ABOUT the mislabel can itself be
+   swept up by keyword heuristics (the bug report mentioning "epic labels" was skip-parked by the
+   epic-title match — see [[automation-loop-exclude-epic-roadmap-issues]]). Title such issues to
+   avoid the automation's own trigger tokens, or fix the heuristic first.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Investigate before removing | Sample timelines before bulk removal | User needed the labels gone immediately; investigation blocked cleanup | Removal is evidence-safe — timelines persist; act first, attribute after |
+| Actor-based attribution | Identify the tagger from `.actor.login` | Automation runs under the operator's token; every event shows the human account | Cluster by TIMESTAMP; 02:00-hour clusters over dozens of issues are automation runs |
+| One issue per symptom | Treat 142 labels as the bug count | Three code paths produced all of them | Count distinct root-cause signatures (see the triage insight in [[automation-ambient-cwd-repo-resolution-breaker-cascade]]) |
+
+## Results & Parameters
+
+```text
+Sweep:    gh repo list ORG --limit 1000 --no-archived; issues endpoint returns PRs (filter .pull_request)
+Removal:  142/142 OK via DELETE .../issues/N/labels/state%3Askip (URL-encode the colon)
+Evidence: labeled/unlabeled timeline events survive removal; actor = token owner; cluster by hour
+Outcome:  3 distinct mechanisms -> Hephaestus #2246/#2249 (merge budget default 1),
+          #2245/#2248 (ambient-cwd cross-repo writes), #2251/#2253 (epic-title false positive)
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| HomericIntelligence org (16 repos) | 2026-07-16/17 state:skip mass-mislabel | 142 labels removed, three mechanisms attributed and fixed (verified-ci each) |

--- a/skills/hephaestus-automation-loop-branch-sync-drive-green.history
+++ b/skills/hephaestus-automation-loop-branch-sync-drive-green.history
@@ -1,5 +1,28 @@
 # hephaestus-automation-loop-branch-sync-drive-green — History
 
+## v1.2.0 (2026-07-17)
+
+**Changed by:** Session root-causing an org-wide state:skip mass-mislabel and the observation that
+--drive-green-all started reviewer machinery for every open PR while driving none of them.
+**Verification:** verified-ci (Hephaestus PRs #2249 and #2254 merged with CI green; #2254's gate
+fix additionally confirmed on the restarted live loop). The orphan-worktree residual gap is
+observed-live and explicitly UNFIXED.
+
+### What changed
+- Added the orphan-PR drop finding: --drive-green-all swept PRs regressed to pr_review, which
+  terminates PR-only items — zero PRs driven. Fixed by skipping the implementation-go gate for
+  issue-less items (PR #2254), with the residual REBASE_WAIT no-worktree gap documented.
+- Added the flag replacement: --max-merge-attempts (default 1, one transient failure skip-parks an
+  issue; 76 issues parked in one overnight run) removed in favor of --drive-green-loops (default 5)
+  (PR #2249).
+- Added When-to-Use triggers for both signatures; bumped 1.1.0 → 1.2.0.
+
+### Why
+v1.1.0 taught the correct --drive-green-all invocation but not that the swept PRs were silently
+dropped downstream, nor that the merge-attempt budget's default of 1 turned every transient failure
+into a durable skip-park. Both defects mass-produce state:skip noise that looks like operator
+intent.
+
 ## v1.1.0 (2026-07-11)
 
 **Changed by:** Session driving all open PRs to green on a ProjectHephaestus repo — a `--dry-run` of `--phases drive-green` surfaced a `KeyError` before any live invocation; `--drive-green-all` then confirmed working on a live ~3-minute run over 14 open PRs.

--- a/skills/hephaestus-automation-loop-branch-sync-drive-green.md
+++ b/skills/hephaestus-automation-loop-branch-sync-drive-green.md
@@ -1,9 +1,9 @@
 ---
 name: hephaestus-automation-loop-branch-sync-drive-green
-description: "Diagnose and fix ProjectHephaestus automation-loop completion failures by enforcing fresh branch/worktree sync before implementation, limiting each worker's drive-green scope to its owned issue/PR, and running a final catch-all drive-green pass. Also: how to drive all existing open PRs to green — use --drive-green-all, NOT --phases drive-green (which crashes with KeyError on the uninitialized REPO stage). Use when: (1) automation loops leave planned issues or PRs unfinished, (2) existing issue worktrees or branches are reused across runs, (3) drive-green acts on unrelated PRs, (4) Codex-authored commits must satisfy signed and Signed-off-by policy gates, (5) you want to drive existing open PRs to green without planning/implementing new issues."
+description: "Diagnose and fix ProjectHephaestus automation-loop completion failures by enforcing fresh branch/worktree sync before implementation, limiting each worker's drive-green scope to its owned issue/PR, and running a final catch-all drive-green pass. Also: how to drive all existing open PRs to green — use --drive-green-all, NOT --phases drive-green (which crashes with KeyError on the uninitialized REPO stage). Use when: (1) automation loops leave planned issues or PRs unfinished, (2) existing issue worktrees or branches are reused across runs, (3) drive-green acts on unrelated PRs, (4) Codex-authored commits must satisfy signed and Signed-off-by policy gates, (5) you want to drive existing open PRs to green without planning/implementing new issues, (6) --drive-green-all logs 'ci:None: PR #N lacks state:implementation-go; regressing to pr_review' and swept-in PRs are dropped instead of driven, (7) a single failed drive-green attempt durably tags issues state:skip (--max-merge-attempts default 1; replaced by --drive-green-loops default 5)."
 category: tooling
-date: 2026-07-11
-version: "1.1.0"
+date: 2026-07-17
+version: "1.2.0"
 user-invocable: false
 verification: verified-local
 history: hephaestus-automation-loop-branch-sync-drive-green.history
@@ -41,6 +41,31 @@ tags:
 - Codex is the selected agent and commits must satisfy both signed-commit and `Signed-off-by` policy checks.
 - You want to drive all **existing open PRs** to green (rebase + fix CI on PRs that already exist) without planning or implementing new issues from scratch.
 - An attempt to run only the drive-green stage via `--phases drive-green` crashes with `KeyError: <StageName.REPO: 'repo'>` and reports the item "poisoned at repo".
+
+## v1.2.0 findings (2026-07-17)
+
+### Orphan PRs swept by --drive-green-all were dropped, not driven (fixed: PR #2254)
+
+`--drive-green-all` seeds orphan open PRs (no tracked issue) into the CI stage as PR-only items
+(`issue=None`). The CI entry gate regressed any PR lacking `state:implementation-go` to pr_review —
+but pr_review terminates PR-only items ("no issue number"), so every swept-in PR logged
+`ci:None: PR #N lacks state:implementation-go; regressing to pr_review` and died without one rebase
+or CI fix. Fix (verified-ci, and confirmed live: the restarted loop logs
+`orphan PR #N ... proceeding with drive-green (no issue-flow gate)`): PR-only items skip the
+implementation-go gate and proceed to REBASE_WAIT. Merge containment is unchanged
+(`defer_auto_merge` + fail-closed merge_wait, #2054).
+
+**Known residual gap (under watch, unfixed):** orphan PRs reach REBASE_WAIT with no item worktree
+(they never passed through implementation) and log
+`ci:N: mechanical rebase requires an item worktree; failing back to implementation` — verify on a
+live run whether the fallback completes before relying on --drive-green-all end-to-end.
+
+### --max-merge-attempts replaced by --drive-green-loops (PR #2249)
+
+`--max-merge-attempts` defaulted to 1, so ONE transient drive-green failure durably tagged the
+issue `state:skip` — a single overnight run (2026-07-11) skip-parked 76 issues org-wide this way.
+The option is REMOVED; use `--drive-green-loops N` (default 5), which feeds the same `merge`
+budget. Old invocations passing `--max-merge-attempts` now fail argparse.
 
 ## Verified Workflow
 


### PR DESCRIPTION
## Summary

Lessons from the 2026-07-16/17 org-wide `state:skip` mass-mislabel triage (142 labels, 14 repos → 3 root-cause defects, each fixed verified-ci in Hephaestus).

**New entry** `github-label-mass-mislabel-forensics` (v1.0.0, verified-local): timeline-histogram triage — bulk removal is evidence-safe (labeled events persist), timestamp clusters separate mechanisms (actors don't: automation runs under the operator token), the running loop doubles as a live re-tag probe, and symptoms reduce to few signatures.

**Amendments** (each with a history file):
- `automation-loop-exclude-epic-roadmap-issues` → v1.1.0: anywhere-in-title epic detection false-positived on an issue that merely mentioned epics; corrected to leading-tokens-only (Hephaestus PR #2253, verified-ci → entry verification upgraded from verified-local).
- `automation-ambient-cwd-repo-resolution-breaker-cascade` → v1.1.0: Key Insight 3's predicted silent-corruption WRITE twin verified in production (cross-repo epic skip-tags, all clean 200s) and its fix documented (Hephaestus PR #2248).
- `hephaestus-automation-loop-branch-sync-drive-green` → v1.2.0: `--drive-green-all` orphan PRs were dropped, not driven (fixed, PR #2254; residual REBASE_WAIT no-worktree gap documented as explicitly unfixed); `--max-merge-attempts` (default 1) replaced by `--drive-green-loops` (default 5) (PR #2249).

## Validation

`just check` in the worktree: 210 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)