### PR TITLE
feat: amend gha-release-package-workflow-patterns skill

### DIFF
--- a/skills/gha-release-package-workflow-patterns.history
+++ b/skills/gha-release-package-workflow-patterns.history
@@ -3,6 +3,43 @@
 
 This file preserves the full original content of the skills merged into this canonical.
 
+## v1.3.0 (2026-07-17)
+
+**Changed by:** Athena v0.3.0 protected-main release
+**Verification:** verified-ci
+
+### What changed
+
+- Added the verified protected-branch release sequence: signed manifest-bump PR, required PR
+  gate, merge-group success, detached `origin/main`, signed annotated tag, remote tag
+  verification, release-workflow watch, and release-asset readback.
+- Added fail-closed remote trust assertions: GitHub's tag ref must point to an annotated tag,
+  `verification.verified` must be true, and the embedded target SHA must be the queue-merged
+  protected-main commit.
+- Added the reusable-workflow permission rule: a called workflow cannot elevate the caller's
+  token, so a release caller must grant required policy reads such as `issues: read`.
+- Corrected the tag command to `git tag -s vX.Y.Z -m ...`; signing already creates an annotated
+  tag, so a redundant `-a` is unnecessary.
+
+### Why
+
+Local checks and a signed PR head alone do not prove the published tag identifies the commit that
+passed merge-queue integration, nor that GitHub accepted the annotation/signature or uploaded the
+expected release artifacts. The Athena v0.3.0 run proved every step in CI and supplied a reusable
+readback contract.
+
+### Previous version (v1.2.0) snapshot
+
+The exact pre-amendment content is preserved by immutable Git object
+`383bf4e:skills/gha-release-package-workflow-patterns.md` (the parent of this amendment branch).
+It is retrievable with:
+
+```bash
+git show 383bf4e:skills/gha-release-package-workflow-patterns.md
+```
+
+---
+
 ## v1.2.0 (2026-06-20)
 
 Release-notes extraction footer-bleed fix (verified-local). MINOR bump because it corrects

--- a/skills/gha-release-package-workflow-patterns.md
+++ b/skills/gha-release-package-workflow-patterns.md
@@ -1,10 +1,11 @@
 ---
 name: gha-release-package-workflow-patterns
-description: "Use when: (1) creating a tag-triggered release workflow with keepachangelog CHANGELOG format and semver version consistency checks across manifests, (2) implementing automated package building via GitHub Actions with artifact publication and GitHub Release creation, (3) adding pre-commit script validation of Python version drift between pyproject.toml classifiers and Dockerfile FROM line, (4) adding CI steps that replace fragile shell printf emoji byte-escape encoding with dedicated Python scripts for better portability."
+description: "Use when: (1) creating a tag-triggered release workflow with keepachangelog CHANGELOG format and semver version consistency checks across manifests, (2) implementing automated package building via GitHub Actions with artifact publication and GitHub Release creation, (3) cutting a protected-branch release through a merge queue and proving the remote signed tag and published assets, (4) adding pre-commit script validation of Python version drift between pyproject.toml classifiers and Dockerfile FROM line, (5) adding CI steps that replace fragile shell printf emoji byte-escape encoding with dedicated Python scripts for better portability."
 category: ci-cd
-date: 2026-06-20
-version: "1.2.0"
+date: 2026-07-17
+version: "1.3.0"
 user-invocable: false
+verification: verified-ci
 history: gha-release-package-workflow-patterns.history
 tags:
   - github-actions
@@ -18,6 +19,8 @@ tags:
   - ci-portability
   - release-automation
   - package-publishing
+  - merge-queue
+  - protected-main
 ---
 
 # GitHub Actions Release and Package Workflow Patterns
@@ -26,10 +29,10 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-06-20 |
-| **Objective** | Capture reusable GitHub Actions patterns for release and packaging automation: tag-triggered release workflows with keepachangelog CHANGELOG and cross-manifest semver consistency, package building with artifact publication and GitHub Release creation, pre-commit checks that catch Python version drift between `pyproject.toml` classifiers and the Dockerfile `FROM` line, and CI portability fixes that replace fragile shell `printf` emoji byte-escapes with dedicated Python scripts. |
-| **Outcome** | Operational across multiple repos — release.yml validates tag/CHANGELOG/manifest consistency before publishing; version-drift checks block silent mismatches; printf-emoji removal makes report-building locale-independent. v1.2.0 fixes a release-notes extraction bug where the end-anchor absorbed the CHANGELOG link-reference footer into the published release body (footer-bleed fix verified-local). |
-| **Verification** | verified-ci (footer-bleed fix verified-local) |
+| **Date** | 2026-07-17 |
+| **Objective** | Capture reusable GitHub Actions patterns for release and packaging automation: tag-triggered release workflows with cross-manifest semver consistency, package building with artifact publication and GitHub Release creation, and the protected-branch operational release path from a manifest-bump PR through merge-queue validation, signed-tag verification, and release-asset readback. |
+| **Outcome** | Operational across multiple repos — release.yml validates tag/manifest consistency before publishing; version-drift checks block silent mismatches; printf-emoji removal makes report-building locale-independent. Athena v0.3.0 additionally proved the protected-branch path end-to-end: required PR gate, synthetic merge-group gate, signed annotated tag on the merged commit, GitHub verification, and six release assets. |
+| **Verification** | verified-ci (the v1.2.0 footer-bleed fixture remains verified-local) |
 
 ## When to Use
 
