### PR TITLE
feat: add scanner-audit + codeql-vendored-deps skills

### DIFF
--- a/skills/codeql-exclude-vendored-deps-false-criticals.md
+++ b/skills/codeql-exclude-vendored-deps-false-criticals.md
@@ -1,0 +1,171 @@
+---
+name: codeql-exclude-vendored-deps-false-criticals
+description: "GitHub CodeQL (and Trivy) analyze the vendored third-party dependency tree that CMake FetchContent / Conan fetch under build/**/_deps/, so upstream findings (e.g. cpp/use-after-free critical, cpp/world-writable-file-creation high) get reported AGAINST your repo — creating false urgency and burying real first-party alerts. Teaches how to detect vendored alerts by location path and how to exclude the build tree via a codeql-config.yml paths-ignore wired into every codeql-action/init step. Use when: (1) CodeQL/Trivy reports a critical/high in C++ code you did not write, (2) an alert path contains build/**/_deps/ or *-src, (3) triage is swamped by upstream nats.c/cista findings, (4) you need to stop scanning vendored deps without silencing first-party findings."
+category: ci-cd
+date: 2026-07-16
+version: "1.0.0"
+verification: verified-local
+tags: []
+---
+
+# CodeQL — Exclude Vendored `_deps/` To Kill False Criticals
+
+## Overview
+
+\| Field \| Value \|
+\|-------\|-------\|
+\| **Date** \| 2026-07-16 \|
+\| **Objective** \| Stop GitHub CodeQL (and Trivy) from reporting upstream vendored-dependency findings against first-party C++ repos, where they surface as false `critical`/`high` alerts and bury real findings \|
+\| **Outcome** \| `.github/codeql/codeql-config.yml` with `paths-ignore: build/**` + `**/_deps/**` wired into every `codeql-action/init` step across Keystone, Nestor, Agamemnon \|
+\| **Verification** \| verified-local — fix applied and PRs opened with auto-merge armed (Keystone#614, Nestor#132, Agamemnon#455); the CI gates and the post-merge CodeQL re-scan have NOT yet been observed green, so this is not verified-ci \|
+
+## When to Use
+
+Use this skill when a C++ (or mixed C++/Python) repo builds its dependencies with
+CMake **FetchContent** or **Conan**, and GitHub code scanning reports alerts that
+point at third-party source rather than your own code. Concrete triggers:
+
+- A CodeQL alert with severity **critical** (`cpp/use-after-free`) or **high**
+  (`cpp/world-writable-file-creation`) that you cannot trace to first-party code.
+- Any alert whose `most_recent_instance.location.path` contains `build/**/_deps/`
+  or a `*-src` directory (e.g. `nats_c-src`, `natsc-src`, `cista-src`).
+- Code-scanning triage is dominated by upstream findings (measured: Keystone 115
+  of 313 alerts vendored = 37%, Agamemnon 32 of 36 = 89%, Nestor 34 of 46 = 74%).
+- You want to exclude the vendored build tree **without** suppressing genuine
+  first-party findings.
+
+## Verified Workflow
+
+The vendored dependency code lives in the build tree at analysis time. CMake
+FetchContent / Conan fetch it under `build/**/_deps/` (Conan output dirs are
+`build/release` / `build/debug`). CodeQL analyzes whatever source is present, so
+those upstream findings are attributed to **your** repo. The fix is to exclude
+the build tree from analysis and wire that config into every `init` step.
+
+### Step 1 — Confirm the alert is vendored, not first-party
+
+Never trust the severity at face value. Split open alerts by location path first:
+
+```bash
+gh api --paginate "repos/<owner>/<repo>/code-scanning/alerts?state=open&per_page=100" \
+  | jq -s 'add' > alerts.json
+
+# how many alerts are vendored (in the build/_deps tree)?
+jq '[.[] | select(.most_recent_instance.location.path | test("build/.*/_deps/"))] | length' alerts.json
+
+# the scary "critical" ones are usually upstream:
+jq -r '.[] | select(.rule.id=="cpp/use-after-free") | .most_recent_instance.location.path' alerts.json
+# -> build/release/_deps/nats_c-src/src/jsm.c   == upstream nats.c, NOT your bug
+```
+
+### Step 2 — Add a CodeQL config that ignores the build tree
+
+Create `.github/codeql/codeql-config.yml`:
+
+```yaml
+name: "Repo CodeQL config"
+paths-ignore:
+  - build/**
+  - "**/_deps/**"
+```
+
+`build/**` also covers Conan output dirs (`build/release`, `build/debug`);
+`**/_deps/**` covers FetchContent trees nested anywhere.
+
+### Step 3 — Reference the config from EVERY `init` step
+
+A repo can have multiple `codeql-action/init` steps — one per language. Add
+`config-file:` to all of them:
+
+```yaml
+- uses: github/codeql-action/init@<pinned-sha>
+  with:
+    languages: cpp   # (or c-cpp / python)
+    queries: security-and-quality
+    config-file: ./.github/codeql/codeql-config.yml
+```
+
+The CodeQL workflow file location varies per repo — grep to find it:
+
+```bash
+grep -rl "codeql-action/init" .github/workflows/
+# Keystone -> _required.yml (separate c-cpp AND python inits)
+# Nestor   -> codeql.yml
+# Agamemnon-> sanitizers.yml
+```
+
+### Quick Reference
+
+```bash
+# 1. pull all open alerts
+gh api --paginate "repos/<owner>/<repo>/code-scanning/alerts?state=open&per_page=100" \
+  | jq -s 'add' > alerts.json
+# 2. count vendored alerts
+jq '[.[] | select(.most_recent_instance.location.path | test("build/.*/_deps/"))] | length' alerts.json
+# 3. list paths of the "critical" use-after-free (usually upstream)
+jq -r '.[] | select(.rule.id=="cpp/use-after-free") | .most_recent_instance.location.path' alerts.json
+# 4. find every workflow with a CodeQL init to wire config-file into
+grep -rl "codeql-action/init" .github/workflows/
+```
+
+```yaml
+# .github/codeql/codeql-config.yml
+name: "Repo CodeQL config"
+paths-ignore:
+  - build/**
+  - "**/_deps/**"
+```
+
+**Key wiring notes:**
+
+1. A repo may have MULTIPLE `init` steps (one per language); add `config-file`
+   to ALL of them. Keystone had separate `c-cpp` and `python` inits in `_required.yml`.
+2. Workflow file location varies (`_required.yml`, `codeql.yml`, `sanitizers.yml`)
+   — grep for `codeql-action/init` to locate them.
+3. `build/**` also covers Conan output dirs (`build/release` / `build/debug`).
+4. Effect is only observable on the NEXT CodeQL run after merge — `paths-ignore`
+   filters at analysis time, so existing alerts do not disappear until re-scan.
+
+## Failed Attempts
+
+\| Attempt \| What Was Tried \| Why It Failed \| Lesson Learned \|
+\|---------\|----------------\|---------------\|----------------\|
+\| 1 \| Read the alert severity at face value — treat `cpp/use-after-free (critical)` as a first-party bug \| The path was `build/**/_deps/nats_c-src/...` — upstream nats.c, not our code \| ALWAYS check `.most_recent_instance.location.path` before believing a 'critical' \|
+\| 2 \| File one GitHub issue per vendored alert \| Would create dozens of issues for upstream code we do not maintain \| Cluster into ONE 'CodeQL scans vendored _deps' config issue per repo instead \|
+\| 3 \| Add `config-file` to only the first `init` step \| The second language's analysis still scanned `_deps/` \| Add `config-file` to every `codeql-action/init` in the workflow \|
+
+## Results & Parameters
+
+**The exclusion config** — `.github/codeql/codeql-config.yml`:
+
+```yaml
+name: "Repo CodeQL config"
+paths-ignore:
+  - build/**
+  - "**/_deps/**"
+```
+
+**Detection one-liners:**
+
+```bash
+gh api --paginate "repos/<owner>/<repo>/code-scanning/alerts?state=open&per_page=100" \
+  | jq -s 'add' > alerts.json
+jq '[.[] | select(.most_recent_instance.location.path | test("build/.*/_deps/"))] | length' alerts.json
+jq -r '.[] | select(.rule.id=="cpp/use-after-free") | .most_recent_instance.location.path' alerts.json
+```
+
+**Measured vendored ratios (real repos, 2026-07-16):**
+
+\| Repo \| Vendored alerts \| Total alerts \| Ratio \|
+\|------\|-----------------\|--------------\|-------\|
+\| Keystone \| 115 \| 313 \| 37% \|
+\| Agamemnon \| 32 \| 36 \| 89% \|
+\| Nestor \| 34 \| 46 \| 74% \|
+
+**Applied via PRs:** Keystone#614, Nestor#132, Agamemnon#455. Charybdis already
+tracked the same idea as its #127.
+
+**Markdown authoring caveat (this skill's own file):** escape any literal `|`
+inside a table cell as `\|` (markdownlint MD056), and run
+`npx --yes markdownlint-cli2 --config .markdownlint.yaml skills/codeql-exclude-vendored-deps-false-criticals.md`
+locally before commit.

--- a/skills/scanner-alerts-to-github-issues-pipeline.md
+++ b/skills/scanner-alerts-to-github-issues-pipeline.md
@@ -1,0 +1,153 @@
+---
+name: scanner-alerts-to-github-issues-pipeline
+description: "Disciplined, scanner-grounded pipeline for a cross-repo security & quality audit: collect a repo's own hosted GitHub scanner alerts (code-scanning + Dependabot), verify each on live origin/main, dedup against the existing issue backlog, cluster by rule, and file one detailed GitHub issue per verified (rule x repo) cluster. Use when: (1) asked to analyze many repos for security/quality and file a GitHub issue per distinct real finding, (2) triaging GitHub-hosted CodeQL/Semgrep/Trivy code-scanning and Dependabot alerts rather than free-form LLM code-reading, (3) filtering scanner false positives (vendored-dep CVEs, docs example keys, stale alerts) before filing, (4) needing the finding source to be the repo's own scanner alerts, not an LLM swarm's claims."
+category: tooling
+date: 2026-07-16
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags: []
+---
+
+# Scanner Alerts to GitHub Issues Pipeline
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-16 |
+| **Objective** | Analyze all repos for security & quality and file a detailed GitHub issue per distinct issue — using the disciplined, scanner-GROUNDED approach (the repo's own hosted scanner alerts as the finding source), not free-form LLM code-reading. |
+| **Outcome** | Successful cross-repo audit of 15 HomericIntelligence submodules: 11 verified, deduped issues filed after filtering scanner false positives (vendored-dep CVEs, docs example keys, stale alerts). |
+| **Verification** | verified-local (11 issues were actually filed and verified to exist; this is a process skill, not CI-gated) |
+
+## When to Use
+
+- You are asked to "analyze all repos for security & quality and file a detailed GitHub issue per distinct issue."
+- You want a scanner-GROUNDED audit — the finding SOURCE is the repo's own GitHub-hosted scanner alerts (CodeQL/Semgrep/Trivy/plugin-scanner SARIF via code-scanning, plus Dependabot), not an LLM reading code free-form.
+- You are triaging hosted code-scanning + Dependabot alerts across many repos and must dedup against an existing issue backlog before filing.
+- You need to filter the recurring scanner false-positive buckets (vendored-dep CVEs, docs example keys, stale-but-open alerts) before creating issues.
+- You want one issue per verified (rule x repo) cluster with note-level noise rolled up, not one issue per raw alert.
+
+This is distinct from `repo-audit-triage-fix-and-issue-workflow` (which triages `/repo-analyze-strict-full` SWARM output). There the finding source is an LLM swarm; here it is the repo's own hosted scanner alerts — a different search surface, so a different pipeline. See `[[repo-audit-triage-fix-and-issue-workflow]]` for the swarm-output variant.
+
+## Verified Workflow
+
+### Quick Reference
+
+Group alerts by rule+severity to see the real clusters before filing:
+
+```bash
+gh api --paginate "repos/<o>/<r>/code-scanning/alerts?state=open&per_page=100" | jq -s add > a.json
+jq -r 'group_by(.tool.name+"|"+.rule.id)[] | "\(length)x sec=\(.[0].rule.security_severity_level // "-") [\(.[0].tool.name)] \(.[0].rule.id)"' a.json | sort
+```
+
+### Pipeline
+
+#### 1. COLLECT — pull the repo's own open scanner alerts
+
+```bash
+gh api --paginate "repos/<owner>/<repo>/code-scanning/alerts?state=open&per_page=100"
+gh api --paginate "repos/<owner>/<repo>/dependabot/alerts?state=open&per_page=100"
+```
+
+- `code-scanning/alerts` covers CodeQL / Semgrep / Trivy / plugin-scanner SARIF uploads.
+- A `404 "no analysis found"` from `code-scanning/alerts` means the repo has NO code scanning
+  configured. That 404 IS a finding — especially for an externally-facing service.
+- Secret-scanning API is often disabled; don't block on it. The token needs only `repo` scope
+  for code-scanning + Dependabot.
+
+#### 2. VERIFY on LIVE origin/main
+
+A `path:line` in an alert is a CLAIM, not a fact. Fetch the current source and confirm the
+finding still reproduces:
+
+```bash
+gh api repos/<r>/contents/<path>?ref=HEAD
+```
+
+Roughly **13%** of findings don't survive this verify step (fixed-but-not-rescanned, moved code,
+or the flagged line is benign on inspection). Drop what doesn't reproduce.
+
+#### 3. DEDUP — against the existing issue backlog
+
+```bash
+gh issue list --repo <r> --state all --search "<rule/keywords>"
+```
+
+Skip anything already filed, including anything already covered by an existing audit taxonomy
+(for example `severity:*` or `audit-finding` labels). Search open AND closed.
+
+#### 4. CLUSTER + FILE — one issue per verified (rule x repo) cluster
+
+- File one issue per verified (rule x repo) cluster, listing every affected `path:line`.
+- AGGREGATE low-severity note-level noise into ONE rollup issue per repo — do not file per-note.
+- Confirm each created issue number from the `gh issue create` output. NEVER invent a `#N`.
+
+```bash
+gh issue create --repo <r> --title "..." --body "..." --label "..."
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Trust a HIGH `private-key` Trivy alert | Treated 5 HIGH private-key alerts in Odyssey as leaked secrets | The path was `/app/.pixi/.../site-packages/cryptography/docs/...` — example keys in the cryptography LIBRARY'S OWN DOCS inside a scanned container image, not a real secret leak | Check the path before trusting a private-key alert; example keys in a vendored library's docs are not a leak |
+| File all Trivy CVE alerts as repo bugs | Planned to file ~180 CVEs across repos as issues | They were in `usr/local/lib/.../node_modules/...` and `site-packages/...` — CONTAINER BASE-IMAGE + transitive deps, not declared deps; already tracked/allowlisted | Skip mass-filing base-image and transitive CVEs; only declared-dependency CVEs are actionable repo bugs |
+| File the dashboard path-injection finding | CodeQL still showed 7 open path-injection alerts, so planned to file them | The fix already landed (a closed-COMPLETED issue existed and `safe_path()` was on live main); the alerts were STALE, never re-scanned | Check close-state AND live source; distinguish a 'stale alert' from a 'live bug' before filing |
+| One issue per alert | Considered filing one GitHub issue per raw scanner alert | Would flood trackers with 100s of dupes — a repo already had a 'Close duplicate audit findings' cleanup issue | Cluster by rule, roll up note-level findings, and dedup against open + closed issues first |
+| Trust a sub-agent's claimed issue `#N` | Accepted a swarm agent's reported issue number to satisfy a `Closes-#N` policy | Swarm agents may fabricate issue numbers to satisfy the policy | Re-list `author:@me` and confirm each number actually exists after filing |
+
+## Results & Parameters
+
+### Collect / verify / dedup / file commands
+
+See the Pipeline above. Core loop per repo:
+
+```bash
+# COLLECT
+gh api --paginate "repos/<o>/<r>/code-scanning/alerts?state=open&per_page=100" | jq -s add > a.json
+gh api --paginate "repos/<o>/<r>/dependabot/alerts?state=open&per_page=100"
+# VERIFY
+gh api repos/<r>/contents/<path>?ref=HEAD
+# DEDUP
+gh issue list --repo <r> --state all --search "<rule/keywords>"
+# FILE (confirm the returned #N)
+gh issue create --repo <r> --title "..." --body "..." --label "..."
+```
+
+### Label mapping
+
+Map CodeQL severity to the repo's issue labels — but repos vary, so always check first:
+
+| CodeQL security severity | Issue label |
+| -------------------------- | ------------- |
+| critical | `critical` |
+| high | `severity:major` |
+| medium | `severity:minor` |
+
+Some repos lack a bare `security` label and use `section-8-security` instead. Run
+`gh label list --repo <r>` before `gh issue create` so the `--label` values exist.
+
+### Outcome (2026-07-16 cross-repo audit)
+
+15 repos surveyed → **11 verified, deduped issues filed**:
+
+| Repo | Issues |
+| ------ | -------- |
+| Odyssey | #5629, #5630, #5631 |
+| Nestor | #130, #131 |
+| Keystone | #612, #613 |
+| Agamemnon | #454 |
+| Hephaestus | #2255 |
+| Hermes | #723 |
+| Scylla | #2052 |
+
+The vendored-`_deps` CodeQL false-criticals were handled separately — see the
+`codeql-exclude-vendored-deps-false-criticals` skill.
+
+### Authoring notes
+
+- Escape literal `|` inside table cells as `\|`.
+- Run markdownlint locally before committing: `npx --yes markdownlint-cli2 --config .markdownlint.yaml skills/scanner-alerts-to-github-issues-pipeline.md`.
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

Ports two skills that were merged to the `mvillmow/Mnemosyne` fork into the canonical
upstream registry, where they belong. Both are new files (absent upstream).

- **scanner-alerts-to-github-issues-pipeline** (`tooling`) — collect a repo's own hosted
  scanner alerts (code-scanning + Dependabot) → verify each `path:line` on live `origin/main`
  → dedup vs open+closed issues → cluster by rule and file one issue per cluster (rollup
  note-level noise). Documents the recurring false-positive buckets: container base-image
  CVEs, cryptography-docs "private keys," and stale-alert-vs-already-closed-issue.
- **codeql-exclude-vendored-deps-false-criticals** (`ci-cd`) — CodeQL/Trivy analyze the
  vendored `build/**/_deps/` FetchContent/Conan tree, so upstream nats.c surfaces as a false
  "critical" `cpp/use-after-free` against your repo; fix via a `paths-ignore` config-file
  wired into every CodeQL `init` step.

## Verification Level

**verified-local** — both skills were validated (markdownlint 0 errors; `validate_plugins.py`
656/656 valid) and were already merged on the fork. Upstream `main` has no CI gate, so this
PR is not CI-verified either.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` → 656/656 valid
- [x] `markdownlint-cli2 --config .markdownlint.yaml` → 0 errors
- [x] Signed commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
