### PR TITLE
docs(skills): capture live benchmark snapshot provenance

### DIFF
--- a/skills/benchmark-artifact-triage-pr-splitting.md
+++ b/skills/benchmark-artifact-triage-pr-splitting.md
@@ -1,12 +1,12 @@
 ---
 name: benchmark-artifact-triage-pr-splitting
-description: "Triage generated benchmark result artifacts before committing them. Use when: (1) benchmark/report runs leave many untracked files, (2) result PRs must include durable reports and complete records without logs or scratch residue, (3) Pareto/report assets need validation before staging, (4) large result sets need split into reviewable PRs."
+description: "Triage and incrementally publish generated benchmark result artifacts. Use when: (1) benchmark/report runs leave many untracked files, (2) result PRs must include durable reports and exact current records without logs or scratch residue, (3) live sweeps need consistency-checked report snapshots with stable record identities, (4) Pareto/report assets need validation before staging, (5) large result sets need split into reviewable PRs."
 category: tooling
-date: 2026-07-24
-version: "1.1.0"
+date: 2026-07-30
+version: "1.2.0"
 user-invocable: false
 verification: verified-local
-tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reproducibility, concurrency, capacity]
+tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reproducibility, concurrency, capacity, provenance, artifact-index, live-sweep, runner-compatibility]
 ---
 
 # Benchmark Artifact Triage and PR Splitting
@@ -15,10 +15,10 @@ tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reprodu
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-24 |
-| **Objective** | Turn a messy benchmark-result worktree into reviewable PRs that preserve useful data and exclude transient run residue. |
-| **Outcome** | Operational. The workflow produced separate result PRs for endpoint reports, model reports, and complete structured benchmark records while leaving logs, placeholders, progress traces, orphan metadata, and partial records untracked. It preserves concurrency as a measurement dimension so latency baselines and capacity claims remain distinguishable. |
-| **Verification** | verified-local. Executed locally in a benchmark-results repository; the concurrency-coverage amendment was checked against complete-result accounting and local benchmark-report behavior. CI and merge completion were not part of the capture. |
+| **Date** | 2026-07-30 |
+| **Objective** | Turn a messy or still-running benchmark campaign into reviewable, identity-stable result PRs that preserve useful data and exclude transient run residue. |
+| **Outcome** | Operational. The workflow produced separate result PRs for endpoint reports, model reports, and complete structured benchmark records while leaving logs, placeholders, progress traces, orphan metadata, and partial records untracked. It preserves concurrency as a measurement dimension, reuses only exact current results, and publishes consistency-checked incremental snapshots without changing existing opaque record identities. |
+| **Verification** | verified-local. The original artifact-triage and concurrency workflows were verified locally. The live-snapshot amendment was exercised on an active endpoint sweep: a canonical indexed-results root preserved 165 existing identities, added 8 records with no removals, and produced 173 complete records and 171 unique comparable coordinates. The resulting report and data commit separately passed 49 result-repository tests in CI; that CI did not exercise worker coordination or snapshot capture. |
 
 ## When to Use
 
@@ -26,6 +26,9 @@ tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reprodu
 - Generated reports reference images, CSV summaries, markdown summaries, raw JSON records, or reproducibility scripts.
 - Some backends or scenarios produced zero-row summaries, placeholders, partial results, interrupted rows, or failure-only evidence.
 - You need to distinguish a single-client latency baseline from a measured concurrency or capacity result.
+- A benchmark sweep is still running, but you need a reproducible incremental report snapshot without reading a moving index directly.
+- Opaque result identifiers are derived from paths and must remain stable across worktrees, resumes, and report refreshes.
+- A benchmark wrapper and runner may be at different revisions, so bulk submission must be gated on the exact interpreter and CLI contract.
 - A large result set needs to be split by model family, backend, endpoint, or dataset so reviewers can inspect it without a huge all-in-one PR.
 - You need to preserve durable benchmark information without committing logs, scratch directories, progress files, overlays, or build/runtime residue.
 
@@ -39,18 +42,33 @@ git fetch origin
 git switch <trunk-branch>
 git pull --ff-only origin <trunk-branch>
 
