### PR TITLE
docs: preserve cross-run review remediation learning

### DIFF
--- a/skills/pr-review-loop-orchestration-agent-patterns.history
+++ b/skills/pr-review-loop-orchestration-agent-patterns.history
@@ -4,6 +4,33 @@
 
 This file preserves the full original content of the skills merged into this canonical.
 
+## v1.7.0 (2026-07-27)
+
+**Changed by:** ProjectHephaestus issue #2496 cross-run review-thread remediation.
+**Verification:** verified-local — targeted transition test plus complete unit suite: 6,515 passed,
+24 skipped, 84.91% coverage. CI pending.
+
+### What changed
+- Added a restart-safe review-thread receipt trigger and detailed workflow.
+- Distinguished a verified prior-loop receipt from a changed, replied-to, malformed, ambiguous, or
+  wont-fix thread.
+- Recorded the failure mode where only external-bot receipts returned to remediation while normal
+  prior-loop receipts terminalized as human handoffs.
+- Bumped 1.6.0 -> 1.7.0.
+
+### Why
+The GitHub adapter already reconstructed canonical prior-loop receipts, but a later reconciliation
+branch applied the remediation transition only to receipts marked external-bot. The resulting
+terminal handoff was retry-invariant despite the validator providing an actionable finding.
+
+### Previous version (v1.6.0) snapshot
+
+The exact v1.6.0 source is preserved by the immutable ProjectMnemosyne parent commit
+`825aefe177e552107bf281ecf8b24921b9f46acb` at
+`skills/pr-review-loop-orchestration-agent-patterns.md`.
+
+---
+
 ## v1.6.0 (2026-07-17)
 
 **Changed by:** Session monitoring a restarted automation loop that parked 5/5 pr_review items in

--- a/skills/pr-review-loop-orchestration-agent-patterns.md
+++ b/skills/pr-review-loop-orchestration-agent-patterns.md
@@ -2,8 +2,8 @@
 name: pr-review-loop-orchestration-agent-patterns
 description: "Use when: (1) building or debugging a Python implement-review loop where an LLM sub-agent reviews a PR and a fixer agent addresses inline comments, (2) a review loop resolves threads even though no commit was produced — resolution must be gated on a real commit not the model self-report, (3) a loop ends AMBIGUOUS or NO-GO too fast before ever earning an explicit GO verdict, (4) LLM or agent-generated inline PR review comments are rejected by GitHub (HTTP 422) because they do not lie on a changed diff hunk, (5) an agent-driven CI-fix session produces no commit and the PR stays red; the correct response is a single bounded retry with unresolved review threads injected verbatim, (6) a review fix plan file concludes no changes are needed and the automation should self-cancel without opening a new PR, (7) a feature-dev:code-reviewer sub-agent cannot execute shell commands and cannot post gh pr review — wrong agent type was chosen, (8) a GitHub GraphQL PR-review mutation field selection is wrong and the automation loop fails on every call with Field X does not exist, (9) pre-commit must cover the full PR diff from the merge-base not just the most-recent-edit files before pushing, (10) an existing-PR review handler short-circuits NO-GO PRs as if they were settled (idempotency `if has_go or has_no_go: skip`) so a failed-review PR never re-enters the loop — short-circuit on GO ONLY, (11) an existing-PR worktree sync fails `git fetch origin {issue}-auto-impl` with exit 128 because the PR head branch was ASSUMED from the issue number instead of read from the PR's real `headRefName`, (12) an in-loop LLM PR reviewer posts a FALSE policy violation (e.g. `POLICY VIOLATION: Closes, auto-merge-premature, signed-commits` on a PR that actually has `Closes #N`, auto-merge OFF, and a signed commit) because its policy fetch failed open to violation, or you are tempted to make the reviewer re-check `Closes #N` / signed commits / auto-merge that a CI gate (`pr-policy` required, `auto-merge-policy` advisory) already enforces, (13) an in-loop implementer review cycle (`_run_impl_review_loop`) converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO instead of re-reviewing up to `MAX_REVIEW_ITERATIONS` and auto-skipping only on TRUE exhaustion, (14) the address-review coordinator is handed a review thread the reviewer itself labels non-blocking / pre-existing / out-of-scope / follow-up-worthy, or that asks for an edit the approved plan explicitly scoped out (e.g. behind a 'count must not increase' verification guard) — the correct disposition is to leave the thread UNADDRESSED (out of the `addressed` set) as a follow-up issue and make NO code change, because resolving a comment means giving it a disposition, not necessarily editing code, (15) a run parks EVERY pr_review item to state:skip via 'zero-thread NOGO retry cap exhausted' or 'exhausted at round N (automation unresolved 0 -> 0)' and you suspect the reviewer model or verdict parsing — check each PR's hephaestus-pr-review-zero-thread-nogo anomaly comment FIRST: a summary like 'NOGO: ... head unchanged (Nth round)' means by-design stale-PR triage (#2079: deterministic no-progress NOGOs escalate to skip instead of burning implement budget), NOT a reviewer failure; only a FRESHLY-implemented PR parked this way indicates a real defect"
 category: ci-cd
