### PR TITLE
feat: strengthen review authorization skills

### DIFF
--- a/skills/automation-review-authorization-ci-boundary.history
+++ b/skills/automation-review-authorization-ci-boundary.history
@@ -1,5 +1,41 @@
 # automation-review-authorization-ci-boundary — History
 
+## v2.0.0 (2026-07-24)
+
+**Changed by:** ProjectHephaestus issues #2419 and #2423 reviewed-head and
+auto-merge-ownership safety work.
+**Verification:** verified-local — live GitHub GraphQL schema inspection and local
+ProjectHephaestus automation tests, Ruff, format, and mypy; implementation CI pending.
+
+### What changed
+
+- Replaced the merge-wait auto-merge arming/defer model with a fail-closed interlock:
+  no queue stage enables, defers, disables, adopts, creates, or polls auto-merge.
+- Bound review authorization to a stable GitHub head SHA and a clean exact-SHA checkout
+  verified by a dedicated Git job.
+- Required fresh `OPEN` plus explicitly present `autoMergeRequest: null` before every
+  state-changing label. An approving/GO label additionally requires the reviewed head
+  to equal the live head; negative/recovery labels deliberately remain available after
+  drift, plus exclusive-label post-write verification.
+- Made reviewed-head proof active-run-only and routed restart, refresh, mismatch, and
+  drift back to PR review.
+
+### Why
+
+A review of one revision cannot authorize another revision. Separately, GitHub's
+enable-auto-merge mutation accepts `expectedHeadOid`, but its disable mutation lacks a
+conditional ownership token and `AutoMergeRequest` does not persist a client nonce.
+Readback therefore cannot prove that a queue is disabling its own request instead of an
+external replacement. The queue must stand down and leave a future normal conditional
+merge to a separately reviewed implementation.
+
+### Previous version (v1.5.0) snapshot
+
+The exact v1.5.0 source is preserved in the parent main commit
+[`ec5e4cb`](https://github.com/HomericIntelligence/ProjectMnemosyne/blob/ec5e4cb/skills/automation-review-authorization-ci-boundary.md).
+
+---
+
 ## v1.5.0 (2026-07-21)
 
 **Changed by:** ProjectHephaestus PR #2357 direct-review admission check.

--- a/skills/automation-review-authorization-ci-boundary.md
+++ b/skills/automation-review-authorization-ci-boundary.md
@@ -1,11 +1,11 @@
 ---
 name: automation-review-authorization-ci-boundary
-description: "Keep automation-loop source-review authorization independent of CI/CD. Use when: (1) a strict PR review is mistakenly implemented as a required CI check, (2) an agent loop cannot observe or control the external workflow that is supposed to authorize it, (3) loop approval must survive restart using only loop-owned PR state, (4) a direct `--prs` review run must prove its closing-issue requirements before consuming a reviewer-model job, or (5) a downstream rerun must short-circuit on a merged PR because GitHub clears autoMergeRequest after merge."
+description: "Keep automation-loop source-review authorization independent of CI/CD and bind it to an exact PR head. Use when: (1) a strict PR review is mistakenly implemented as a required CI check, (2) a review can race with a changed PR head or dirty checkout, (3) a label advances implementation or merge state, (4) an external actor may own auto-merge, (5) a direct `--prs` review run must prove its closing-issue requirements before consuming a reviewer-model job, or (6) a downstream rerun sees a merged PR."
 category: architecture
-date: 2026-07-21
-version: "1.5.0"
+date: 2026-07-24
+version: "2.0.0"
 user-invocable: false
-verification: verified-ci
+verification: verified-local
 history: automation-review-authorization-ci-boundary.history
 tags:
   - automation-loop
@@ -16,6 +16,10 @@ tags:
   - restart-safety
   - state-label
   - source-review
+  - reviewed-head
+  - checkout-verification
+  - auto-merge-ownership
+  - fail-closed
 ---
 
 # Automation Review Authorization: CI Boundary
@@ -24,10 +28,10 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-20 |
-| **Objective** | Keep a code-automation loop's strict source-review decision inside that loop rather than delegating its authorization to CI/CD, and enforce it at the auto-merge boundary. |
-| **Outcome** | ProjectHephaestus moved strict-review proof, workflow triggers, artifacts, leases, and CI-status contracts out of the authorization path. The loop's own CI-free PR review applies `state:implementation-go` after a GO verdict; its review-local payload is then reduced to a fixed non-authorizing context before `merge_wait` can consume the label. PR #2347 showed the complete path: a B/GO review reported its own sandbox verification gap, applied the label, and merged after the repository's independent required checks passed. PR #2357 confirmed the complementary admission behavior: a direct `--prs 2357` run with `reviewer-model=sol` and medium effort produced zero agent jobs because the PR had no standalone `Closes #N` requirement link. |
-| **Verification** | verified-ci — PR #2347's full CI suite and required-checks gate passed before merge; the review decision itself remained source-review-only. |
+| **Date** | 2026-07-24 |
+| **Objective** | Keep a code-automation loop's strict source-review decision inside that loop rather than delegating its authorization to CI/CD, bind the decision to the exact GitHub head SHA, and prevent the queue from mutating externally owned auto-merge. |
+| **Outcome** | The ProjectHephaestus design now snapshots a stable GitHub body/diff/head and verifies the exact head in a clean checkout through a dedicated Git job. Every label write requires fresh open/unarmed state; approving/GO labels additionally require the matching reviewed head. Queue stages stand down on any populated auto-merge request; the conditional normal merge replacement remains separately tracked in issue #2419. |
+| **Verification** | verified-local for the v2.0.0 head-proof and no-auto-merge interlock: live GitHub schema inspection plus local ProjectHephaestus tests, Ruff, format, and mypy. CI is pending. Earlier CI-free authorization observations remain historical evidence, not evidence for the new interlock. |
 
 ## When to Use
 
@@ -37,9 +41,12 @@ tags:
 - You need to retire an external review-proof system while preserving historical ADRs and making the active contract unambiguous.
 - A direct `--prs` discovery route can create an issue-less work item that reaches merge-wait with a stale or externally applied GO label.
 - You are about to launch a direct `--prs` review run and need to know whether a selected reviewer model will actually be invoked, rather than merely selected by CLI configuration.
-- A process-local strict-review mutex is released at a stage handoff even though the successor has not yet confirmed the live head and armed auto-merge.
+- A process-local strict-review mutex is released at a stage handoff even though the successor has not yet confirmed the live reviewed head and safe continuation.
 - Review-local head, verdict, or evidence data remains in a work item after the label has been applied, where a later stage could accidentally turn it into a second authorization requirement.
 - A downstream rerun evaluates a PR after merge and must short-circuit on PR state instead of expecting `autoMergeRequest` to still be present; GitHub clears `autoMergeRequest` on merged PRs.
+- A PR body/diff is fetched while a push may occur, or the reviewer can inspect a dirty/stale checkout rather than the GitHub head it is supposed to approve.
+- A label write would advance the pipeline without fresh proof that the PR is `OPEN` and explicitly unarmed, or an approving/GO label would advance without also proving the reviewed head still matches.
+- The queue sees `autoMergeRequest` populated and is tempted to defer, disable, adopt, or replace it. GitHub does not expose a conditional disable operation that can prove ownership of that request.
 
 ## Verified Workflow
 
@@ -47,16 +54,18 @@ tags:
 
 ```text
 automation loop owns source-review authorization
-  1. read the live PR source, diff, and loop-owned state
-  2. run the strict PR review in the loop (CI-free)
-  3. if and only if the review returns GO, apply state:implementation-go
-  4. merge_wait consumes that loop-owned label and the live PR head
+  1. snapshot GitHub PR body, diff, and head; reject the snapshot if the head moves
+  2. verify a clean checkout at that exact head in a dedicated Git job
+  3. run the strict PR review in the loop (CI-free) against the snapshot
+  4. before every state-changing label, re-read OPEN + explicit autoMergeRequest:null
+  5. require the exact reviewed head only for an approving/GO label; drift revokes proof and re-reviews
+  6. merge_wait consumes the label and exact-head proof but only stands by; it never mutates auto-merge
 
 merge-wait is also the authorization boundary of last resort
-  1. reject an item without required issue/requirements context before any arm
-  2. durably defer any existing auto-merge request and re-read its state
-  3. only then terminally fail the orphaned item
-  4. retain the strict-review guard until the first successful arm confirmation
+  1. reject an item without required issue/requirements context before consuming a label
+  2. route missing or drifted reviewed-head proof back to PR review
+  3. stand down without mutation when external auto-merge is present or state is partial
+  4. retain the strict-review guard until the terminal or reviewed-head-safe continuation
 
 CI/CD is outside this decision:
   - do not query checks, workflow runs, artifacts, or deployments
@@ -88,7 +97,9 @@ reviewable one.
 
 1. Establish a single decision owner. Source-review authorization belongs to the automation loop when that loop is responsible for planning, implementation, review, and advancement. CI/CD may validate a repository independently, but it is not evidence the loop can depend on for this decision.
 
-2. Run the strict PR review as an in-loop, CI-free operation against the live PR diff. Require an explicit GO result before transition; a missing, ambiguous, or NO-GO result must not apply the approval label.
+2. Capture a stable review context before dispatching the reviewer. Read GitHub PR metadata including its head SHA, fetch the mutable diff, and read the head again. If the two heads differ, discard the context rather than reviewing a moving target. Run a dedicated Git job that proves the worktree was clean, synchronized to that exact head, has `HEAD` equal to it, and remained clean after synchronization. An expected SHA embedded only in an agent prompt is not checkout evidence.
+
+   Run strict PR review as an in-loop, CI-free operation against that immutable body/diff/head snapshot. Require an explicit GO result before transition; a missing, ambiguous, or NO-GO result must not apply the approval label.
 
    For direct `--prs` operation, first verify the requirements context deterministically. `--prs`
    identifies the PR but does not waive the exact standalone `Closes #N` contract or synthesize
@@ -99,13 +110,17 @@ reviewable one.
 
 3. Report review evidence precisely. A reviewer may issue GO from sufficient source and local evidence even when its sandbox cannot independently rerun every claimed test, but it must name the gap, avoid claiming those tests passed, and grade the evidence accordingly. Do not turn that disclosure into a CI dependency for the loop decision.
 
-4. Record the completed loop decision with one loop-owned state marker such as `state:implementation-go`. `merge_wait` should consume that marker and the live PR head when it restarts; it must not require a workflow artifact, lease, status context, or an external proof document.
+4. Record the completed loop decision with one loop-owned state marker such as `state:implementation-go`, but only after a fresh authorization read proves all three conditions: PR state is `OPEN`, the response explicitly includes `autoMergeRequest` with value `null`, and the live head equals the reviewed head. A missing auto-merge field is partial data, not proof that the request is absent. Verify the exclusive label state by a post-write readback.
 
-5. Discard review-local state after the label's post-write current-head confirmation and before transition to `merge_wait`. Use a fixed allowlist of ordinary issue/implementation context, the cleanup worktree path, and the process-local handoff mutex. Do not retain review heads, verdicts, attempts, artifacts, leases, evidence, or a dynamically captured ingress-key list. A denylist cannot anticipate aliases; a dynamic ingress list can preserve a forged or stale proof after a retry. The current-head check must precede sanitization so a concurrent head change still follows the normal containment path with the original review state available.
+   Apply the fresh `OPEN`/explicitly-unarmed guard to every state-changing label path, including exhaustion and skip paths, but do **not** require an old reviewed head to write a no-go/recovery result. A head drift revokes approval and routes to review precisely so the system may record that safe negative outcome.
 
-6. Enforce the requirements-context invariant at `merge_wait.on_enter`, not only at strict review. An unlinked direct PR may have an externally retained GO label, and a stage-routing regression can otherwise bypass the strict-stage orphan check. Before recovery, label consumption, or arming, invoke the same fail-closed helper used for unsafe arm state: request auto-merge deferral, re-read live PR state to confirm it is disarmed, then return terminal failure. This makes stale labels non-authoritative when the work item lacks its required context.
+   `merge_wait` may consume the label only with an in-memory reviewed-head proof. On restart, refresh, checkout mismatch, or head drift, clear the proof and route back to PR review. It must not require a workflow artifact, lease, status context, or an external proof document.
 
-7. Treat the strict-review guard as a handoff mutex, not merely a strict-stage mutex. Keep it held after strict review advances to merge-wait. Release it only when merge-wait's first arm operation has returned its successful continuation after live-label/head verification and arm confirmation. Preserve ownership through fail-back/retry to strict review; release idempotently on terminal finish, shutdown parking, or exception handling.
+5. Keep the reviewed head proof only in active-run memory and clear it on refresh, restart, failure, checkout mismatch, or head drift. Discard other review-local state after the label's post-write current-head confirmation and before transition to `merge_wait`. Use a fixed allowlist of ordinary issue/implementation context, the cleanup worktree path, and the process-local handoff mutex. A denylist cannot anticipate aliases; a dynamic ingress list can preserve a forged or stale proof after a retry.
+
+6. Enforce the requirements-context invariant at `merge_wait.on_enter`, not only at strict review. An unlinked direct PR may have an externally retained GO label, and a stage-routing regression can otherwise bypass the strict-stage orphan check. Before recovery or label consumption, return a terminal blocked result for the orphaned item. Do not defer, disable, adopt, create, or poll auto-merge as cleanup.
+
+7. Treat the strict-review guard as a handoff mutex, not merely a strict-stage mutex. Keep it held after strict review advances to merge-wait. Preserve ownership through fail-back/retry to strict review; release idempotently on terminal finish, shutdown parking, or exception handling. The no-auto-merge interlock has no first-arm continuation; queue work stands by after exact-head verification until a separately reviewed normal conditional merge mechanism is available.
 
 8. Keep the boundary mechanically enforceable. Delete CI workflows and automatic tasks that trigger from review or implementation-go solely to produce authorization proof. Remove their references from active documentation, agent directions, prompt contracts, and tests.
 
@@ -113,7 +128,7 @@ reviewable one.
 
 10. Preserve ADR history. Do not rewrite accepted historical decisions just to erase obsolete policy. Add a new superseding ADR and update the ADR index so active readers find the current contract while audits retain the original record.
 
-11. Validate the source-only behavior locally: resolve the PR identity and exact head, inspect the source diff and active contracts, run targeted stage/documentation tests, and run `git diff --check`. Tests must cover (a) an orphaned merge-wait item with GO label: defer is attempted, no arm occurs, terminal failure; (b) a competing strict reviewer remains blocked during merge-wait arm and proceeds only after the successful arm continuation; and (c) known, unknown, and forged review-proof aliases do not cross the successful GO handoff. State clearly that this is not CI evidence.
+11. Validate the source-only behavior locally: resolve the PR identity and exact head, inspect the source diff and active contracts, run targeted stage/documentation tests, and run `git diff --check`. Tests must cover (a) a moving head revokes review context, (b) a dirty or mismatched checkout never dispatches review, (c) every advancing label path blocks a populated or partial auto-merge state, (d) absent or drifted reviewed-head proof routes to review, and (e) no queue stage calls an auto-merge mutator. State clearly that this is not CI evidence.
 
 12. Short-circuit downstream reruns on terminal PR state. If a later workflow or review pass reruns after the PR has merged, fetch PR `state` first and exit 0 when it is not `OPEN`. GitHub clears `autoMergeRequest` on merged PRs, so a null arm is expected and not a blocker.
 
@@ -122,26 +137,31 @@ reviewable one.
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Put strict-review proof in CI/CD | A required workflow generated proof artifacts and gated progress. | The automation loop did not control the CI loop, so it could neither make progress nor make a trustworthy decision from that external state. | The component that owns the review decision must execute and persist it; make strict source review an in-loop CI-free operation. |
-| Restart from external proof data | `merge_wait` depended on workflow artifacts, leases, and status records. | Those records were external coupling, could be absent or stale after restart, and were unnecessary once loop-owned approval existed. | Restart from the loop-owned approval label and live PR state only. |
+| Restart from external proof data | `merge_wait` depended on workflow artifacts, leases, and status records. | Those records were external coupling, could be absent or stale after restart. A label alone also cannot prove which SHA was reviewed. | Restart from loop-owned label and live PR state, but route to PR review when the active-run reviewed-head proof is absent. |
 | Preserve strict-review ingress fields dynamically | A review pass snapshotted its ingress payload keys and kept those keys after GO. | An unknown alias or forged snapshot entry could preserve review evidence; after a NOGO retry, the stale snapshot could drop fresh implementation context. | At the GO boundary, retain a small fixed set of non-authorizing context keys instead of trying to classify or remember review fields. |
 | Treat a repository-wide PR as an issue-less strict review | Direct PR discovery constructed a work item with `issue=None`. | The strict stage requires issue/comment context and rejected the work item as terminal. | For direct PR review, use the PR number as the work-item context unless the design supplies an equivalent explicit context. |
 | Retry an orphaned direct PR with a different reviewer setting | Launched `hephaestus-automation-loop --prs 2357 --reviewer-model sol --reviewer-reasoning-effort medium` without first proving an exact closing requirement. | The admission gate found no standalone `Closes #N` line, completed with `agent jobs: 0`, and no reviewer model was invoked; `Addresses #2138 and #2223` was not usable requirements context. | Preflight direct PR metadata before dispatch. `--prs` and model flags select work only after the deterministic requirements-context invariant passes. |
-| Trust strict review as the only orphan check | An unlinked direct PR with a stale `state:implementation-go` label was routed around strict review and into merge-wait. | The strict-stage check never ran on that path, so merge-wait could otherwise arm auto-merge without requirements context. | Repeat the invariant at the irreversible side-effect boundary: defer, confirm deferral, and fail before merge-wait reads labels or arms. |
-| Release strict guard at the stage transition | The guard was released as soon as strict review routed to merge-wait. | A competing strict reviewer could enter while the first item was between review approval and confirmed arming. | Retain ownership through merge-wait's first successful arm and release on its `POLL` continuation; all finish/park/exception paths remain idempotent releases. |
+| Trust strict review as the only orphan check | An unlinked direct PR with a stale `state:implementation-go` label was routed around strict review and into merge-wait. | The strict-stage check never ran on that path, so merge-wait could otherwise consume an authorization without requirements context. | Repeat the invariant at the irreversible state boundary: terminally block before merge-wait consumes labels; do not perform auto-merge cleanup. |
+| Release strict guard at the stage transition | The guard was released as soon as strict review routed to merge-wait. | A competing strict reviewer could enter while the first item was between review approval and final exact-head verification. | Retain ownership through the reviewed-head-safe continuation; all finish/park/exception paths remain idempotent releases. |
 | Treat `autoMergeRequest` as a post-merge signal | A rerun checked `autoMergeRequest` after the PR had already merged. | GitHub clears `autoMergeRequest` on merged PRs, so the rerun misread a terminal PR as still pending. | Post-merge consumers must check `state` and short-circuit on non-`OPEN` instead of treating `autoMergeRequest` as durable. |
+| Review a PR without binding its head | The reviewer saw a diff while a push could occur, and the later label write reused the result. | Approval of one revision was treated as approval of a different revision. | Fetch head before and after the diff, verify a clean checkout at that SHA in a Git job, and clear the proof on every drift or refresh. |
+| Treat a missing `autoMergeRequest` field as null | A partial PR response defaulted absent data to unarmed. | A failed or narrowed fetch became false safety evidence for a label mutation. | Require the field to be present with value `null`; otherwise fail closed. |
+| Try to disable a request that looked queue-owned | The design compared a later request's visible fields to an earlier queue arm before disabling it. | GitHub has no conditional disable mutation or persisted client nonce; another actor can replace an indistinguishable request between reads. | Never enable, defer, disable, adopt, create, or poll auto-merge from a shared queue; stand down on every populated request. |
 | Rewrite accepted ADRs to remove obsolete instructions | Historical ADR text was modified in place. | It obscured the decision record and broke the repository's ADR immutability convention. | Preserve accepted ADRs verbatim; add a superseding ADR and make the index point to the active policy. |
 
 ## Results & Parameters
 
 | Item | Result |
 |------|--------|
-| Decision marker | `state:implementation-go` is the sole loop-owned authorization after a current review GO. |
+| Decision marker | `state:implementation-go` is the loop-owned authorization only after a review of the exact GitHub head and a fresh mutation guard. |
 | Prohibited dependencies | CI checks, workflow runs, artifacts, deployments, external status contexts, and review-proof leases. |
-| Review-state handoff | After the label's current-head readback, retain only fixed non-authorizing context, cleanup, and the ephemeral handoff mutex; discard all review result and proof aliases. |
+| Review-state handoff | Keep `reviewed_head_sha` only for the active run; clear it on refresh, restart, mismatch, or drift. After label readback, retain only fixed non-authorizing context, cleanup, and the ephemeral handoff mutex. |
 | Direct-PR correction | Use the PR number as strict-review work-item context rather than `None`. |
 | Direct-PR admission | Before launching reviewer work, require one exact standalone `Closes #N` line and a usable linked requirement. `Addresses #N` is not a substitute; failed admission means zero agent jobs by design. |
-| Defense in depth | `merge_wait.on_enter` rejects `issue=None` before consuming labels or arming; deferral is confirmed by a fresh PR-state read. |
-| Guard lifetime | Strict-review ownership covers the strict-to-merge-wait handoff and first successful arm; it is released only after that arm confirms continuation to polling. |
+| Label mutation guard | Every mutation needs fresh `OPEN` plus explicitly present `autoMergeRequest: null`; an approving/GO label additionally needs live head equal to `reviewed_head_sha`. A post-write label read verifies exclusivity. |
+| External auto-merge | A populated request is unprovably externally owned. Queue stages stand down and never enable, defer, disable, adopt, create, or poll auto-merge. |
+| Defense in depth | `merge_wait.on_enter` rejects `issue=None` before consuming labels and routes absent/drifted head proof back to PR review. |
+| Guard lifetime | Strict-review ownership covers the strict-to-merge-wait handoff through a terminal or reviewed-head-safe continuation; no auto-merge arm continuation exists. |
 | Post-merge terminality | PR #2306 / issue #2177 merged at `2026-07-21T01:53:35Z` with `state=MERGED`; `autoMergeRequest` is `null` and `mergeStateStatus` was `UNKNOWN` after merge. Downstream reruns must key off PR state and treat terminal PRs as complete. |
 | Review evidence boundary | PR #2347's reviewer passed `diff --check`, Ruff, formatting, mypy, and direct probes but could not rerun pytest or artifact builds in its sandbox. It reported a B/GO without overclaiming those tests; source review authorized the label, while the independent required-checks gate completed before merge. |
 | Local validation example | `uv run pytest` over pipeline stage/coordinator and active-documentation/ADR tests: 85 passed; `git diff --check` passed. |
@@ -151,6 +171,7 @@ reviewable one.
 
 | Project | Context | Details |
 |---------|---------|---------|
+| ProjectHephaestus | Issue #2423 reviewed-head interlock | Verified locally: GitHub head is snapshotted before and after diff collection; a clean-checkout Git job proves the reviewed SHA before dispatch; all label paths require fresh open/unarmed state, while GO additionally requires the matching reviewed head; merge-wait stands by. Live schema inspection established that auto-merge disable has no conditional ownership token. CI pending. |
 | ProjectHephaestus | PR #2280 / issues #2053 and #2276 | CI-free source review and loop-owned `state:implementation-go` authorization. The direct repository-wide PR route now supplies PR context to strict review. Local swarm review then found that dynamic review-payload preservation could retain an aliased proof or survive a NOGO retry; a fixed allowlist removes those fields only after the label's current-head readback. Local verification only; no CI/CD state was queried. |
 | ProjectHephaestus | PR #2306 / issue #2177 | Docs PR that reached merged state through the normal review-to-merge path: review GO, loop-owned `state:implementation-go`, and merge_wait. Post-merge `gh pr view` showed `state=MERGED` with `autoMergeRequest=null`, confirming reruns must short-circuit on terminal PR state. |
 | ProjectHephaestus | PR #2347 / issue #2283 | The review posted B/GO at `ecba01d9`, explicitly recorded that its sandbox could not rerun pytest or artifact builds, and applied `state:implementation-go` at `2026-07-21T04:35:08Z`. `merge_wait` completed the merge at `2026-07-21T04:44:01Z` as `fde855ad`, after the independent required-checks gate succeeded. |

--- a/skills/github-auto-merge-ci-gating-merge-method.history
+++ b/skills/github-auto-merge-ci-gating-merge-method.history
@@ -2,6 +2,39 @@
 
 # History: github-auto-merge-ci-gating-merge-method
 
+## v1.8.0 (2026-07-24)
+
+**Changed by:** ProjectHephaestus issues #2419 and #2423 queue-safety review.
+**Verification:** verified-local — live GitHub GraphQL schema inspection and local
+ProjectHephaestus test/lint/type validation; implementation CI is pending.
+
+### What changed
+
+- Bumped the skill from v1.7.0 to v1.8.0 and added the shared-queue ownership trigger.
+- Added the proof that auto-merge ownership cannot be recovered from a later
+  `autoMergeRequest` readback: enable supports `expectedHeadOid`, while disable has no
+  matching conditional ownership token and the request does not persist a client nonce.
+- Added a fail-closed queue interlock: no enable, defer, disable, adoption, or polling;
+  require `OPEN` and explicit `autoMergeRequest: null` before every state-changing
+  label, and require the reviewed head SHA only for approving/GO labels; use a
+  separately reviewed conditional normal merge instead.
+
+### Why
+
+An external actor can replace an indistinguishable auto-merge request between the
+queue's read and its final disable. A queue that performs that disable can revoke
+another actor's approval. GitHub's exposed API does not supply the compare-and-swap
+operation necessary to close that race.
+
+### Previous version (v1.7.0) snapshot
+
+The exact v1.7.0 document is retained in the immediately preceding main-branch
+commit (`ec5e4cb`) and its v1.7.0 release entry remains below. This addition changes
+the queue-ownership recommendation while preserving the historical diagnostic and
+repository-owned auto-merge guidance.
+
+---
+
 ## v1.7.0 (2026-07-21)
 
 Added merge-queue fallback handling to `github-auto-merge-ci-gating-merge-method`: when the direct REST merge API returns HTTP 405 `Pull Request is in the merge queue`, `_merge_pr` now falls back to `_enqueue_pr`, `gh pr merge <n>` is used with no merge-method flag, and `queued` is logged as success.

--- a/skills/github-auto-merge-ci-gating-merge-method.md
+++ b/skills/github-auto-merge-ci-gating-merge-method.md
@@ -1,9 +1,9 @@
 ---
 name: github-auto-merge-ci-gating-merge-method
-description: "Use when: (1) a PR has mergeStateStatus CLEAN or MERGEABLE but auto-merge never fires despite all checks passing, (2) gh pr merge --auto --rebase or --squash returns an error or silently fails on a squash-only repo, (3) a PR is BLOCKED because required CI status contexts never post (workflow never triggered, paths filter excluded PR, required check name mismatch), (4) GPG-signing failures or mismatched committer emails cause commits to be unsigned and block the pr-policy gate, (5) branch protection rulesets and classic branch protection disagree and their union blocks merge, (6) a CI ruleset chicken-and-egg deadlock blocks a PR that introduces a new workflow, (7) an advisory check should not block merge but currently does because it lives in the required gate, (8) deciding which merge method a repo supports before arming auto-merge, (9) auditing required-check names after adding or removing CI jobs, (10) state:implementation-go label or pr-policy gates auto-merge arming, (11) per-issue arming-state machine is triggered on the wrong event (optimistic point vs detected merge), (12) mergeStateStatus=BLOCKED with all CI green and auto-merge armed - unresolved review threads are the PRIMARY blocker to check FIRST before assuming CI failure, (13) stale failed status-rollup entries must be distinguished from current-head required checks before deciding a PR is blocked or complete, (14) you applied state:implementation-go with `gh issue edit` and the auto-merge-policy gate stays FAILURE - the label must be on the PR (`gh pr edit`) not the issue, (15) required-checks-gate shows FAILURE alongside a later SUCCESS of the same check - the newer run is current, the FAILURE is stale, (16) your isolated-clean PR's lint job fails because CI runs pre-commit on the merge-result (pull/N/merge) and main drifted since you branched (e.g. ruff-format), (17) hephaestus-review-prs first run truncates at worktree-setup and posts zero threads - an empty thread list is NOT a clean pass unless the log reached 'Analysis complete for PR #N', (18) a sub-agent's disk-direct file writes leaked into the MAIN checkout, breaking editable-installed console scripts with ModuleNotFoundError for all later runs, (19) merge-queue-protected repos return HTTP 405 from the REST merge API and must enqueue via `gh pr merge` with no merge-method flag"
+description: "Use when: (1) a PR has mergeStateStatus CLEAN or MERGEABLE but auto-merge never fires despite all checks passing, (2) gh pr merge --auto --rebase or --squash returns an error or silently fails on a squash-only repo, (3) a PR is BLOCKED because required CI status contexts never post (workflow never triggered, paths filter excluded PR, required check name mismatch), (4) GPG-signing failures or mismatched committer emails cause commits to be unsigned and block the pr-policy gate, (5) branch protection rulesets and classic branch protection disagree and their union blocks merge, (6) a CI ruleset chicken-and-egg deadlock blocks a PR that introduces a new workflow, (7) an advisory check should not block merge but currently does because it lives in the required gate, (8) deciding which merge method a sole-owner workflow supports before arming auto-merge, (9) auditing required-check names after adding or removing CI jobs, (10) state:implementation-go label or pr-policy gates auto-merge arming, (11) per-issue arming-state machine is triggered on the wrong event (optimistic point vs detected merge), (12) mergeStateStatus=BLOCKED with all CI green and auto-merge armed - unresolved review threads are the PRIMARY blocker to check FIRST before assuming CI failure, (13) stale failed status-rollup entries must be distinguished from current-head required checks before deciding a PR is blocked or complete, (14) you applied state:implementation-go with `gh issue edit` and the auto-merge-policy gate stays FAILURE - the label must be on the PR (`gh pr edit`) not the issue, (15) required-checks-gate shows FAILURE alongside a later SUCCESS of the same check - the newer run is current, the FAILURE is stale, (16) your isolated-clean PR's lint job fails because CI runs pre-commit on the merge-result (pull/N/merge) and main drifted since you branched (e.g. ruff-format), (17) hephaestus-review-prs first run truncates at worktree-setup and posts zero threads - an empty thread list is NOT a clean pass unless the log reached 'Analysis complete for PR #N', (18) a sub-agent's disk-direct file writes leaked into the MAIN checkout, breaking editable-installed console scripts with ModuleNotFoundError for all later runs, (19) a repository-owned merge queue receives HTTP 405 from the REST merge API and may enqueue via its documented native path, or (20) a shared queue must coexist with an externally owned auto-merge request without adopting, disabling, or replacing it"
 category: ci-cd
-date: 2026-07-21
-version: "1.7.0"
+date: 2026-07-24
+version: "1.8.0"
 user-invocable: false
 history: github-auto-merge-ci-gating-merge-method.history
 tags:
@@ -27,6 +27,10 @@ tags:
   - merge-queue
   - queued
   - rest-merge-api
+  - auto-merge-ownership
+  - conditional-merge
+  - expected-head-oid
+  - toctou
   - pr-label-not-issue-label
   - stale-required-checks-gate
   - lint-on-merge-result
@@ -41,7 +45,8 @@ tags:
 
 | Date | Objective | Outcome |
 | ------ | ----------- | --------- |
-| 2026-07-21 | Extend the auto-merge / merge-method guidance to cover merge-queue-protected repos where the direct REST merge API returns HTTP 405 and the correct path is to enqueue via `gh pr merge` with no merge-method flag. | verified-ci: `hephaestus-merge-prs` now falls back from REST merge to queue enqueue on merge-queue repos, and `queued` is treated as success rather than a retryable error. |
+| 2026-07-21 | Historical repository-owned merge-queue guidance: direct REST merge returned HTTP 405 and the native queue enqueue path succeeded. | verified-ci: ProjectHephaestus then used `hephaestus-merge-prs` fallback to queue enqueue; this does not apply to the current reviewed-SHA shared queue. |
+| 2026-07-24 | Make an automation queue fail closed when it discovers an external auto-merge request. GitHub exposes `expectedHeadOid` to enable auto-merge but exposes no conditional disable mutation and does not persist an attributable client nonce. | verified-local: live schema inspection and local ProjectHephaestus tests. The conditional direct-merge replacement is pending CI in issue #2419; do not treat this row as an authorization to arm, adopt, or disable an existing request. |
 | 2026-06-07 | Consolidated canonical for why GitHub auto-merge does not fire and how to arm it correctly: wrong merge method, missing/required CI status contexts, two-layer branch protection, GPG-signing blockers, ruleset bootstrap deadlock, the `state:implementation-go` arming-state machine, and advisory-vs-required gate split | Each failure mode has a verified diagnosis + fix; verified across many HomericIntelligence repos in live CI |
 | 2026-06-14 | Add the classic-vs-ruleset review-count UNION hard gate (a required human approval automation cannot provide), the keystone-PR self-introduced-required-context merge-train deadlock (merge keystone first, then re-rebase the queue), and duplicate check-run resolution after a re-run | Diagnosed live across 13 open ProjectHephaestus PRs during a `/myrmidon-swarm` drive (verified-local; the PRs had not yet merged at capture, the review-union gate was confirmed by API inspection) |
 | 2026-06-14 | Expanded unresolved review thread diagnostic to verified-ci status: PR #1282 was BLOCKED despite all CI green and auto-merge armed; the stated "lint failure" was stale; the real blockers were 2 unresolved review threads. Resolving via `resolveReviewThread` GraphQL mutation immediately triggered auto-merge (merged 2026-06-15T03:05:38Z by app/github-actions). Added full GraphQL copy-paste workflow for thread query + reply + resolve. | verified-ci — PR #1282 ProjectHephaestus merged within seconds of thread resolution |
@@ -50,6 +55,8 @@ tags:
 | 2026-07-06 | Added the "why is my armed ProjectHephaestus PR not merging" operational gotcha set observed while manually driving 6 PRs in epic #1809: (1) `state:implementation-go` must go on the PR (`gh pr edit`) NOT the issue (`gh issue edit`) — the auto-merge-policy/required-checks-gate jobs read the PR's labels; (2) a `required-checks-gate: FAILURE` is usually STALE — a newer SUCCESS of the same check supersedes it; (3) CI lint runs on the merge-result `pull/N/merge`, so main's ruff-format drift fails your isolated-clean PR; (4) `hephaestus-review-prs` first run intermittently truncates at worktree-setup, and an empty unresolved-thread list is NOT a clean pass; (5) a sub-agent's disk-direct writes can leak into the MAIN checkout and break editable-installed console scripts. Corrected the pre-existing `gh issue edit <PR> --add-label` mislabel bug in the checklist to `gh pr edit`. | verified-ci — all observed while merging 6 ProjectHephaestus PRs in epic #1809 |
 
 GitHub auto-merge is **stricter than branch protection** and fires only when EVERY check (required and non-required) reaches a clean terminal state, the chosen merge method is allowed, every required status context has actually posted, all commits are verified-signed, and BOTH protection layers (ruleset + classic) are satisfied. A PR that looks ready (`mergeStateStatus: CLEAN`/`MERGEABLE`) can sit forever when any one of those is silently unmet. This skill covers the merge-blocking mechanics; it does NOT cover general CI failure diagnosis, rebase-conflict resolution, review-loop orchestration, or PR enumeration.
+
+> **Queue ownership boundary (ProjectHephaestus, pending issue #2419):** a queue must not enable, defer, disable, adopt, or poll GitHub auto-merge. A later readback cannot safely prove that the request it sees is the request it created: `enablePullRequestAutoMerge` has an expected-head precondition, but `disablePullRequestAutoMerge` has no matching conditional ownership field and `AutoMergeRequest` does not expose a persistent client nonce. If an unarmed proof is required for a label transition, require a fresh explicit `autoMergeRequest: null`; otherwise stand down without mutation. The replacement merge action must be a normal conditional REST merge pinned to the reviewed SHA, not an auto-merge mutation. This newer queue rule overrides the historical arming examples below for that pipeline.
 
 **Verification: verified-ci** (most failure modes observed and fixed live; the advisory-split and per-issue arming refinements are verified-local where noted).
 
@@ -73,6 +80,7 @@ GitHub auto-merge is **stricter than branch protection** and fires only when EVE
 - `hephaestus-review-prs` (the standalone reviewer) posted 0 threads on its first run — verify the log reached `Analysis complete for PR #N` before trusting an empty unresolved-thread list; a truncated worktree-setup death also yields zero threads but is NOT a clean pass.
 - After a sub-agent that did "disk-direct" file writes (bypassing Read/Edit), the editable-installed console scripts break with `ModuleNotFoundError` — the sub-agent leaked worktree-only files into the MAIN checkout; `git -C <main-repo> status` and restore the leaked tracked files.
 - `hephaestus-merge-prs` hits HTTP 405 `Pull Request is in the merge queue` from the direct REST merge API and should enqueue instead of retrying the merge call.
+- Your automation sees `autoMergeRequest` already populated and needs to decide whether it may disable, defer, or replace it. It may not: treat the request as externally owned and stop queue mutations. Use a conditional merge by reviewed SHA only after a separately reviewed design has implemented it.
 
 ## Verified Workflow
 
@@ -88,7 +96,8 @@ gh run list --branch "$(gh pr view <PR> --json headRefName --jq .headRefName)"  
 # 3. Which merge method does the TARGET repo allow? (detect, do not hardcode)
 gh api repos/<OWNER>/<REPO> --jq '{rebase:.allow_rebase_merge, squash:.allow_squash_merge, merge:.allow_merge_commit}'
 
-# 4. Arm with the correct flag, then verify it actually armed
+# 4. ONLY when the acting system is the sole documented owner: arm with the correct flag,
+# then verify it actually armed. A shared automation queue must stand down instead.
 gh pr merge <PR> --auto --squash         # squash-only repos REJECT/ignore --rebase
 gh pr view <PR> --json autoMergeRequest --jq '.autoMergeRequest.mergeMethod'   # expect SQUASH
 
@@ -100,14 +109,16 @@ gh api repos/<O>/<R>/rulesets/<RID> --jq '.rules[]|select(.type=="required_statu
 gh api graphql -f query='{repository(owner:"O",name:"R"){pullRequest(number:N){reviewThreads(first:50){nodes{isResolved}}}}}' \
   --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
 
-# 7. pr-policy "Auto-merge enabled before GO": un-arm, rerun, let the label workflow arm it
+# 7. HISTORICAL SOLE-OWNER REPOSITORY ONLY: repair a policy mismatch.
+# A shared queue must stand down and never disable or arm auto-merge.
 gh run view <run-id> --log-failed | grep '::error::'
 gh pr merge <PR> --disable-auto && gh run rerun <run-id> --failed
 
 # 8. Bulk batch: list ALL open PRs (default limit is 30 — silently omits older PRs)
 gh pr list -R <O>/<R> --state open --limit 200 --json number,mergeStateStatus,autoMergeRequest
 
-# 9. ProjectHephaestus PR completion: policy + current-head checks
+# 9. HISTORICAL SOLE-OWNER ProjectHephaestus completion example.
+# Do not use this to make the current shared queue mutate auto-merge.
 git log --show-signature -1 --format=fuller
 gh issue create --repo HomericIntelligence/ProjectHephaestus --title "..." --body "..."
 gh issue view <ISSUE> --repo HomericIntelligence/ProjectHephaestus
@@ -120,6 +131,10 @@ gh pr view <PR> --repo HomericIntelligence/ProjectHephaestus \
 ```
 
 ### Detailed Steps
+
+> **Scope:** Except for the current **Queue ownership** subsection, enable/disable
+> instructions in the legacy detailed steps are historical examples for a documented
+> sole-owner repository workflow. They are not commands for a shared automation queue.
 
 #### Squash-only merge-method detection
 
@@ -174,6 +189,45 @@ arm_auto_merge() {  # retry through transient clean/unstable arm-time GraphQL er
   return 1
 }
 ```
+
+#### Queue ownership: no safe conditional auto-merge disable
+
+> **Warning:** This is a verified-local safety finding. The ProjectHephaestus
+> implementation that replaces queue-owned auto-merge with a normal conditional
+> REST merge is pending CI in issue #2419.
+
+Do not infer ownership from an `autoMergeRequest` readback. Its visible fields
+(`enabledAt`, `enabledBy`, and merge method) are descriptive, not a compare-and-swap
+token. A competing actor can disable and enable an indistinguishable request between
+your reads. GitHub accepts `expectedHeadOid` on `enablePullRequestAutoMerge`, but
+the corresponding disable mutation accepts only the pull-request ID and a transient
+client mutation ID; the resulting `AutoMergeRequest` does not retain that ID. There
+is therefore no final conditional operation that proves a queue is disabling its own
+request rather than an external actor's replacement.
+
+For a queue that must preserve external ownership:
+
+1. Remove every queue call that enables, defers, disables, adopts, or polls
+   auto-merge. Blocking only the final disable leaves earlier create/adoption paths
+   unsafe.
+2. Before each state-changing label write, read the PR's full state. Require
+   `state == OPEN` and an **explicitly present** `autoMergeRequest: null`. A missing
+   field is a partial response, not evidence of an unarmed request. An approving/GO
+   label additionally requires that the live head still equals the reviewed head;
+   a drift instead revokes approval and routes the item back to review, where a
+   no-go/recovery write remains safely possible.
+3. When a request is present, write nothing. Report that the queue stood down; do
+   not call disable as cleanup and do not claim it can safely resume later.
+4. Bind approval to a reviewed head SHA. Once normal merge is implemented, call the
+   REST merge endpoint with that exact `sha` and an allowed merge method. Handle head
+   drift as a non-merge result requiring a new review, rather than retrying against a
+   new head. On merge-queue repositories, handle HTTP 405 as a typed failure or
+   re-read result; do not enqueue a non-conditional merge that drops the reviewed-SHA
+   guarantee.
+
+This is not a reason to bypass branch protection, use an administrator merge, or
+force-push. It narrows an automation queue to the authority GitHub can actually
+enforce.
 
 #### Required-check name management
 
@@ -383,7 +437,11 @@ Resolve via: Option 1 admin "Merge without waiting for requirements" (fastest); 
 
 A timing-sensitive sub-check bundled into a REQUIRED gate (e.g. the auto-merge ↔ `state:implementation-go` state machine inside `pr-policy`) blocks correct PRs. The fix is to SPLIT it into its own job (e.g. `auto-merge-policy`) whose name is NOT in the ruleset — making it advisory (reports red as a signal, never blocks). The new job needs its OWN `gh pr view --json autoMergeRequest,labels,state` fetch and the SAME triggers (re-run on `auto_merge_enabled`/`auto_merge_disabled`/`labeled`/`unlabeled`, no `needs:`); trim the parent's fetch to `--json body`. Required-check membership lives in the ruleset, OUTSIDE the YAML — a new job is non-required BY DEFAULT until an operator adds its name. Update any text-based workflow tests that asserted the old bundled fetch string.
 
-#### Arming-state machine (`state:implementation-go` + detected-merge)
+#### Historical sole-owner arming-state machine (`state:implementation-go` + detected-merge)
+
+> **Historical context only:** the following describes an earlier repository-owned
+> workflow. The current shared ProjectHephaestus queue must not copy its enable,
+> disable, or polling actions.
 
 Two distinct state machines gate arming:
 
@@ -522,7 +580,7 @@ pixi run python -c "import hephaestus.automation.review_prs"   # or the leaked m
 Prevention: after ANY sub-agent that did "disk-direct writes", run `git -C <main-repo> status` and
 restore leaked tracked files before the next console-script run.
 
-**Gotcha 6 — merge-queue-protected repos must enqueue on HTTP 405, not retry REST merge.**
+**Historical sole-owner Gotcha 6 — merge-queue-protected repos enqueue on HTTP 405.**
 When the direct GitHub REST merge API returns `HTTP 405` `Pull Request is in the merge queue`,
 `_merge_pr` should treat that as a queue-protected repo signal and call `_enqueue_pr` instead of
 retrying the merge call. The enqueue path must use `gh pr merge <n>` with no merge-method flag,
@@ -530,7 +588,10 @@ because the queue owns the strategy; the returned `queued` result is success and
 "enqueued in the merge queue" rather than another failure. This is the same behavior that fixed
 ProjectHephaestus PR #2312 / issue #2311.
 
-#### Merge-readiness checklist for driving a ProjectHephaestus PR to green (manual)
+#### Historical sole-owner checklist for driving a ProjectHephaestus PR to green (manual)
+
+> **Historical context only:** this checklist predates the shared-queue interlock.
+> The current queue must not execute its auto-merge step.
 
 Walk this in order; each step maps to one of the five gotchas above plus the pre-existing policy gates:
 
@@ -567,6 +628,7 @@ Walk this in order; each step maps to one of the five gotchas above plus the pre
 | Treated `cancelled` sibling jobs as real failures | Counted every non-success rollup entry | One `pr-policy` race failure tore down the run via the `concurrency` group, cancelling all siblings; a green re-run superseded them | Filter by `conclusion=="FAILURE"` AND `startedAt` later than open+60s; cross-check `state` (may be MERGED); never force-merge to escape |
 | Ran `--auto --squash` right after create on a #899 repo | Old habit | `pr-policy` Check 2 fails `Auto-merge is enabled before implementation review GO` | Match the label to the auto-merge state; add `state:implementation-go` OR `--disable-auto` |
 | Enabled auto-merge before the implementation GO label | `gh pr merge --auto --squash` before `state:implementation-go` existed on the PR | The auto-merge-policy/pr-policy gate saw auto-merge armed before review approval state and failed the earlier Required Checks run | Apply `state:implementation-go` first, then rely on auto-merge policy; if a stale pre-label failure remains in the rollup, verify the later current run |
+| Tried to attribute auto-merge ownership from a later `autoMergeRequest` readback | Planned to disable the request only if its enabled-at time, method, and user still matched the queue's earlier arm | Another actor can replace the request with the same observable identity; GitHub has no conditional disable mutation or persisted client nonce to close the final TOCTOU gap | Do not arm, adopt, defer, disable, or poll auto-merge from a shared queue. Treat every populated request as external and use a separately reviewed conditional merge by SHA instead. |
 | Treated stale failed Required Checks rollup entries as current blockers | Read a failed Required Checks entry from before the GO label as if it described the current HEAD | A later Required Checks run passed after the label and did not block the merge | Check current-head `gh pr checks --watch` and the later Required Checks run before deciding the PR is blocked |
 | Claimed completion before the Test matrix reached a terminal state | Saw auto-merge armed and policy prerequisites in place, then stopped watching | Auto-merge only merges after the active required checks finish; queued or in-progress matrix jobs can still fail | Keep `gh pr checks --watch --interval 30` running until the current-head Test matrix is terminal, then confirm `state=MERGED` / `mergedAt` |
 | Added `{"type":"required_conversation_resolution"}` to a ruleset | PUT it into `rules[]` | `HTTP 422: data matches no possible input` — it is classic-only | Keep convo-resolution in classic; `required_linear_history`/`non_fast_forward` ARE valid ruleset types |
@@ -597,9 +659,13 @@ Walk this in order; each step maps to one of the five gotchas above plus the pre
 | Trusted `hephaestus-review-prs` empty-thread result on its first run | Read "0 unresolved threads" as a clean review | The first run intermittently truncated at worktree-setup (~8-line log, no `Analysis complete for PR #N`); a truncated run ALSO posts zero threads, indistinguishable from a genuine clean pass by thread-count alone | Require the log line `Analysis complete for PR #N` before trusting an empty thread list; re-run if the log is truncated |
 | Ignored a sub-agent's "disk-direct" writes; ran console scripts afterward | Let a sub-agent write files via a python script (bypassing Read/Edit) "because the harness cache was stale" | The script targeted the MAIN repo path instead of `build/.worktrees/issue-N`; main's `X.py` got uncommitted mods importing a worktree-only module → `ModuleNotFoundError` broke editable-installed console scripts for ALL later runs | After any disk-direct sub-agent, `git -C <main-repo> status`; restore leaked tracked files via `git show HEAD:path > path` (checkout/restore/reset are safety-net-blocked); confirm `pixi run python -c "import ..."`; the PUSHED branch is fine — only the main tree was contaminated |
 
+> Rows about arming, disabling, and queue enqueue before the shared-queue ownership
+> entry are historical sole-owner observations. The current shared queue follows the
+> explicit no-mutation interlock instead.
+
 ## Results & Parameters
 
-### Auto-merge non-firing decision tree
+### Historical sole-owner auto-merge non-firing decision tree
 
 ```text
 auto-merge armed but not merged
@@ -621,7 +687,25 @@ auto-merge armed but not merged
        → required_signatures / pr-policy signature gate → re-sign with -S (registered key verified)
 ```
 
-### Tiered helper sourcing for cross-repo callers
+### Shared queue interlock
+
+```text
+fresh PR state needed before label or merge action
+├── response lacks autoMergeRequest field
+│      → partial/unknown state → fail closed; write nothing
+├── autoMergeRequest is non-null
+│      → externally owned or unprovable ownership → stand down; do not disable/adopt
+├── reviewed head SHA differs from live head
+│      → review proof stale → return to PR review
+└── OPEN + explicit autoMergeRequest:null + reviewed SHA matches
+       → approving/GO label may proceed; later normal merge must use that SHA conditionally
+
+negative/recovery/skip labels
+└── OPEN + explicit autoMergeRequest:null is sufficient
+       → record the safe outcome; do not demand a stale reviewed head
+```
+
+### Historical sole-owner helper sourcing for cross-repo callers
 
 Prefer **sourcing the helper** over re-defining `choose_merge_flag` inline. The helper exists as
 a real, sourceable file in ProjectHephaestus: `scripts/choose_merge_flag.sh`. A sub-agent running
@@ -713,8 +797,16 @@ call-site bug. Asserting on `_AGENT_PROMPT_TEMPLATE` (assuming a module constant
 | GO label set | `state:plan-go`, `state:plan-no-go`, `state:needs-plan`, `state:implementation-go`, `state:implementation-no-go` |
 | Arming record path | `state_dir/drive-green-armed-<issue>.json` |
 | `gh pr list` default limit | 30 — use `--limit 200` for backlogs |
+| Shared-queue auto-merge ownership | Unprovable from GitHub readback; do not mutate a populated request |
+| Label-mutation safety read | Every label: `OPEN` + explicit `autoMergeRequest: null`; approving/GO label also requires live SHA equal to reviewed SHA |
+| Queue merge direction (pending #2419 CI) | Normal REST merge conditioned on reviewed SHA; no administrator bypass and no auto-merge mutation |
 
-### Label-gated auto-merge workflow constraints
+### Historical repository-owned auto-merge constraints (not shared queue behavior)
+
+The following mechanism is retained as historical guidance for a repository-owned
+workflow whose authority and exclusive ownership are explicit. It is **not** valid
+for the ProjectHephaestus shared automation queue described in the queue-ownership
+section above.
 
 | Constraint | Value |
 | --------- | ----- |
@@ -724,12 +816,13 @@ call-site bug. Asserting on `_AGENT_PROMPT_TEMPLATE` (assuming a module constant
 | Forbidden | `actions/checkout` (do not execute PR-controlled code) |
 | Input guard | numeric-only `PR_NUMBER` |
 | Metadata | re-fetch `gh pr view --json autoMergeRequest,isDraft,labels,state` (event payload is stale) |
-| Arm | `gh pr merge "$PR" --repo "$REPO" --auto --squash` |
+| Arm | Historical sole-owner behavior: `gh pr merge "$PR" --repo "$REPO" --auto --squash`; forbidden for a shared queue |
 
-### ProjectHephaestus current-head PR-policy completion checklist
+### Historical ProjectHephaestus completion checklist (not current queue behavior)
 
-Use this sequence when finishing a ProjectHephaestus PR by hand or verifying that automation did it
-correctly:
+This legacy sequence documents earlier repository policy. Do not use it to make the
+current shared automation queue arm auto-merge; follow the shared-queue interlock
+instead.
 
 ```bash
 # Verify the commit identity and signature before pushing or before trusting the PR policy gate.


### PR DESCRIPTION
## Summary

Amends the review-authorization and auto-merge skills with two durable safety learnings.

- Bind approving labels to an exact reviewed PR head and verified clean checkout.
- Preserve negative/recovery labels after head drift while requiring fresh explicit unarmed state.
- Make shared queues stand down on populated auto-merge; GitHub cannot prove conditional ownership for disable.

## Verification

- `uv run python scripts/validate_plugins.py` — 712/712 valid
- Pre-push test suite — 219 passed

## Scope

The conditional normal merge remains separately tracked in ProjectHephaestus issue #2419; this PR documents the verified-local safety boundary only.

Co-Authored-By: Codex <noreply@openai.com>