@@ -37,6 +40,8 @@ tags:
 - CHANGELOG must transition from aspirational to dated release sections with the `[Unreleased]` convention.
 - CI must fail closed when a git tag does not match the version declared in all manifests (`pixi.toml`, `pyproject.toml`, `dagger/package.json`, etc.).
 - Release artifacts / packages need to be built and published to GitHub Releases on tag push.
+- A repository uses protected `main` and a merge queue, so a release tag must point to the **queue-merged** commit rather than a PR head SHA.
+- You need auditable proof that a release tag is annotated, GitHub-verified, targets protected `main`, and that the release actually contains its expected archive, SBOM, and checksum artifacts.
 - You are adding a Python version classifier to `pyproject.toml` and want to guard against the Dockerfile `FROM python:X.Y` line silently drifting.
 - A GitHub Actions workflow embeds emoji via `printf '\xf0\x9f...'` byte escapes in report-building steps and needs to be made locale/shell-independent.
 - A pre-commit hook should guard `pyproject.toml`, `docker/Dockerfile`, or version-bearing manifest changes before they reach `main`.
@@ -53,6 +58,9 @@ tags:
 | Package publish | `softprops/action-gh-release` after `validate` job | `publish` job `needs: validate` |
 | Release notes body | Python step regexes the dated CHANGELOG section into `RELEASE_NOTES` (end-anchor stops at next `## [`, the link-ref footer, or EOF) | `body: ${{ steps.notes.outputs.RELEASE_NOTES }}` (empty body = missing step; footer in body = missing `\n\[[^\]]+\]: ` anchor) |
 | Signed release tag | `git tag -s -a vX.Y.Z` + `git log --format='%h %G? %s'` | Every line shows `G` (good signature) |
+| Protected-branch release | Merge a signed manifest-bump PR through the queue; tag detached `origin/main` only after its `merge_group` run succeeds | The release tag points at the queue-merged commit, not the unmerged PR head |
+| Remote tag trust | GitHub `git/ref/tags` then `git/tags/<tag-object-sha>` API readback | `object.type == tag`, `verification.verified == true`, and `object.sha` is the intended `main` commit |
+| Published-release readback | `gh release view vX.Y.Z --json tagName,isDraft,isPrerelease,assets` | Non-draft, non-prerelease release with every expected archive/SBOM/checksum asset |
 | Python version drift | `scripts/check_python_version_consistency.py` | Highest `pyproject.toml` classifier == Dockerfile `FROM python:X.Y` |
 | CI emoji portability | `scripts/build_<report>.py` Python script | pytest asserts `b"\xf0\x9f"` not in output |
 
@@ -298,11 +306,11 @@ dispatch-contract-test:
 **6. Create the release tag *signed*, then verify the signature**
 
 Branch protection and the `mattlqx/pre-commit-sign` hook only cover commits — the release **tag**
-must also be signed, or the published release cannot be verified for authorship. Use `-s` (sign)
-together with `-a` (annotated):
+must also be signed, or the published release cannot be verified for authorship. Use `-s` (sign;
+it creates an annotated tag):
 
 ```bash
-git tag -s -a v0.1.0 -m "Release v0.1.0: initial versioned release"
+git tag -s v0.1.0 -m "Release v0.1.0: initial versioned release"
 git push origin v0.1.0
 ```
 
@@ -315,6 +323,48 @@ git log --format='%h %G? %s' | head -10
 
 `%G?` legend: `G` good, `B` bad, `U` good-but-unknown-validity, `N` no signature, `E` cannot
 check. Treat anything other than `G` as a failed release gate.