-date: 2026-06-12
-version: "1.6.0"
+date: 2026-07-27
+version: "1.7.0"
 user-invocable: false
 history: pr-review-loop-orchestration-agent-patterns.history
 tags:
@@ -50,6 +50,8 @@ tags:
   - count-must-not-increase-guard
   - follow-up-issue-disposition
   - empty-addressed-no-op
+  - cross-run-review-receipt
+  - restart-remediation
   - homericintelligence
 ---
 
@@ -59,11 +61,11 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-12 |
+| **Date** | 2026-07-27 |
 | **Objective** | Build and debug a Python implement-review loop that drives LLM sub-agents to review a PR and fix its inline comments, converging on an EVIDENCE-BASED `Verdict: GO`. Covers: commit-gated thread resolution, inline-comment diff-hunk (422) validation, one-shot no-commit retry with unresolved review threads injected, agent-type selection for review tasks, GraphQL field/input validation for PR-review mutations, self-cancelling review plans, full merge-base pre-commit scope, the existing-PR short-circuit being GO-ONLY (NO-GO PRs MUST re-enter the loop), using the PR's real `headRefName` for the worktree instead of an assumed `{issue}-auto-impl`, and the "zero threads != GO" rule applying to the LOOP's TERMINATION condition (a zero-thread non-GO pass RE-REVIEWS up to `MAX_REVIEW_ITERATIONS`; `state:skip` only on TRUE exhaustion). |
 | **Outcome** | Merged across multiple ProjectHephaestus PRs (commit-gate + verdict-GO convergence #1084; inline-comment 422 validation #1043; no-commit retry + thread injection #847; GraphQL field/input validation #906/#1006; existing-PR NO-GO re-review #1104; real PR head-branch resolution #1106; in-loop policy enforcement removed in favor of CI gates #1112; in-loop zero-thread non-GO re-reviews + `state:skip` only on exhaustion #1114) plus ProjectOdyssey and gh-tidy upstream review rounds. |
 | **Verification** | verified-ci |
-| **Version** | 1.5.0 |
+| **Version** | 1.7.0 |
 
 ## When to Use
 
@@ -80,6 +82,7 @@ tags:
 - An in-loop LLM reviewer posts a FALSE policy violation, or you are tempted to make the reviewer re-check `Closes #N` / signed commits / auto-merge that a CI gate already enforces.
 - An in-loop implementer review cycle converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO.
 - The address-review coordinator is handed a review thread the reviewer ITSELF labels non-blocking / pre-existing / out-of-scope for #N / follow-up-worthy, or a thread that asks for an edit the approved plan explicitly scoped out (often behind a "count must not increase" verification guard), and the per-comment loop pressure ("every comment MUST be resolved") tempts a fixer-dispatch + code edit.
+- A fresh loop invocation reconstructs a canonical prior-run automated review thread, the validator marks it unaddressed, and reconciliation still hands it off instead of returning it to the normal remediation path.
 
 ## Verified Workflow
 
@@ -185,6 +188,21 @@ can share a line (original + a re-open) and path normalization drifts across hun
 editing an existing comment, FETCH+CONCATENATE its body first: `updatePullRequestReviewComment`
 REPLACES, it does not append. FENCE all untrusted comment text before interpolating into a
 prompt — first-line truncation is not injection-safe.
+
+#### Cross-run review-thread receipts
+
+An invocation boundary is not a human-review boundary. A restarted loop must continue work on a
+prior automation finding when GitHub still proves the same unresolved thread and the validator says
+it remains unaddressed. Reconstruct only a canonical receipt: durable thread and initial-comment
+identities, a complete participant/body snapshot, an automated parent review, and its reviewed
+commit. On every mutation, re-read the PR head and entire thread snapshot; require a changed head
+after the fix and stop if a reply, body, participant, or provenance fact differs.
+
+Route a validator-confirmed unaddressed canonical receipt through the same difficulty and address
+workflow used in the original run. Do not special-case external-bot receipts while handing off
+normal prior-loop receipts: that creates a retry-invariant terminal state even though the
+implementer has a concrete finding. Malformed, changed, replied-to, ambiguous, or validator-wont-fix
+receipts remain fail-closed handoffs.
 
 Severity-tag every inline comment (`critical | major | minor | nitpick`) and SUPPRESS
 nitpick by default; a `--nitpick` flag opts back in. Per-comment dispatch: classify each
@@ -493,6 +511,7 @@ recurring traps:
 | Converge the in-loop review cycle on zero posted threads + force `state:skip` on a single AMBIGUOUS | `_run_impl_review_loop` had `if not posted_thread_ids and not reopened: break` (converge regardless of verdict) and force-applied `state:skip` after one iteration-0 non-GO via `is_ambiguous` | A malformed/transient review with 0 threads ended the loop at R0 and stranded a fixable PR with `state:skip` — observed on #725 / PR #996, fed by the pre-#1112 false POLICY VIOLATION (only a `POLICY VIOLATION:` line, no `Verdict:` → AMBIGUOUS, 0 threads) | Re-review on a zero-thread non-GO pass up to `MAX_REVIEW_ITERATIONS` (no threads → skip the address step via `continue`); converge ONLY on GO; auto-skip ONLY on TRUE exhaustion (`iterations_run >= MAX_REVIEW_ITERATIONS and last_verdict != "GO"`). Distinguish zero-threads-posted (re-review) from address-step-resolved-nothing (`break`) (PR #1114). |
 | Dispatch a fixer sub-agent for every review thread because the coordinator prompt says "every comment MUST be resolved" | Treating "resolve" as "must edit code", including for a thread the reviewer labelled non-blocking / pre-existing / out-of-scope | The requested edit (`pixi shell -e dev` in `CONTRIBUTING.md:63` / `README.md:494`) was pre-existing drift the approved plan EXPLICITLY scoped out behind a "count must not increase" guard; editing it would breach the plan and re-introduce scope-creep (PR #1245 / #1216) | Resolving a thread = giving it a disposition. "Not addressable in code within this issue's scope → follow-up issue" is a valid resolution; leave it out of `addressed` and change nothing (verified-local). |
 | Edit the redirect target's content because the anchor was correct | Saw a correct pointer to `CONTRIBUTING.md` / `README.md` and assumed the doc itself was THIS PR's defect to fix | A correct anchor to a doc whose downstream step is buggy is not a defect introduced by this PR; the reviewer themselves recommended a follow-up issue, not an in-PR fix | Distinguish the redirect/anchor (often correct) from the redirect target's content (the actual, out-of-scope complaint); honor the scope contract and emit `{"addressed": []}` (verified-local). |
+| Treat restart adoption as a terminal handoff | A later loop reconstructed a canonical prior automation receipt, but reconciliation allowed only external-bot receipts to reach remediation. | Validator-confirmed unaddressed normal receipts were labelled as requiring human resolution, so a fresh run could never make progress. | Provenance, head, reply, and readback checks protect the mutation; they do not justify an iteration boundary. Route all verified unaddressed automation receipts back to remediation. |
 
 ## Results & Parameters
 
@@ -507,6 +526,22 @@ recurring traps:
 | Existing-PR short-circuit is GO-ONLY | `_review_existing_pr`: `if has_go: return` (NOT `has_go or has_no_go`) | a NO-GO label is NOT terminal; it must re-enter the loop (PR #1104) |
 | Existing-PR worktree uses the PR's real head branch | `get_pr_head_branch(pr)` → `headRefName`; fall back to `{issue}-auto-impl` only on `None` | the PR may have matched via `Closes #N`, so the head branch can differ from the issue number (PR #1106) |
 | Out-of-scope / non-blocking thread → resolve by NON-action | coordinator emits `{"addressed": []}`, dispatches ZERO sub-agents, commits nothing, leaves loop scratch file (`.claude-address-review-*.md`) UNTRACKED | "resolve" = give a disposition, not edit; editing a plan-scoped-out thread (e.g. behind a "count must not increase" guard) breaches the scope contract (verified-local, PR #1245 / #1216) |
+
+### Cross-run receipt remediation (verified locally)
+
+```text
+restart -> reconstruct canonical immutable receipt from live GitHub facts
+validator says unaddressed -> difficulty classification -> address implementation
+fresh reviewed head + unchanged receipt snapshot -> reply and resolve
+
+Do not hand off solely because the receipt was created by an earlier invocation.
+Do hand off on malformed provenance, a changed/replied-to thread, ambiguous validation,
+or a validator wont-fix disposition.
+```
+
+ProjectHephaestus regression evidence: a targeted stage test passed before and after the minimal
+transition fix; the complete unit suite then passed with 6,515 passed, 24 skipped, and 84.91%
+coverage. CI was pending when this learning was recorded.
 
 ### `--nitpick` severity model and per-comment dispatch
 
@@ -620,6 +655,7 @@ mutation {
 | ProjectHephaestus | PR #1114 | In-loop `_run_impl_review_loop` (`implementer_phase_runner.py`): a zero-thread non-GO pass (no re-opens) now RE-REVIEWS up to `MAX_REVIEW_ITERATIONS` instead of `break`ing on `if not posted_thread_ids and not reopened: break`; GO still converges immediately; a posted-thread NO-GO still runs the address step (`if not addressed: break` unchanged). `state:skip` is applied ONLY on TRUE iteration exhaustion (`iterations_run >= MAX_REVIEW_ITERATIONS and last_verdict != "GO"`), not on a single iteration-0 AMBIGUOUS/NO-GO. Fixes #725 → PR #996 being stranded at R0 with `state:skip` by a malformed 0-thread review. 81 implementer-suite tests pass, ruff + mypy 342 files clean; PR CLEAN/MERGEABLE |
 | ProjectHephaestus | PR #1112 | Removed in-loop policy enforcement from the LLM reviewer — deleted the "Policy checks (MANDATORY)" block + `POLICY VIOLATION` contract from `prompts/pr_review.py`, the `D1 — Policy compliance` rubric gate from `prompts/_strict_rubric.py`, and `_fetch_signing_state` + auto-merge/signing context from `pr_reviewer.py`. CI gates `pr-policy` (required) + `auto-merge-policy` (advisory) own policy; reviewer judges code quality only. Fixes false POLICY VIOLATION on compliant PR #996. Net +78/-345; prompt + pr_reviewer suites green, ruff + mypy 342 files clean |
 | ProjectHephaestus | PR #1245 (issue #1216) | Out-of-scope / non-blocking / pre-existing review-thread disposition: the sole address-review thread was reviewer-labelled "Non-blocking (pre-existing, out of scope for #1216)" and asked to edit `pixi shell -e dev` (`CONTRIBUTING.md:63` / `README.md:494`) — drift the approved plan explicitly scoped out behind a "count must not increase" guard. Coordinator dispatched zero sub-agents, changed no code, committed nothing, returned `{"addressed": []}`. verified-local (CI not yet confirming the disposition) |
+| ProjectHephaestus | Issue #2496 / prior-loop review-thread remediation | Verified locally: canonical restart receipt adoption already worked, but a later reconciliation branch incorrectly restricted remediation to external-bot receipts. A normal prior-loop receipt classified as unaddressed now returns to the difficulty/address workflow; malformed, changed, replied-to, ambiguous, and wont-fix paths remain fail-closed. |
 | HomericIntelligence/AchaeanFleet | 11 Dependabot PRs, 2026-05-31 | `feature-dev:code-reviewer` read-only blocker discovered; agent-type selection rule |
 | ProjectOdyssey | PR #3343 (issue #3152) / PR #3109 (issue #3033) | Self-cancelling review plan no-op; comprehensive multi-specialist PR review orchestration |
 | gh-tidy (HaywardMorihara/gh-tidy) | PRs #63/#67/#68/#69 | Upstream bash PR review rounds; logic/safety traps (verified-local) |

--- a/skills/pr-review-loop-orchestration-agent-patterns.md
+++ b/skills/pr-review-loop-orchestration-agent-patterns.md
@@ -2,8 +2,8 @@
 name: pr-review-loop-orchestration-agent-patterns
 description: "Use when: (1) building or debugging a Python implement-review loop where an LLM sub-agent reviews a PR and a fixer agent addresses inline comments, (2) a review loop resolves threads even though no commit was produced — resolution must be gated on a real commit not the model self-report, (3) a loop ends AMBIGUOUS or NO-GO too fast before ever earning an explicit GO verdict, (4) LLM or agent-generated inline PR review comments are rejected by GitHub (HTTP 422) because they do not lie on a changed diff hunk, (5) an agent-driven CI-fix session produces no commit and the PR stays red; the correct response is a single bounded retry with unresolved review threads injected verbatim, (6) a review fix plan file concludes no changes are needed and the automation should self-cancel without opening a new PR, (7) a feature-dev:code-reviewer sub-agent cannot execute shell commands and cannot post gh pr review — wrong agent type was chosen, (8) a GitHub GraphQL PR-review mutation field selection is wrong and the automation loop fails on every call with Field X does not exist, (9) pre-commit must cover the full PR diff from the merge-base not just the most-recent-edit files before pushing, (10) an existing-PR review handler short-circuits NO-GO PRs as if they were settled (idempotency `if has_go or has_no_go: skip`) so a failed-review PR never re-enters the loop — short-circuit on GO ONLY, (11) an existing-PR worktree sync fails `git fetch origin {issue}-auto-impl` with exit 128 because the PR head branch was ASSUMED from the issue number instead of read from the PR's real `headRefName`, (12) an in-loop LLM PR reviewer posts a FALSE policy violation (e.g. `POLICY VIOLATION: Closes, auto-merge-premature, signed-commits` on a PR that actually has `Closes #N`, auto-merge OFF, and a signed commit) because its policy fetch failed open to violation, or you are tempted to make the reviewer re-check `Closes #N` / signed commits / auto-merge that a CI gate (`pr-policy` required, `auto-merge-policy` advisory) already enforces, (13) an in-loop implementer review cycle (`_run_impl_review_loop`) converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO instead of re-reviewing up to `MAX_REVIEW_ITERATIONS` and auto-skipping only on TRUE exhaustion, (14) the address-review coordinator is handed a review thread the reviewer itself labels non-blocking / pre-existing / out-of-scope / follow-up-worthy, or that asks for an edit the approved plan explicitly scoped out (e.g. behind a 'count must not increase' verification guard) — the correct disposition is to leave the thread UNADDRESSED (out of the `addressed` set) as a follow-up issue and make NO code change, because resolving a comment means giving it a disposition, not necessarily editing code, (15) a run parks EVERY pr_review item to state:skip via 'zero-thread NOGO retry cap exhausted' or 'exhausted at round N (automation unresolved 0 -> 0)' and you suspect the reviewer model or verdict parsing — check each PR's hephaestus-pr-review-zero-thread-nogo anomaly comment FIRST: a summary like 'NOGO: ... head unchanged (Nth round)' means by-design stale-PR triage (#2079: deterministic no-progress NOGOs escalate to skip instead of burning implement budget), NOT a reviewer failure; only a FRESHLY-implemented PR parked this way indicates a real defect"
 category: ci-cd
-date: 2026-07-27
-version: "1.7.0"
+date: 2026-07-30
+version: "1.8.0"
 user-invocable: false
 history: pr-review-loop-orchestration-agent-patterns.history
 tags:
@@ -52,6 +52,10 @@ tags:
   - empty-addressed-no-op
   - cross-run-review-receipt
   - restart-remediation
+  - implementation-reply-batch
+  - one-review-per-pass
+  - pending-review-ownership
+  - preserve-review-conflicts
   - homericintelligence
 ---
 
@@ -61,11 +65,11 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-27 |
+| **Date** | 2026-07-30 |
 | **Objective** | Build and debug a Python implement-review loop that drives LLM sub-agents to review a PR and fix its inline comments, converging on an EVIDENCE-BASED `Verdict: GO`. Covers: commit-gated thread resolution, inline-comment diff-hunk (422) validation, one-shot no-commit retry with unresolved review threads injected, agent-type selection for review tasks, GraphQL field/input validation for PR-review mutations, self-cancelling review plans, full merge-base pre-commit scope, the existing-PR short-circuit being GO-ONLY (NO-GO PRs MUST re-enter the loop), using the PR's real `headRefName` for the worktree instead of an assumed `{issue}-auto-impl`, and the "zero threads != GO" rule applying to the LOOP's TERMINATION condition (a zero-thread non-GO pass RE-REVIEWS up to `MAX_REVIEW_ITERATIONS`; `state:skip` only on TRUE exhaustion). |
 | **Outcome** | Merged across multiple ProjectHephaestus PRs (commit-gate + verdict-GO convergence #1084; inline-comment 422 validation #1043; no-commit retry + thread injection #847; GraphQL field/input validation #906/#1006; existing-PR NO-GO re-review #1104; real PR head-branch resolution #1106; in-loop policy enforcement removed in favor of CI gates #1112; in-loop zero-thread non-GO re-reviews + `state:skip` only on exhaustion #1114) plus ProjectOdyssey and gh-tidy upstream review rounds. |
 | **Verification** | verified-ci |
-| **Version** | 1.7.0 |
+| **Version** | 1.8.0 |
 
 ## When to Use
 
@@ -83,6 +87,7 @@ tags:
 - An in-loop implementer review cycle converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO.
 - The address-review coordinator is handed a review thread the reviewer ITSELF labels non-blocking / pre-existing / out-of-scope for #N / follow-up-worthy, or a thread that asks for an edit the approved plan explicitly scoped out (often behind a "count must not increase" verification guard), and the per-comment loop pressure ("every comment MUST be resolved") tempts a fixer-dispatch + code edit.
 - A fresh loop invocation reconstructs a canonical prior-run automated review thread, the validator marks it unaddressed, and reconciliation still hands it off instead of returning it to the normal remediation path.
+- One implementation pass posts a separate empty GitHub review for every addressed thread, or a transport failure leaves a pending review draft and the recovery path is tempted to delete, reuse, or partially replay it.
 
 ## Verified Workflow
 
@@ -203,6 +208,26 @@ workflow used in the original run. Do not special-case external-bot receipts whi
 normal prior-loop receipts: that creates a retry-invariant terminal state even though the
 implementer has a concrete finding. Malformed, changed, replied-to, ambiguous, or validator-wont-fix
 receipts remain fail-closed handoffs.
+
+#### Batched implementation-review replies
+
+An implementation address pass owns one immutable response batch: exact PR head, complete thread
+snapshot, complete reply map, and a CSPRNG batch nonce persisted before the first GitHub mutation.
+Create at most one `PENDING` pull-request review for that batch, attach every thread reply to that
+review, verify every receipt from live GitHub state, then submit exactly that one review. The
+implementation actor replies but never resolves a thread; a fresh reviewer validates the submitted
+batch and is the sole resolver.
+
+The nonce identifies a proposed batch; it is not a GitHub lease. GitHub review writes have no
+compare-and-swap precondition, and a deterministic marker plus `viewerDidAuthor` cannot prove that
+an incomplete draft is safe to mutate. After create and before submit, re-inventory the current
+head. Preserve and diagnose every incomplete, stale, duplicate, or competing review rather than
+deleting it or compensating with more mutations. Stop the handoff before any thread resolution and
+begin a fresh review after manual cleanup or changed state.
+
+A host-only retry must retain the entire immutable batch. Never retain a nonce while filtering its
+thread or reply set: that changes the derived review body, turns the original draft into a conflict,
+and defeats recovery. Treat a mixed stale/ambiguous result as stale, or retry the exact full batch.
 
 Severity-tag every inline comment (`critical | major | minor | nitpick`) and SUPPRESS
 nitpick by default; a `--nitpick` flag opts back in. Per-comment dispatch: classify each
@@ -512,6 +537,7 @@ recurring traps:
 | Dispatch a fixer sub-agent for every review thread because the coordinator prompt says "every comment MUST be resolved" | Treating "resolve" as "must edit code", including for a thread the reviewer labelled non-blocking / pre-existing / out-of-scope | The requested edit (`pixi shell -e dev` in `CONTRIBUTING.md:63` / `README.md:494`) was pre-existing drift the approved plan EXPLICITLY scoped out behind a "count must not increase" guard; editing it would breach the plan and re-introduce scope-creep (PR #1245 / #1216) | Resolving a thread = giving it a disposition. "Not addressable in code within this issue's scope → follow-up issue" is a valid resolution; leave it out of `addressed` and change nothing (verified-local). |
 | Edit the redirect target's content because the anchor was correct | Saw a correct pointer to `CONTRIBUTING.md` / `README.md` and assumed the doc itself was THIS PR's defect to fix | A correct anchor to a doc whose downstream step is buggy is not a defect introduced by this PR; the reviewer themselves recommended a follow-up issue, not an in-PR fix | Distinguish the redirect/anchor (often correct) from the redirect target's content (the actual, out-of-scope complaint); honor the scope contract and emit `{"addressed": []}` (verified-local). |
 | Treat restart adoption as a terminal handoff | A later loop reconstructed a canonical prior automation receipt, but reconciliation allowed only external-bot receipts to reach remediation. | Validator-confirmed unaddressed normal receipts were labelled as requiring human resolution, so a fresh run could never make progress. | Provenance, head, reply, and readback checks protect the mutation; they do not justify an iteration boundary. Route all verified unaddressed automation receipts back to remediation. |
+| Retry a filtered subset of a nonce-bound implementation batch | A stale thread was removed while an ambiguous thread retained the original nonce. | The review body derives from the whole reply map, so the original full-batch draft no longer matches and is correctly preserved as a conflict instead of being retried. | Retry the exact immutable batch, or classify any mixed stale/ambiguous outcome as stale and start a fresh pass. Never use a nonce as a subset-retry token. |
 
 ## Results & Parameters
 
@@ -542,6 +568,25 @@ or a validator wont-fix disposition.
 ProjectHephaestus regression evidence: a targeted stage test passed before and after the minimal
 transition fix; the complete unit suite then passed with 6,515 passed, 24 skipped, and 84.91%
 coverage. CI was pending when this learning was recorded.
+
+### One-review implementation reply batch (reviewed, CI-passing)
+
+```text
+complete address pass + persisted CSPRNG nonce
+  -> create at most one PENDING review
+  -> add every original-thread reply to that review
+  -> re-read head, review state, receipts, and competing reviews
+  -> submit one complete review
+  -> fresh reviewer validates and resolves only proven threads
+
+Any incomplete, stale, duplicate, or competing review -> preserve + diagnose;
+never delete it, resolve a thread, or replay a filtered subset of the batch.
+```
+
+ProjectHephaestus PR #2525 exercised the adapter and stage regressions (358 focused tests) and the
+locked full suite (6,892 collected tests), with required CI checks passing at the reviewed head. A
+strict review exposed the latent mixed stale/ambiguous subset-retry condition captured above; do not
+treat that recovery path as complete until it is corrected.
 
 ### `--nitpick` severity model and per-comment dispatch
 
@@ -656,6 +701,7 @@ mutation {
 | ProjectHephaestus | PR #1112 | Removed in-loop policy enforcement from the LLM reviewer — deleted the "Policy checks (MANDATORY)" block + `POLICY VIOLATION` contract from `prompts/pr_review.py`, the `D1 — Policy compliance` rubric gate from `prompts/_strict_rubric.py`, and `_fetch_signing_state` + auto-merge/signing context from `pr_reviewer.py`. CI gates `pr-policy` (required) + `auto-merge-policy` (advisory) own policy; reviewer judges code quality only. Fixes false POLICY VIOLATION on compliant PR #996. Net +78/-345; prompt + pr_reviewer suites green, ruff + mypy 342 files clean |
 | ProjectHephaestus | PR #1245 (issue #1216) | Out-of-scope / non-blocking / pre-existing review-thread disposition: the sole address-review thread was reviewer-labelled "Non-blocking (pre-existing, out of scope for #1216)" and asked to edit `pixi shell -e dev` (`CONTRIBUTING.md:63` / `README.md:494`) — drift the approved plan explicitly scoped out behind a "count must not increase" guard. Coordinator dispatched zero sub-agents, changed no code, committed nothing, returned `{"addressed": []}`. verified-local (CI not yet confirming the disposition) |
 | ProjectHephaestus | Issue #2496 / prior-loop review-thread remediation | Verified locally: canonical restart receipt adoption already worked, but a later reconciliation branch incorrectly restricted remediation to external-bot receipts. A normal prior-loop receipt classified as unaddressed now returns to the difficulty/address workflow; malformed, changed, replied-to, ambiguous, and wont-fix paths remain fail-closed. |
+| ProjectHephaestus | PR #2525 (issue #2523) | One implementation response pass creates one pending review, associates every original-thread reply, verifies receipts, and submits one review. CSPRNG nonce-bound batches preserve incomplete, stale, duplicate, and competing drafts for diagnosis because GitHub lacks a write CAS; only a fresh reviewer can resolve threads. Required CI passed at the reviewed head; strict review identified a latent subset-retry correction. |
 | HomericIntelligence/AchaeanFleet | 11 Dependabot PRs, 2026-05-31 | `feature-dev:code-reviewer` read-only blocker discovered; agent-type selection rule |
 | ProjectOdyssey | PR #3343 (issue #3152) / PR #3109 (issue #3033) | Self-cancelling review plan no-op; comprehensive multi-specialist PR review orchestration |
 | gh-tidy (HaywardMorihara/gh-tidy) | PRs #63/#67/#68/#69 | Upstream bash PR review rounds; logic/safety traps (verified-local) |


### PR DESCRIPTION
## Summary

Amends the existing PR-review-loop orchestration skill from v1.6.0 to v1.7.0.

- Documents that canonical prior-run automation receipts re-enter remediation when validation says unaddressed.
- Preserves fail-closed handoffs for changed, replied-to, malformed, ambiguous, and wont-fix threads.
- Records local regression evidence and the underlying reconciliation failure mode.

## Verification

- uv run --with pyyaml python scripts/validate_plugins.py — 714/714 valid
- Pre-push uv run --all-extras --locked pytest -q — 219 passed

## Scope

Verified locally; CI validation remains pending.