### PR TITLE
fix(docs): remove MD012 trailing blank line breaking markdownlint on main

### DIFF
--- a/skills/timeout-centralization-plan-risk-review.md
+++ b/skills/timeout-centralization-plan-risk-review.md
@@ -108,4 +108,3 @@ _Not applicable._ This skill is `unverified`: it captures a planning risk checkl
 - Grep completeness: search for positional timeout args, assigned variables, and wrapper defaults, not just timeout=<literal>.
 - Diagnostics: warnings and logs should interpolate the resolved constants so env overrides are visible.
 ```
-


### PR DESCRIPTION
## Summary

- `skills/timeout-centralization-plan-risk-review.md` (added in #3162) ends with a double newline; markdownlint-cli2 counts this as two consecutive blank lines (MD012, reported at phantom line 112).
- This fails the `markdownlint` job on `main` itself (latest Required Checks run on main is red) and, because the job lints the PR merge ref, on **every open PR** (#3180-#3187 all show the identical failure).
- One-line fix: trim the file to end with a single newline.

## Testing

- `markdownlint-cli2 v0.23.0` with `.markdownlint.yaml` over `**/*.md !.claude/**`: 0 errors on 825 files after the fix (1 error before).

Once this merges, the other open PRs need their checks re-run (or a rebase/merge of main) to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)