### PR TITLE
skill: amend mojo-tensor-unit-test — optimizer step-1 state test ≠ full-run convergence (v1.2.0)

### DIFF
--- a/skills/mojo-tensor-unit-test-and-gradient-checking.history
+++ b/skills/mojo-tensor-unit-test-and-gradient-checking.history
@@ -1,5 +1,24 @@
 <!-- markdownlint-disable MD024 -->
 
+## v1.2.0 (2026-07-19)
+
+**Changed by:** Predictive-coding Odyssey optimizer-underfit root-cause session
+**Verification:** verified-ci
+
+### What changed
+- Added one Failed Attempts row: "Trusting an optimizer's step-1 state unit test" — a passing
+  per-step state test (e.g. ADOPT `v0=g0^2`, Adan `prev_grad=g0`) does NOT prove full-run
+  convergence; ALWAYS sanity-run one real cell before a long campaign, and add a PyTorch-parity
+  reference column to localize which optimizer arm is wrong.
+
+### Why
+Extends the existing "Trusting FD checks as sufficient" row with a distinct instance: after the
+step-1 seed fixes passed their unit tests, a multi-hour campaign was re-run and STILL underfit
+~40pts vs PyTorch. The residual cause was an optimizer-DISPATCH bug (baseline adam/momentum
+bypassed the parity-tested library op via a hand-rolled `_adam_update`), not a gradient bug — so
+the parity reference column (plain matches torch, adam doesn't) was the tool that localized it.
+
+
 # mojo-tensor-unit-test-and-gradient-checking — History
 
 ## v1.1.0 (2026-06-07)

--- a/skills/mojo-tensor-unit-test-and-gradient-checking.md
+++ b/skills/mojo-tensor-unit-test-and-gradient-checking.md
@@ -2,8 +2,8 @@
 name: mojo-tensor-unit-test-and-gradient-checking
 description: "Use when: (1) writing or extending Mojo tensor unit tests (dtype-aware string/repr, BFloat16 NaN canonicalization, UInt bitwise boundary tests, view vs copy semantics in slice tests), (2) re-enabling NOTE-disabled or TODO-stubbed Mojo test files and resolving TODO(#N) markers, (3) writing numerical gradient checks for conv2d, depthwise conv2d, batch norm, layer norm, or pooling backward passes in Mojo, (4) a gradient check reports analytical≈0 vs numerical≈nonzero for a normalization layer (often caused by symmetric weight initialization), (5) adding end-to-end convergence tests as a complement to per-op finite-difference checks, (6) diagnosing symmetric-weight-init dead-symmetry pathology where uniform-fill weights produce algebraically zero gradients to early layers, (7) adding hardware-guarded BF16 precision recommendations to dtype selection functions."
 category: testing
-date: 2026-06-07
-version: "1.1.0"
+date: 2026-07-19
+version: "1.2.0"
 user-invocable: false
 history: mojo-tensor-unit-test-and-gradient-checking.history
 tags:
@@ -320,6 +320,7 @@ large+no-BF16→float16 (Apple guard), large+no-FP16→float32.
 | Blamed conv2d backward for ln(C) plateau | Saw chance-loss plateau + 1e-8 conv grads | Symmetric init produces the SAME fingerprint as a real substrate bug | Rerun with asymmetric init AND do manual-vs-autograd L2 compare to disambiguate |
 | `_make_asymmetric(shape, 0.05, 0.0)` | Wanted "almost uniform" init | `slope=0.0` IS uniform — same pathology | Slope must be measurably nonzero; `slope = base/n` |
 | Trusting FD checks as sufficient | Per-op tests passed while training hit 2.76% (chance) | FD validates gradient values, not training dynamics; missed upstream batch-copy bug | Pair every per-op check with ≥1 end-to-end convergence test |
+| Trusting an optimizer's step-1 state unit test | `test_adopt_step1_bounded`/`test_adan_prev_grad_seeded` passed after the fix, so re-ran a multi-hour campaign — full run STILL underfit ~40pts vs PyTorch | A passing per-step state test does not prove full-run convergence; the residual cause was separate (baseline adam/momentum bypassed the parity-tested library op via a hand-rolled `_adam_update`) | ALWAYS sanity-run ONE real cell with the fixed binary before a long campaign; add a PyTorch-parity **reference column** and localize by arm — if plain/momentum match the reference but adam doesn't, the bug is the adaptive-optimizer dispatch, not the backward |
 | Run tests via `just test-group` | Used `just` runner | `just` not in PATH in worktree | Use `pixi run mojo test <file>` directly |
 
 ## Results & Parameters


### PR DESCRIPTION
## Summary
Amends `mojo-tensor-unit-test-and-gradient-checking` (v1.1.0 → v1.2.0) with one Failed Attempts row extending the existing "Trusting FD checks as sufficient" lesson.

**New row:** a passing optimizer **step-1 STATE** unit test (e.g. ADOPT `v0=g0²`, Adan `prev_grad=g0`) does NOT prove full-run convergence. After the seed fixes passed their unit tests, a multi-hour campaign was re-run and STILL underfit ~40pts vs PyTorch. The residual cause was an **optimizer-dispatch bug** (baseline adam/momentum bypassed the parity-tested library op via a hand-rolled `_adam_update`), not a gradient bug.

**Lesson:** sanity-run ONE real cell with the fixed binary before a long campaign; add a **PyTorch-parity reference column** and localize by arm — if plain/momentum match the reference but adam doesn't, the bug is the adaptive-optimizer dispatch, not the backward.

## Why amend (not new)
The existing skill already carries the "unit test ≠ full-run convergence" theme (the FD-checks row from ProjectOdyssey PR #5466). This is a distinct, sharper instance in the same table — an amendment keeps one canonical entry rather than a near-duplicate.

## Verification
`verified-ci` — the underlying step-1 seed fixes' regression tests (PR #97, mvillmow/Random) + the corrected campaign path. `scripts/validate_plugins.py` passes 701/701.

## Test Plan
- [x] `python3 scripts/validate_plugins.py` → Valid 701/701
- [x] Previous version snapshot archived in `.history`
- [x] Version bumped 1.1.0 → 1.2.0, date 2026-07-19