### PR TITLE
feat(skills): loop templates-crash packaging guard + session cwd-mismatch recurrence

### DIFF
--- a/skills/automation-session-naming-pr-scoped-not-commit-scoped.history
+++ b/skills/automation-session-naming-pr-scoped-not-commit-scoped.history
@@ -1,5 +1,18 @@
 # automation-session-naming-pr-scoped-not-commit-scoped — History
 
+## v1.2.0 (2026-07-18)
+
+**Changed by:** Session analyzing a ProjectHephaestus automation-loop run's on-disk session transcripts, which showed cause-2 (cwd mismatch) recurring at a call-site family the PR #1100 fix did not cover.
+**Verification:** verified-local — 19 same-artifact sessions found written twice under two cwd-encoded project dirs (~940K redundant re-sent tokens); root cause confirmed in code (`agent_stage.py:92,121` `cwd=repo_root` vs pipeline stages `cwd=<worktree>`; probe `claude_invoke.py:307`). Fix tracked in Hephaestus #2284.
+
+### What changed
+- Added a When-to-Use trigger: DIFFERENT invocation helpers disagreeing on `cwd` for the same session key fork the session family; audit ALL invoker call sites, not one.
+- Added a Verified-On row documenting the 2026-07-17 recurrence with the exact divergent call sites, the on-disk duplicate-transcript evidence, and the token-waste floor.
+- Bumped 1.1.0 -> 1.2.0.
+
+### Why
+v1.1.0 fixed the cwd invariant for the advise/implement two-turn pattern (PR #1100) but the same class of bug reappeared where a *shared* agent-invocation helper (`agent_stage`) uses `repo_root` while the pipeline stages use the worktree. The lesson generalizes: the cwd invariant must hold across EVERY caller of the session invoker, and the audit must enumerate all call sites.
+
 ## v1.1.0 (2026-06-08)
 
 **Changed by:** PR #1100 — advise session isolation bug-fix (ProjectHephaestus)

--- a/skills/automation-session-naming-pr-scoped-not-commit-scoped.md
+++ b/skills/automation-session-naming-pr-scoped-not-commit-scoped.md
@@ -2,8 +2,8 @@
 name: automation-session-naming-pr-scoped-not-commit-scoped
 description: "When an automation loop drives a long-lived artifact (issue / PR) with short-lived Claude sessions via `claude --resume <session_id>`, the deterministic session id MUST be scoped to the artifact, not to the live trunk commit. Silent session recreation has two independent causes: (1) id-scope drift — tuple includes `githash` so every main-bump mints a new UUID the wrapper cannot resume; (2) cwd mismatch — `invoke_claude_with_session` determines create-vs-resume by checking `transcript = session_jsonl_path(sid, cwd); should_resume = transcript.exists()`, so if turn 1 and turn 2 use different `cwd` values the transcript resolves to a non-existent path and the second turn silently creates a fresh session. Fix (1): drop `githash` from the session-name tuple. Fix (2): all turns in a multi-turn session MUST pass the same `cwd`. Also covers: advise-as-first-implementer-turn two-turn pattern; marketplace-path relativization bug when `cwd=worktree_path`. Use when: session resume silently fails, an agent starts fresh each iteration, implementing multi-turn session patterns with advise + implementation turns."
 category: architecture
-date: 2026-06-08
-version: "1.1.0"
+date: 2026-07-18
+version: "1.2.0"
 user-invocable: false
 history: automation-session-naming-pr-scoped-not-commit-scoped.history
 tags:
@@ -50,6 +50,7 @@ Use this skill when any of the following apply:
 - You are auditing the call graph of an automation pipeline and notice **only some** of the agent invocation sites pass a `githash` (any subset is wrong — a partial removal forks the session family at the boundary between updated and not-updated callers).
 - You are implementing a **two-turn session pattern** where turn 1 is an advise/context-gathering step and turn 2 is the main implementation, and you want both to share the same transcript.
 - A **path-relativization helper** is called with `repo_root` but the session runs with `cwd=worktree_path` — paths outside the worktree become incorrect relative paths.
+- **DIFFERENT invocation helpers disagree on `cwd` for the SAME session key**: one family of call sites passes `cwd=repo_root`, another passes `cwd=worktree`. The create-vs-resume probe is `create = not session_jsonl_path(sid, cwd).exists()`, so a session created under one cwd is probed under the other, `.exists()` is False, and turn 2 silently re-creates. **Audit ALL call sites of the invoker, not one** — a single divergent family (e.g. a shared `agent_stage`/`run_direct_agent` helper vs the per-stage pipeline calls) forks the whole session family.
 
 ## Verified Workflow
 
@@ -277,3 +278,4 @@ hephaestus/automation/<wrapper>.py
 | --------- | --------- | --------- |
 | ProjectHephaestus | PR #845 closes #841 — session-naming fix (id-scope) | `session_name` and `session_uuid` lost `githash`; `invoke_claude_with_session` lost the matching kwarg; 8 callers updated in lockstep. Regression test uses `**bad_kwargs` unpacking. PR merged via CI. |
 | ProjectHephaestus | PR #1100 — advise session isolation + cwd invariant + marketplace-path fix | Two-turn advise-as-implementer-turn pattern; cwd=worktree_path enforced for both turns; `repo_root=str(worktree_path)` passed to `get_advise_prompt`; Codex guard preserved. 1303 tests pass; pre-commit hooks clean. |
+| ProjectHephaestus | 2026-07-17 run — cause-2 RECURRENCE at a NEW call-site family | On-disk proof: 19 same-artifact sessions written twice under two cwd-encoded project dirs (e.g. `Hephaestus_2164_pr-reviewer_fable` = 150KB under the repo-root dir + 143KB under the `issue-2164` worktree dir), ~940K redundant re-sent tokens. Cause: `agent_stage.py:92,121` (`run_agent_stage`/`run_direct_agent`) pass `cwd=repo_root` while every pipeline stage (`planning.py:289,313`, `implementation.py:394+`, `plan_review`, `pr_review`, `ci.py:551`, `merge_wait.py:440`) passes `cwd=<worktree>`; probe is `claude_invoke.py:307`. Session *id* was correct (no SHA drift). Fix direction: make `agent_stage` use the worktree cwd to match the pipeline convention. Tracked Hephaestus #2284. |

--- a/skills/python-packaging-pyproject-editable-install.history
+++ b/skills/python-packaging-pyproject-editable-install.history
@@ -1,6 +1,21 @@
 <!-- markdownlint-disable MD024 -->
 # Change History: python-packaging-pyproject-editable-install
 
+## v1.1.0 (2026-07-18)
+
+**Changed by:** Session triaging a 2.25h ProjectHephaestus automation-loop run that produced 0 commits/0 PRs — every agent prompt render crashed in `jinja2.PackageLoader` because the running checkout had the prompt-catalog code but not its committed `templates/*.j2` data tree.
+**Verification:** verified-local — root cause confirmed on disk (`origin/main` has 55 committed templates; the running off-`main` checkout had 0) and against the run log (172 identical `PackageLoader could not find 'templates/default'` errors); the two guards (package-data ship-test + startup preflight) are recommended, tracked in Hephaestus #2283.
+
+### What changed
+- Added subsection **2b. Runtime DATA files missing from the checkout the code runs against**: an importable-but-resource-less package (Jinja templates / packaged resources absent) crashes at runtime; declare the data as package data AND add a fail-fast startup preflight; includes the sdist content-test pattern and the on-disk detection commands.
+- Added a When-to-Use trigger (6/7) for `PackageLoader`/`importlib.resources` "could not find" runtime failures and no-op agent runs from a missing resource.
+- Added a Failed Attempts row for running the loop against the resource-less package.
+- Noted the related classifier smell: an infra "cannot build a prompt" error must not be routed to `finished(fail)` as agent *poison*.
+- Bumped 1.0.0 -> 1.1.0; tags += package-data, jinja-templates, packageloader, importlib-resources, runtime-resource-missing, startup-preflight, fail-fast.
+
+### Why
+v1.0.0 covered stale *console scripts* after an editable install, but not the distinct failure where the code is importable yet its runtime DATA files are missing — which silently burned a multi-hour agent run. Both share the intent "the install/checkout doesn't actually contain what the running code needs," so this is the correct home.
+
 ## v1.0.0 (2026-06-07)
 
 Consolidated 4 overlapping pyproject.toml-centric packaging skills into this general canonical:

--- a/skills/python-packaging-pyproject-editable-install.md
+++ b/skills/python-packaging-pyproject-editable-install.md
@@ -1,9 +1,9 @@
 ---
 name: python-packaging-pyproject-editable-install
-description: "Use when: (1) migrating a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags, (2) a newly-merged [project.scripts] entry yields 'command not found' after git pull because the editable install is stale — re-run 'pixi run dev-install' or 'pip install -e .', (3) a console-script sweep needs to enumerate [project.scripts] in pyproject.toml rather than grep for 'def main' (misses *_main-suffixed callables), (4) migrating from pytest-watch to pytest-watcher to drop the unmaintained docopt transitive dependency, (5) shipping a Python package to PyPI with hatchling/hatch-vcs/pixi.lock and configuring trusted-publishing."
+description: "Use when: (1) migrating a Python project from hardcoded version in pyproject.toml to hatch-vcs dynamic versioning from git tags, (2) a newly-merged [project.scripts] entry yields 'command not found' after git pull because the editable install is stale — re-run 'pixi run dev-install' or 'pip install -e .', (3) a console-script sweep needs to enumerate [project.scripts] in pyproject.toml rather than grep for 'def main' (misses *_main-suffixed callables), (4) migrating from pytest-watch to pytest-watcher to drop the unmaintained docopt transitive dependency, (5) shipping a Python package to PyPI with hatchling/hatch-vcs/pixi.lock and configuring trusted-publishing, (6) code imports a package that loads NON-.py DATA FILES at runtime (Jinja templates, JSON/YAML resources) via importlib.resources / jinja2.PackageLoader and it raises 'could not find a <dir> directory in the <pkg> package' / FileNotFoundError because the data tree is present in the repo but MISSING from the checkout/build the code runs against, (7) a long automation/agent run does a large amount of no-op work because a required runtime resource was absent and nothing failed fast — add a startup preflight."
 category: tooling
-date: 2026-06-07
-version: "1.0.0"
+date: 2026-07-18
+version: "1.1.0"
 user-invocable: false
 history: python-packaging-pyproject-editable-install.history
 tags:
@@ -25,6 +25,13 @@ tags:
   - trusted-publishing
   - pixi
   - pytest-watcher
+  - package-data
+  - jinja-templates
+  - packageloader
+  - importlib-resources
+  - runtime-resource-missing
+  - startup-preflight
+  - fail-fast
 ---
 
 # Python Packaging: pyproject.toml, hatch-vcs, and Editable Installs
@@ -230,6 +237,78 @@ NEW=$(python -c "import hephaestus; print(hephaestus.__version__)")  # 0.9.3.dev
 
 **Diff-trigger heuristic** — re-run `dev-install` after a pull whenever the `pyproject.toml` diff touches any of: `[project.scripts]` (new entry-point stubs), `[project.optional-dependencies]`, `[project.dependencies]`, `[tool.hatch.build.hooks.vcs]` / `version-file`, or any `[build-system]` change. Cost: a few seconds vs. minutes of "command not found" debugging.
 
+#### 2b. Runtime DATA files (templates/resources) missing from the checkout the code runs against
+
+A package can be **importable** yet **broken at runtime** because its non-`.py`
+data tree (Jinja templates, packaged JSON/YAML) is absent from the tree the code
+actually executes against. Verified failure (ProjectHephaestus, 2026-07-17): a
+2.25h `hephaestus-automation-loop` run produced **0 commits / 0 PRs** because
+`hephaestus.prompts.catalog` (a `jinja2.PackageLoader(..., "templates/default")`)
+raised on **every** agent-prompt render — plan, implement, review, AND the
+`commit_push` commit-message generation — **172 times**:
+
+```text
+ValueError: PackageLoader could not find a 'templates/default' directory
+in the 'hephaestus.prompts' package.
+```
+
+**Why it happened:** the loop ran from a checkout at an off-`main` WIP commit that
+had the catalog `catalog.py` **code** but **zero committed** `templates/*.j2`
+files (a stray `hephaestus/prompts/__pycache__/` made the module importable with
+no templates). `origin/main` had all 55 templates committed. Downstream symptoms
+MASKED the cause: "no commits vs base → state:skip", "poisoned at implementation",
+and reviewer "zero-thread NOGO" were all consequences, not the disease.
+
+**Two independent guards — do BOTH:**
+
+1. **Declare the data as package data** so an installed/built artifact can never
+   be resource-less. With hatchling, `[tool.hatch.build.targets.wheel]
+   packages = ["<pkg>"]` includes non-`.py` files under the package, but ADD an
+   sdist/wheel content test that asserts the data ships:
+
+```python
+# tests/integration/test_sdist_contents.py style — fail if templates are dropped
+import tarfile, subprocess, glob
+subprocess.run(["python", "-m", "build", "--sdist", "--no-isolation"], check=True)
+sdist = sorted(glob.glob("dist/*.tar.gz"))[-1]
+names = tarfile.open(sdist).getnames()
+assert any(n.endswith("prompts/templates/default/implementation/implementation.j2")
+           for n in names), "prompt templates missing from sdist"
+```
+
+2. **Fail fast with a startup preflight** — a long agent/automation run must NOT
+   dispatch work when a required runtime resource is absent. Render one prompt (or
+   probe the resource) BEFORE the first job; abort with a clear remediation:
+
+```python
+def preflight_prompt_catalog() -> None:
+    """Abort fast if the prompt templates are missing (packaging regression)."""
+    try:
+        from mypkg.prompts.catalog import current
+        current()  # constructs the PackageLoader -> raises here if templates absent
+    except Exception as exc:
+        raise SystemExit(
+            f"prompt templates unavailable ({exc}); the checkout/install is "
+            f"missing package data - run `uv sync` (or reinstall) and retry"
+        ) from exc
+```
+
+**Detect it after the fact:** grep the run log for a single repeated
+resource-loader error (`PackageLoader could not find`, `FileNotFoundError`,
+`importlib.resources`), then confirm on disk that the data tree is absent from
+the RUNNING checkout while present on `main`:
+
+```bash
+git ls-tree -r origin/main --name-only | grep -c '<pkg>/prompts/templates/'   # e.g. 55
+find <running-checkout>/<pkg>/prompts/templates -name '*.j2' | wc -l          # 0 == broken
+git -C <running-checkout> rev-parse --short HEAD    # is it even an on-main commit?
+```
+
+The classifier bug (an infra "cannot build a prompt" routed to `finished(fail)`
+as if the work item were *poison*) is a related smell: distinguish "the harness
+could not build a prompt" from "the agent produced bad output" so a packaging
+regression fails fast instead of silently burning items.
+
 #### 3. Enumerate `[project.scripts]` — do NOT `grep '^def main'`
 
 `grep -rln '^def main'` only finds entry points named `module:main`. It silently misses suffixed callables like `check_version_consistency_main`, `bench_precommit_main`, `validate_agents_main`. In one verified session this missed **10 of 41 console_scripts (24%)**. Suffixed names are correct and idiomatic — a module can host several CLIs (e.g. `validation/markdown.py` exposes both `main` and `check_readmes_main`).
@@ -305,6 +384,7 @@ Wheel-only build: add `[tool.hatch.build] targets = ["wheel"]` ABOVE the `[tool.
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --------- | --------------- | --------------- | ---------------- |
+| Ran the loop against an importable-but-resource-less package | Launched `hephaestus-automation-loop` from a checkout whose `prompts` package had `catalog.py` but no committed `templates/*.j2` (only `__pycache__`) | `jinja2.PackageLoader(..., "templates/default")` raised on every prompt render — 172x — so 0 commits/PRs across a 2.25h run; symptoms ("no commits->skip", "poisoned") masked the cause | Declare runtime data as package data + ship-test it; add a startup preflight that renders one prompt and aborts fast; verify the running checkout has the data tree (and is an on-`main` commit) before launching |
 | Use the **import name** with `importlib.metadata.version()` | `__version__ = _pkg_version("hephaestus")` when the distribution is `HomericIntelligence-Hephaestus` | `PackageNotFoundError`: the lookup is a PEP 503 normalized match against installed `*.dist-info`; there is no `hephaestus-*.dist-info`. `__version__` silently becomes `"unknown"` | `importlib.metadata.version()` requires the **distribution name** (literal `[project].name`), not the import package directory name |
 | Parse `pyproject.toml` for `[project].version` in a drift check | `tomllib.load(...)["project"]["version"]` after the migration | `KeyError` — once `dynamic = ["version"]` is set, `[project].version` no longer exists; hatch-vcs removes it | Derive the canonical version from `git describe --tags --abbrev=0 --match 'v[0-9]*'` with `importlib.metadata` fallback |
 | Add `hatch-vcs` to `pixi.toml [pypi-dependencies]` | `hatch-vcs = ">=0.4.0,<1"` under `[pypi-dependencies]` | Unnecessary; pip resolves it from `[build-system].requires`. Adds lockfile noise | `hatch-vcs` is build-time only — declare it in `[build-system].requires` only |


### PR DESCRIPTION
## Summary

Two verified lessons from the 2026-07-17 ProjectHephaestus automation-loop run that produced **0 commits / 0 PRs** over 2.25h.

**`python-packaging-pyproject-editable-install` → v1.1.0** (+history): new subsection **2b** — a package can be importable yet broken at runtime because its non-`.py` DATA tree (Jinja templates via `PackageLoader`, packaged resources) is missing from the checkout the code runs against. The loop crashed **172×** on `PackageLoader could not find 'templates/default'`; symptoms ("no commits → skip", "poisoned") masked the cause. Two guards: declare + ship-test the package data (sdist content test), and add a fail-fast startup preflight that renders one prompt before dispatching work. Root cause confirmed on disk (main has 55 committed templates; the running off-`main` checkout had 0). Tracked in Hephaestus #2283.

**`automation-session-naming-pr-scoped-not-commit-scoped` → v1.2.0** (+history): cause-2 (cwd mismatch) **recurred** at a call-site family the PR #1100 fix didn't cover — `agent_stage.py:92,121` passes `cwd=repo_root` while every pipeline stage passes `cwd=<worktree>`, so the create-vs-resume probe (`claude_invoke.py:307`) misses and sessions regenerate. On-disk proof: 19 same-artifact sessions written twice under two cwd-encoded dirs (~940K redundant re-sent tokens). Generalized lesson: audit **all** invoker call sites, not one. Tracked in Hephaestus #2284.

## Validation

`just check` in the worktree: 218 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)