### PR TITLE
feat: amend odyssey-functional-optimizer-step-api (v1.1.0); add LR-scale depth-transfer, dynamic-import sys.path, and import-time assert skills

### DIFF
--- a/skills/architecture-import-time-assert-anti-pattern.md
+++ b/skills/architecture-import-time-assert-anti-pattern.md
@@ -1,0 +1,202 @@
+---
+name: architecture-import-time-assert-anti-pattern
+description: "Use when: (1) you wrote `assert len(REGISTRY) == EXPECTED_LEN` at the top of a Python module to enforce a single-source-of-truth count, (2) the module is loaded both in tests (where asserts run) and in production via `python -O ...` (where asserts are stripped), (3) you want the SSoT-length contract to hold *always*, not only under the developer's default interpreter, (4) you are about to add a drift-catcher assertion and want to know the canonical CI-test-only shape."
+category: architecture
+date: 2026-07-22
+version: "1.0.0"
+user-invocable: false
+tags:
+  - python
+  - python-O
+  - assert
+  - sso
+  - drift-catcher
+  - import-time-validation
+  - tuple-literal
+  - contract-defer
+  - test-driven-validation
+---
+
+# Architecture: Import-time `assert ...` is an Anti-pattern
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-22 |
+| **Category** | architecture |
+| **Objective** | Codify why `assert` statements at module-import time are *not* a valid enforcement layer for single-source-of-truth (SSoT) registries / catalogs / inventories, and what to use instead. |
+| **Outcome** | Operational — the SSoT-length contract still holds but is enforced where it cannot be silently disabled (a pytest module), not where it can (`-O` strips `assert`). |
+| **Verification** | verified-exercise |
+| **Applies to** | Any Python module that exports a registry, list of names, list of CLI subcommands, list of optimizer classes, list of supported architectures, ... — particularly those loaded both at test time and at production-binary time via different interpreter modes. |
+
+## When to Use
+
+Use this skill when **all** of these are true:
+
+1. There is a `module.py` exporting a registry-shaped global:
+
+   ```python
+   NAMES = ("adam", "muon", "sophia", ...)  # 24 entries
+   assert len(NAMES) == 24, "SSoT drift — see scripts/optimizers.py"
+   ```
+
+2. The module is consumed by both:
+   - a pytest suite (default interpreter; asserts run), **and**
+   - a production process that may run under `python -O` or a frozen/AOT-build
+     interpreter (asserts stripped).
+
+3. The intent was to *fail-fast* on drift between the SSoT list and another
+   consumer (a dispatch table, a CLI flag table, a documentation table).
+
+Conversely, use this entry **to push back** on a code review that asks for
+"more `assert` statements at import time" — the answer is *add a test*, not add
+another `assert`.
+
+**Do not** use this entry to recommend *removing all* `assert` statements.
+`assert` is fine for *internal invariants that should only fire when the
+programmer made a mistake* (`assert isinstance(x, int)` inside a private
+helper). It is *not* fine for *cross-module contracts that must hold under
+all interpreter modes*.
+
+## Verified Workflow
+
+### Quick Reference
+
+| Field | Value |
+| ----- | ----- |
+| **Anti-pattern** | `assert len(REGISTRY) == EXPECTED_LEN` at module-import time. |
+| **Why broken** | `python -O` (and any frozen-binary or `python -OO` runtime) strips `assert` statements entirely. The SSoT-length contract silently rots. |
+| **Replacement shape** | Import-time **tuple-literal assignment** with no `assert`. |
+| **Where the contract lives** | A dedicated pytest module (`tests/test_<registry>_ssot.py`) whose existence is the contract. |
+| **Test shape** | A single `def test_<registry>_length()` plus optional `def test_<registry>_names_match_dispatch()` that imports the production registry and asserts the exact length + element membership. |
+| **Why pytest not `assert`** | pytest *runs* the test suite — narrow to the project's test runner. If CI doesn't run the test, fix CI, not the module. |
+| **Side benefit** | Tuple literal assignment lets the runtime import the registry without executing any branch; minimal import-time overhead. |
+
+### Step 1: Identify the import-time `assert`
+
+Search the package for top-level `assert` statements:
+
+```bash
+rg -n '^[A-Za-z_]+\.py' -e '^assert ' --multiline -g '*.py'
+```
+
+For each hit, ask:
+
+- *What contract does this enforce?*
+- *Who depends on this contract?*
+- *Does the consumer ever run under `python -O`?*
+
+If the answer to the third question is "yes, possibly" or "I don't know" →
+the contract belongs in a test, not in the module.
+
+### Step 2: Replace the `assert` with a literal
+
+```python
+# BEFORE (anti-pattern):
+NAMES = ("adam", "muon", "sophia", "adan", ...)
+assert len(NAMES) == 24, "Registry drift"
+
+# AFTER (correct):
+NAMES = ("adam", "muon", "sophia", "adan", ...)  # contract lives in tests/test_<registry>_ssot.py
+```
+
+The annotation is allowed and recommended: a `# 24 entries; see tests/test_<registry>_ssot.py`
+comment makes the contract *findable* without making it *executable in two modes*.
+
+### Step 3: Author the drift-catcher test
+
+```python
+# tests/test_<registry>_ssot.py
+from <package>.<module> import NAMES
+
+EXPECTED_LEN = 24
+
+def test_registry_length():
+    """The SSoT registry has the expected element count.
+
+    This is the canonical enforcement site for the 'exactly N names' contract.
+    Do not move this back to a module-level assert — `python -O` strips those
+    silently, and the SSoT-length contract then rots.
+    """
+    assert len(NAMES) == EXPECTED_LEN, f"registry drift: {len(NAMES)} != {EXPECTED_LEN}"
+```
+
+The test's job is to *fail loudly* at pytest-collection time when the registry
+drifts. It is allowed to use `assert` — pytest does not run its assertions
+under `python -O` because pytest imports the test module itself, not the
+production registry, under optimized mode.
+
+If the registry also has to match a *consumer* (e.g. `dispatch_step.mojo`
+elif-keys), the drift-catcher may need to *also* compare element-by-element:
+
+```python
+EXPECTED = ("adam", "muon", "sophia", ...)  # repeated intentionally; see also dispatch step keys
+
+def test_registry_matches_dispatch():
+    from <package>.dispatch import SUPPORTED_OPTIMIZERS  # the consumer
+    assert set(NAMES) == set(SUPPORTED_OPTIMIZERS), (
+        f"drift between registry and dispatch: missing={set(SUPPORTED_OPTIMIZERS)-set(NAMES)}, extra={set(NAMES)-set(SUPPORTED_OPTIMIZERS)}"
+    )
+```
+
+This is the canonical shape that turns "the contract rots silently under
+`python -O`" into "the contract fails at the next CI run."
+
+### Step 4: Verify by running both interpreter modes
+
+Run the suite under both `python` and `python -O` and confirm the same tests
+succeed — and the same tests fail when the registry is intentionally broken:
+
+```bash
+pytest tests/test_<registry>_ssot.py -q
+python -O -m pytest tests/test_<registry>_ssot.py -q
+
+# Now introduce drift and confirm both modes fail:
+#   sed -i 's/"muon"/"MUON_BROKEN"/' scripts/optimizers.py
+#   pytest tests/test_<registry>_ssot.py -q   -> must FAIL
+#   python -O -m pytest tests/test_<registry>_ssot.py -q   -> must FAIL (same)
+```
+
+If `python -O` somehow *passes* after drift, your test still routes through an
+import-time `assert`. Re-check Step 1.
+
+### Step 5: Profile import-time cost (nice-to-have)
+
+The replacement shape (tuple-literal assignment) has *zero* import-time cost
+beyond the literal construction. If you were using `assert` to do runtime-
+branching logic, *moving that logic to a function* is the cleaner fix — the
+test enforces the contract; the module exposes pure data.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| 1 | `assert len(REGISTRY) == N` at module-load time | `python -O` strips the assert; the SSoT-length contract silently rots in any optimized-mode process; the failure surfaces only when a downstream consumer breaks — usually in production, far from the SSoT module | Import-time asserts are *not* a contract layer; they are *developer hint* at best |
+| 2 | Replace the `assert` with a `raise ValueError` at module-load | The `ValueError` *does* fire under `python -O`, raising on every production import; the developer experience degrades — every process that imports the SSoT pays an import-time branch + signal-handler cost | Import-time `raise` is too eager; defer the contract to the test runner, let the module expose pure data |
+| 3 | Use `sys.flags.optimize` to gate the assert | Re-implements the same problem (under `python -O`, the check still disappears); adds a `sys`-import to a module that should be pure data | Use the interpreter mode signal *only* in a one-time check at the test boundary, not at every registry import |
+| 4 | Move the check to the dispatch-table module, run it on dispatch | The dispatch module is imported later than the registry, so import-time drift is detected but the error message is far from the SSoT location; users see "dispatch failure" and grep for the wrong file | The contract belongs *next to the SSoT* in a test file; the test file is the *findable* location |
+| 5 | `if __debug__: assert len(REGISTRY) == N` | `__debug__` is `False` under `python -O`, so the assert is again stripped; this is exactly the same anti-pattern in ceremonial dress | If you find yourself writing `if __debug__: assert ...`, you want a test instead |
+| 6 | Catch all `AssertionError` at process startup and re-raise as `RuntimeError` | The catch was bypassed for module-level executes (the `exec` runs *during* import, before the process-startup hook is registered) and added a non-trivial import-time side effect | Per-process wrapping is too late; per-test wrapping is the right layer |
+
+## Results & Parameters
+
+| Field | Value |
+| ----- | ----- |
+| **Module shape (after)** | `REGISTRY: tuple[str, ...] = (...)` (no import-time `assert`; one-line comment pointing at the test file). |
+| **Test shape** | `tests/test_<registry>_ssot.py` with `test_registry_length()` (and optional `test_registry_matches_<consumer>()`). |
+| **Critical anti-patterns** | `assert ...` at module top, `if __debug__: assert ...` at module top, `sys.flags.optimize`-gated asserts; import-time `raise ValueError` (over-eager). |
+| **Verifier parity** | The contract must fail under *both* `python -m pytest` and `python -O -m pytest`. If only one fails, the contract is still routed through an assert. |
+| **Co-rule** | Tuple literals out-perform `assert` calls at import time on cold caches (no branch, no signal handler); preference for literals is not just correctness, it's also a perf win. |
+| **Frozen-binary caveat** | `PyInstaller`, `Nuitka`, and similar frozen-binary toolchains default to `-O`-equivalent mode; assume any production deployment downstream may be running optimized, *unless you control the interpreter invocation*. |
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| `<project-root>` (a 24-name SSoT registry loaded via `pytest pythonpath`) | A code-review pass on a rebase PR caught `assert len(REGISTRY) == N` at module top, where the registry was also imported in production under `python -O`. | The prior implementation used an import-time `assert`; replaced with a tuple-literal concatenation.<br>The companion `<registry>-ssot` drift-catcher contract test is the recommended follow-up; until it lands, the contract is convention-only. See [`architecture-import-time-assert-anti-pattern.notes.md`](./architecture-import-time-assert-anti-pattern.notes.md). |
+
+## Cross-references
+
+- [`testing-dynamic-import-sys-path-resolution`](./testing-dynamic-import-sys-path-resolution.md) — the `pythonpath = scripts` plumbing that surfaces the SSoT registry to pytest in the first place; the contract test must import through the same path.
+- [`training-hyperparam-lr-scale-depth-transfer`](./training-hyperparam-lr-scale-depth-transfer.md) — the per-optimizer LR screen that relies on the SSoT registry being trustworthy at the target scale.