+
+#### A.7 Protected-branch release: merge queue, signed tag, and remote readback
+
+For a protected repository, the release is an operational sequence, not just a `git tag` command.
+Prepare the version values in **every shipped host manifest** on a signed, DCO-attested PR. Let
+the current-head required gate pass, enqueue it, and wait for a successful `merge_group` run.
+Only then fetch `main` and tag the queue-created commit. Do not tag the PR head: queue integration
+can create a distinct SHA.
+
+```bash
+# After the release-preparation PR has merged through the queue:
+git fetch origin main
+git switch --detach origin/main
+git status --short                         # expected: no output
+
+# Verify each release contract's source of truth before creating an irreversible tag.
+git show origin/main:.claude-plugin/plugin.json
+git show origin/main:.claude-plugin/marketplace.json
+git show origin/main:.codex-plugin/plugin.json
+
+# `-s` produces an annotated signed tag; explicitly name the verified main SHA.
+git tag -s vX.Y.Z -m "Project vX.Y.Z" origin/main
+git verify-tag --raw vX.Y.Z
+git push origin vX.Y.Z
+
+# GitHub must confirm this is an annotated tag whose signature is valid and whose
+# target is the intended queue-merged main commit.
+gh api repos/OWNER/REPO/git/ref/tags/vX.Y.Z
+gh api repos/OWNER/REPO/git/tags/<tag-object-sha>
+
+# Watch the tag-triggered workflow, then read back the published release and its assets.
+gh run watch <release-run-id> --repo OWNER/REPO --exit-status
+gh release view vX.Y.Z --repo OWNER/REPO --json tagName,targetCommitish,isDraft,isPrerelease,url,assets
+```
+
+The second API response must report `verification.verified: true`; its embedded `object.sha`
+must be the queue-merged `main` commit (not the annotated tag object SHA). The release readback
+must show `isDraft: false`, `isPrerelease: false`, and every expected archive/SBOM/checksum.
+
+If the release reuses a required workflow that consults issue-backed policy, grant its **caller**
+job the required read permission (for example, `issues: read`). A reusable workflow cannot elevate
+the caller token, so permissions declared only in the callee cannot repair a tag-time failure.
 
 #### B. Python version drift detection (pyproject.toml ↔ Dockerfile)
 