-# 2. Snapshot visible candidates.
+# 2. Record and preflight the exact runner before bulk submission.
+runner_repo="/path/to/runner-repo"
+runner_python="/path/to/runner-python"
+runner_script="/path/to/runner-script"
+git -C "$runner_repo" rev-parse HEAD
+"$runner_python" "$runner_script" --help | rg -- '--required-runner-flag'
+
+# 3. Select one canonical result root and a separate snapshot destination.
+result_repo="/path/to/result-repo"
+cluster="<cluster>"
+campaign="<campaign>"
+dataset="<dataset>"
+result_root="$result_repo/inferencex/$cluster/endpoint"
+snapshot_root="/tmp/$campaign-snapshot"
+
+# 4. Snapshot visible candidates.
 git status --short --untracked-files=all
 git status --short --untracked-files=all | awk '$1=="??"{print $2}' > /tmp/benchmark-candidates.txt
 
-# 3. Build reviewed file lists by logical PR.
-rg -n "PARETO|summary.csv|summary.md|request_rate_pareto|throughput_pareto" <result-root>
-find <result-root> -type f > /tmp/<dataset>-all.txt
+# 5. Build reviewed file lists by logical PR.
+rg -n "PARETO|summary.csv|summary.md|request_rate_pareto|throughput_pareto" "$result_root"
+find "$result_root" -type f > "/tmp/$dataset-all.txt"
 
-# 4. Stage only reviewed paths.
-git add --pathspec-from-file=/tmp/<dataset>-commit-list.txt
+# 6. Stage only reviewed paths after rendering and auditing the snapshot.
+git add --pathspec-from-file="/tmp/$dataset-commit-list.txt"
 
-# 5. Verify staged content before every commit.
+# 7. Verify staged content before every commit.
 git diff --cached --stat
 git diff --cached --name-only | wc -l
 git diff --cached --name-only | rg -n '(^|/)(logs?|runtime|progress\.jsonl|preflight|overlay|.*\.pid|.*\.err|.*\.out)$|failure|metadata\.json' || true
@@ -65,10 +83,28 @@ git diff --cached --check
 2. **Inspect branch state separately from artifact state.**
    First decide whether old branches are merged, stale, or still carrying independent work. Do not mix branch cleanup with result artifact commits. If a branch contains a large unrelated archive or old experiment corpus, split that decision from the benchmark result PRs.
 
-3. **Create explicit candidate lists in `/tmp`.**
+3. **Preflight the exact runner revision before bulk submission.**
+   Record the immutable runner revision and interpreter that the workers will use. Inspect that exact runner's `--help` output for every wrapper-supplied flag, then execute the smallest representative live coordinate. A wrapper-compatible local checkout does not prove that a stale shared worktree or interpreter accepts the same flags. Fail before creating bulk scheduler jobs if either preflight fails.
+
+4. **Give each live endpoint a single writer.**
+   Run at most one benchmark worker or lease per independently capacity-isolated endpoint, while parallelizing across distinct endpoints. This worker limit is separate from the request concurrency measured inside each coordinate. Write endpoint results to distinct result and index shards; do not let overlapping workers mutate the same result index.
+
+5. **Anchor indexing to one canonical result root.**
+   Choose a stable indexed-results root from the result repository's logical hierarchy, independent of the runner worktree and current directory. Reuse that exact root for every resume and report refresh. Some report generators derive opaque record IDs from a result path relative to the selected root; choosing a different ancestor can churn every ID even when the metrics are unchanged.
+
+6. **Reuse only exact current coordinates.**
+   Accept an indexed result only when it is parseable, marked current by the repository's freshness contract, complete, has zero failed requests, and exactly matches the requested model, checkpoint, input tokens, output tokens, concurrency, and prompt count. Keep rejected or failed attempts as explicit non-comparable evidence when the result schema supports it, but never treat them as successful coverage or Pareto points.
+
+7. **Freeze and verify an incremental snapshot.**
+   Publish while workers continue only when the campaign provides a consistency boundary: a lock or immutable generation, or unchanged pre/post index digests plus validation that every indexed immutable result was captured. Otherwise, pause workers at a safe boundary before copying. Render the captured generation into a temporary snapshot directory rather than directly into the clean PR worktree. Compare the previous and candidate identity sets: existing IDs should remain unless a documented supersession rule applies, and unexpected removals or broad ID churn must stop publication. Reconcile complete, comparable, and non-comparable counts before copying only the validated generated artifacts into the clean PR worktree.
+
+8. **Keep campaign execution separate from publication.**
+   Leave raw results and live worker residue in the campaign worktree. Promote only the frozen aggregate, detailed reports, data bundles, and intentional generator changes into a clean result-PR worktree. This prevents runtime logs and a partially refreshed report tree from entering the publication diff.
+
+9. **Create explicit candidate lists in `/tmp`.**
    Write one file list per intended PR, such as `/tmp/endpoint-reports.txt`, `/tmp/model-baseline.txt`, or `/tmp/inference-json-complete.txt`. Avoid `git add -A` and broad directory adds; generated benchmark directories often contain valuable reports next to useless runtime files.
 
