### PR TITLE
fix(docs): retarget dangling CLAUDE.md references left by #3192

### DIFF
--- a/.claude/shared/plugin-standards.md
+++ b/.claude/shared/plugin-standards.md
@@ -7,7 +7,7 @@ Standards for creating and validating skills in the Mnemosyne skills/memory stor
 > nested `<name>/SKILL.md`, no per-skill `plugin.json`, and no `.claude-plugin/`
 > directory inside each skill. The only documented exception is
 > `plugins/tooling/mnemosyne/` (command infrastructure), which is *not* a skill.
-> See `CLAUDE.md` for repo structure and `templates/skill-template.md` for a
+> See `AGENTS.md` for repo structure and `templates/skill-template.md` for a
 > ready-to-copy template.
 
 ## Required Structure

--- a/plugins/tooling/mnemosyne/README.md
+++ b/plugins/tooling/mnemosyne/README.md
@@ -30,4 +30,4 @@ The SKILL.md files here document their behaviour and remain the authoritative re
 - Do **not** convert this directory to the flat-file format — the harness expects the
   nested layout for plugin manifests.
 - Do **not** add new skills here. New skills belong in `skills/<name>.md`.
-- See `CLAUDE.md` → *Plugin Standards* for the full rationale and the exception note.
+- See `AGENTS.md` → *Plugin Standards* for the full rationale and the exception note.

--- a/skills/skill-corpus-count-excludes-notes-and-history-files.md
+++ b/skills/skill-corpus-count-excludes-notes-and-history-files.md
@@ -107,4 +107,4 @@ done | sort | uniq -c | sort -rn
 ## References
 
 - [Epic #1823 — second-pass consolidation](https://github.com/HomericIntelligence/Mnemosyne/issues/1823)
-- [CLAUDE.md — Plugin Standards](../CLAUDE.md)
+- [AGENTS.md — Plugin Standards](../AGENTS.md)


### PR DESCRIPTION
#3192 (CLAUDE.md->AGENTS.md consolidation) merged without retargeting two internal cross-references:

- `plugins/tooling/mnemosyne/README.md`'s "Plugin Standards" pointer
- `.claude/shared/plugin-standards.md`'s repo-structure pointer

Both were left pointing at the now-stubbed CLAUDE.md. AGENTS.md's `## Plugin Standards` section is the correct target for both.

Docs-only, no functional change.