### PR TITLE
feat: add automation review authorization CI boundary skill

### DIFF
--- a/skills/automation-review-authorization-ci-boundary.md
+++ b/skills/automation-review-authorization-ci-boundary.md
@@ -1,0 +1,94 @@
+---
+name: automation-review-authorization-ci-boundary
+description: "Keep automation-loop source-review authorization independent of CI/CD. Use when: (1) a strict PR review is mistakenly implemented as a required CI check, (2) an agent loop cannot observe or control the external workflow that is supposed to authorize it, or (3) loop approval must survive restart using only loop-owned PR state."
+category: architecture
+date: 2026-07-17
+version: "1.0.0"
+user-invocable: false
+verification: verified-local
+tags:
+  - automation-loop
+  - pr-review
+  - ci-independent
+  - authorization-boundary
+  - implementation-go
+  - restart-safety
+  - state-label
+  - source-review
+---
+
+# Automation Review Authorization: CI Boundary
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-17 |
+| **Objective** | Keep a code-automation loop's strict source-review decision inside that loop rather than delegating its authorization to CI/CD. |
+| **Outcome** | ProjectHephaestus moved strict-review proof, workflow triggers, artifacts, leases, and CI-status contracts out of the authorization path. The loop's own CI-free PR review applies `state:implementation-go` after a GO verdict. |
+| **Verification** | verified-local — focused stage and documentation tests passed locally; CI/CD evidence was intentionally not consulted. |
+
+## When to Use
+
+- A strict source review has been added as a required CI check even though the automation loop, not CI, is expected to decide whether implementation may advance.
+- The loop is blocked by a workflow artifact, status, lease, or trigger that it cannot start, observe reliably, or repair.
+- A restart path needs to determine whether a PR may proceed without reconstructing a CI-run proof artifact.
+- You need to retire an external review-proof system while preserving historical ADRs and making the active contract unambiguous.
+
+## Verified Workflow
+
+### Quick Reference
+
+```text
+automation loop owns source-review authorization
+  1. read the live PR source, diff, and loop-owned state
+  2. run the strict PR review in the loop (CI-free)
+  3. if and only if the review returns GO, apply state:implementation-go
+  4. merge_wait consumes that loop-owned label and the live PR head
+
+CI/CD is outside this decision:
+  - do not query checks, workflow runs, artifacts, or deployments
+  - do not create review-proof workflows or triggers on review/implementation-go
+  - do not make an external CI result a prerequisite for loop progress
+```
+
+### Detailed Steps
+
+1. Establish a single decision owner. Source-review authorization belongs to the automation loop when that loop is responsible for planning, implementation, review, and advancement. CI/CD may validate a repository independently, but it is not evidence the loop can depend on for this decision.
+
+2. Run the strict PR review as an in-loop, CI-free operation against the live PR diff. Require an explicit GO result before transition; a missing, ambiguous, or NO-GO result must not apply the approval label.
+
+3. Record the completed loop decision with one loop-owned state marker such as `state:implementation-go`. `merge_wait` should consume that marker and the live PR head when it restarts; it must not require a workflow artifact, lease, status context, or an external proof document.
+
+4. Keep the boundary mechanically enforceable. Delete CI workflows and automatic tasks that trigger from review or implementation-go solely to produce authorization proof. Remove their references from active documentation, agent directions, prompt contracts, and tests.
+
+5. Cover direct PR discovery as well as issue-driven discovery. If the strict stage needs issue/comment context, pass the PR number as its work-item context for a PR discovered without a closing issue. Passing `None` converts a valid PR into a terminal strict-review failure.
+
+6. Preserve ADR history. Do not rewrite accepted historical decisions just to erase obsolete policy. Add a new superseding ADR and update the ADR index so active readers find the current contract while audits retain the original record.
+
+7. Validate the source-only behavior locally: resolve the PR identity and exact head, inspect the source diff and active contracts, run targeted stage/documentation tests, and run `git diff --check`. State clearly that this is not CI evidence.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Put strict-review proof in CI/CD | A required workflow generated proof artifacts and gated progress. | The automation loop did not control the CI loop, so it could neither make progress nor make a trustworthy decision from that external state. | The component that owns the review decision must execute and persist it; make strict source review an in-loop CI-free operation. |
+| Restart from external proof data | `merge_wait` depended on workflow artifacts, leases, and status records. | Those records were external coupling, could be absent or stale after restart, and were unnecessary once loop-owned approval existed. | Restart from the loop-owned approval label and live PR state only. |
+| Treat a repository-wide PR as an issue-less strict review | Direct PR discovery constructed a work item with `issue=None`. | The strict stage requires issue/comment context and rejected the work item as terminal. | For direct PR review, use the PR number as the work-item context unless the design supplies an equivalent explicit context. |
+| Rewrite accepted ADRs to remove obsolete instructions | Historical ADR text was modified in place. | It obscured the decision record and broke the repository's ADR immutability convention. | Preserve accepted ADRs verbatim; add a superseding ADR and make the index point to the active policy. |
+
+## Results & Parameters
+
+| Item | Result |
+|------|--------|
+| Decision marker | `state:implementation-go` is the sole loop-owned authorization after a current review GO. |
+| Prohibited dependencies | CI checks, workflow runs, artifacts, deployments, external status contexts, and review-proof leases. |
+| Direct-PR correction | Use the PR number as strict-review work-item context rather than `None`. |
+| Local validation example | `uv run pytest` over pipeline stage/coordinator and active-documentation/ADR tests: 85 passed; `git diff --check` passed. |
+| Historical-policy migration | Preserve accepted ADRs; record the new label-only rule in a superseding ADR and its index entry. |
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #2280 / issues #2053 and #2276 | CI-free source review and loop-owned `state:implementation-go` authorization. The direct repository-wide PR route now supplies PR context to strict review. Local verification only: 85 targeted tests and whitespace validation passed; no CI/CD state was queried. |


### PR DESCRIPTION
## Summary

Adds a verified-local skill for keeping an automation loop's strict source-review authorization independent of CI/CD.

- The loop executes strict PR review and owns its approval transition.
- state:implementation-go is the durable loop-owned authorization after GO.
- Restart and direct-PR handling must not depend on CI proof artifacts, checks, or leases.

## Verification Level

**verified-local**

The ProjectHephaestus source-only review passed 85 targeted tests and git diff --check; no CI/CD evidence was consulted. ProjectMnemosyne validation passed and its pre-push suite completed successfully (218 tests).

## Key Findings

**What Worked**:
- Moving strict review into the automation loop eliminates an external authority boundary the loop cannot control.
- Preserving accepted ADRs while superseding them keeps active policy clear and historical records auditable.

**What Failed**:
- CI-generated strict-review proof caused false ownership coupling and blocked loop progress.

## Test Plan

- [x] Validate with uv run --with pyyaml python scripts/validate_plugins.py
- [x] Run ProjectMnemosyne pre-push test suite
- [ ] Verify skill appears in marketplace
- [ ] Test skill discovery with relevant keywords

Co-Authored-By: Codex <noreply@openai.com>