### PR TITLE
feat: amend CI policy authority skills

### DIFF
--- a/skills/github-ruleset-enforcement-drift.history
+++ b/skills/github-ruleset-enforcement-drift.history
@@ -1,13 +1,41 @@
+# github-ruleset-enforcement-drift — History
+
+## v1.1.0 (2026-07-20)
+
+**Changed by:** ProjectHephaestus issue #2330 CI simplification planning record
+**Verification:** verified-local precondition; retirement implementation unverified
+
+### What changed
+
+- Added a fail-closed precondition for retiring duplicate CI enforcement: verify the default
+  branch, ruleset name, branch target, active enforcement, ref conditions, and
+  `required_signatures` before editing and again before shipping.
+- Added a cross-layer retirement audit covering workflow YAML, runtime exact-name special cases,
+  regression tests, test-only helpers, hooks, script inventories, documentation, and comments.
+- Added the rule that shared commit-message metadata must remain when Conventional Commit and DCO
+  checks still consume it.
+- Recorded live Hephaestus evidence for ruleset `15556494` and explicitly marked the proposed
+  workflow/runtime cleanup as unverified.
+
+### Why
+
+Removing a duplicate CI check is safe only while the replacement enforcement layer is demonstrably
+active on the protected branch. A ruleset name alone does not prove coverage: its target,
+enforcement state, ref conditions, and rule types can drift. Deleting the YAML job alone is also
+incomplete when coordinators, exemptions, tests, and docs still encode the retired policy name.
+
+### Previous version (v1.0.0) snapshot
+
+~~~~markdown
 ---
 name: github-ruleset-enforcement-drift
-description: "Canonical config file says `evaluate` but live GitHub ruleset is already `active`; idempotent re-apply would silently downgrade enforcement. Use when: (1) flipping a GitHub branch ruleset from evaluate to active mode and the on-disk JSON carries `evaluate`, (2) confirming whether a canonical config file matches its live deployed state before re-applying, (3) preserving a rollback/shadow-test path after the base config file changes enforcement mode, (4) aligning variant apply-target files (e.g. `*-active.json`) that were not updated when the base file was fixed, (5) auditing required_status_checks context strings for the correct bare-name + integration_id form vs stale prefixed form, (6) retiring a duplicate CI policy check only after proving an active branch ruleset still enforces the same invariant on the default branch."
+description: "Canonical config file says `evaluate` but live GitHub ruleset is already `active`; idempotent re-apply would silently downgrade enforcement. Use when: (1) flipping a GitHub branch ruleset from evaluate to active mode and the on-disk JSON carries `evaluate`, (2) confirming whether a canonical config file matches its live deployed state before re-applying, (3) preserving a rollback/shadow-test path after the base config file changes enforcement mode, (4) aligning variant apply-target files (e.g. `*-active.json`) that were not updated when the base file was fixed, (5) auditing required_status_checks context strings for the correct bare-name + integration_id form vs stale prefixed form."
 category: ci-cd
-date: 2026-07-20
-version: "1.1.0"
+date: 2026-06-19
+version: "1.0.0"
 user-invocable: false
 verification: verified-local
-history: github-ruleset-enforcement-drift.history
-tags: [github, rulesets, branch-protection, enforcement, drift, rollback, evaluate, active, integration_id, required-signatures, ci-policy-retirement, fail-closed]
+tags: [github, rulesets, branch-protection, enforcement, drift, rollback, evaluate, active, integration_id]
 ---
 
 # GitHub Ruleset Enforcement Drift