@@ -413,7 +463,10 @@ A pytest guard asserts the bytes are gone: `assert b"\xf0\x9f" not in out.read_b
 | Committing the new Python script once | Staged all files and ran `git commit` | ruff-format/ruff-check modified files and aborted the first commit (and an SQLite pre-commit lock briefly blocked the retry) | Re-stage the linter-modified files and commit again; retry clears the transient lock |
 | Leaving emoji in `comment-marker` YAML | Kept `"\U0001F4CA Test Metrics Report"` while making the file body plain text | The marker locates existing bot comments; a unicode escape is inconsistent with the new plain header | Set the marker to plain ASCII to match the script's header string |
 | Release published with empty notes | Wired only `tag_name` into `action-gh-release` and assumed it would pull notes from the CHANGELOG automatically | `softprops/action-gh-release` does not read CHANGELOG.md — with no `body`, the release notes are blank | Add an explicit extraction step (regex the dated section, escape `%`/`\n`/`\r` for `$GITHUB_OUTPUT`) and wire `body: ${{ steps.notes.outputs.RELEASE_NOTES }}` |
-| Pushing an unsigned (or lightweight) release tag | Ran `git tag v0.1.0` / `git tag -a v0.1.0` and pushed | The tag had no signature, so authorship could not be verified and `%G?` showed `N` | Sign the tag with `git tag -s -a vX.Y.Z -m "..."` and gate the release on `git log --format='%h %G? %s'` showing `G` |
+| Pushing an unsigned (or lightweight) release tag | Ran `git tag v0.1.0` / `git tag -a v0.1.0` and pushed | The tag had no signature, so authorship could not be verified and `%G?` showed `N` | Sign the tag with `git tag -s vX.Y.Z -m "..."` and gate the release on `git log --format='%h %G? %s'` showing `G` |
+| Tagging the release-preparation PR head | Treated the signed PR commit as the release commit before it passed the merge queue | A merge queue validates and lands a synthetic integration commit; the tag would not identify the exact protected-main commit that passed merge-group checks | Wait for PR merge, fetch `origin/main`, detach at that SHA, then create the signed tag there |
+| Trusting only local signature output | Ran `git verify-tag` and assumed the remote tag object had the same target and verification result | Local success does not prove the pushed ref is annotated, GitHub accepted the signature, or the tag points at the merged commit | Read back `git/ref/tags` and `git/tags/<tag-object-sha>`; require `type: tag`, `verification.verified: true`, and the expected commit SHA |
+| Omitting caller `issues: read` from a reusable release gate | The called required-check workflow read an active issue-backed vulnerability exception, but its release caller supplied only `contents: read` | Reusable workflows cannot raise their caller's token permissions, so the tag workflow fails before publication | Declare every required read scope, including `issues: read`, on the caller job and cover the workflow contract with a regression test |
 | Release notes absorbed the CHANGELOG link-footer | Extracted the dated section with end-anchor `(?=\n## \[\|$)` | For the top/most-recent dated section there is no next `## [` below it — only the keepachangelog link-reference footer — so `.*?` (re.DOTALL) ran to EOF and pulled `[Unreleased]: …/compare/…` and `[X.Y.Z]: …/releases/tag/…` into the published release body (verified-local: synthetic top-section fixture, old anchor → footer in body) | Extend the end-anchor to also stop at the first link-reference line: `(?=\n## \[\|\n\[[^\]]+\]: \|$)`; prove it with a synthetic top-section CHANGELOG fixture asserting `compare/`/`releases/tag/` are absent from the body |
 
 ## Results & Parameters
@@ -448,6 +501,15 @@ python3 scripts/check_python_version_consistency.py --repo-root /path/to/repo
 Regex patterns: `r"^\s*FROM\s+python:(\d+\.\d+)"` (IGNORECASE | MULTILINE) and `r"Programming Language :: Python :: (\d+\.\d+)$"`. Verified with 31 unit tests across 3 classes (classifier parsing, Dockerfile parsing, consistency check).
 
 **release.yml execution flow on `git push origin v0.1.0`:** GitHub detects the tag → `validate` job extracts version, checks tag format, verifies all manifests + CHANGELOG agree, runs regression tests → on success `publish` job creates the GitHub Release with notes from the CHANGELOG section → any failure stops the workflow.
+
+**Protected-main release evidence (verified-ci):** Athena v0.3.0 used a signed manifest PR
+([#46](https://github.com/HomericIntelligence/Athena/pull/46)) that passed the required PR gate
+and merge-group run before landing at `03590735aad37a2a97fe3a73278aa01a87022ed9`. Annotated tag
+object `2ed1659decd9458a9016b92f8a44227cbb991181` was GitHub-verified and targets that commit. The
+tag-triggered [Release run](https://github.com/HomericIntelligence/Athena/actions/runs/29613538587)
+passed trust verification, reusable required checks, package/SBOM generation, and publication.
+The release readback returned six uploaded assets: the plugin archive plus checksum and two SBOM
+formats plus their checksums.
 
 **Release-notes footer-bleed guard (verified-local):**
 
@@ -501,3 +563,4 @@ def test_no_emoji_byte_escapes(tmp_path: Path) -> None:
 | ProjectProteus | Issue #101 — first v0.1.0 release (commit 1c04a4a) | release.yml validates tag/manifest/CHANGELOG consistency; dispatch-contract-test job runs bash regression tests |
 | ProjectScylla | Issue #1168 / PR #1292 (follow-up from #1118) | Python version drift check; 31 new tests, 3615 total project tests passed |
 | ProjectOdyssey | Issue #3345 / PR #3977 | Replaced coverage.yml printf emoji byte-escape with `scripts/build_pr_comment.py`; 4 tests passed |
+| Athena | v0.3.0 / PR #46 | Protected-main release: signed manifest PR → successful merge group → signed annotated tag targeting `0359073` → GitHub signature verification → successful release with archive, SBOMs, and checksums |


### PR DESCRIPTION
## Summary

Amends gha-release-package-workflow-patterns from v1.2.0 to v1.3.0.

Documents the verified protected-main release path.

- Prepare release manifests in a signed PR and wait for merge-group success.
- Tag only the queue-merged main commit, then verify the remote annotated tag and GitHub signature.
- Read back the non-draft release and its archive, SBOM, and checksum assets.

## Verification Level

**verified-ci**

The Athena v0.3.0 release completed this workflow end to end. Mnemosyne marketplace validation also passed locally.

## Key Findings

**What Worked**:
- A signed manifest-bump PR merged through the queue before tag creation.
- GitHub API tag verification and release-asset readback provided durable publication evidence.

**What Failed**:
- Project metadata declares Python >=3.9 but pytest >=9 requires >=3.10; the validator ran successfully in a disposable environment containing its runtime PyYAML dependency.

## Test Plan

- [x] Run scripts/validate_plugins.py (656/656)
- [x] Pre-push test suite (218 passed)
- [x] Verify skill discovery with release, merge queue, and signed-tag keywords