-4. **Classify artifacts by information value.**
+10. **Classify artifacts by information value.**
    Keep durable information:
    - generated reports such as `PARETO.md`, backend reports, and README files that summarize results;
    - `summary.csv` and `summary.md` files with non-empty result rows;
@@ -84,29 +120,29 @@ git diff --cached --check
    - empty failure logs;
    - partial or zero-completion JSON benchmark records unless the PR is explicitly a failure-analysis archive.
 
-5. **Validate CSV report artifacts before staging.**
+11. **Validate CSV report artifacts before staging.**
    For each summary, check row count, status values, profile/scenario coverage, and backend/model labels. A useful report PR should say exactly what it includes, such as "69 rows across short, medium, and long" or "TRT rows only, SGLang absent." If rows are marked interrupted but still plotted, put that caveat in the PR body.
 
-6. **Validate report asset references.**
+12. **Validate report asset references.**
    Search markdown reports for referenced images and confirm each image exists. If a referenced image is untracked, include it with the report. A report without its referenced Pareto images is broken rendered documentation, not a clean text-only result.
 
-7. **Validate structured JSON benchmark records by completion.**
-   Parse JSON rather than relying on filenames. Require `completed == prompt_count` or `completed == num_prompts` for result PRs that claim complete records. Leave zero-completion and partial records untracked unless the PR title and body are explicitly about failure evidence.
+13. **Validate structured JSON benchmark records by completion.**
+   Parse JSON rather than relying on filenames. Require `completed == prompt_count` or `completed == num_prompts` and zero failed requests for result PRs that claim comparable records. Validate freshness separately from the canonical benchmark index; raw result JSON may not carry `freshness_status`. Leave zero-completion and partial records untracked unless the PR title and body are explicitly about failure evidence.
 
-8. **Preserve concurrency coverage and scope capacity claims.**
+14. **Preserve concurrency coverage and scope capacity claims.**
    Treat concurrency as a first-class result dimension. Record the requested and observed concurrency for every retained result, and state the observed set in the report or PR body. A concurrency-one result is a latency baseline; it cannot establish saturation, largest supported concurrency, or maximum throughput. Make those claims only after an explicit sweep over higher concurrency values, and only select a capacity or maximum-performance point from a run with complete prompt accounting, zero failed requests, and finite non-negative throughput. Retain failed or partial sweep records only when they are deliberately included as failure evidence, and never use them as peak-performance candidates.
 
-9. **Stage from the reviewed file lists.**
+15. **Stage from the reviewed file lists.**
    Use `git add --pathspec-from-file=/tmp/<list>.txt` so the staged set exactly matches the reviewed set. After staging, compare `git diff --cached --name-only` to the list and investigate any mismatch.
 
-10. **Run a pre-commit staged audit for every PR.**
+16. **Run a pre-commit staged audit for every PR.**
    Before each commit, run staged stats, staged file count, a transient-pattern scan, `git diff --cached --check`, and data-specific validation. The transient scan is allowed to have false positives, but every match should be intentionally explained or removed from staging.
 
-11. **Split PRs by dataset and review size.**
+17. **Split PRs by dataset and review size.**
    Prefer one PR per endpoint/model family/report surface. For large structured JSON sets, split by model family or experiment group so each PR remains reviewable. State exact included counts and excluded categories in every PR body.
 
-12. **Return to trunk and inspect leftovers.**
-    After opening PRs, switch back to trunk and run `git status --short --untracked-files=all`. The remaining untracked files should all be intentionally excluded categories, not forgotten report assets.
+18. **Return to trunk and inspect leftovers.**
+   After opening PRs, switch back to trunk and run `git status --short --untracked-files=all`. The remaining untracked files should all be intentionally excluded categories, not forgotten report assets.
 
 ## Failed Attempts
 