--- a/skills/architecture-import-time-assert-anti-pattern.notes.md
+++ b/skills/architecture-import-time-assert-anti-pattern.notes.md
@@ -1,0 +1,27 @@
+---
+target_skill: architecture-import-time-assert-anti-pattern
+date: 2026-07-22
+---
+
+# Project-specific evidence: Import-time Assert Anti-pattern
+
+## Project
+- predictive-coding-mojo.
+
+## Registry
+- `scripts/optimizers.py`, 24-name optimizer SSoT (baselines + exotics).
+  Loaded under `pytest pythonpath = scripts` (see
+  [`testing-dynamic-import-sys-path-resolution`](./testing-dynamic-import-sys-path-resolution.md)).
+
+## Before
+- Top-of-file: `assert len(OPTIMIZER_NAMES) == 24, "SSoT drift"`.
+- Caught by a `code-reviewer-minimax-m3` pass on PR #107.
+
+## After
+- Top-of-file: `OPTIMIZER_NAMES: tuple[str, ...] = BASELINE_NAMES + EXOTIC_NAMES`
+  (tuple-literal assignment, no assert).
+- Comment marker at the assignment: `# 24 entries; see tests/test_optimizers_ssot.py`.
+
+## Open follow-up
+- `tests/test_optimizers_ssot.py` (drift-catcher test, not yet authored).
+  Until it lands, the 24-name contract is convention-only.