@@ -16,11 +44,10 @@ tags: [github, rulesets, branch-protection, enforcement, drift, rollback, evalua
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-20 |
-| **Objective** | Keep repository policy aligned with live GitHub rulesets and retire duplicate CI enforcement without opening a protection gap |
-| **Outcome** | Existing drift remediation remains verified locally; v1.1.0 adds a fail-closed retirement workflow whose live ruleset precondition was verified locally, while the planned code and workflow changes remain unverified |
-| **Verification** | verified-local — the original pre-commit/jq checks passed, and the v1.1.0 Hephaestus ruleset query confirmed an active branch ruleset covering `main` with `required_signatures`; the retirement implementation and CI were not executed |
-| **History** | [changelog](./github-ruleset-enforcement-drift.history) |
+| **Date** | 2026-06-19 |
+| **Objective** | Fix `enforcement: evaluate` in canonical GitHub ruleset JSON files that should be `active`, without downgrading the live deployed state or breaking the rollback/shadow-test path |
+| **Outcome** | Successful — on-disk config aligned with live enforcing ruleset; rollback path preserved via dedicated evaluate file and explicit `--evaluate` flag; stale prefixed contexts in variant files corrected |
+| **Verification** | verified-local — pre-commit and jq assertions passed; PR #307 merged to HomericIntelligence/Odysseus; Mnemosyne CI gate not observed |
 
 ## When to Use
 
@@ -29,8 +56,6 @@ tags: [github, rulesets, branch-protection, enforcement, drift, rollback, evalua
 - A runbook's two-phase rollout uses bare script invocation as the "shadow (evaluate) pass", but the script's bare default was changed to `active` — the documented flow is now silently active-then-active.
 - A variant file (`*-active.json`, `*-evaluate.json`) was left unedited when the base file was fixed, remaining a live apply path with stale context strings.
 - `required_status_checks` context entries use the stale prefixed form (`"Required Checks / lint"`) instead of the canonical bare-name + `integration_id` form (`"lint"` + `"integration_id": 15368`).
-- A GitHub Actions job duplicates an invariant already enforced by a live branch ruleset, and you need to remove the duplicate without weakening merge-time policy.
-- A retired workflow job name still appears in runtime filtering, documentation, test exemptions, or test-only helpers after the YAML job is removed.
 
 ## Verified Workflow
 
@@ -70,24 +95,6 @@ jq '[.rules[] | select(.type=="required_status_checks")
 jq '[.rules[] | select(.type=="required_status_checks")
      | .parameters.required_status_checks[]] | length' configs/github/repo-ruleset.json
 # Expected: 8 (not 9 — forbid-suppressions is a workflow job, NOT a required context)
-
-# 7. Before removing duplicate signature validation, prove the live ruleset owns it.
-repo=ORG/REPO
-default_branch=$(gh api "repos/$repo" --jq .default_branch)
-ruleset_id=$(gh api "repos/$repo/rulesets" --paginate --jq '
-  .[] | select(.name == "homeric-main-baseline"
-    and .target == "branch" and .enforcement == "active") | .id' | head -n 1)
-test "$default_branch" = main
-test -n "$ruleset_id"
-gh api "repos/$repo/rulesets/$ruleset_id" | python3 -c '
-import json, sys
-r = json.load(sys.stdin)
-include = r.get("conditions", {}).get("ref_name", {}).get("include", [])
-exclude = r.get("conditions", {}).get("ref_name", {}).get("exclude", [])
-assert any(ref in include for ref in ("refs/heads/main", "~DEFAULT_BRANCH", "~ALL"))
-assert not any(ref in exclude for ref in ("refs/heads/main", "~DEFAULT_BRANCH", "~ALL"))
-assert any(rule.get("type") == "required_signatures" for rule in r.get("rules", []))
-'
 ```
 
 ### Detailed Steps
@@ -115,38 +122,6 @@ assert any(rule.get("type") == "required_signatures" for rule in r.get("rules", 
      configs/github/repo-ruleset-evaluate.json && echo OK
    ```
 
-### Ruleset-backed CI policy retirement
-
-> **Warning:** The retirement sequence below is proposed from ProjectHephaestus issue #2330.
-> Its live precondition was verified locally on 2026-07-20, but the workflow/runtime edits and
-> CI validation were not executed. Treat the sequence as unverified until the implementation PR
-> passes CI and the post-edit ruleset query still succeeds.
-
-1. **Name the policy owner before deleting anything.** A workflow check may be removed only when
-   another active enforcement layer owns the same invariant. For cryptographic commit signing,
-   verify the default branch, named ruleset, branch target, active enforcement, ref include/exclude
-   conditions, and the `required_signatures` rule. A matching ruleset name alone is insufficient.
-2. **Run the proof twice.** Execute the live precondition immediately before editing and again
-   immediately before shipping. If the first check fails, leave the CI check intact. If the final
-   check fails, restore the removed workflow query/step and its documentation attribution, then
-   stop without shipping.
-3. **Remove only the duplicated assertion.** If other checks still need the same fetched metadata,
-   preserve that query. For example, removing signature fields from a commit query must not remove
-   full commit messages still consumed by Conventional Commit or DCO validation.
-4. **Retire the policy across every layer.** Search the workflow job name and checker symbol across
-   workflow YAML, runtime coordinators, docs, tests, pre-commit hooks, script inventories, and code
-   comments. Delete exact-name filters and policy-only success branches so a former advisory check
-   cannot keep bypassing the generic failure/fix path after its job disappears.
-5. **Write regression tests against the former special-case name.** A terminal poll should classify
-   any failed required check as failing, and the failure handler should route that same name into
-   the normal fix flow. Using the retired name in the test proves the old bypass branch is gone.
-6. **Do not preserve retired YAML shape as a unit-test API.** Delete tests and test-only helpers
-   whose only behavior is parsing repository-owned workflow files. Keep fixture-based tests for
-   reusable parsers/helpers and use YAML/schema/security tooling to validate live workflows.
-7. **Reassign documentation authority.** Every policy statement should identify the ruleset as the
-   merge-time signature authority while retaining CI ownership for independent checks such as PR
-   linkage, Conventional Commit subjects, and DCO trailers.
-
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -155,9 +130,6 @@ assert any(rule.get("type") == "required_signatures" for rule in r.get("rules", 
 | Change bare default without updating runbook | Apply script bare default changed from evaluate to active, but runbook still called bare invocation as the "evaluate mode shadow pass" | Reviewer caught that the two-phase rollout was now silently active-then-active — shadow step lost | Every time a script flag default changes, audit ALL runbook examples that relied on that bare invocation and update them to use explicit flags |
 | Remove `-active.json` variant files to reduce duplication | Prior plan proposed deleting `repo-ruleset-active.json` and `org-ruleset-active.json` as they were now identical to the base | Removing them broke the rollback path and the `--active` flag; the NOGO review flagged scope creep + irreversible delete | Preserve variant files even when they become temporarily identical to the base — they serve as explicit named apply paths; cleanup is a separate issue |
 | Use prefixed context form in org-ruleset-active.json | Kept `"Required Checks / lint"` form from the original config | GitHub Actions reports bare job `name:` values (`"lint"`), not workflow-prefixed; contexts without `integration_id` are also unreliable | Always derive context strings from the LIVE ruleset API, not from the config file or KB assumption |
-| Remove duplicate CI signature validation after checking only the ruleset name | Assumed an existing `homeric-main-baseline` object protected the default branch | A ruleset can be inactive, target another resource, exclude `main`, or omit `required_signatures`; the workflow removal would silently open a policy gap | Prove default branch, target, enforcement, ref conditions, and rule type before editing and again before shipping; fail closed and restore on final drift |
-| Delete an advisory job but keep its exact-name runtime branch | Removed workflow YAML while retaining coordinator logic that treated that name as policy-only success/blocking | The dead name continued to bypass the generic CI fix flow and obscured the real state machine | Search by the exact retired job name across production code and add a regression using that former name to prove generic failure routing |
-| Keep unit tests that parse the retired live workflow structure | Preserved tests and a helper whose only contract was the old YAML job inventory | The tests coupled Python code to mutable workflow layout and forced dead policy concepts to survive after deletion | Delete live-tree structural assertions with the policy; retain fixture-based helper behavior and validate live YAML through workflow-native tooling |
 
 ## Results & Parameters
 
@@ -202,20 +174,15 @@ test "$(jq '[.rules[] | select(.type=="required_status_checks")
 jq -e '.enforcement == "evaluate"' configs/github/repo-ruleset-evaluate.json
 ```
 
-### Ruleset-backed signature authority evidence
-
-| Field | ProjectHephaestus observation on 2026-07-20 |
-|-------|---------------------------------------------|
-| Default branch | `main` |
-| Ruleset | `homeric-main-baseline` (ID `15556494`) |
-| Target and enforcement | `branch`, `active` |
-| Ref condition | Includes `refs/heads/main`; exclusion list empty |
-| Relevant rule | `required_signatures` present |
-| Retirement implementation | Unverified — the live Hephaestus tree still contained the duplicate workflow signature step, `auto-merge-policy`, runtime special cases, and the tag-coupled security hook at capture time |
-
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | HomericIntelligence/Odysseus | PR #307, issue #177, 2026-06-19 | Flipped `repo-ruleset.json` and `org-ruleset.json` to `active`; fixed `org-ruleset-active.json` prefixed contexts; added `repo-ruleset-evaluate.json`; added `--evaluate` flag; updated runbook two-phase rollout |
-| HomericIntelligence/Hephaestus | Issue #2330 planning record, 2026-07-20 | Live precondition verified locally: default `main`, active branch ruleset `15556494`, `refs/heads/main` included, no exclusions, and `required_signatures` present. Proposed CI/runtime/test cleanup was not implemented or CI-verified. |
+~~~~
+
+---
+
+## v1.0.0 (2026-06-19)
+
+**Initial version.**

--- a/skills/security-md-version-sync.history
+++ b/skills/security-md-version-sync.history
@@ -1,5 +1,189 @@
 # security-md-version-sync — History
 
+## v3.1.0 (2026-07-20)
+
+**Changed by:** ProjectHephaestus issue #2330 CI simplification planning record
+**Verification:** unverified guard-retirement workflow; prior v3.0.0 remains verified-local
+
+### What changed
+
+- Separated release identity from security-support policy authority.
+- Added a trigger and proposed workflow for retiring a tag-coupled `SECURITY.md` checker when
+  repository policy no longer says the newest tag is the only supported series.
+- Added a complete removal surface: checker, unit suite, pre-commit hook, inventory entry, docs,
+  smoke references, and comments.
+- Preserved independent freshness checks such as rejecting hard-coded `As of YYYY-MM-DD` dates.
+- Marked the new workflow unverified because the Hephaestus script and hook still existed at
+  capture time and no implementation tests or CI ran.
+
+### Why
+
+The latest release tag answers which version was released; it does not, by itself, decide which
+release lines receive security fixes. A tag-to-table equality checker is valid only when explicit
+support policy declares that coupling. When policy changes, preserving the checker mistakes an
+implementation mechanism for authority and forces policy churn on every release.
+
+### Previous version (v3.0.0) snapshot
+
+~~~~markdown
+---
+name: security-md-version-sync
+description: "Keep SECURITY.md release-support and Python-compatibility statements synchronized with the project's actual version authority and executable guards. Use when: (1) a release tag or static version changes, (2) a hatch-vcs project has no static version field, (3) a supported-versions table drifts, (4) a guard requires a specific number of supported series, (5) a CI interpreter matrix changes."
+category: documentation
+date: 2026-07-20
+version: "3.0.0"
+user-invocable: false
+verification: verified-local
+tags: ["security", "versioning", "documentation", "SECURITY.md", "hatch-vcs", "release-tags", "pre-commit", "ci-matrix", "compatibility"]
+history: security-md-version-sync.history
+---
+
+# SECURITY.md Version and Compatibility Sync
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-20 |
+| **Objective** | Keep release-support rows and interpreter-support prose synchronized with the project's declared version authority, release tags, CI, and executable policy guards |
+| **Outcome** | Source-aware workflow covers static versions and VCS-derived versions without overriding repository-specific support-series rules |
+| **Verification** | verified-local — direct guard plus 19 targeted ProjectHephaestus tests passed; CI validation pending |
+| **History** | [changelog](./security-md-version-sync.history) |
+
+## When to Use
+
+- A release tag or static package version advances and `SECURITY.md` may still name the previous minor series
+- A project uses hatch-vcs or another dynamic version provider and intentionally has no static `[project].version`
+- A repository guard rejects stale, missing, or multiple supported-version rows
+- The main CI matrix adds or removes a Python version
+- `SECURITY.md` or `COMPATIBILITY.md` may be reflecting each other rather than authoritative metadata
+
+## Verified Workflow
+
+> **Verification scope:** Verified locally only — CI validation pending.
+
+### Quick Reference
+
+```bash
+# Discover whether version authority is static metadata or VCS tags.
+rg -n 'dynamic = \["version"\]|^version\s*=|source\s*=\s*"vcs"' pyproject.toml
+git tag --list 'v*' --sort=-version:refname | head
+
+# Inspect policy and executable enforcement before choosing a table shape.
+sed -n '/Supported Versions/,+8p' SECURITY.md
+rg -n 'SECURITY\.md|supported.*version|version.*consisten' scripts .pre-commit-config.yaml tests
+
+# ProjectHephaestus example; use the repository's equivalent guard and tests.
+python3 scripts/check_security_version_consistency.py
+uv run pytest tests/unit/scripts/test_check_security_version_consistency.py --no-cov -q
+uv run pytest 'tests/unit/scripts/test_scripts_smoke.py::test_script_help_exits_zero' \
+  -k check_security_version_consistency --no-cov -q
+```
+
+### Detailed Steps
+
+1. Identify the repository's version authority before editing policy data:
+   - For a static package version, read `[project].version` or the repository's declared equivalent.
+   - For hatch-vcs or another VCS-derived version, keep static metadata absent and derive the current minor from version-sorted release tags.
+2. Read the existing policy guard and its unit tests. Treat their accepted table shape as an executable repository invariant unless the task explicitly changes policy.
+3. Compare the canonical current minor `X.Y` with the supported and end-of-life rows in `SECURITY.md`.
+4. Make the smallest policy-data edit. Do not modify a correct guard or broaden test scope merely because the document drifted.
+5. Run the guard directly against the real repository and available tags. A `--help` smoke test does not prove the policy is aligned.
+6. Run the guard's focused unit suite, including aligned, drifted, missing-row, and multiple-row cases.
+7. Run the affected script smoke test and the configured pre-commit hook when present.
+8. Report `verified-local` until CI confirms the branch; only then promote the evidence level to `verified-ci`.
+
+### Worked Example — VCS-derived single supported series
+
+Suppose hatch-vcs derives the package version from tags, the latest version-sorted tag is
+`v0.10.0`, and the guard accepts exactly one supported series. The policy data is:
+
+```markdown
+| Version | Supported      |
+|---------|----------------|
+| 0.10.x  | Supported      |
+| < 0.10  | End of life    |
+```
+
+Do not add a static `version` field, preserve `0.9.x` as a second supported row, or edit a
+correct guard. Those actions conflict with the repository's version model or executable policy.
+
+### Worked Example — Static version with an explicit overlap policy
+
+If the repository stores a static `X.Y.Z` version and explicitly supports the current and
+preceding minor series, a two-series table can be correct:
+
+```markdown
+| Version   | Supported   |
+|-----------|-------------|
+| X.Y.x     | Supported   |
+| X.(Y-1).x | Supported   |
+| < X.(Y-1) | End of life |
+```
+
+The overlap is a project policy, not a universal default. Confirm it in the guard, release
+policy, or tests before retaining the previous series.
+
+### Python support provenance prose
+
+For interpreter policy, derive the install-time floor from `requires-python` and the tested
+range from all relevant CI matrices. Treat development-environment constraints as
+corroborating information, and verify `SECURITY.md` and `COMPATIBILITY.md` independently.
+
+```markdown
+Project supports **Python 3.10–3.13** (`requires-python = ">=3.10"` in
+`pyproject.toml`; CI exercises 3.10, 3.11, 3.12, and 3.13). See
+[COMPATIBILITY.md](COMPATIBILITY.md) for the full compatibility policy.
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assume `[project].version` always exists | Used static package metadata as the universal release source | hatch-vcs projects intentionally declare `dynamic = ["version"]` and derive versions from tags | Discover the repository's version model first; do not introduce a static version field |
+| Sort tags as plain text | Compared `v0.10.0` and `v0.9.9` lexicographically | Lexical ordering can place `0.9` after `0.10` | Use version-aware sorting such as `git tag --sort=-version:refname` |
+| Keep the previous minor supported by default | Applied a generic two-series table | Some guards require exactly one supported series | Read the executable guard and tests before choosing the table shape |
+| Edit the guard and tests with the policy row | Expanded a documentation-drift fix into enforcement changes | The existing guard already encoded the intended invariant | Change policy data only when enforcement is already correct |
+| Run only the script help smoke test | Verified CLI startup but not tag-to-policy consistency | `--help` exits before evaluating the repository state | Run the real guard first, then focused unit and smoke tests |
+| Read only one CI workflow | Treated a single job as the entire interpreter support matrix | Auxiliary jobs may use a narrower subset | Inspect all workflow files before stating a tested range |
+| Trust `COMPATIBILITY.md` | Used one policy document to validate another | Both documents can drift together | Compare both with metadata, tags, and CI independently |
+| Run an incompatible formatter unconditionally | Ran all hooks on a host lacking the formatter's runtime requirements | The formatter failed for the host, not the documentation | Skip only a known incompatible hook and baseline unrelated failures on main |
+
+## Results & Parameters
+
+| Source | Authority |
+|--------|-----------|
+| Static `[project].version` | Canonical release only when the repository declares a static version |
+| Version-sorted release tags | Canonical release series for hatch-vcs/VCS-derived projects |
+| Repository consistency guard and its tests | Executable table-shape and alignment invariant |
+| `pyproject.toml` `requires-python` | Canonical install-time Python floor |
+| Main CI matrices | Canonical tested interpreter range |
+| Development environment constraint | Corroborating signal only |
+| `SECURITY.md` and `COMPATIBILITY.md` | Policy outputs to validate, not independent sources of truth |
+
+### Acceptance checks
+
+- The current canonical minor appears in the supported-version table.
+- The number and range of supported rows match the repository's explicit policy guard.
+- The direct consistency guard passes against real tags or metadata.
+- Focused tests cover aligned, drifted, missing, and multiple-row policies.
+- The affected script smoke test passes.
+- If interpreter prose changed, both ends of the CI-tested Python range are present and attributable.
+
+ProjectHephaestus's observed commands and outputs are preserved in
+[session notes](./security-md-version-sync.notes.md).
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | `v0.10.*` supported-series correction, commit `31ed68e` | Direct guard, 18 guard unit tests, and 1 filtered smoke test passed locally on 2026-07-20; [notes](./security-md-version-sync.notes.md) |
+| ProjectHephaestus | Issue #47, PR #76 | Supported release table updated and pre-commit verified |
+| ProjectHephaestus | Issue #1204 | Python-range provenance prose verified with pre-commit |
+~~~~
+
+---
+
 ## v3.0.0 (2026-07-20)
 
 **Changed by:** ProjectHephaestus `v0.10.*` SECURITY.md drift correction (commit `31ed68e`; local verification session)

--- a/skills/security-md-version-sync.md
+++ b/skills/security-md-version-sync.md
@@ -1,12 +1,12 @@
 ---
 name: security-md-version-sync
-description: "Keep SECURITY.md release-support and Python-compatibility statements synchronized with the project's actual version authority and executable guards. Use when: (1) a release tag or static version changes, (2) a hatch-vcs project has no static version field, (3) a supported-versions table drifts, (4) a guard requires a specific number of supported series, (5) a CI interpreter matrix changes."
+description: "Keep SECURITY.md release-support and Python-compatibility statements synchronized with explicit project policy without mistaking release metadata for the support-policy authority. Use when: (1) a release tag or static version changes, (2) a hatch-vcs project has no static version field, (3) a supported-versions table drifts, (4) a guard requires a specific number of supported series, (5) a CI interpreter matrix changes, (6) a tag-coupled SECURITY.md guard should be retired because release cadence no longer defines the support window."
 category: documentation
 date: 2026-07-20
-version: "3.0.0"
+version: "3.1.0"
 user-invocable: false
 verification: verified-local
-tags: ["security", "versioning", "documentation", "SECURITY.md", "hatch-vcs", "release-tags", "pre-commit", "ci-matrix", "compatibility"]
+tags: ["security", "versioning", "documentation", "SECURITY.md", "hatch-vcs", "release-tags", "pre-commit", "ci-matrix", "compatibility", "support-policy", "guard-retirement"]
 history: security-md-version-sync.history
 ---
 
@@ -17,9 +17,9 @@ history: security-md-version-sync.history
 | Field | Value |
 |-------|-------|
 | **Date** | 2026-07-20 |
-| **Objective** | Keep release-support rows and interpreter-support prose synchronized with the project's declared version authority, release tags, CI, and executable policy guards |
-| **Outcome** | Source-aware workflow covers static versions and VCS-derived versions without overriding repository-specific support-series rules |
-| **Verification** | verified-local — direct guard plus 19 targeted ProjectHephaestus tests passed; CI validation pending |
+| **Objective** | Keep release-support rows and interpreter-support prose synchronized with explicit support policy, release facts, CI, and justified executable guards |
+| **Outcome** | Source-aware workflow covers static and VCS-derived versions; v3.1.0 adds a proposed path for retiring a guard when latest-release identity is no longer the support-policy authority |
+| **Verification** | verified-local — the v3.0.0 direct guard plus 19 targeted ProjectHephaestus tests passed; the v3.1.0 guard-retirement workflow is planning-only and unverified |
 | **History** | [changelog](./security-md-version-sync.history) |
 
 ## When to Use
@@ -29,6 +29,8 @@ history: security-md-version-sync.history
 - A repository guard rejects stale, missing, or multiple supported-version rows
 - The main CI matrix adds or removes a Python version
 - `SECURITY.md` or `COMPATIBILITY.md` may be reflecting each other rather than authoritative metadata
+- A consistency script equates the latest release tag with the only supported series, but the repository's support policy no longer declares that coupling
+- A policy guard, its unit suite, pre-commit hook, and script inventory entry must be retired together without removing independent documentation checks
 
 ## Verified Workflow
 
@@ -50,6 +52,10 @@ python3 scripts/check_security_version_consistency.py
 uv run pytest tests/unit/scripts/test_check_security_version_consistency.py --no-cov -q
 uv run pytest 'tests/unit/scripts/test_scripts_smoke.py::test_script_help_exits_zero' \
   -k check_security_version_consistency --no-cov -q
+
+# Before preserving or retiring a tag-coupled guard, locate every policy authority and consumer.
+rg -n 'Supported Versions|support(ed)? series|release tag|version consistency' \
+  SECURITY.md CONTRIBUTING.md docs scripts tests .pre-commit-config.yaml
 ```
 
 ### Detailed Steps
@@ -57,13 +63,34 @@ uv run pytest 'tests/unit/scripts/test_scripts_smoke.py::test_script_help_exits_
 1. Identify the repository's version authority before editing policy data:
    - For a static package version, read `[project].version` or the repository's declared equivalent.
    - For hatch-vcs or another VCS-derived version, keep static metadata absent and derive the current minor from version-sorted release tags.
-2. Read the existing policy guard and its unit tests. Treat their accepted table shape as an executable repository invariant unless the task explicitly changes policy.
+2. Identify the support-policy authority separately from the release-version authority. Read the existing guard and tests, but do not treat an implementation mechanism as policy evidence by itself. Preserve its accepted table shape only when repository policy explicitly says support follows the latest release series.
 3. Compare the canonical current minor `X.Y` with the supported and end-of-life rows in `SECURITY.md`.
-4. Make the smallest policy-data edit. Do not modify a correct guard or broaden test scope merely because the document drifted.
+4. Make the smallest change at the correct layer. For ordinary drift, edit policy data without broadening the guard. When the task explicitly decouples support policy from release tags, retire the tag-coupled guard and all of its wiring rather than weakening it into a vague check.
 5. Run the guard directly against the real repository and available tags. A `--help` smoke test does not prove the policy is aligned.
 6. Run the guard's focused unit suite, including aligned, drifted, missing-row, and multiple-row cases.
 7. Run the affected script smoke test and the configured pre-commit hook when present.
 8. Report `verified-local` until CI confirms the branch; only then promote the evidence level to `verified-ci`.
+
+### Retiring a tag-coupled support guard
+
+> **Warning:** This workflow is proposed from ProjectHephaestus issue #2330 and has not been
+> implemented or validated end-to-end. The live tree still contained the script and hook at capture
+> time. Treat this as `unverified` until focused tests, the full suite, and CI pass after removal.
+
+1. State the policy change explicitly: the latest release tag identifies released software, but it
+   does not automatically define which release series receive security fixes.
+2. Search the guard symbol and hook ID across scripts, tests, pre-commit configuration, docs, smoke
+   inventories, and comments. A removal is incomplete while any invocation or claimed enforcement
+   remains.
+3. Delete the tag-coupled checker, its dedicated unit suite, its pre-commit hook, and its script
+   inventory entry in one change.
+4. Preserve independent checks. For example, a guard rejecting hard-coded `As of YYYY-MM-DD` dates
+   in `SECURITY.md` can remain because it enforces freshness hygiene without deriving support policy
+   from the latest Git tag.
+5. Verify absence by parsing `.pre-commit-config.yaml` and asserting the old hook ID is gone, then
+   search the repository for the script name. Run documentation, pre-commit, and full test suites.
+6. Update this skill's verification only after the removal lands and CI proves the repository no
+   longer depends on the deleted checker.
 
 ### Worked Example — VCS-derived single supported series
 
@@ -120,14 +147,16 @@ Project supports **Python 3.10–3.13** (`requires-python = ">=3.10"` in
 | Read only one CI workflow | Treated a single job as the entire interpreter support matrix | Auxiliary jobs may use a narrower subset | Inspect all workflow files before stating a tested range |
 | Trust `COMPATIBILITY.md` | Used one policy document to validate another | Both documents can drift together | Compare both with metadata, tags, and CI independently |
 | Run an incompatible formatter unconditionally | Ran all hooks on a host lacking the formatter's runtime requirements | The formatter failed for the host, not the documentation | Skip only a known incompatible hook and baseline unrelated failures on main |
+| Treat the latest release tag as the support-policy authority | Required `SECURITY.md` to name exactly the newest minor because that minor was latest | Release identity and support lifetime are different decisions; the coupling forces policy churn on every tag and prevents intentional overlap or independent support windows | Derive support rows from explicit security policy. Keep a tag-coupled guard only when that coupling is itself the declared policy; otherwise retire the checker and all wiring |
 
 ## Results & Parameters
 
 | Source | Authority |
 |--------|-----------|
 | Static `[project].version` | Canonical release only when the repository declares a static version |
-| Version-sorted release tags | Canonical release series for hatch-vcs/VCS-derived projects |
-| Repository consistency guard and its tests | Executable table-shape and alignment invariant |
+| Version-sorted release tags | Canonical release identity for hatch-vcs/VCS-derived projects; not automatically the support-window authority |
+| Explicit repository security/support policy | Canonical supported-series and end-of-life decisions |
+| Repository consistency guard and its tests | Enforcement mechanism only when it reflects the declared support policy |
 | `pyproject.toml` `requires-python` | Canonical install-time Python floor |
 | Main CI matrices | Canonical tested interpreter range |
 | Development environment constraint | Corroborating signal only |
@@ -135,11 +164,11 @@ Project supports **Python 3.10–3.13** (`requires-python = ">=3.10"` in
 
 ### Acceptance checks
 
-- The current canonical minor appears in the supported-version table.
-- The number and range of supported rows match the repository's explicit policy guard.
-- The direct consistency guard passes against real tags or metadata.
-- Focused tests cover aligned, drifted, missing, and multiple-row policies.
-- The affected script smoke test passes.
+- The supported-version table matches explicit support policy; matching the current canonical minor is required only when policy says it is supported.
+- If a tag-coupled guard remains policy-backed, the supported rows match it and its direct,
+  focused, and smoke tests pass against real tags or metadata.
+- If that guard is retired, its script, hook ID, dedicated tests, inventory entry, and claimed
+  enforcement references are all absent while independent `SECURITY.md` checks still pass.
 - If interpreter prose changed, both ends of the CI-tested Python range are present and attributable.
 
 ProjectHephaestus's observed commands and outputs are preserved in
@@ -152,3 +181,4 @@ ProjectHephaestus's observed commands and outputs are preserved in
 | ProjectHephaestus | `v0.10.*` supported-series correction, commit `31ed68e` | Direct guard, 18 guard unit tests, and 1 filtered smoke test passed locally on 2026-07-20; [notes](./security-md-version-sync.notes.md) |
 | ProjectHephaestus | Issue #47, PR #76 | Supported release table updated and pre-commit verified |
 | ProjectHephaestus | Issue #1204 | Python-range provenance prose verified with pre-commit |
+| ProjectHephaestus | Issue #2330 planning record | Proposed retirement of the tag-coupled checker, unit suite, hook, and inventory entry while retaining the independent no-hardcoded-date guard. Unverified: no removal or CI run occurred in this learning session. |

--- a/tests/test_skill_consolidation_integrity.py
+++ b/tests/test_skill_consolidation_integrity.py
@@ -81,7 +81,7 @@ CONSOLIDATIONS: list[Consolidation] = [
     },
     {
         "canonical": "security-md-version-sync",
-        "version": "3.0.0",
+        "version": "3.1.0",
         "absorbed": ["security-md-version-sync-planning-gaps"],
     },
     {


### PR DESCRIPTION
## Summary

Amends two canonical skills from the ProjectHephaestus #2330 planning record.

- Updates `github-ruleset-enforcement-drift` from v1.0.0 to v1.1.0 with a fail-closed, twice-checked precondition for ruleset-backed CI policy retirement.
- Updates `security-md-version-sync` from v3.0.0 to v3.1.0 to distinguish release identity from explicit security-support policy and document complete tag-coupled guard retirement.
- Archives exact previous-version snapshots and updates the consolidation-version invariant.

## Verification Level

**Mixed: verified-local preconditions; proposed retirement workflows unverified.**

The live Hephaestus query confirmed default branch `main`, active branch ruleset `homeric-main-baseline` (ID `15556494`), `refs/heads/main` coverage, no exclusions, and `required_signatures`. The Hephaestus implementation was not performed; both skills state that limitation explicitly.

## Key Findings

**What worked:**

- Verify the replacement enforcement layer before editing and again before shipping.
- Remove retired policy names across workflow, runtime, test, hook, inventory, and documentation surfaces.
- Treat release tags as release identity, not automatic support-window policy.

**What fails:**

- Checking only a ruleset name can miss inactive, excluded, or incomplete enforcement.
- Deleting YAML while retaining exact-name runtime branches leaves obsolete bypass behavior.
- Preserving tag-coupled guards without explicit policy backing mistakes mechanism for authority.

## Test Plan

- [x] `uv run python scripts/validate_plugins.py` (708/708 valid)
- [x] `uv run python -m pytest tests/ -q` (219 passed)
- [x] Targeted pre-commit hooks
- [x] Exact previous-version history snapshots compared with `HEAD`
- [ ] Confirm skill discovery with relevant keywords in CI

Refs HomericIntelligence/Hephaestus#2330

Co-Authored-By: Codex <noreply@openai.com>