### PR TITLE
feat: git-rebase-signing-ci v1.3.0 — merge queue makes re-signed rebase unnecessary

### DIFF
--- a/skills/git-rebase-signing-ci.history
+++ b/skills/git-rebase-signing-ci.history
@@ -1,5 +1,37 @@
 # git-rebase-signing-ci — History
 
+## v1.3.0 (2026-07-17)
+
+**Changed by:** HomericIntelligence/Athena PR #45 (pytest GHSA bump) merge — the repo has a
+GitHub **merge queue** enabled. A local re-signed rebase (`9b0f1fd`) was prepared to satisfy the
+strict up-to-date rule, but the merge queue rebuilt and merged the PR server-side (merge commit
+`93a2e7f`, GitHub-signed) and it landed MERGED before the re-signed branch was ever pushed.
+
+**Verification:** verified-ci (PR #45 observed MERGED via the queue, pytest 9.x on `main`, no
+author force-push)
+
+### What changed
+
+- New guidance: a real GitHub **merge queue** makes the local re-signed rebase + force-push cycle
+  UNNECESSARY. A green PR queued for merge is rebuilt on the current base and merged server-side
+  (merge-signed by GitHub), landing MERGED with no author push. Check
+  `gh pr view <N> --json state,mergeStateStatus` before starting any serial re-sign-rebase cycle.
+- Disambiguated the former "serial merge queue" bullet: it described the *no-queue* manual case
+  and was relabeled accordingly, with an explicit contrast bullet for the queue-enabled case.
+- New warning: the merge queue's transient head can show as unsigned (`N`) and carry extra
+  queue-machinery commits while processing — ephemeral queue state, not a signature failure to fix.
+- Description trigger (7) qualified with "and NO merge queue is enabled"; new trigger (9) for the
+  queue-enabled case; added a `When to Use` item, a Failed Attempts row, a Verified On row, and the
+  `merge-queue` tag.
+
+### Why
+
+v1.2.0 taught a strict serial local re-sign-rebase cycle for every open PR under up-to-date +
+signed protection, and metaphorically called that a "serial merge queue." That advice is wrong when
+the repo has an ACTUAL GitHub merge queue: the queue performs the up-to-date rebuild and the signed
+merge itself, so the manual rebase is wasted work. Athena PR #45 demonstrated this concretely —
+the queue merged it while a hand-prepared re-signed rebase sat unpushed.
+
 ## v1.2.0 (2026-07-16)
 
 **Changed by:** HomericIntelligence/Athena PRs #35/#36 merge sequence — a repo with

--- a/skills/git-rebase-signing-ci.md
+++ b/skills/git-rebase-signing-ci.md
@@ -1,13 +1,13 @@
 ---
 name: git-rebase-signing-ci
-description: "Rebase and sign commits to pass CI pr-policy checks. Use when: (1) CI pr-policy fails on unsigned commits, (2) need to re-sign all PR commits after rebase, (3) force push signed commits to update a PR, (4) a rebase using --exec stops on a real conflict and you need to resume it correctly instead of hand-invoking the exec command, (5) pr-policy fails with 'commit signature is missing or invalid' immediately after GitHub's Update branch button or gh pr update-branch --rebase — the server-side rebase re-creates every commit UNSIGNED, so never use it on a signed-commits repo, (6) git push --force-with-lease is rejected with 'stale info' after a server-side branch update — fetch the branch to refresh the remote-tracking ref, verify the remote head is the expected rewrite, then push, (7) branch protection requires strictly up-to-date branches AND signed commits — every merge to main invalidates sibling PRs and each needs its own local re-signed rebase + force-push, one PR per cycle (server-side update is never usable), (8) a stacked PR's base branch was squash-merged — rebase with git rebase --onto origin/main <old-base-head> to shed the base's commits before pushing."
+description: "Rebase and sign commits to pass CI pr-policy checks. Use when: (1) CI pr-policy fails on unsigned commits, (2) need to re-sign all PR commits after rebase, (3) force push signed commits to update a PR, (4) a rebase using --exec stops on a real conflict and you need to resume it correctly instead of hand-invoking the exec command, (5) pr-policy fails with 'commit signature is missing or invalid' immediately after GitHub's Update branch button or gh pr update-branch --rebase — the server-side rebase re-creates every commit UNSIGNED, so never use it on a signed-commits repo, (6) git push --force-with-lease is rejected with 'stale info' after a server-side branch update — fetch the branch to refresh the remote-tracking ref, verify the remote head is the expected rewrite, then push, (7) branch protection requires strictly up-to-date branches AND signed commits and NO merge queue is enabled — every merge to main invalidates sibling PRs and each needs its own local re-signed rebase + force-push, one PR per cycle (server-side update is never usable), (8) a stacked PR's base branch was squash-merged — rebase with git rebase --onto origin/main <old-base-head> to shed the base's commits before pushing, (9) a GitHub merge queue IS enabled — do NOT prepare a local re-signed rebase + force-push cycle at all; a green PR queued for merge is rebuilt and merged server-side (merge-signed by GitHub) and lands MERGED without any author force-push, so check pr state before rebasing."
 category: tooling