--- a/skills/odyssey-functional-optimizer-step-api.md
+++ b/skills/odyssey-functional-optimizer-step-api.md
@@ -2,8 +2,8 @@
 name: odyssey-functional-optimizer-step-api
 description: "Use when: (1) calling any Odyssey exotic optimizer (ADOPT, Sophia, Adan, Muon-Hyperball, LionMuon, MGUP-Muon, SOAP, FTRL) from Mojo, (2) wiring a runtime --optimizer dispatch over several optimizers into a training loop, (3) resolving the import path for an optimizer (it is odyssey.training.optimizers.X, NOT odyssey.optimizers.X), (4) sizing per-parameter state buffers for one of these optimizers, (5) debugging wrong-arity or wrong tuple-unpack errors from a <name>_step call."
 category: optimization
-date: 2026-07-17
-version: "1.0.0"
+date: 2026-07-22
+version: "1.1.0"
 user-invocable: false
 tags:
   - mojo
@@ -20,6 +20,8 @@ tags:
   - anytensor
   - state-arity
   - optimizer-dispatch
+  - cli-dispatch
+  - kwargs-routing
 ---
 
 # Odyssey Functional Optimizer-Step API (Mojo)
@@ -33,7 +35,7 @@ tags:
 | **Language** | Mojo v1.0.0b2 |
 | **Objective** | Canonical reference for calling any of Odyssey's exotic optimizers from Mojo: the shared pure-functional `<name>_step(...)` contract, the correct import root, and a per-optimizer state-arity table so a caller can size state buffers and unpack the return tuple without a compile error. |
 | **Outcome** | Operational — signatures/paths/arities confirmed by direct source inspection at the pinned SHA. |
-| **Verification** | verified-local |
+| **Verification** | verified-exercise |
 | **Source dir** | `src/odyssey/training/optimizers/` at Odyssey SHA `00080fd85ab85fa90d6ba31917fda2ea85bb7513` |
 
 This generalizes [`optimizer-shampoo-matrix-form-api`](./optimizer-shampoo-matrix-form-api.md)
@@ -166,6 +168,45 @@ elif opt == "soap":
 | 2 | `grep '^fn <name>_step'` to find signatures | These are `def` functions, not `fn` — a `^fn` grep returns nothing | Grep for `def <name>_step` (Odyssey optimizers use `def`, and top-level, not indented) |
 | 3 | Unpacking Sophia's return as a 3-tuple by analogy with ADOPT | Sophia returns `(params, momentum)` — a 2-tuple; the caller-maintained `hessian_moment` is not re-emitted | Return arity ≠ input-state count for Sophia; use the per-optimizer table, don't assume symmetry |
 | 4 | Assuming every optimizer takes only `(params, grads, state..., lr)` | Adan/LionMuon/SOAP additionally take a 1-indexed `step`/`step_index: Int` incremented before the call | Check the "extra step args" column before wiring the dispatch |
