### PR TITLE
feat(skill): add odyssey-functional-optimizer-step-api

### DIFF
--- a/skills/odyssey-functional-optimizer-step-api.md
+++ b/skills/odyssey-functional-optimizer-step-api.md
@@ -1,0 +1,181 @@
+---
+name: odyssey-functional-optimizer-step-api
+description: "Use when: (1) calling any Odyssey exotic optimizer (ADOPT, Sophia, Adan, Muon-Hyperball, LionMuon, MGUP-Muon, SOAP, FTRL) from Mojo, (2) wiring a runtime --optimizer dispatch over several optimizers into a training loop, (3) resolving the import path for an optimizer (it is odyssey.training.optimizers.X, NOT odyssey.optimizers.X), (4) sizing per-parameter state buffers for one of these optimizers, (5) debugging wrong-arity or wrong tuple-unpack errors from a <name>_step call."
+category: optimization
+date: 2026-07-17
+version: "1.0.0"
+user-invocable: false
+tags:
+  - mojo
+  - odyssey
+  - optimizer
+  - functional-api
+  - adopt
+  - sophia
+  - adan
+  - muon
+  - lionmuon
+  - soap
+  - ftrl
+  - anytensor
+  - state-arity
+  - optimizer-dispatch
+---
+
+# Odyssey Functional Optimizer-Step API (Mojo)
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-17 |
+| **Category** | optimization |
+| **Language** | Mojo v1.0.0b2 |
+| **Objective** | Canonical reference for calling any of Odyssey's exotic optimizers from Mojo: the shared pure-functional `<name>_step(...)` contract, the correct import root, and a per-optimizer state-arity table so a caller can size state buffers and unpack the return tuple without a compile error. |
+| **Outcome** | Operational — signatures/paths/arities confirmed by direct source inspection at the pinned SHA. |
+| **Verification** | verified-local |
+| **Source dir** | `src/odyssey/training/optimizers/` at Odyssey SHA `00080fd85ab85fa90d6ba31917fda2ea85bb7513` |
+
+This generalizes [`optimizer-shampoo-matrix-form-api`](./optimizer-shampoo-matrix-form-api.md)
+(single-optimizer) to the whole exotic-optimizer family and pins the cross-cutting contract they
+all share. If you are working with Shampoo specifically, read that entry too — it carries the
+Newton-Schulz / eligibility detail this entry does not.
+
+## When to Use
+
+Use this skill when working with any Odyssey optimizer beyond plain SGD/Adam and any of these apply:
+
+1. Calling ADOPT, Sophia, Adan, Muon-Hyperball, LionMuon, MGUP-Muon, SOAP, or FTRL from Mojo.
+2. Building a runtime `--optimizer <name>` dispatch that routes one training step to any of them.
+3. Resolving the import path (the directory is under `training/`, not at the package root).
+4. Deciding how many per-parameter state buffers to allocate and in what order to pass them.
+5. Fixing a "wrong number of return values" / wrong tuple-index compile error from a step call.
+
+Do NOT rely on this for exact update math — read the source module's docstring for the algorithm.
+This entry pins the **calling contract** (path, signature shape, state arity), not the numerics.
+
+## Verified Workflow
+
+### Quick Reference
+
+| Fact | Value |
+| ---- | ----- |
+| **Import root** | `odyssey.training.optimizers.<name>` — **NOT** `odyssey.optimizers.<name>` |
+| **Function form** | pure free-function `def <name>_step(...)` + a defaulted `def <name>_step_simple(...)` |
+| **State ownership** | caller owns ALL state; nothing is stored on a struct — every buffer is passed in and a new one returned |
+| **Return** | `Tuple[new_params, ...new_state]` — same order as the state args in the signature |
+| **`_simple` variant** | same params/state args, hyperparameters dropped to their defaults (fewer keyword args to pass) |
+| **Param/grad dtype** | `AnyTensor`; scalars are `Float64`; step counters are `Int` |
+
+```mojo
+# CORRECT import (note the `.training.` segment)
+from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
+from odyssey.training.optimizers.soap import soap_step
+# WRONG — this path does not exist:
+# from odyssey.optimizers.adopt import adopt_step
+```
+
+### Per-optimizer state-arity table
+
+`state buffers` = AnyTensor buffers the caller must allocate (zeros/`full_like`) and thread across
+steps. `extra` = non-tensor per-step args beyond `(params, grads, ..., learning_rate)`. `returns` =
+tuple arity = `1 (params) + N state buffers`.
+
+| Optimizer | `<name>_step` state args (in order) | state buffers | extra step args | returns (arity) |
+| --------- | ----------------------------------- | :-----------: | --------------- | :-------------: |
+| **ADOPT** | `momentum, second_moment` | 2 | — | 3 |
+| **Sophia** | `momentum, hessian_moment` | 2 | (Hessian estimate maintained externally by caller) | 2 |
+| **Adan** | `exp_avg, exp_avg_diff, exp_avg_sq, prev_grad` | 4 | `step: Int` | 5 |
+| **Muon-Hyperball** | `momentum` | 1 | — | 2 |
+| **LionMuon** | `lion_momentum, muon_momentum` | 2 | `step_index: Int` | 3 |
+| **MGUP-Muon** | `momentum` | 1 | — | 2 |
+| **SOAP** | `exp_avg, exp_avg_sq, gg_left, gg_right, q_left, q_right` | 6 | `step: Int` (rank-2 params only) | 7 |
+| **FTRL** | `z, n` | 2 | — | 3 |
+
+Note Sophia returns a **2-tuple** `(new_params, new_momentum)` even though it takes a
+`hessian_moment` in — the Hessian buffer is caller-maintained across steps and passed through, not
+re-emitted by the step. Adan and SOAP take a 1-indexed `step: Int` that the caller increments
+**before** the call.
+
+### Exact signatures (source-verified at SHA 00080fd8)
+
+```mojo
+adopt_step(params, gradients, momentum, second_moment, learning_rate,
+           beta1=0.9, beta2=0.9999, epsilon=1e-6, clip_value=1.0e30, weight_decay=0.0)
+    -> Tuple[AnyTensor, AnyTensor, AnyTensor]                           # params, momentum, second_moment
+
+sophia_step(params, gradients, momentum, hessian_moment, learning_rate,
+            beta1=0.96, gamma=1.0, rho=0.04, epsilon=1e-12, weight_decay=0.0)
+    -> Tuple[AnyTensor, AnyTensor]                                      # params, momentum
+
+adan_step(params, gradients, exp_avg, exp_avg_diff, exp_avg_sq, prev_grad, step, learning_rate,
+          beta1=0.98, beta2=0.92, beta3=0.99, epsilon=1e-8, weight_decay=0.0)
+    -> Tuple[AnyTensor, AnyTensor, AnyTensor, AnyTensor, AnyTensor]     # params, exp_avg, exp_avg_diff, exp_avg_sq, prev_grad
+
+muon_hyperball_step(params, gradients, momentum, learning_rate,
+          weight_norm_max=1.0, update_norm_max=0.1, momentum_beta=0.95, weight_decay=0.01,
+          ns_steps=5, nesterov=True)
+    -> Tuple[AnyTensor, AnyTensor]                                      # params, momentum
+
+lionmuon_step(params, gradients, lion_momentum, muon_momentum, learning_rate, step_index,
+          period=4, lion_beta1=0.9, lion_beta2=0.99, muon_beta=0.95, weight_decay=0.0,
+          ns_steps=5, nesterov=True)
+    -> Tuple[AnyTensor, AnyTensor, AnyTensor]                           # params, lion_momentum, muon_momentum
+
+mgup_muon_step(params, gradients, momentum, learning_rate,
+          selected_fraction=0.25, select_scale=2.0, momentum_beta=0.95, weight_decay=0.01,
+          ns_steps=5, nesterov=True)
+    -> Tuple[AnyTensor, AnyTensor]                                      # params, momentum
+
+soap_step(params, gradients, exp_avg, exp_avg_sq, gg_left, gg_right, q_left, q_right, step, learning_rate,
+          beta1=0.95, beta2=0.95, shampoo_beta=0.95, weight_decay=0.01,
+          precondition_frequency=10, epsilon=1e-8, correct_bias=True)
+    -> Tuple[AnyTensor, AnyTensor, AnyTensor, AnyTensor, AnyTensor, AnyTensor, AnyTensor]
+       # params, exp_avg, exp_avg_sq, gg_left, gg_right, q_left, q_right  (rank-2 params only)
+
+ftrl_step(params, gradients, z, n, learning_rate,
+          alpha=0.1, beta=1.0, lambda1=0.0, lambda2=0.0)
+    -> Tuple[AnyTensor, AnyTensor, AnyTensor]                           # params, z, n
+```
+
+Every optimizer also exposes a `<name>_step_simple(params, gradients, <state...>, learning_rate[, step/step_index])`
+that takes only the state args + LR (+ the Int step counter where the full signature has one) and
+uses default hyperparameters — use it when you don't need to tune betas/decay.
+
+### Dispatch pattern (runtime `--optimizer <name>`)
+
+Because arities differ, a single dispatch cannot store one uniform state buffer. Allocate the max
+state set per parameter (or a per-optimizer state struct) and branch on the optimizer name, unpacking
+exactly the returned arity for that branch:
+
+```mojo
+if opt == "adopt":
+    var r = adopt_step(w, g, m, v, lr)
+    w = r[0]; m = r[1]; v = r[2]
+elif opt == "soap":
+    var r = soap_step(w, g, m, v, ggl, ggr, ql, qr, step, lr)
+    w = r[0]; m = r[1]; v = r[2]; ggl = r[3]; ggr = r[4]; ql = r[5]; qr = r[6]
+# ... one branch per optimizer, unpacking its exact arity from the table above
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| 1 | `from odyssey.optimizers.adopt import adopt_step` | The optimizers package lives under `training/`, not at the package root | Import root is `odyssey.training.optimizers.<name>` |
+| 2 | `grep '^fn <name>_step'` to find signatures | These are `def` functions, not `fn` — a `^fn` grep returns nothing | Grep for `def <name>_step` (Odyssey optimizers use `def`, and top-level, not indented) |
+| 3 | Unpacking Sophia's return as a 3-tuple by analogy with ADOPT | Sophia returns `(params, momentum)` — a 2-tuple; the caller-maintained `hessian_moment` is not re-emitted | Return arity ≠ input-state count for Sophia; use the per-optimizer table, don't assume symmetry |
+| 4 | Assuming every optimizer takes only `(params, grads, state..., lr)` | Adan/LionMuon/SOAP additionally take a 1-indexed `step`/`step_index: Int` incremented before the call | Check the "extra step args" column before wiring the dispatch |
+
+## Results & Parameters
+
+- **Import root:** `odyssey.training.optimizers.<name>` for all of adopt / sophia / adan /
+  muon_hyperball / lionmuon / mgup_muon / soap / ftrl (module basename == optimizer name).
+- **Contract:** pure functional, caller-owns-all-state, `Tuple[new_params, ...new_state]` in the same
+  order as the state args. `_simple` sibling for default-hyperparameter calls.
+- **State arities:** ADOPT 2 · Sophia 2 (return 2) · Adan 4 (+step) · Muon-Hyperball 1 ·
+  LionMuon 2 (+step_index) · MGUP-Muon 1 · SOAP 6 (+step, rank-2 only) · FTRL 2.
+- **Verified against:** Odyssey SHA `00080fd85ab85fa90d6ba31917fda2ea85bb7513`, files
+  `src/odyssey/training/optimizers/{adopt,sophia,adan,muon_hyperball,lionmuon,mgup_muon,soap,ftrl}.mojo`.
+  Dispatch wiring into a consumer training loop was not yet CI-verified at capture time — hence
+  `verified-local`, not `verified-ci`.


### PR DESCRIPTION
## Summary

New knowledge entry pinning the calling contract for Odyssey's exotic optimizers (ADOPT, Sophia, Adan, Muon-Hyperball, LionMuon, MGUP-Muon, SOAP, FTRL) from Mojo.

Generalizes the existing single-optimizer `optimizer-shampoo-matrix-form-api` to the whole family, and captures the cross-cutting facts a caller repeatedly gets wrong:

- **Import root** is `odyssey.training.optimizers.<name>` — NOT `odyssey.optimizers.<name>`.
- All are pure free-functions `<name>_step(...)` + defaulted `<name>_step_simple(...)`; caller owns all state; return is `Tuple[new_params, ...new_state]`.
- **Per-optimizer state-arity table** so buffers can be sized and the return tuple unpacked without a compile error: ADOPT 2 / Sophia 2 / Adan 4 (+step) / Muon-Hyperball 1 / LionMuon 2 (+step_index) / MGUP-Muon 1 / SOAP 6 (+step) / FTRL 2.

## Verification Level

**verified-local** — signatures, import paths, and return arities confirmed by direct source inspection at Odyssey SHA `00080fd85ab85fa90d6ba31917fda2ea85bb7513`. Dispatch wiring into a consumer training loop is not yet CI-verified.

## Key Findings

**What Worked**
- Reading each optimizer module's `def <name>_step` signature + return `Tuple[...]` directly.

**What Failed**
- `from odyssey.optimizers.X` → wrong path (package lives under `training/`).
- `grep '^fn <name>_step'` → returns nothing; these are `def`, not `fn`.
- Assuming Sophia returns a 3-tuple by analogy with ADOPT → it returns a 2-tuple (Hessian buffer is caller-maintained, not re-emitted).

## Test Plan

- [x] `python3 scripts/validate_plugins.py` → 655/655 valid
- [ ] Discovery via keywords (optimizer, adopt, soap, ftrl, dispatch)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>