### PR TITLE
ci: fast (<5 min) merge-queue smoke gate

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   push:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.ref }}

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -1,0 +1,45 @@
+name: Merge Queue Smoke
+
+# Fast merge-queue gate. The full required matrix (_required.yml) runs on
+# every pull_request and on push to main, exactly as before; merge_group
+# re-validation is this single fast job, so a queued merge occupies one
+# runner slot for < 5 min instead of re-running the whole matrix. The
+# `merge-queue-smoke` context this job produces is the single required
+# status check for the merge queue after the ruleset flip.
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mq-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-queue-smoke:
+    name: merge-queue-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
+        with:
+          python-version: '3.11'
+      - name: Validate workflow YAML files against GitHub schema
+        run: |
+          # Same check as the schema-validation required job.
+          uvx check-jsonschema \
+            --builtin-schema vendor.github-workflows \
+            .github/workflows/*.yml
+      - name: Run symlink check
+        run: bash scripts/check-symlinks.sh
+      - name: Validate all JSON files are parseable
+        run: |
+          find . -name "*.json" -not -path "*/.git/*" | while read f; do
+            jq . "$f" > /dev/null || { echo "Invalid JSON: $f"; exit 1; }
+          done
+          echo "All JSON files valid"

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -11,6 +11,7 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 REQUIRED_WORKFLOW = WORKFLOWS_DIR / "_required.yml"
 VALIDATE_WORKFLOW = WORKFLOWS_DIR / "validate-plugins.yml"
 RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
+SMOKE_WORKFLOW = WORKFLOWS_DIR / "merge-queue-smoke.yml"
 MERGE_QUEUE_POLICY = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
 
 EXPECTED_REQUIRED_CONTEXTS_BY_RULESET = {
@@ -86,20 +87,32 @@ def test_policy_pins_exact_approved_queue_rule() -> None:
     assert _load_policy()["merge_queue_rule"] == EXPECTED_MERGE_QUEUE_RULE
 
 
-def test_only_required_workflow_adds_exact_merge_group_trigger() -> None:
+def test_only_smoke_workflow_adds_exact_merge_group_trigger() -> None:
     required_on = _on_block(_load_workflow(REQUIRED_WORKFLOW))
     validate_on = _on_block(_load_workflow(VALIDATE_WORKFLOW))
+    smoke_on = _on_block(_load_workflow(SMOKE_WORKFLOW))
 
     assert required_on == {
         "pull_request": {"branches": ["main"]},
         "push": {"branches": ["main"]},
-        "merge_group": {"types": ["checks_requested"]},
     }
     assert validate_on == {
         "pull_request": None,
         "push": {"branches": ["main"]},
         "workflow_dispatch": None,
     }
+    assert smoke_on == {
+        "merge_group": {"types": ["checks_requested"]},
+    }
+
+
+def test_smoke_workflow_runs_exactly_one_fast_merge_queue_job() -> None:
+    smoke = _load_workflow(SMOKE_WORKFLOW)
+
+    assert list(smoke["jobs"]) == ["merge-queue-smoke"]
+    job = smoke["jobs"]["merge-queue-smoke"]
+    assert job["name"] == "merge-queue-smoke"
+    assert job["timeout-minutes"] == 5
 
 
 def test_required_workflow_emits_every_policy_context_exactly_once() -> None:


### PR DESCRIPTION
## Diagnosis

merge_group events currently re-trigger the full required workflow (`_required.yml`, 17 jobs). Each job waits 8-16+ min for a self-hosted runner slot, so a single queued merge consumes many runner slots and takes 70-90 minutes of wall time before the queue can merge.

## Design

- `_required.yml` no longer triggers on `merge_group`. That is the ONLY change to it — its `pull_request` and `push: branches: [main]` triggers and every job are byte-identical to main. PR-side CI is completely untouched.
- New `.github/workflows/merge-queue-smoke.yml` triggers ONLY on `merge_group` and runs a single job named `merge-queue-smoke` (one runner slot, `timeout-minutes: 5`) with real fast validation borrowed from the existing quick jobs: GitHub workflow schema validation (`check-jsonschema --builtin-schema vendor.github-workflows`), `scripts/check-symlinks.sh`, and repo-wide JSON parseability via `jq`.
- All action refs are the same pinned SHAs already used in this repo.
- Minimal contract-test update: `tests/test_merge_queue.py` now asserts the new topology (no `merge_group` on `_required.yml`; `merge-queue-smoke.yml` owns `merge_group` with a single 5-minute `merge-queue-smoke` job). Ruleset/policy pins (`configs/github/merge-queue-policy.json`) are untouched — they describe the live rulesets, which this PR does not change.

## Post-merge ruleset rollout (REQUIRED)

After merge, replace ALL `required_status_checks` contexts (in every ruleset — `homeric-main-baseline` id 17852368 and `homeric-main-extras` id 18221133) with the single context `merge-queue-smoke` and set `min_entries_to_merge_wait_minutes` to 0; PR-side checks keep running on PRs but become non-blocking; the queue must not be used between merge and flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