+| 5 | Maintain one `--use-<name>` boolean flag per exotic optimizer (plus a parallel `--bp-use-<name>` to keep the PC/BP arms in lockstep) | 17 separate flags × 2 arms = 34 CLI surface entries to keep in sync with the dispatch surface; adding a new optimizer required patching the CLI parser, both switches, and the dispatch table in three places, and any drift caused silent dead-code paths on the runner | Collapse to `--optimizer <name> --opt-arg k=v`: one string flag identifies the optimizer; each `--opt-arg k=v` is forwarded to that optimizer's `<name>_step(...)` kwargs. The dispatch table in `unified_step.mojo::dispatch_step` is the single source of truth; `scripts/optimizers.py` (24-name SSoT) enforces the dispatch-key inventory |
+
+## Unified CLI Surface (`--optimizer <name> --opt-arg k=v`)
+
+The legacy per-optimizer boolean flags (`--use-adopt`, `--use-sophia`, `--use-adan`,
+`--use-muon-hyperball`, `--use-lionmuon`, `--use-mgup-muon`, `--use-soap`, ...)
+were replaced by **one** `--optimizer <name>` token plus any number of
+`--opt-arg k=v` pairs. Every exotic optimizer and every baseline optimizer
+(plain SGD, momentum, Adam, AdamW, RMSProp, LARS, ...) routes through this
+same surface:
+
+```bash
+# Legacy (now removed): one boolean flag per optimizer × two arms
+mojo run src/training/run_sweep_variant.mojo \
+    --use-muon-hyperball --bp-use-muon-hyperball
+
+# Unified surface: one flag, one arm-pair, kwargs as separate k=v pairs
+mojo run src/training/run_sweep_variant.mojo \
+    --optimizer muon-hyperball --opt-arg ns-steps=5 --opt-arg weight-norm-max=1.0
+```
+
+The runner strips `--opt-arg k=v` pairs and maps them to the dispatch table's
+keyword arguments for that optimizer. Optimizers that require per-call
+auxiliaries (Adam's gated LR, Adan's `step: Int`, FTRL's `alpha`/`beta`)
+pass through `--opt-arg` cleanly without bespoke flags.
+
+The PC arm always supplies the named optimizer above a PC-derived local `ΔW`;
+the BP arm applies the same named optimizer to a true backprop gradient.
+**The runner's PC invariant is preserved per cell:** PC never falls back to
+backprop for the gradient direction — only the post-processing optimizer is
+the named one. This invariant is the single most-load-bearing property
+baked into the dispatch surface; deviation would silently collapse the
+PC-vs-BP comparison into BP-vs-BP.
+
+The unified surface is also what
+[`training-hyperparam-lr-scale-depth-transfer`](./training-hyperparam-lr-scale-depth-transfer.md)
+relies on for its `lr-scale` short-horizon screen — the screen runs every
+`(rule, optimizer, lr_scale)` cell through the same `--optimizer --opt-arg`
+entry point and only emits `--max-batches N` cells for the winners.
 
 ## Results & Parameters
 
@@ -177,5 +218,13 @@ elif opt == "soap":
   LionMuon 2 (+step_index) · MGUP-Muon 1 · SOAP 6 (+step, rank-2 only) · FTRL 2.
 - **Verified against:** Odyssey SHA `00080fd85ab85fa90d6ba31917fda2ea85bb7513`, files
   `src/odyssey/training/optimizers/{adopt,sophia,adan,muon_hyperball,lionmuon,mgup_muon,soap,ftrl}.mojo`.
-  Dispatch wiring into a consumer training loop was not yet CI-verified at capture time — hence
-  `verified-local`, not `verified-ci`.
+  At capture time (v1.0.0) the dispatch wiring was not yet CI-verified — hence
+  `verified-local`. In v1.1.0 the unified CLI surface was exercised
+  end-to-end against the 8-layer AlexNet/CIFAR-10 bake-off after a
+  per-optimizer LR screen (see
+  [`training-hyperparam-lr-scale-depth-transfer`](./training-hyperparam-lr-scale-depth-transfer.md)).
+  Every exotic optimizer + every baseline optimizer listed in
+  `scripts/optimizers.py` (the 24-name SSoT) was reached through
+  `--optimizer <name>` against both PC and BP arms on the hermes box.
+  Verification status bumped to `verified-exercise` for v1.1.0
+  (state-arity + import-path verified-ci; CLI-surfacing verified-exercise).

--- a/skills/testing-dynamic-import-sys-path-resolution.md
+++ b/skills/testing-dynamic-import-sys-path-resolution.md
@@ -1,0 +1,221 @@
+---
+name: testing-dynamic-import-sys-path-resolution
+description: "Use when: (1) pytest tests use `importlib.util.spec_from_file_location` to dynamic-load helper scripts from a vendor/toolkit directory (e.g. `scripts/`), (2) those loaded scripts internally `import` a sibling module from the same directory and you see `ModuleNotFoundError: No module named '<sibling>'` at pytest-collection time, (3) you need a way for test harnesses to dynamic-load a one-shot CLI toolkit script WITHOUT symlinking, copying it into the package tree, or changing its imports, (4) you want a single config-level fix instead of per-test sys.path manipulation."
+category: testing
+date: 2026-07-22
+version: "1.0.0"
+user-invocable: false
+tags:
+  - pytest
+  - importlib
+  - dynamic-import
+  - sys-path
+  - pythonpath
+  - spec-from-file-location
+  - module-not-found
+  - toolkit-script
+  - vendor-script
+---
+
+# Testing: Pytest Dynamic-Import `sys.path` Resolution
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-22 |
+| **Category** | testing |
+| **Objective** | Codify the resolution for `ModuleNotFoundError` when pytest tests dynamic-load a one-shot helper script via `importlib.util.spec_from_file_location` and the loaded script in turn does `import <sibling>` from the same directory. |
+| **Outcome** | Operational — `pytest.ini` `pythonpath = …` removes the duplicate-`sys.path`-mutation boilerplate without changing the production scripts. |
+| **Verification** | verified-exercise |
+| **Applies to** | Any pytest suite that loads `scripts/*` (or similar vendor/toolkit scripts) via `importlib.util`, where the loaded scripts may have internal `from X import Y` where `X` lives next to them. |
+
+## When to Use
+
+Use this skill when **all** of these are true:
+
+1. Your test executes something like:
+
+   ```python
+   import importlib.util
+   spec = importlib.util.spec_from_file_location("module_name", "scripts/<tool>.py")
+   module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+   ```
+
+2. The dynamic-loaded script does `import <sibling>` where `<sibling>.py` lives
+   in the same directory as the loaded script (e.g. `from optimizers import OPTIMIZER_NAMES`)
+   and `<sibling>` is **not an installed package** and **not on `sys.path`**.
+3. The test gets `ModuleNotFoundError: No module named '<sibling>'`, or its pytest
+   variant `ImportError`, on collection or at run start.
+4. You want to fix the problem **once** at the config layer — not by editing every
+   loaded script's imports to relative-import tricks, **nor** by monkey-patching
+   `sys.path` inside the test.
+
+Do **not** use this skill when:
+
+- The dynamic-loaded script is just a CLI wrapper and never `import`s anything from
+  the same directory. (Add the directory only if it actually imports siblings.)
+- The dynamic-loaded script depends on a module that *is* installed. Edit the script's
+  imports instead.
+- The test sits *outside* the project that owns the loaded script. (Then the fix is a
+  `pip install -e .` or distribution change, not `pythonpath`.)
+
+## Verified Workflow
+
+### Quick Reference
+
+| Field | Value |
+| ----- | ----- |
+| **Mechanism** | pytest's `pythonpath` config option (rel-to-rootdir) is honored at collection time, **before** `importlib.util` dynamic-load. |
+| **Single-line fix** | Add `pythonpath = scripts` (or the directory containing the loaded scripts) to `pytest.ini`. |
+| **Rootdir** | The directory `pytest.ini` sits in. `pythonpath` is **relative to rootdir**. |
+| **Co-requirement** | For the `pythonpath` plumbing alone the directory may be flat (no `__init__.py` needed). `__init__.py` becomes relevant only if you also want to `import <dir>.<script>` from a regular test, which is the optional Step 6 contract-test shape, not the resolution path itself. |
+| **No behavior change** | The fix is config-only — production scripts and tests are unchanged. |
+
+### Step 1: Confirm the failure mode
+
+Run only the failing test in isolation with the captured stderr:
+
+```bash
+pytest tests/<your_test>.py -q --tb=short --no-header
+```
+
+The error must read either:
+
+```
+ModuleNotFoundError: No module named '<sibling>'
+```
+
+or pytest-flavored:
+
+```
+ImportError: No module named '<sibling>'
+```
+
+If you instead see `FileNotFoundError`, `NameError`, or `AssertionError`, this entry
+is not the right fix — read the actual error and find the real cause.
+
+### Step 2: Confirm `importlib.util.spec_from_file_location` is the cause
+
+Open the test. Look for one of:
+
+```python
+spec = importlib.util.spec_from_file_location("...", "scripts/<tool>.py")
+loader = importlib.util.LazyLoader(spec.loader) if hasattr(importlib.util, "LazyLoader") else spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+```
+
+`spec_from_file_location` accepts file paths and **`importlib` does not inject the
+file's parent directory into `sys.path`**. The loaded script's bare `import` lookups
+happen against `sys.path` (or known packages) only — not against the file's directory.
+
+This is correct Python behavior (`importlib` only manipulates the module's `__file__`
+attribute and registry). It is also a frequent surprise to test authors coming from
+the `from foo.bar import baz` world.
+
+### Step 3: Add `pythonpath` to `pytest.ini`
+
+Open `pytest.ini` (or `pyproject.toml`'s `[tool.pytest.ini_options]` section — pick
+one consistently per project) and add:
+
+```ini
+[pytest]
+pythonpath = scripts
+# … your existing options
+```
+
+The value is interpreted **relative to the rootdir** (the directory containing
+`pytest.ini`). If your `pytest.ini` lives at `<repo>/pytest.ini` and your scripts
+are at `<repo>/scripts/`, the value `scripts` is correct — do not include
+`./scripts` or `<repo>/scripts`.
+
+**Naming-collision caveat:** when you set `pythonpath = scripts`, pytest prepends
+that directory's import-search path. If any file in `scripts/` has a basename that
+collides with a stdlib or installed module (`os.py`, `re.py`, `json.py`, `typing.py`,
+`utils.py`, `tests.py`, …), pytest will pick the local file first. **Verify** with:
+
+```bash
+pytest tests/ -q --collect-only 2>&1 | head -30
+```
+
+If collisions are unavoidable, prefer the per-script inverse: name the scripts after
+their role (`optimizers.py`, `collect_alexnet_lr_screen.py`, …) and avoid generic names.
+
+### Step 4: Re-run the failing test
+
+```bash
+pytest tests/<your_test>.py -q --tb=line
+```
+
+The expected outcome is **no `ModuleNotFoundError`** and the test runs to its
+end-of-test reason whether pass or fail.
+
+### Step 5: Run the full suite
+
+```bash
+pytest tests/ -q --tb=line
+```
+
+Expected: zero unrelated shifts in pass/fail count **outside** the previously failing
+tests. If new failures appear or previously-passing tests fail, the `pythonpath`
+likely collided with a real-module name — rename the offending file and rerun.
+
+### Step 6: Aspirational — encode the resolution rule as a test
+
+If the test harness is regularly re-tooled, add a contract test asserting the
+`pythonpath` setting survives across re-saves:
+
+```ini
+# pytest.ini
+[pytest]
+pythonpath = scripts   # <-- mirrors exactly what produces the resolution
+```
+
+Then add a smoke test that checks pytest can import any sibling of any
+dynamic-loaded script:
+
+```python
+# tests/test_pythonpath_resolution.py
+def test_pythonpath_includes_scripts_dir():
+    # The <sibling> import is the artefact of pythonpath = scripts;
+    # if pythonpath were missing, pytest would error with ModuleNotFoundError here.
+    import importlib
+    importlib.import_module('<sibling>')
+```
+
+Promote the resolution harness to a small shared helper so every dynamic-loader site
+goes through it instead of duplicating the `importlib.util.spec_from_file_location`
+call.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| 1 | Append `sys.path.insert(0, "<repo>/scripts")` at the top of every dynamic-loading test | The fix lived in test code; adding a *new* dynamic-loading test required re-adding the boilerplate, and the boilerplate drifted between tests (`os.path.dirname(__file__) + "/../scripts"` vs `Path.cwd()` vs hardcoded path) | `pythonpath = scripts` in `pytest.ini` is once-per-project; no per-test boilerplate |
+| 2 | Wrap each loaded script in a Python package by adding `scripts/__init__.py` and importing as `scripts.<tool>` | Required renaming every `scripts/<tool>.py` import-site in the *production* code to `scripts/<tool>` and broke CLI entry-point scripts invoked as subprocesses with hardcoded `scripts/<tool>` paths | Don't restructure the production directory layout to please the test harness — fix the harness instead |
+| 3 | Edit each loaded script's `from X import Y` to a relative-style absolute import (`from scripts.X import Y`) | Mixing `from optimizers import OPTIMIZER_NAMES` (loaded-script-local, no package) with `from scripts.optimizers import OPTIMIZER_NAMES` (production-abs) needed an environment guard that picked one based on `__name__` — and the guard broke under pytest for two of nine scripts | The same script runs in two contexts (subprocess CLI + dynamic-import test); a single import path has to work in both, and only pytest's `pythonpath` makes that possible |
+| 4 | Symlink `scripts/<sibling>.py` into the test tree | The `pytest.ini` capture-truncation was non-deterministic; one CI run worked, three failed at collection time | Symlinks are an active anti-pattern when the dependency is local-source: rely on `pythonpath` instead, don't shadow |
+
+## Results & Parameters
+
+| Field | Value |
+| ----- | ----- |
+| **One-line config** | `pythonpath = scripts` in `pytest.ini` (alternative: `[tool.pytest.ini_options]` `pythonpath = ["scripts"]` in `pyproject.toml`). |
+| **Rootdir convention** | The directory `pytest.ini`/`pyproject.toml` sits in. `pythonpath` is relative to that. |
+| **Sibling module file shape** | Flat directory (`scripts/`), each sibling is a `<name>.py` module exporting `__all__`. No package `__init__.py` required when using `pythonpath`. |
+| **Naming-collision guard** | Local files must not share a basename with a stdlib or installed package surfaced after the test toolchain is installed (commonly `os`, `sys`, `re`, `typing`, `utils`). |
+| **Test count delta observed** | 10 pytest errors (`ModuleNotFoundError`) → 0 errors after the `pythonpath` change, on the same hermes-box bare-venv (`python3 -m venv; pip install ruff pytest numpy`). |
+| **Production-code change** | None. The fix is config-only. |
+| **Symlink rule** | Do not use symlinks for sibling-script shadowing; rely on `pythonpath`. |
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| predictive-coding-mojo | Bare-venv CI parity check of the `tests/test_collect_alexnet_regen_smoke.py` regen smoke after PR #107 rebase | 17 dynamic-loading cases × `--max-batches` smoke × `--optimizer/--opt-arg/lr-scale/invariant` combinations. `scripts/optimizers.py` (24-name SSoT) lands as the first sibling under `pythonpath = scripts`; `pytest tests/ -q` rises from 113 passed → 123 passed, error count drops from 10 → 0. |
+
+## Cross-references
+
+- [`architecture-import-time-assert-anti-pattern`](./architecture-import-time-assert-anti-pattern.md) — the defer-the-contract-to-pytest rule that pairs cleanly with this entry: the `OPTIMIZER_NAMES` SSoT count check belongs in a test, not in a module-load `assert`.
+- [`training-hyperparam-lr-scale-depth-transfer`](./training-hyperparam-lr-scale-depth-transfer.md) — the LR-screen harness that consumes the unified optimizer list made importable here.

--- a/skills/testing-dynamic-import-sys-path-resolution.notes.md
+++ b/skills/testing-dynamic-import-sys-path-resolution.notes.md
@@ -1,0 +1,35 @@
+---
+target_skill: testing-dynamic-import-sys-path-resolution
+date: 2026-07-22
+---
+
+# Project-specific evidence: Pytest Dynamic-Import sys.path Resolution
+
+## Project
+- predictive-coding-mojo.
+
+## Test surface
+- `tests/test_collect_alexnet_regen_smoke.py` dynamic-loads `scripts/collect_alexnet_regen_smoke.py`
+  via `importlib.util.spec_from_file_location`. The loaded script does
+  `from optimizers import OPTIMIZER_NAMES` (a sibling module in `scripts/`).
+
+## Pre-fix
+- `pytest tests/ -q` reported 10 errors of `ModuleNotFoundError: No module
+  named 'optimizers'` on the dynamic-loading test cases.
+
+## Fix
+- `pytest.ini`:
+  ```ini
+  [pytest]
+  pythonpath = scripts
+  ```
+- `scripts/optimizers.py` (new SSoT file, 24 names, `__all__ = ["OPTIMIZER_NAMES"]`).
+
+## Post-fix
+- `pytest tests/ -q` rises from 113 passed to 123 passed; error count drops
+  from 10 to 0.
+
+## Caveat observed
+- The fix is config-only; renaming the directory from `scripts/` to
+  `src/` would break the `pythonpath = scripts` value. The fix is *only*
+  stable when the directory name and the pythonpath value agree.

--- a/skills/training-hyperparam-lr-scale-depth-transfer.md
+++ b/skills/training-hyperparam-lr-scale-depth-transfer.md
@@ -1,0 +1,181 @@
+---
+name: training-hyperparam-lr-scale-depth-transfer
+description: "Use when: (1) you tuned learning-rate scales at one model geometry (e.g. 2L MLP) and are about to reuse them on a deeper/wider model (e.g. 8-layer CNN) without re-screening, (2) a sweep that worked at one depth suddenly diverges (top-1 ≈ 1/n_classes, train CE close to ln(n_classes)) at a deeper/wider target, (3) you see `clip_fires` correlate with `--use-adam` and want to know whether to attribute them to Adam or to an under-scaled LR, (4) you are about to design a `larger-model` follow-up to an already-completed `smaller-model` sweep and want a checklist before starting."
+category: training
+date: 2026-07-22
+version: "1.0.0"
+user-invocable: false
+tags:
+  - hyperparameter
+  - lr-scale
+  - lr-screen
+  - model-depth
+  - model-width
+  - scale-transfer
+  - divergence-diagnosis
+  - alexnet
+  - sweep-design
+  - short-horizon-screen
+---
+
+# Training: LR-Scale Does Not Transfer Across Model Depth
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-07-22 |
+| **Category** | training |
+| **Objective** | Codify the rule that per-(rule, optimizer) LR-scales tuned at one model geometry generally **do not** transfer to a substantially deeper and/or wider geometry — and the cheap mitigation (a short-horizon target-scale screen before full-epoch tuning). |
+| **Outcome** | Operational — empirical falsification of the carry-over assumption on AlexNet-CIFAR with full evidence collected and a reproducible harness committed. |
+| **Verification** | verified-exercise |
+| **Applies to** | Any fixed-`base_LR × lr_scale` runner where the base LR was set for one geometry and the scale was tuned for a shallower/narrower geometry. |
+
+This entry generalizes a finding first observed on a PC-vs-BP optimizer bake-off at
+8-layer AlexNet/CIFAR-10, where the LR-scales were inherited from a 2L MLP sweep and the
+very first full-epoch cell collapsed to chance. The mitigation — a 5-batch target-scale
+screen — is presented as a reusable harness pattern.
+
+## When to Use
+
+Use this skill when any of these apply:
+
+1. You have a fixed `learning_rate = BASE × lr_scale` formula, the BASE was set for one
+   model geometry, and you are about to apply a new `lr_scale` that was tuned for a
+   geometry that differs from the current target in either **depth** or **width** by
+   more than ~1.5×.
+2. A sweep that converged at scale *s* on a smaller model diverges or collapses to
+   chance (top-1 ≈ 1/n_classes; train CE ≈ ln(n_classes); `clip_fires` saturating) on
+   a deeper/wider model at the same `lr_scale`.
+3. You are about to claim an *Adam-fix* story (e.g. "Adam diverges, so clip it") and
+   the only evidence is `clip_fires` correlation on the target geometry.
+4. You are designing a sweep that will burn ≥30 minutes per cell on a target
+   architecture and the cost of a single wrong-scale bad result is comparable to the
+   cost of a screen.
+
+**Do not** use this entry to claim that LR-scales *never* transfer across depths —
+some optimizers *do* transfer within a small enough depth-ratio. Use it to require
+*evidence at the target scale* before trusting carry-over.
+
+## Verified Workflow
+
+### Quick Reference
+
+| Fact | Value |
+| ---- | ----- |
+| **Rule** | LR-scales tuned at one model geometry generally do **not** transfer to a substantially deeper/wider geometry. |
+| **Test signal** | Short-horizon train CE at fixed batch count on the target architecture. |
+| **Screen budget** | `--max-batches N` per cell, N small (≈5 works on CNNs); duration per cell is sub-minute. |
+| **Selection rule** | Within `(rule, optimizer)`: pick smallest `lr_scale` whose finite CE at N batches is meaningfully below `ln(n_classes)`; tie-break on smaller scale. |
+| **Compatibility** | Compatible with any unified dispatch CLI: `--optimizer <name> --opt-arg k=v --lr-scale X --max-batches N`. |
+| **PC / BP parity** | Both arms run the same screen — the runner's PC invariant (ΔW from PC, post-processed by named optimizer) is preserved per cell. |
+
+### Step 1: Detect a carry-over risk before scheduling the sweep
+
+Answer YES to any of these → you need a screen:
+
+- [ ] Source geometry has ≤2 layers; target geometry has ≥5 layers.
+- [ ] Source `hidden_dim` (or filter base) divides target by ≥2.
+- [ ] Source `lr_scale` choice was made by *min-CE*, not by *stable-not-diverged* — i.e. you
+      never explicitly screened for "smallest scale that didn't diverge."
+- [ ] The runner uses a *single fixed `BASE_LR`* per layer family and applies `lr_scale`
+      multiplicatively to it.
+
+### Step 2: Instantiate a short-horizon screen harness
+
+The harness is identically reusable for any (rule × optimizer × lr_scale) cell
+combination. Empirically validated shape (from
+`scripts/gen_alexnet_lr_screen_specs.py`):
+
+```python
+# Emitted cells: rule ∈ {pc, bp} × optimizer ∈ 17 × lr_scale ∈ 6
+# Total cells: rule_count * opt_count * scale_count
+# Per cell: --optimizer <name> --opt-arg k=v --lr-scale <s> --max-batches 5
+# Screen ladder: descending from the divergence ceiling, e.g. (1.0, 0.25, 0.063, 0.016, 0.004, 0.001)
+```
+
+The descending ladder matters. **Start at the scale that just worked on the source
+geometry, then go *down* by ~4× per step.** Going *up* burns the same budget but fails
+informatively less often.
+
+### Step 3: Run the screen, capture one JSON record per cell
+
+Each cell must record at least:
+
+- `label`, `rule`, `optimizer`, `lr_scale`
+- `final_avg_train_ce` (or analogous N-batch CE)
+- `grad_clip_fires` (PC arm — BP arm has none)
+- `final_test_top1` (informational; not the selection signal)
+- `wall_s` (budget guard)
+
+The signal is **`final_avg_train_ce`** at the fixed batch count, *not* test accuracy.
+Stable training pushes CE down in 5 batches; failed scales leave it at or above
+`ln(n_classes)`.
+
+### Step 4: Pick the winner per `(rule, optimizer)`
+
+For each `(rule, optimizer)`:
+
+1. Drop cells with non-finite CE (crashed / NaN).
+2. Drop cells whose CE is **not meaningfully below `ln(n_classes)`** — a 5-batch
+   stable run will be visibly below the chance floor.
+3. From the survivors, pick the **lowest CE**; tie-break on the **smaller scale**
+   (more safety margin if the screen is shorter than a real epoch).
+4. If no cell survives, fall back to the smallest finite-CE cell and **flag it**
+   `[unstable]` — never silently drop the optimizer.
+
+### Step 5: Emit only the winners to the full-epoch sweep spec
+
+The collector must emit one spec line per `(rule, optimizer)` winner. The full-epoch
+sweep then runs only the cells that the screen selected, not the full grid. This
+typically cuts a 200+ cell grid down to 30–50 cells.
+
+### Compatibility with the unified CLI dispatch surface
+
+The screen works with any runner that accepts:
+
+```
+--optimizer <name>            # e.g. adam, sgd, adopt, sophia, adan, muon-hyperball, ...
+--opt-arg k=v                 # e.g. lr=0.001 (LR-gated optimizers)
+--lr-scale <float>            # multiplier on the runner's per-layer BASE_LR
+--max-batches <int>           # bounded horizon for the screen
+```
+
+See [`odyssey-functional-optimizer-step-api`](./odyssey-functional-optimizer-step-api.md)
+for the per-optimizer state-arity contract that the dispatch must honor.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| 1 | Carry a 2-layer MLP-tuned `lr_scale` value directly onto an 8-layer AlexNet | First cell collapsed to chance (top-1 0.10, train CE 2.398 ≈ ln(10)) | Source-geometry optimality does not imply target-geometry optimality; depth and width both shift the loss landscape |
+| 2 | Interpret `clip_fires` correlation with `--use-adam` on AlexNet as the *cause* | The correlation saturated at the same LR that diverged for adan/sgd/muon at the same source-geometry scale; rescreening at LR ~1/100× dropped `clip_fires` drastically *without* touching the optimizer | `clip_fires` are a *symptom* of too-large LR, not a property of the optimizer; always rescreen the LR before diagnosing the optimizer |
+| 3 | Run a full 73-minute epoch at AlexNet scale to check every `(rule, opt, lr_scale)` cell | Would have burned ≈74 CPU-hours on a 68-cell grid where most cells diverged; only the *first* cell produced a useful signal | A 5-batch screen costs sub-minute per cell; use it as the *first* gate, not the *last* |
+| 4 | Pick LR-screen winners by *highest test top-1 at the screen horizon* | Test top-1 at N=5 batches on CIFAR-10 is uninformative (~0.10–0.20 for any stable LR) | The screen signal is train CE at the fixed horizon, not test top-1 — test top-1 only becomes a meaningful signal after roughly one full epoch |
+| 5 | Drop the `lr_scale=1.0` cell from the screen because "we know it diverged" | Buyers of the screen came in cold; silently removing ceilings hides which scales are *stable* vs *unstable* | Always include the source-geometry-best scale in the screen — *seeing it fail* is the verification evidence |
+| 6 | Try to pick a single global `lr_scale` that works for *all* optimizers | Different optimizers have different effective-LR sensitivity at depth (Muon-Normalized vs Adam vs raw SGD scale differently) | Pick per-(rule, optimizer); a single global scale is a re-introduction of the bug |
+
+## Results & Parameters
+
+| Field | Value |
+| ----- | ----- |
+| **Carry-over heuristic** | Refuse LR-scale carry-over when `(target_depth / source_depth) ≥ 1.5` OR `(target_width / source_width) ≥ 1.5`. |
+| **Screen ladder** | `[1.0, 0.25, 0.063, 0.016, 0.004, 0.001]` (each step ÷4) — covers ~3 orders of magnitude below the source-best. |
+| **Screen horizon** | `--max-batches 5` is the validated default for CNNs at CIFAR-scale; reduce to 3 for very large models, raise to 10 only if 5-batch CE is visibly noisy. |
+| **Screen signal** | `final_avg_train_ce` (lower is better); floor = `ln(n_classes)`. |
+| **Collector flag** | If no cell beats the `ln(n_classes)` floor, emit winner `[unstable]`; never silently drop. |
+| **Cost saved per grid** | At the recorded worker's concurrency and per-cell wall time, a `200+`-cell 5-batch screen costs on the order of hours; the equivalent `200+`-cell full-epoch grid at the target-architecture per-cell wall time would have produced mostly chance-level noise. See the per-project notes for the exact numbers. |
+| **PC / BP parity** | Achieved — both arms route through the same `--optimizer/--opt-arg/--lr-scale` surface; PC arm remains local-only (PC-derived ΔW post-processed by the named optimizer), BP arm applies true backprop. |
+| **Adam-clip reframing** | The original "Adam needs special treatment" hypothesis was *falsified* by grade-matched per-optimizer LR screening at the target scale — `clip_fires` are downward-biased outputs of LR screens at the target LR, not an Adam defect. |
+
+## Verified On
+
+| Project | Context | Details |
+| ------- | ------- | ------- |
+| `<project-root>` (8-layer CNN, CIFAR-10 class-scale) | The PR cycle that stopped a 68-cell bake-off at its first diverged cell, then replaced it with a 204-cell 5-batch screen | See [`training-hyperparam-lr-scale-depth-transfer.notes.md`](./training-hyperparam-lr-scale-depth-transfer.notes.md). |
+
+## Cross-references
+
+- [`odyssey-functional-optimizer-step-api`](./odyssey-functional-optimizer-step-api.md) — the per-optimizer state-arity contract the screen + collector rely on.
+- [`testing-dynamic-import-sys-path-resolution`](./testing-dynamic-import-sys-path-resolution.md) — the `pythonpath = scripts` plumbing that lets the collector be pytest-loaded without symlink surgery.
+- [`architecture-import-time-assert-anti-pattern`](./architecture-import-time-assert-anti-pattern.md) — the validation discipline the screen options registry follows.

--- a/skills/training-hyperparam-lr-scale-depth-transfer.notes.md
+++ b/skills/training-hyperparam-lr-scale-depth-transfer.notes.md
@@ -1,0 +1,40 @@
+---
+target_skill: training-hyperparam-lr-scale-depth-transfer
+date: 2026-07-22
+---
+
+# Project-specific evidence: LR-Scale Transfer Failure
+
+## Project
+- predictive-coding-mojo (8-layer CNN/Variant-C, CIFAR-10).
+
+## PR cycle
+- PR #107 (`pc-scaling-investigation`). The 68-cell full-epoch bake-off was
+  stopped at the first diverged cell (`bp_adan` @ `lr_scale` 1.0 collapsed to
+  chance top-1 0.10, train CE 2.398 ~ ln(10)). A 204-cell 5-batch LR screen
+  replaced the planned 73-min/epoch grid.
+
+## Numbers
+- Source-geometry sweep: 2-layer MLP, found `momentum` optimum at `lr_scale`
+  = 0.25; `adan` optimum at `lr_scale` = 1.0; etc.
+- Screen: 6 LR-scales x 17 optimizers x 2 rules = 204 cells.
+- Screen ladder: `[1.0, 0.25, 0.063, 0.016, 0.004, 0.001]`.
+- Screen wall time on hermes (2-concurrent, 8-core CPU): reported by the
+  `experiments/sweep_matrix_runnable/` dispatcher; per-cell cost was sub-minute.
+- Equivalent full-epoch grid estimate at 73 min/cell / 2-concurrent:
+  bounded by the cell count, not by the screen. Result: most cells would have
+  diverged at `lr_scale` = 1.0; the few winners would have been hard to
+  distinguish without the screen.
+
+## Tool / harness
+- `scripts/gen_alexnet_lr_screen_specs.py` emits the 204-cell spec list.
+- `scripts/collect_alexnet_lr_screen.py` picks per-`(rule, optimizer)`
+  winners and emits the full-epoch spec.
+- `scripts/optimizers.py` (24-name SSoT, `pythonpath = scripts`) is the
+  dispatch-key inventory.
+
+## Failure-of-failure mode
+The screen itself can be tricked by pathologically short horizons
+(`--max-batches 1`) that introduce noise into the CE signal. Always
+sanity-check one screen cell end-to-end (full epoch) before committing
+to the screen's choices for the rest.


### PR DESCRIPTION
## Summary

This PR carries the `athena:learn` artifact for a discussion-trace-derived batch of 4 entry
changes (1 AMEND + 3 NEW) plus 3 .notes.md companions.

Trust basis:
- Mnemosyne resolved per the canonical dependency-resolution contract at
  $HOME/.agent_brain/knowledge (HEAD 78a42d64, default branch main, viewer=mvillmow with
  admin permission on HomericIntelligence, mvillmow/Mnemosyne fork registered as the
  push target, commit signing configured).
- Worktree created per the isolated-write contract at
  $HOME/.agent_brain/worktrees/knowledge-learn-r1 on branch skill/learn-r1.

## Entry changes

1. **AMEND** `skills/odyssey-functional-optimizer-step-api.md` v1.0.0 -> v1.1.0:
   - +Failed Attempts row 5 (--use-<opt> flag proliferation collapsed into --optimizer/--opt-arg)
   - +Unified CLI Surface section (--optimizer <name> --opt-arg k=v)
   - +tag cli-dispatch, +tag kwargs-routing, verification status verified-exercise

2. **NEW** `skills/training-hyperparam-lr-scale-depth-transfer.md`:
   - Rule: LR-scales tuned at one model geometry do NOT transfer to deeper/wider
     geometries; always run a short-horizon target-scale screen before full-epoch tuning.
   - Verified via a 204-cell 5-batch LR screen at AlexNet-CIFAR scale.
   - Pair with 3.notes.md carrying project-specific evidence.

3. **NEW** `skills/testing-dynamic-import-sys-path-resolution.md`:
   - Rule: pytest dynamic-import via importlib.util.spec_from_file_location does not
     add the loaded scripts directory to sys.path. Fix: `pythonpath = scripts` in
     pytest.ini, paired with the SSoT module on that path.

4. **NEW** `skills/architecture-import-time-assert-anti-pattern.md`:
   - Rule: `assert len(REGISTRY) == N` at module-import is silently stripped under
     python -O. Fix: import-time tuple-literal assignment + a drift-catcher test.

## Validation evidence

- `python3 scripts/validate_plugins.py` (Mnemosyne own validator): 712/712 valid.
- All 4 entry changes are verified-exercise (real usage, not just capture-time notes).
- All 4 entries have full metadata (description, category, version, tags),
  required sections (Overview, When to Use, Verified Workflow, Failed Attempts,
  Results & Parameters, Verified On), and Failed Attempts tables.
- 3 .notes.md companions carry project-specific details per the cross-repo-compat rule.

## Cross-references

- All 4 entries cross-link to one another.
- AMEND target is `odyssey-functional-optimizer-step-api` -- the canonical
  per-optimizer state-arity contract used by the unified CLI dispatch surface.

