### PR TITLE
feat: amend odysseus-multi-branch-submodule-pin-management skill (v1.2.0)

### DIFF
--- a/skills/odysseus-multi-branch-submodule-pin-management.history
+++ b/skills/odysseus-multi-branch-submodule-pin-management.history
@@ -1,5 +1,76 @@
 # Amendment History — odysseus-multi-branch-submodule-pin-management
 
+## v1.2.0 — 2026-07-18
+
+**Changed by:** Session resolving an Odysseus cherry-pick submodule pointer conflict (`/learn`).
+**Verification:** verified-local (the cherry-pick pointer-conflict resolution was executed this
+session and produced a clean commit whose `git diff origin/main --stat` showed all 15 pins bumped
+as intended; this skill PR's own CI gate has not yet been observed green).
+
+### What changed
+
+- Added a new Verified-Workflow subsection "Resolve a Cherry-Pick Submodule Pointer Conflict
+  (keep the commit)" — the in-place `git ls-tree <bump-sha> <path>` → `git -C <path> checkout
+  <target-sha>` → `git add <path>` → `cherry-pick --continue` procedure for
+  `CONFLICT (submodule): ... commits don't follow merge-base`.
+- Added 2 Failed Attempts rows: (1) plain cherry-pick of a pin-bump commit onto a branch off
+  main → merge-base pointer conflict → resolve in place, don't abort; (2) assuming the submodule
+  conflict is a file-content clash → wasted time hunting for text markers.
+- Extended `description` with trigger (8) and added tags `merge-base`,
+  `cherry-pick-conflict-resolution`.
+- Added Overview + Verified-On rows for the 2026-07-18 session; bumped date and version.
+
+### Why
+
+v1.1.0's Step 2 said to AVOID cherry-picking a submodule pointer (advance the pin directly
+instead). That is correct when you only need the SHA, but it left a gap: when you deliberately
+WANT the cherry-picked commit (moving an accidental pin-bump to a dedicated PR), aborting is the
+wrong move. The `commits don't follow merge-base` conflict is a pointer that cannot fast-forward,
+not a code merge — the correct resolution is to check out the target SHA from the cherry-picked
+commit's tree and `git add` it. Same search surface as the existing skill (anyone hitting the
+submodule conflict lands here), so amended rather than split into a new skill.
+
+### Previous version (v1.1.0) snapshot
+
+```yaml
+---
+name: odysseus-multi-branch-submodule-pin-management
+description: >-
+  Manage submodule pins across multiple Odysseus branches with rebase, cherry-pick avoidance,
+  and justfile recipe collision resolution. Use when: (1) updating a submodule SHA on a feature
+  branch while main has a different pin, (2) rebasing an Odysseus feature branch onto main after
+  justfile changes on both sides, (3) cherry-picking a submodule pointer update between branches
+  fails with CONFLICT (submodule), (4) CI "Harden checks" job fails with justfile recipe
+  redefinition error after rebase, (5) branch-switching causes missing files/directories in the
+  working tree, (6) running `git submodule update --remote <path>` produces unexpected
+  modifications to OTHER submodules in `git status` (the selective-vs-all foot-gun), (7) doing
+  a partial pin bump where only some submodules are eligible because others have open PRs.
+category: ci-cd
+date: 2026-05-16
+version: "1.1.0"
+user-invocable: false
+verification: verified-ci
+history: odysseus-multi-branch-submodule-pin-management.history
+tags:
+  - odysseus
+  - submodule
+  - pin
+  - rebase
+  - justfile
+  - multi-branch
+  - cherry-pick
+  - force-with-lease
+  - submodule-update-remote
+  - selective-pin-bump
+---
+```
+
+v1.1.0 body added the "Safe Selective Pin Bump" section (6-step procedure, verified on Odysseus
+PR #284, 2026-05-16) and 2 Failed Attempts rows about the `--remote` selective foot-gun and the
+`git add .` hazard, on top of the v1.0.0 base.
+
+---
+
 ## v1.0.0 — 2026-05-04
 
 Initial skill capturing the verified-local workflow for managing submodule pins across multiple Odysseus branches: rebase, cherry-pick avoidance, justfile recipe collision resolution, and force-with-lease workflows. Verified on Odysseus `feat/issue-22-ci-hardening` (2026-05-04).

--- a/skills/odysseus-multi-branch-submodule-pin-management.md
+++ b/skills/odysseus-multi-branch-submodule-pin-management.md
@@ -9,10 +9,14 @@ description: >-
   redefinition error after rebase, (5) branch-switching causes missing files/directories in the
   working tree, (6) running `git submodule update --remote <path>` produces unexpected
   modifications to OTHER submodules in `git status` (the selective-vs-all foot-gun), (7) doing
-  a partial pin bump where only some submodules are eligible because others have open PRs.
+  a partial pin bump where only some submodules are eligible because others have open PRs,
+  (8) a `git cherry-pick` of a pin-bump commit onto a fresh branch off main fails with
+  `CONFLICT (submodule): ... commits don't follow merge-base` and you WANT to keep the
+  cherry-picked commit (not abort) — resolve by checking out the target SHA inside the
+  submodule and `git add`-ing it, since it is a pointer that cannot fast-forward, not a code merge.
 category: ci-cd
-date: 2026-05-16
-version: "1.1.0"
+date: 2026-07-18
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
 history: odysseus-multi-branch-submodule-pin-management.history
@@ -27,6 +31,8 @@ tags:
   - force-with-lease
   - submodule-update-remote
   - selective-pin-bump
+  - merge-base
+  - cherry-pick-conflict-resolution
 ---
 
 # Odysseus Multi-Branch Submodule Pin Management
@@ -35,15 +41,16 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-05-16 (v1.1.0); originally 2026-05-04 (v1.0.0) |
-| **Objective** | Manage submodule pins across Odysseus branches: rebase, cherry-pick avoidance, justfile recipe collisions, AND safe selective `--remote` pin bumps on long-lived clones |
-| **Outcome** | Successful — original 2026-05-04 CI hardening shipped; 2026-05-16 partial pin-bump PR #284 shipped with EXACTLY the 5 intended bumps (8 unintended rewinds caught) |
-| **Verification** | verified-ci — Odysseus PR #284 (2026-05-16) shipped via this procedure; original v1.0.0 verified-local on 2026-05-04 |
+| **Date** | 2026-07-18 (v1.2.0); 2026-05-16 (v1.1.0); originally 2026-05-04 (v1.0.0) |
+| **Objective** | Manage submodule pins across Odysseus branches: rebase, cherry-pick avoidance AND in-place cherry-pick pointer-conflict resolution, justfile recipe collisions, AND safe selective `--remote` pin bumps on long-lived clones |
+| **Outcome** | Successful — original 2026-05-04 CI hardening shipped; 2026-05-16 partial pin-bump PR #284 shipped with EXACTLY the 5 intended bumps (8 unintended rewinds caught); 2026-07-18 cherry-pick pointer-conflict resolution produced a clean commit bumping all 15 pins as intended |
+| **Verification** | verified-ci for the established workflow (Odysseus PR #284, 2026-05-16); the 2026-07-18 cherry-pick pointer-conflict resolution is verified-local (executed this session, clean commit produced; its own skill-PR gate not yet observed green) |
 
 ## When to Use
 
 - A submodule's upstream PR (e.g., ProjectHephaestus adding `install.sh`) merges to main while your Odysseus feature branch still pins the old SHA
 - You need to cherry-pick a submodule pointer update between branches but get `CONFLICT (submodule)`
+- A `git cherry-pick <pin-bump-sha>` onto a fresh branch off main fails with `CONFLICT (submodule): ... commits don't follow merge-base` and you want to KEEP the cherry-picked commit (a dedicated pins PR), not abort it
 - Rebasing an Odysseus feature branch fails because both main and your branch added justfile recipes
 - CI "Harden checks" fails with `Recipe 'X' first defined on line N is redefined on line M`
 - Switching branches in the same Odysseus worktree causes `ls tests/install/` or similar to fail with "no such file or directory"
@@ -206,6 +213,58 @@ git commit -m "chore(submodules): refresh pins ..."
 3. **NEVER** `git add .` for submodule bumps. Always stage explicit paths.
 4. Cross-reference [[multi-repo-pr-orchestration-swarm-pattern]] for the broader guardrail: do NOT bump a submodule pin while that submodule has an open PR in flight (defer it).
 
+### Resolve a Cherry-Pick Submodule Pointer Conflict (keep the commit)
+
+> _(verified-local — executed this session on Odysseus; the clean commit was produced, but
+> this skill PR's own CI gate has not yet been observed green.)_
+
+Step 2 above says to AVOID cherry-picking a submodule pointer when you can just advance the pin
+directly. But sometimes you genuinely want the **cherry-picked commit itself** — e.g. a pin-bump
+commit was accidentally made on a feature branch (that also carries other, unrelated submodule
+bumps) and you want a clean, dedicated pins PR: `git checkout -b <new> origin/main && git
+cherry-pick <bump-sha>`.
+
+That cherry-pick fails with:
+
+```text
+CONFLICT (submodule): Merge conflict in provisioning/Myrmidons
+Failed to merge submodule provisioning/Myrmidons (commits don't follow merge-base)
+```
+
+**Why:** the source branch recorded the submodule at commit `A` (a bump NOT present on main);
+main records it at commit `B`. The cherry-picked diff is "`A` → target", which git cannot replay
+onto main's `B` because `A` is not an ancestor of `B` — there is no linear merge-base for the
+submodule POINTER. This is **not** a text/content conflict; there is nothing to hand-merge.
+
+For a "bump pins to latest/target" intent, the correct resolution is always "take the target SHA
+recorded in the commit you are cherry-picking". Resolve it in place — do NOT abort, do NOT hunt
+for text conflict markers:
+
+```bash
+# 1. Read the TARGET submodule SHA straight out of the commit being cherry-picked.
+git ls-tree <bump-sha> provisioning/Myrmidons
+#    -> 160000 commit <target-sha>    provisioning/Myrmidons  (SHA is the 3rd field)
+
+# 2. Check that exact SHA out INSIDE the submodule.
+git -C provisioning/Myrmidons checkout <target-sha>
+
+# 3. Stage the resolved pointer in the superproject.
+git add provisioning/Myrmidons
+
+# 4. Continue the cherry-pick. If a non-executable / noisy pre-commit hook blocks it,
+#    bypass hooks ONLY for the continue (the content is already correct):
+git cherry-pick --continue --no-edit
+# git -c core.hooksPath=/dev/null cherry-pick --continue   # only if hook noise blocks it
+
+# 5. Verify the final pins BEFORE pushing — all intended bumps, nothing rewound.
+git submodule status
+git diff origin/main --stat   # confirms exactly the pins you intended (e.g. all 15) changed
+```
+
+**Key insight:** treat every `CONFLICT (submodule)` as "pick the right SHA, then `git add`",
+never as a code merge. When the intent is "bump to latest", the right SHA is the one recorded in
+the cherry-picked commit's tree (`git ls-tree <bump-sha> <path>`), so step 1 resolves it exactly.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -217,6 +276,8 @@ git commit -m "chore(submodules): refresh pins ..."
 | Checking GitHub merge status immediately after force-push | `gh pr view --json mergeable` right after `git push --force-with-lease` | Shows `CONFLICTING` / `DIRTY` for 10-30 seconds while GitHub re-evaluates | `sleep 15 && gh pr view <PR> --json mergeable,mergeStateStatus` |
 | Trust `git submodule update --remote <path1> <path2>` to be selective | Ran `git submodule update --remote infrastructure/ProjectHermes control/ProjectNestor ...` on a long-lived working clone; expected only the 5 listed submodules to show modified in `git status` | 8 OTHER submodules showed modified because their working-tree HEADs had drifted from pinned SHAs in prior session work; `--remote` (and the implicit `--init`) surfaced/advanced them as a side effect | ALWAYS run `git submodule update --init --recursive` to reset the working clone FIRST, then `--remote` only on intended paths; inspect `git status --short` before staging |
 | `git add .` after `git submodule update --remote` | Staged everything visible in `git status` after bumping pins, including unintended submodule rewinds | Would have shipped 8 incorrect pin downgrades in the Odysseus PR #284 pin-bump (caught only by manual inspection) | NEVER `git add .` for submodule bumps — always `git add <explicit-path-1> <explicit-path-2> ...` and re-run `git status --short` to confirm only intended paths staged |
+| Plain cherry-pick of a pin-bump commit onto a branch off main | `git checkout -b <new> origin/main && git cherry-pick <bump-sha>` to move an accidental pin-bump commit to a dedicated PR | `CONFLICT (submodule): ... commits don't follow merge-base` — the source branch's submodule SHA is not an ancestor of main's, so the pointer cannot fast-forward | Do NOT abort; resolve in place: `git ls-tree <bump-sha> <path>` for the target SHA, `git -C <path> checkout <target-sha>`, `git add <path>`, then `git cherry-pick --continue` |
+| Assumed the submodule conflict was a file-content clash | Searched the working tree for text conflict markers / tried to hand-merge after `CONFLICT (submodule)` | It is purely a submodule POINTER that cannot fast-forward — there is no text to merge; time wasted looking for `<<<<<<<` markers | Treat every `CONFLICT (submodule)` as "pick the right SHA, then `git add`", not a code merge; for a bump-to-latest intent the right SHA is the cherry-picked commit's tree entry |
 
 ## Results & Parameters
 
@@ -262,3 +323,4 @@ ecosystem-install:
 |---------|---------|---------|
 | Odysseus | feat/issue-22-ci-hardening — CI hardening PR with justfile extensions and submodule updates | Session 2026-05-04 |
 | Odysseus | PR #284 — partial pin bump sweep (5 of 10 in-scope submodules bumped: Nestor, Hermes, Keystone, Telemachy, Mnemosyne; 5 deferred because their bundle PRs were still open). Caught 8 unintended pin rewinds via manual `git status` inspection before staging. | Session 2026-05-16 — verified the 6-step Safe Selective Pin Bump procedure |
+| Odysseus | Cherry-picked a pin-bump commit onto a fresh branch off main; hit `CONFLICT (submodule): ... commits don't follow merge-base` on `provisioning/Myrmidons`; resolved via `git ls-tree` target SHA + `git -C <path> checkout` + `git add` + `cherry-pick --continue`. Final `git diff origin/main --stat` showed all 15 pins bumped as intended. | Session 2026-07-18 (verified-local) — clean commit produced; skill-PR CI gate not yet observed green |


### PR DESCRIPTION
## Summary

Amends the existing `odysseus-multi-branch-submodule-pin-management` skill from v1.1.0 to v1.2.0.

Adds the in-place resolution for a cherry-pick submodule **pointer** conflict when you want to KEEP the cherry-picked pin-bump commit (a dedicated pins PR), rather than aborting per the skill's existing Step 2.

- New Verified-Workflow subsection: `git ls-tree <bump-sha> <path>` → `git -C <path> checkout <target-sha>` → `git add <path>` → `git cherry-pick --continue`
- 2 new Failed Attempts rows (plain cherry-pick `commits don't follow merge-base`; assuming a content clash)
- `description` trigger (8) + tags `merge-base`, `cherry-pick-conflict-resolution`

## Verification Level

**verified-local** for the new cherry-pick pointer-conflict resolution — it was executed this session and produced a clean commit whose `git diff origin/main --stat` showed all 15 pins bumped as intended. This skill PR's own CI gate has **not** yet been observed green, so the new content is not claimed `verified-ci`. The pre-existing workflow remains `verified-ci` (Odysseus PR #284).

## Key Findings

**What Worked**:
- `CONFLICT (submodule): ... commits don't follow merge-base` is a POINTER that cannot fast-forward, not a code merge
- Resolving to the cherry-picked commit's tree entry (`git ls-tree <bump-sha> <path>`) is exactly right for a bump-to-latest intent

**What Failed**:
- Plain `git cherry-pick <bump-sha>` onto a branch off main → submodule merge-base conflict (source SHA not an ancestor of main's)
- Treating it as a file-content clash → wasted time hunting for `<<<<<<<` markers

## Test Plan

- [x] `python3 scripts/validate_plugins.py` → 699/699 valid
- [x] `markdownlint-cli2` → 0 errors
- [x] `pre-commit run --files` → passed
- [ ] Verify skill appears in marketplace after merge

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>