@@ -118,6 +154,10 @@ git diff --cached --check
 | Include empty backend placeholders | Commit empty summaries for backends that did not run | Empty files imply coverage that does not exist and inflate reviews | Exclude zero-row placeholders unless documenting absence is the explicit objective. |
 | Accept every JSON record in a result directory | Stage partial or zero-completion JSON next to complete records | Partial records contaminate result datasets and make counts misleading | Parse JSON and require complete prompt accounting before staging result records. |
 | Treat concurrency one as a capacity result | Report a latency baseline as the largest supported concurrency or maximum-performance point | A single-client run contains no saturation evidence and conflates latency with capacity | Preserve concurrency in every record and require a higher-concurrency sweep with complete, zero-failure points before making capacity or peak-throughput claims. |
+| Submit the full sweep with an unverified runner | Assume the runner worktree accepts every flag emitted by the wrapper | A stale runner rejected a required identity flag, creating immediate non-comparable failures instead of requests | Pin the exact runner revision, inspect its CLI, and pass a tiny representative live coordinate before bulk submission. |
+| Change the indexed-results root during a refresh | Render once from the canonical result subtree and later from a higher repository ancestor | Path-relative opaque IDs changed for all existing records although their metrics were identical | Reuse one canonical indexed-results root and compare identity sets before publication. |
+| Render directly into the PR worktree during a live sweep | Let the report generator consume mutating indexes while replacing published assets | The result can mix generations and leave reports, counts, and referenced data out of sync | Establish a lock, immutable generation, or stable pre/post index digests with referenced-result validation; render to a temporary snapshot, validate it, then promote it. |
+| Run overlapping workers against one endpoint | Treat benchmark worker parallelism as equivalent to request concurrency | Workers contend for one capacity surface and can race on the same index, obscuring both performance and provenance | Use one writer per independently isolated endpoint; express load through the coordinate's request concurrency. |
 
 ## Results & Parameters
 
@@ -129,7 +169,12 @@ git diff --cached --check
 | `summary.csv`, `summary.md` | Keep if non-empty | Count rows and inspect status, profile, backend, model, and scenario fields. |
 | Pareto/report images | Keep if referenced | Confirm every referenced image path exists and is staged. |
 | Reproducibility scripts | Keep when tied to committed results | Confirm script names and paths are described in the PR body. |
-| Complete structured JSON benchmark records | Keep | Require `completed == prompt_count` or `completed == num_prompts`. |
+| Complete structured JSON benchmark records | Keep | Require `completed == prompt_count` or `completed == num_prompts` and zero failed requests. |
+| Exact current indexed coordinates | Reuse | Require current freshness, exact model/checkpoint/token/concurrency/prompt-count match, complete accounting, and zero failures. |
+| Non-comparable attempt evidence | Keep only when deliberate | Label explicitly, exclude from coverage and Pareto lines, and separate it from successful performance records. |
+| Stable canonical indexed-results root | Keep invariant | Do not change the path ancestor used to derive opaque record identities between snapshots. |
+| Incremental live-sweep snapshot | Keep after consistency audit | Use a lock, immutable generation, or stable pre/post index digests with referenced-result validation; preserve prior IDs unless explicitly superseded and render outside the PR worktree first. |
+| Benchmark workers | One per isolated endpoint | Parallelize across distinct endpoints; use request concurrency inside a coordinate to measure capacity. |
 | Concurrency-one records | Keep as latency baselines | Label as `concurrency=1`; do not use for saturation or capacity claims. |
 | Higher-concurrency sweep records | Keep when complete | Record the requested and observed set; use only complete, zero-failure records for capacity or peak-throughput selection. |
 | Logs, Slurm output, PIDs, server output, progress traces | Exclude | Usually transient runtime evidence. |
@@ -170,8 +215,11 @@ for path in Path("<json-result-root>").rglob("*.json"):
     data = json.loads(path.read_text())
     completed = data.get("completed")
     expected = data.get("prompt_count", data.get("num_prompts"))
+    failed = data.get("failed_requests", data.get("failed", 0))
     if expected is None:
         bad.append((path, "missing expected prompt count"))
+    elif failed:
+        bad.append((path, f"failed_requests={failed}"))
     elif completed == expected:
         complete += 1
     else:
@@ -193,9 +241,13 @@ PY
 - Validation commands run before commit.
 - Caveats such as interrupted rows, partial backend coverage, or local-only verification.
 - Whether the PR is a result PR or a failure-analysis archive.
