### PR TITLE
feat: generalize inference360 orphan-branch lessons into two host-neutral skills

### DIFF
--- a/skills/machine-local-container-artifact-validation-lane.md
+++ b/skills/machine-local-container-artifact-validation-lane.md
@@ -1,0 +1,82 @@
+---
+name: machine-local-container-artifact-validation-lane
+description: "Keep a local validation lane containerized against a machine-local, digest-verified image artifact while hosted CI uses a host lane, and fail closed when the artifact is missing. Use when: (1) `just validate` (or equivalent) must run in a reviewed container locally but hosted runners lack that container runtime, (2) a validation wrapper must bootstrap before the normal language/private helpers can be trusted, (3) a build/run tool does NOT fetch or build the runtime image so it must be materialized per machine, (4) a digest check only validates manifest text rather than the actual image bytes, (5) strict review flags stale rootfs reuse, unsafe shell interpolation, or a PR bundling unrelated scope."
+category: ci-cd
+date: 2026-07-18
+version: "1.0.0"
+tags: [ci-cd, validation, container, image-artifact, digest, fail-closed, host-vs-local-lane, materialization, shell-wrapper, strict-review, scope-reduction]
+user-invocable: false
+---
+
+# Machine-Local Container-Artifact Validation Lane
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-18 |
+| **Objective** | Preserve a containerized local validation lane backed by a machine-local, digest-verified image artifact, split from a host lane for hosted CI, without stale-rootfs reuse or unsafe shell parsing. |
+| **Outcome** | Reusable pattern: dual local/host lanes, verify-image-bytes-by-digest, fail-closed on a missing artifact, treat the image as separately materialized per machine, and reduce unrelated PR scope under strict review. |
+| **Verification** | verified-ci (generalized from a container-validation wrapper hardening whose local + hosted PR checks passed; the concrete container runtime and product names are intentionally omitted). |
+
+## When to Use
+
+- Local `just validate` (or an equivalent gate) must run inside a reviewed container, but hosted CI runners do not have that container runtime and must run a host lane instead.
+- A shell wrapper must bootstrap validation before the normal language/private helpers can be trusted or installed.
+- The build/run tool (e.g. `uv run`, `npm`, a task runner) does NOT build or download the runtime image, so the image is a machine-local reviewed artifact that must be materialized on each target environment.
+- A digest check currently only validates manifest text rather than the actual image bytes.
+- Strict review flags stale container rootfs reuse, regex/interpolation injection in a shell parser, missing fail-closed behavior, or a PR that bundles unrelated lifecycle/logging/evidence changes with the wrapper work.
+- The build/run tool reports the runtime image missing on one machine but succeeds on another, and you must tell a missing reviewed artifact apart from a language/runtime/lifecycle failure.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# 1. Keep two lanes explicit: containerized local vs host CI.
+just validate         # local: runs the reviewed container wrapper
+just _validate-host   # hosted CI: runs validation directly on the host
+
+# 2. Wrapper preflight contract — prove it before trusting it.
+bash -n scripts/run_validation_container.sh      # syntax
+scripts/run_validation_container.sh --help       # documented interface
+just --dry-run validate                          # command it will run
+just --dry-run _validate-host
+
+# 3. Verify the IMAGE BYTES, not just the manifest text.
+#    require the configured digest to match sha256:<64 hex>,
+#    compute the real image digest, and exit BEFORE any container call on mismatch.
+```
+
+### Detailed Steps
+
+1. **Minimize drift first.** Rebase the branch on the target base before fixing review findings. If a rebase drops a patch-equivalent commit already on base, that is legitimate scope reduction — then prove the branch is not behind (`git rev-list --left-right --count base...HEAD`).
+2. **Reduce unrelated scope.** If the PR bundles changes unrelated to the validation wrapper (lifecycle logging, progress docs, unrelated evidence), restore those files to base. Strict reviewers block on bundled scope; a focused diff merges.
+3. **Preserve the CI/local split.** Keep a containerized local lane and a separate host lane for hosted runners that lack the container runtime. Do not "simplify" by collapsing the local lane into the host lane — that silently drops the reviewed-container guarantee. Document why the wrapper bootstraps before the normal language/private helpers, so a future maintainer does not replace it with broader host calls that run before validation.
+4. **Verify image bytes by digest, fail closed.** Require the configured image digest to match `sha256:<64 hex>`; compute the actual image artifact's digest and exit on mismatch **before** any container create/start. A digest check that only validates manifest text is false assurance — validate the bytes that will actually run.
+5. **Bind the verified bytes to the started rootfs.** If a same-named container rootfs already exists, remove it before create/start so a stale rootfs is never silently reused. Repeated staging must overwrite stale staged files and restore the expected permission mode.
+6. **Avoid unsafe shell parsing.** Do not interpolate untrusted manifest fields into regexes or command strings in the wrapper; parse defensively so a crafted manifest value cannot inject behavior.
+7. **Treat the image as per-machine materialized.** The runtime image is a machine-local reviewed artifact — it is not built or downloaded by the build/run tool. When it is missing on one machine but present on another, the fix is to materialize it on that machine, not to debug the language runtime. Document this so a "missing runtime artifact" is diagnosed as materialization, distinct from a language/scheduler/lifecycle failure.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Collapse the containerized local lane into the host lane | "Simplified" validation to one path | Silently dropped the reviewed-container guarantee locally | Keep local-container and host lanes separate; hosted CI uses the host lane because it lacks the runtime |
+| Digest check that validates only the manifest text | Compared the digest string in the manifest | The actual image bytes could differ from the manifest claim | Compute the real artifact digest and exit on mismatch before any container call |
+| Reuse an existing same-named container rootfs | Started validation against whatever rootfs was present | Stale rootfs contents contaminated the run | Remove the same-named rootfs before create/start; bind the freshly verified bytes |
+| Interpolate manifest fields into a shell regex/parser | Built the wrapper's parsing with raw interpolation | Injection risk / brittle parsing flagged by strict review | Parse defensively; never interpolate untrusted manifest values into regex or command strings |
+| Debug the language runtime when the image was "missing" | Chased a Python/runtime error on one machine | The image is a machine-local artifact not fetched by the build tool | Materialize the reviewed image per machine; diagnose a missing artifact as materialization, not a runtime bug |
+| Ship the wrapper fix bundled with unrelated changes | Left lifecycle/logging/evidence edits in the PR | Strict review blocked on bundled scope | Restore unrelated files to base; keep the PR focused on the wrapper |
+
+## Results & Parameters
+
+- **Two lanes**: `validate` (containerized local) and `_validate-host` (host CI); never collapse them.
+- **Digest contract**: `sha256:<64 hex>`, verified against the real image bytes, fail-closed before any container call.
+- **Rootfs**: remove same-named rootfs before start; overwrite stale staged files; restore expected mode.
+- **Materialization**: image is per-machine reviewed artifact, not fetched by the build/run tool.
+- **Review discipline**: rebase to minimize drift, restore unrelated files to base, keep the diff focused.
+
+## Attribution
+
+Generalized from a project-specific container-validation wrapper hardening (a SquashFS/Enroot-backed `just validate` lane), with the concrete container runtime, product, and cluster names removed. The transferable core — dual local/host lanes, digest-verified image bytes, fail-closed on missing artifacts, per-machine materialization, and strict-review scope discipline — is host- and project-neutral.

--- a/skills/service-validation-fresh-isolated-allocation.md
+++ b/skills/service-validation-fresh-isolated-allocation.md
@@ -1,0 +1,83 @@
+---
+name: service-validation-fresh-isolated-allocation
+description: "Validate or reproduce a service on a FRESH, isolated compute allocation instead of reusing a running one, and treat teardown + cleanup proof as part of the validation. Use when: (1) proving a service/endpoint launch end-to-end when other instances are already running, (2) reproducing a corruption/regression that needs a clean environment, (3) a manifest- or config-driven launch fails and you must separate control-plane failures from missing-artifact and probe failures, (4) running an A/B ablation where baseline and treatment must differ in exactly one variable, (5) you need evidence that the run allocated its own resources and released them afterward."
+category: debugging
+date: 2026-07-18
+version: "1.0.0"
+user-invocable: false
+tags: [validation, reproduction, isolation, fresh-allocation, teardown, cleanup-evidence, control-plane, artifact-validation, ablation, scheduler, gpu, service-lifecycle]
+---
+
+# Service Validation on a Fresh, Isolated Allocation
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-18 |
+| **Objective** | Validate, debug, or reproduce a service's behavior on a clean, independently-allocated environment rather than an already-running one, and prove both the allocation and its release as part of the evidence. |
+| **Outcome** | Reusable workflow: fresh-allocation-by-default, layered failure isolation (control-plane vs artifact vs probe), single-variable ablation discipline, and cleanup-as-validation. |
+| **Verification** | verified-ci (generalized from a scheduler/GPU service validation whose fresh-allocation runbook and single-variable forward-path ablation both passed CI; the concrete scheduler/hardware specifics are intentionally omitted here). |
+
+## When to Use
+
+- You must prove a service or endpoint works end-to-end, but instances are already running and the user has not said reusing them is acceptable.
+- You are reproducing a corruption, non-determinism, or regression that a dirty/shared environment could mask or contaminate.
+- A manifest-, config-, or checkpoint-driven launch fails and you need to tell apart a control-plane failure, a missing/renamed artifact, and a probe/parameter failure.
+- You are running an A/B ablation and must guarantee baseline and treatment differ in exactly one variable.
+- Your completion claim needs evidence that the run allocated its own resources and released them, not just that a probe returned 200.
+
+## Verified Workflow
+
+### Quick Reference
+
+```text
+Rule: do NOT reuse an existing allocation/endpoint for validation unless the
+user explicitly approves reuse. Default to a fresh, isolated allocation.
+
+1. Read the surface's own contract/docs before acting.
+2. Enumerate resources already in use and EXCLUDE them from the new allocation.
+3. Allocate a fresh, isolated, labeled unit of compute for this test only.
+4. If control-plane bring-up fails, confirm it did not leave a partial
+   allocation before falling back to a simpler control path — then release it.
+5. Validate every artifact path/digest the launch references BEFORE relaunch.
+6. Probe with realistic parameters (e.g. enough output budget); tiny defaults
+   can return empty/blank results that look like failures.
+7. For ablations, hold everything constant except the one variable and confirm
+   from logs that the intended variant actually bound.
+8. Tear down: stop the service, release the allocation, stop control, and VERIFY
+   the allocation left the scheduler/queue. Cleanup is evidence, not a footnote.
+```
+
+### Detailed Steps
+
+1. **Read the contract first.** Read the service's README/AGENTS/product-contract/runbook docs for the exact surface under test before allocating anything — the launch contract (manifest schema, required artifacts, control API) is where most failures originate.
+2. **Fresh-by-default.** Treat a running endpoint or job as off-limits for validation unless the user explicitly approves reuse. Reusing a warm allocation hides launch, allocation, and cleanup defects — the very things validation is supposed to prove.
+3. **Exclude occupied resources.** Enumerate what is already allocated and explicitly exclude it, so the fresh allocation cannot accidentally land on or contend with in-use resources. Label the new allocation with its purpose so it is auditable and reclaimable.
+4. **Isolate failure layers.** When a launch fails, classify the failure before retrying:
+   - **Control-plane**: bring-up failed before any resource was allocated. Confirm no partial allocation was created; if one was, release it before retrying. Fall back to a simpler/foreground control path only after confirming the clean state.
+   - **Artifact**: the config/manifest references a path, checkpoint, image, or digest that is missing or renamed. Verify the referenced facts against the real filesystem/registry, correct the manifest (a scratch copy is fine), and re-validate it through the service's own validation API before relaunch.
+   - **Probe/parameter**: the service is up but the probe used unrealistic parameters. Re-probe with realistic values.
+5. **Single-variable ablation.** For A/B or forward-path ablations, keep baseline and treatment byte-for-byte identical except the one variable under test, and confirm from server/runtime logs that the intended variant actually bound — do not trust that a flag took effect.
+6. **Cleanup is part of validation.** Stop the service, release the allocation, stop the control process, then actively verify the allocation has left the scheduler/queue (poll until the job/reservation is gone, through any transitional "completing" state). A validation that leaks an allocation has not passed.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Probe an already-running endpoint as the validation path | Reused a warm allocation to save setup time | It proves nothing about launch/allocation/cleanup and can be contaminated by prior state | Allocate fresh and isolated unless the user explicitly approves reuse |
+| Relaunch immediately after a manifest launch failed | Retried without checking the referenced artifacts | The manifest pointed at a missing/renamed checkpoint; the retry failed the same way | Verify every referenced artifact path/digest against the real filesystem before relaunch |
+| Trust a control-plane failure left nothing behind | Switched to a fallback control path without checking | A partial allocation could leak and contend with the fresh run | After a control-plane failure, confirm no partial allocation exists (and release it) before falling back |
+| Probe with the status helper's tiny default output budget | Used a minimal `max_tokens`/output limit | Reasoning-heavy or slow-first-token services returned blank/empty output that looked like a failure | Probe with realistic parameters; distinguish "empty because too small a budget" from a real fault |
+| Treat cleanup as an optional follow-up | Declared success when the probe returned OK | The allocation leaked in the scheduler queue | Stop → release → stop control → verify the queue is clear; cleanup is part of the pass criteria |
+
+## Results & Parameters
+
+- **Default posture**: fresh, isolated, labeled allocation per validation run; reuse only on explicit user approval.
+- **Failure taxonomy**: control-plane vs artifact vs probe/parameter — classify before retrying.
+- **Ablation rule**: exactly one variable differs; confirm the intended variant bound from logs.
+- **Cleanup proof**: the allocation is observed leaving the scheduler/queue; a leaked allocation fails the run.
+
+## Attribution
+
+Generalized from a project-specific GPU/scheduler service-validation and corruption-reproduction runbook, with the concrete cluster, hardware, scheduler, engine, and checkpoint details removed. The transferable core — fresh-allocation-by-default, layered failure isolation, single-variable ablation, and cleanup-as-validation — is host- and project-neutral.


### PR DESCRIPTION
## Summary

During pre-release Mnemosyne branch cleanup, three project-specific `inference360-*` orphan branches were slated for deletion. Rather than lose what they taught, this PR captures their transferable lessons as two host-neutral skills (concrete cluster, hardware, scheduler, container-runtime, and product names removed).

## New skills

- **service-validation-fresh-isolated-allocation** — validate/reproduce a service on a FRESH isolated allocation instead of reusing a running one; isolate control-plane vs missing-artifact vs probe failures; single-variable ablation discipline; cleanup/teardown as part of the pass criteria. (from the fresh-allocation staging-control + RMSNorm-ablation branches)
- **machine-local-container-artifact-validation-lane** — keep a containerized local validation lane + a host lane for CI; digest-verify the image BYTES fail-closed; treat the runtime image as a per-machine materialized artifact not fetched by the build tool; strict-review scope discipline. (from the sqsh-harden-wrapper branch)

## Verification

`just check` — 668/668 skills valid, 218 tests passing. Signed + DCO-attested.

The three source inference360 branches are being deleted separately (their project-specific content is superseded by these generalizations).