-date: 2026-07-16
-version: "1.2.0"
+date: 2026-07-17
+version: "1.3.0"
 user-invocable: false
 verification: verified-ci
 history: git-rebase-signing-ci.history
-tags: [git, signing, rebase, ci, gpg, exec, conflict-resolution, update-branch, force-with-lease, stale-info, branch-protection, up-to-date, stacked-pr, squash-merge]
+tags: [git, signing, rebase, ci, gpg, exec, conflict-resolution, update-branch, force-with-lease, stale-info, branch-protection, up-to-date, stacked-pr, squash-merge, merge-queue]
 ---
 
 # Git Rebase Signing for CI
@@ -34,8 +34,10 @@ tags: [git, signing, rebase, ci, gpg, exec, conflict-resolution, update-branch, 
 - `pr-policy` fails with `commit signature is missing or invalid` right after the PR branch was
   updated via GitHub's **Update branch** button or `gh pr update-branch --rebase`
 - `git push --force-with-lease` is rejected with `stale info` after a server-side branch update
-- The repository requires strictly up-to-date branches AND signed commits, and several PRs must
-  merge in sequence
+- The repository requires strictly up-to-date branches AND signed commits, no merge queue is
+  enabled, and several PRs must merge in sequence
+- A GitHub merge queue IS enabled — before preparing any re-signed rebase, confirm the PR is not
+  simply queueable (the queue makes the local rebase unnecessary)
 - A stacked PR's base branch was squash-merged and the branch now shows CONFLICTING
 
 ## Verified Workflow
@@ -123,10 +125,20 @@ git push --force-with-lease --force-if-includes origin <branch>
   longer matches the remote, and `--force-with-lease` (correctly) refuses. Fetch the branch,
   confirm the remote head is exactly the known server-side rewrite (not someone else's work),
   then push again.
-- **Strict up-to-date + signed commits = serial merge queue:** each merge advances `main` and
-  flips every sibling PR to BEHIND, and the server-side updater is unusable, so each PR needs its
-  own local re-signed rebase, force-push, and full CI cycle — plan merges one at a time and
-  rebase the NEXT PR only after the previous one lands.
+- **Strict up-to-date + signed commits, NO merge queue = manual serial merges:** each merge
+  advances `main` and flips every sibling PR to BEHIND, and the server-side updater is unusable, so
+  each PR needs its own local re-signed rebase, force-push, and full CI cycle — plan merges one at a
+  time and rebase the NEXT PR only after the previous one lands. This is the *no-queue* case; if a
+  real GitHub merge queue is enabled, do the opposite (next bullet).
+- **A real GitHub merge queue makes the local re-signed rebase UNNECESSARY:** when the repo has a
+  merge queue enabled (branch protection "Require merge queue" / a `merge_group`-triggered required
+  workflow), a green PR does NOT need to be brought up-to-date by hand. Queue it and the queue
+  rebuilds the branch on the current base and merges it **server-side**, signing the resulting merge
+  with GitHub's key — the PR lands MERGED with no author force-push. So before starting the
+  serial re-sign-rebase cycle above, check `gh pr view <N> --json state,mergeStateStatus`: if the
+  PR is already MERGED or is queueable, skip the rebase entirely. Note the queue's transient head
+  can appear unsigned (`N`) and carry extra queue-machinery commits while it processes — that is
+  ephemeral queue state, not the final signed merge commit, and it is not a signature failure to fix.
 - **Stacked PR whose base was squash-merged:** the branch still carries the base's original
   commits (now absent from `main`'s history), so it shows CONFLICTING. Shed them with
   `git rebase --onto origin/main <old-base-head> <branch>`, then re-verify signatures and push.
@@ -139,6 +151,7 @@ git push --force-with-lease --force-if-includes origin <branch>
 | `git push --force` | Force push without lease check | Could overwrite remote changes from other collaborators | Use `--force-with-lease` for safety |
 | `gh pr update-branch --rebase` to satisfy a strict up-to-date branch-protection rule | Server-side rebase to bring two green PRs current with main | GitHub re-created every commit unsigned; the previously-green signed-commits `pr-policy` gate failed on both PRs with `commit signature is missing or invalid` | Never update a signed-commits PR server-side; do a local `git -c commit.gpgsign=true rebase origin/main` and force-push with lease |
 | `git push --force-with-lease` immediately after a server-side branch update | Pushing the locally re-signed rebase over the server-side rewrite | Rejected with `stale info` — the local remote-tracking ref predated the server-side rewrite, so the lease check failed | Fetch the branch first, verify the remote head is the expected rewrite, then push; the rejection is the lease working as designed |
+| Preparing a local re-signed rebase + user force-push cycle for a green PR on a repo with a merge queue enabled | Rebased the branch onto the new `main`, re-signed, ran full local gates, and waited on a user force-push to satisfy the strict up-to-date rule before merging | Unnecessary work: the merge queue rebuilt and merged the PR server-side (GitHub-signed merge commit) and it landed MERGED while the re-signed branch was still waiting to be pushed — the whole rebase cycle was moot | On a merge-queue repo, check `gh pr view <N> --json state,mergeStateStatus` first; if queueable, just let the queue merge it — do NOT prepare a serial re-sign-rebase cycle. The queue absorbs the up-to-date requirement itself |
 | Hand-invoking the queued `--exec` command (`git add <file>` then `git commit --amend --no-edit -s -S`) after resolving a conflict, instead of `git rebase --continue` | Rebase paused mid-conflict showing "Next command to do: exec ..."; resolved the conflict then manually replicated the exec command to "help it along" | The conflicted commit had not yet been finalized as a commit object — `git rebase` was still mid-`pick`. `git commit --amend` amended the rebase's "onto" checkout (base branch tip, which was HEAD at that moment) instead of the picked change, producing a corrupted commit whose diff was the union of an unrelated upstream commit's changes plus the PR's own changes, under the wrong commit message/title. Diagnosed via `git reflog` showing `rebase (start): checkout <base>` immediately followed by `commit (amend): <wrong title>` with no intervening pick entry, plus `git diff <merge-base> <bad-commit> --stat` showing far more files than the original commit's own `git show <sha> --stat` | Always run `git rebase --continue` after resolving a conflict, even when the rebase reports a queued `exec` line next — never hand-invoke the exec command yourself. If already corrupted: recover via `git reset --keep <pre-rebase-sha>` + `git rebase --quit` (when `--abort` is blocked), then redo as a plain rebase followed by one standalone amend pass |
 
 ## Results & Parameters
@@ -158,3 +171,4 @@ git push --force-with-lease --force-if-includes origin <branch>
 | example-org/inference-service | PR #82 — Move inference_service module | Commits signed for pr-policy compliance |
 | HomericIntelligence/ProjectHephaestus | PR #2099 — branch `2053-auto-impl`, rebase onto ~38 new commits with one real conflict; `--exec` hand-invocation corrupted a commit by merging in an unrelated upstream commit's diff; recovered via `reset --keep` + `rebase --quit`, redone as plain rebase + standalone amend | verified-local (not yet confirmed in this skill PR's own CI) |
 | HomericIntelligence/Athena | PRs #35/#36 — `gh pr update-branch --rebase` stripped signatures on both (pr-policy red with `commit signature is missing or invalid`); recovered with local `git -c commit.gpgsign=true rebase origin/main` + lease push after a branch fetch (first push rejected `stale info`); #35 re-merged green | verified-ci (pr-policy observed red on the server-side rewrite and green on the re-signed heads) |
+| HomericIntelligence/Athena | PR #45 — pytest GHSA bump; a local re-signed rebase (`9b0f1fd`) was prepared for the strict up-to-date rule, but the repo's merge queue rebuilt and merged the PR server-side (merge commit `93a2e7f`, GitHub-signed) and it landed MERGED before the re-signed branch was pushed — proving the merge queue makes the manual re-sign-rebase cycle unnecessary | verified-ci (PR observed MERGED via the queue with pytest 9.x on `main`, no author force-push) |


### PR DESCRIPTION
## Summary

Amends `git-rebase-signing-ci` (v1.2.0 → **v1.3.0**) to correct a wrong-in-context instruction: v1.2.0 taught a strict serial local re-signed rebase + force-push cycle for every open PR under up-to-date + signed branch protection, and metaphorically called that a "serial merge queue." That advice is **wrong when the repo has an actual GitHub merge queue** — the queue rebuilds the branch on the current base and merges it server-side (GitHub-signed), so the manual rebase is wasted work.

## What changed

- Disambiguated the former "serial merge queue" bullet as the *no-queue* manual case.
- Added a contrast bullet: a real merge queue makes the local re-signed rebase **unnecessary** — check `gh pr view <N> --json state,mergeStateStatus` before starting any serial re-sign-rebase cycle.
- Warned that the queue's transient head can appear unsigned (`N`) with extra queue commits — ephemeral state, not a signature failure to fix.
- Qualified description trigger (7) with "and NO merge queue is enabled"; added trigger (9), a When to Use item, a Failed Attempts row, a Verified On row, and the `merge-queue` tag.

## Verification

verified-ci — Athena PR #45 (pytest GHSA bump) landed **MERGED** via the queue (merge commit `93a2e7f`, pytest 9.x on `main`) while a hand-prepared re-signed rebase (`9b0f1fd`) sat unpushed, proving the queue makes the manual cycle moot.

Local: `just check` -> 666/666 skills valid, 218 tests passing.

Signed + DCO-attested commit.