+- Exact runner revision and interpreter used for new coordinates.
+- Canonical indexed-results root and snapshot cutoff or generation.
+- Prior, added, removed, comparable, and non-comparable record counts.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
 | PerformanceHarness | After benchmark artifact ignore-rule PR #31 merged, remaining result artifacts were triaged into five follow-up PRs | Produced PRs #32 through #36 locally: endpoint reports/assets, Qwen 9B baseline, Qwen 27B baseline with interrupted-row caveat, K2-family complete InferenceX JSON records, and Gemma/Qwen complete InferenceX JSON records. |
+| PerformanceHarness | Incremental endpoint-matrix refresh while benchmark workers continued | A consistency-checked snapshot preserved all 165 prior opaque record IDs, added 8 with no removals, rendered 173 complete records and 171 unique comparable coordinates, and the resulting report/data commit passed 49 tests in CI. |

--- a/skills/benchmark-artifact-triage-pr-splitting.md
+++ b/skills/benchmark-artifact-triage-pr-splitting.md
@@ -106,19 +106,19 @@ git diff --cached --check
 
 10. **Classify artifacts by information value.**
    Keep durable information:
-   - generated reports such as `PARETO.md`, backend reports, and README files that summarize results;
-   - `summary.csv` and `summary.md` files with non-empty result rows;
-   - Pareto or report images referenced by committed markdown;
-   - reproducibility scripts used to generate the committed results;
-   - complete structured benchmark JSON records.
+- generated reports such as `PARETO.md`, backend reports, and README files that summarize results;
+- `summary.csv` and `summary.md` files with non-empty result rows;
+- Pareto or report images referenced by committed markdown;
+- reproducibility scripts used to generate the committed results;
+- complete structured benchmark JSON records.
 
    Exclude transient or low-information artifacts:
-   - logs, process IDs, Slurm output, server output, progress traces, preflight scratch, and runtime directories;
-   - overlay/build residue and generated config overlays;
-   - zero-row backend placeholders for backends that did not run;
-   - orphan metadata-only raw files without adjacent rows or result data;
-   - empty failure logs;
-   - partial or zero-completion JSON benchmark records unless the PR is explicitly a failure-analysis archive.
+- logs, process IDs, Slurm output, server output, progress traces, preflight scratch, and runtime directories;
+- overlay/build residue and generated config overlays;
+- zero-row backend placeholders for backends that did not run;
+- orphan metadata-only raw files without adjacent rows or result data;
+- empty failure logs;
+- partial or zero-completion JSON benchmark records unless the PR is explicitly a failure-analysis archive.
 
 11. **Validate CSV report artifacts before staging.**
    For each summary, check row count, status values, profile/scenario coverage, and backend/model labels. A useful report PR should say exactly what it includes, such as "69 rows across short, medium, and long" or "TRT rows only, SGLang absent." If rows are marked interrupted but still plotted, put that caveat in the PR body.


### PR DESCRIPTION
## Summary

- amend the existing generic benchmark-artifact skill from v1.1.0 to v1.2.0;
- add exact-current coordinate reuse, a stable indexed-results root, and runner CLI preflight;
- document one writer per independently isolated endpoint while preserving request concurrency as a measurement dimension;
- require a real consistency boundary before publishing an incremental snapshot from a live sweep;
- keep non-comparable attempts as explicit evidence while excluding them from coverage and Pareto claims.

## Why

An incremental benchmark refresh exposed two provenance failures that ordinary
completion checks do not catch:

1. a stale runner can reject wrapper flags before any requests are sent; and
2. changing the indexed-results path ancestor can churn opaque record IDs even
   when the underlying metrics are unchanged.

The verified refresh preserved 165 existing identities, added 8 records with no
removals, and produced 173 complete records representing 171 unique comparable
coordinates. This amendment captures the generic workflow without restoring the
previously removed project-specific skill.

## Validation

- `uvx pre-commit run --files skills/benchmark-artifact-triage-pr-splitting.md`
- `just validate` — 714/714 skills valid
- `just check` — 219 tests passed
- `uv run python scripts/check_pii.py`
- `git diff --cached --check`
- independent post-edit semantic and public-safety audit: PASS

## Delivery

- Base: `main` at `56ac4d189f495dc96e2bf26eca8e5592ff7dbf39`
- Commit: `b01f31fdf5b3a201ec2153353a21896a5409d353`
- Commit signature: verified
- DCO signoff: present
