### PR TITLE
feat: amend pr-review-loop orchestration skill (v1.9.0)

### DIFF
--- a/skills/pr-review-loop-orchestration-agent-patterns.history
+++ b/skills/pr-review-loop-orchestration-agent-patterns.history
@@ -4,6 +4,745 @@
 
 This file preserves the full original content of the skills merged into this canonical.
 
+## v1.9.0 (2026-08-04)
+
+**Changed by:** ProjectHephaestus malformed remediation reply-map design.
+**Verification:** unverified — implementation and stage regressions are specified; execution and
+CI are pending.
+
+### What changed
+- Split malformed reply evidence from independently verified push evidence.
+- Added the recovery rule for a valid pushed full SHA on an existing PR: post no replies, create no
+  handoff or journal entry, clear only stale remediation-agent output, and return the PR to fresh
+  review.
+- Preserved the terminal `implementation_reply_failed` path when no commit was pushed or no PR can
+  receive fresh review.
+- Added an exact-ID typo regression pattern that proves no fuzzy matching or reply-post mutation.
+- Bumped 1.8.0 -> 1.9.0.
+
+### Why
+A malformed `addressed`/`replies` map invalidates the agent's proposed reply evidence, but it
+does not invalidate a commit already proven pushed by a trusted result parser. Treating both failures
+as terminal strands valid code; guessing a mistyped thread ID risks posting an unverified reply. The
+safe split preserves strict exact-ID validation, posts nothing, and asks a fresh reviewer to judge
+the independently verified head. Without a pushed commit, there is no new evidence to review, so
+the existing terminal path remains correct.
+
+### Previous version (v1.8.0) snapshot
+
+``````markdown
+---
+name: pr-review-loop-orchestration-agent-patterns
+description: "Use when: (1) building or debugging a Python implement-review loop where an LLM sub-agent reviews a PR and a fixer agent addresses inline comments, (2) a review loop resolves threads even though no commit was produced — resolution must be gated on a real commit not the model self-report, (3) a loop ends AMBIGUOUS or NO-GO too fast before ever earning an explicit GO verdict, (4) LLM or agent-generated inline PR review comments are rejected by GitHub (HTTP 422) because they do not lie on a changed diff hunk, (5) an agent-driven CI-fix session produces no commit and the PR stays red; the correct response is a single bounded retry with unresolved review threads injected verbatim, (6) a review fix plan file concludes no changes are needed and the automation should self-cancel without opening a new PR, (7) a feature-dev:code-reviewer sub-agent cannot execute shell commands and cannot post gh pr review — wrong agent type was chosen, (8) a GitHub GraphQL PR-review mutation field selection is wrong and the automation loop fails on every call with Field X does not exist, (9) pre-commit must cover the full PR diff from the merge-base not just the most-recent-edit files before pushing, (10) an existing-PR review handler short-circuits NO-GO PRs as if they were settled (idempotency `if has_go or has_no_go: skip`) so a failed-review PR never re-enters the loop — short-circuit on GO ONLY, (11) an existing-PR worktree sync fails `git fetch origin {issue}-auto-impl` with exit 128 because the PR head branch was ASSUMED from the issue number instead of read from the PR's real `headRefName`, (12) an in-loop LLM PR reviewer posts a FALSE policy violation (e.g. `POLICY VIOLATION: Closes, auto-merge-premature, signed-commits` on a PR that actually has `Closes #N`, auto-merge OFF, and a signed commit) because its policy fetch failed open to violation, or you are tempted to make the reviewer re-check `Closes #N` / signed commits / auto-merge that a CI gate (`pr-policy` required, `auto-merge-policy` advisory) already enforces, (13) an in-loop implementer review cycle (`_run_impl_review_loop`) converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO instead of re-reviewing up to `MAX_REVIEW_ITERATIONS` and auto-skipping only on TRUE exhaustion, (14) the address-review coordinator is handed a review thread the reviewer itself labels non-blocking / pre-existing / out-of-scope / follow-up-worthy, or that asks for an edit the approved plan explicitly scoped out (e.g. behind a 'count must not increase' verification guard) — the correct disposition is to leave the thread UNADDRESSED (out of the `addressed` set) as a follow-up issue and make NO code change, because resolving a comment means giving it a disposition, not necessarily editing code, (15) a run parks EVERY pr_review item to state:skip via 'zero-thread NOGO retry cap exhausted' or 'exhausted at round N (automation unresolved 0 -> 0)' and you suspect the reviewer model or verdict parsing — check each PR's hephaestus-pr-review-zero-thread-nogo anomaly comment FIRST: a summary like 'NOGO: ... head unchanged (Nth round)' means by-design stale-PR triage (#2079: deterministic no-progress NOGOs escalate to skip instead of burning implement budget), NOT a reviewer failure; only a FRESHLY-implemented PR parked this way indicates a real defect"
+category: ci-cd
+date: 2026-07-30
+version: "1.8.0"
+user-invocable: false
+history: pr-review-loop-orchestration-agent-patterns.history
+tags:
+  - implement-review-loop
+  - review-thread-resolution
+  - evidence-based-resolution
+  - commit-gated-progress
+  - verdict-go-convergence
+  - inline-comment-diff-hunk
+  - "422"
+  - unprocessable-entity
+  - no-commit-retry
+  - review-thread-injection
+  - force-engagement-retry
+  - agent-type-selection
+  - feature-dev-code-reviewer
+  - general-purpose
+  - graphql-field-validation
+  - schema-introspection
+  - addPullRequestReviewThreadReply
+  - self-cancelling-review-plan
+  - pre-commit-merge-base-diff
+  - graphql-review-threads
+  - existing-pr-short-circuit
+  - no-go-re-review
+  - go-only-short-circuit
+  - pr-head-branch-resolution
+  - headrefname
+  - assumed-branch-name-fetch-128
+  - ci-gate-owns-policy
+  - llm-reviewer-fails-open
+  - false-policy-violation
+  - pr-policy-gate
+  - auto-merge-policy
+  - no-duplicate-hard-gate
+  - zero-thread-converge
+  - loop-termination-condition
+  - state-skip-on-exhaustion
+  - max-review-iterations
+  - out-of-scope-thread-disposition
+  - non-blocking-review-thread
+  - resolve-is-not-edit
+  - approved-plan-scope-contract
+  - count-must-not-increase-guard
+  - follow-up-issue-disposition
+  - empty-addressed-no-op
+  - cross-run-review-receipt
+  - restart-remediation
+  - implementation-reply-batch
+  - one-review-per-pass
+  - pending-review-ownership
+  - preserve-review-conflicts
+  - homericintelligence
+---
+
+# PR Review Loop Orchestration and Agent Patterns
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-30 |
+| **Objective** | Build and debug a Python implement-review loop that drives LLM sub-agents to review a PR and fix its inline comments, converging on an EVIDENCE-BASED `Verdict: GO`. Covers: commit-gated thread resolution, inline-comment diff-hunk (422) validation, one-shot no-commit retry with unresolved review threads injected, agent-type selection for review tasks, GraphQL field/input validation for PR-review mutations, self-cancelling review plans, full merge-base pre-commit scope, the existing-PR short-circuit being GO-ONLY (NO-GO PRs MUST re-enter the loop), using the PR's real `headRefName` for the worktree instead of an assumed `{issue}-auto-impl`, and the "zero threads != GO" rule applying to the LOOP's TERMINATION condition (a zero-thread non-GO pass RE-REVIEWS up to `MAX_REVIEW_ITERATIONS`; `state:skip` only on TRUE exhaustion). |
+| **Outcome** | Merged across multiple ProjectHephaestus PRs (commit-gate + verdict-GO convergence #1084; inline-comment 422 validation #1043; no-commit retry + thread injection #847; GraphQL field/input validation #906/#1006; existing-PR NO-GO re-review #1104; real PR head-branch resolution #1106; in-loop policy enforcement removed in favor of CI gates #1112; in-loop zero-thread non-GO re-reviews + `state:skip` only on exhaustion #1114) plus ProjectOdyssey and gh-tidy upstream review rounds. |
+| **Verification** | verified-ci |
+| **Version** | 1.8.0 |
+
+## When to Use
+
+- You are building or auditing a Python loop where one LLM sub-agent reviews a PR and another fixes the inline review comments, and you need the contract for "what counts as progress" and "who resolves threads."
+- A review loop resolved a thread but no commit was produced (the fixer replied "documented as a limitation" with a clean worktree).
+- A loop ends NO-GO / AMBIGUOUS "too fast" before ever earning a `Verdict: GO`.
+- A runtime log shows `gh: Unprocessable Entity (HTTP 422)` on a `POST .../pulls/{n}/reviews` because an LLM-generated inline comment is off-hunk.
+- An agent CI-fix driver logs "agent session produced no new commit (HEAD unchanged …); skipping push" while required checks stay red.
+- A `.claude-review-fix-*.md` plan says "implement all fixes" but its inner Fix Plan concludes no changes are required.
+- A `feature-dev:code-reviewer` sub-agent returns "I cannot run shell commands. Available tools: Read, WebFetch, WebSearch, Grep, Glob, TaskStop."
+- A `gh api graphql` PR-review mutation fails on every call with `Field 'X' doesn't exist on type 'Y'` or `InputObject '<Input>' doesn't accept argument '<arg>'`.
+- You want a comprehensive multi-specialist PR review filed as structured GitHub review comments.
+- An existing-PR review loop skips NO-GO PRs as if settled (e.g. `Successful: 0 / Skipped: N`, every PR already carries a terminal label), or fails `git fetch origin {issue}-auto-impl` with `exit 128` on an assumed `{issue}-auto-impl` branch.
+- An in-loop LLM reviewer posts a FALSE policy violation, or you are tempted to make the reviewer re-check `Closes #N` / signed commits / auto-merge that a CI gate already enforces.
+- An in-loop implementer review cycle converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO.
+- The address-review coordinator is handed a review thread the reviewer ITSELF labels non-blocking / pre-existing / out-of-scope for #N / follow-up-worthy, or a thread that asks for an edit the approved plan explicitly scoped out (often behind a "count must not increase" verification guard), and the per-comment loop pressure ("every comment MUST be resolved") tempts a fixer-dispatch + code edit.
+- A fresh loop invocation reconstructs a canonical prior-run automated review thread, the validator marks it unaddressed, and reconciliation still hands it off instead of returning it to the normal remediation path.
+- One implementation pass posts a separate empty GitHub review for every addressed thread, or a transport failure leaves a pending review draft and the recovery path is tempted to delete, reuse, or partially replay it.
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# ── Review loop progress + convergence contract ───────────────────────────
+addressed = run_fixer_agent(...)          # model self-report (untrusted alone)
+committed = _commit_if_changes(worktree)  # True only if HEAD advanced
+made_progress = addressed and committed   # BOTH required; clean worktree = no progress
+if reviewer_verdict == "GO":              # converge ONLY on the literal GO token
+    converge()                            # "zero threads" + AMBIGUOUS/NO-GO is NOT GO
+# Thread RESOLUTION lives in the reviewer, never the fixer:
+for thread in prior_threads:
+    if validator_says_addressed_by_diff(thread, new_diff):
+        resolve(thread.id)                # match by thread id, NOT (path, line)
+    else:
+        reopen_as_new_thread(thread)      # re-open OVERRIDES a stale GO
+```
+
+```text
+# ── Inline-comment 422 validation pipeline ────────────────────────────────
+full_diff = gh pr diff <n>            # NOT the 8000-char model context
+accepted  = parse(full_diff)          # {path -> {(line, side)}}
+kept      = [c for c in comments if (c.line, c.side) in accepted[c.path]]
+if not full_diff: return comments     # FAIL OPEN on empty/unfetchable diff
+POST review(body, event, comments=kept)   # summary-only OK if kept == []
+# RIGHT side = '+'/context numbered in NEW file; LEFT = '-'/context in OLD file.
+# Hunk header @@ -oldStart[,oldLen] +newStart[,newLen] @@  (",len" OPTIONAL)
+```
+
+```bash
+# ── GraphQL: validate against the LIVE schema before shipping ──────────────
+gh api graphql -f query='{ __type(name: "PullRequestReviewComment") { fields { name } } }'
+gh api graphql -f query='{ __type(name: "AddPullRequestReviewThreadReplyInput") { inputFields { name } } }'
+# Two error signatures, one discipline:
+#   wrong OUTPUT field  -> Field 'X' doesn't exist on type 'Y'
+#   wrong mutation NAME -> InputObject '<Input>' doesn't accept argument '<arg>'
+#                          + Variable $X is declared by <Mutation> but not used
+```
+
+```text
+# ── Agent type selection ──────────────────────────────────────────────────
+Need to write back (post review / create issue / commit / push)?
+  YES -> general-purpose         (has Bash/Edit/Write; prompt includes the gh command)
+  NO  -> feature-dev:code-reviewer (read-only; forbid gh syntax, return VERDICT + BODY)
+```
+
+### Detailed Steps
+
+#### Evidence-based thread resolution
+
+Gate "progress" on a real commit (`addressed AND committed`). `_commit_if_changes`
+returns `True` only if HEAD advanced. The fixer's self-reported "addressed" list is
+untrusted on its own — a clean worktree with prose replies (e.g., "documented as a
+limitation", "this is intended") must count as ZERO progress and must NOT resolve any
+thread.
+
+Move thread RESOLUTION into the reviewer/validator on the NEXT pass. The fixer agent
+ONLY edits, commits, and pushes; it MUST NOT call the GitHub resolve mutation. On the
+next review pass, a fresh READ-ONLY sub-agent compares each prior thread against the new
+diff and:
+
+- resolves a thread ONLY if the diff genuinely addressed it (evidence-based);
+- re-opens (as a NEW inline thread — GitHub has no "unresolve" mutation) every thread the
+  diff did NOT address. A re-open OVERRIDES a stale GO so the loop keeps going.
+
+Converge ONLY on an explicit `Verdict: GO`. Do not converge on "reviewer posted zero
+threads" — a zero-thread pass with verdict AMBIGUOUS or NO-GO ends the loop too fast.
+Parse the verdict explicitly (last line, not substring) and require the literal `GO`.
+
+**Verified-ci (PR #1114): "zero threads != GO" governs the loop's TERMINATION condition,
+not just the verdict parser.** The in-loop implementer review cycle
+(`_run_impl_review_loop` in `implementer_phase_runner.py`) actually VIOLATED this at the
+code level: it had `if pr_number is not None and not posted_thread_ids and not reopened:
+break`, converging on zero posted threads REGARDLESS of verdict. Observed live (issue #725
+→ PR #996): a malformed review (only a `POLICY VIOLATION:` summary line, no `Verdict:` line
+→ `parse_review_verdict` returned AMBIGUOUS) posted 0 threads, so the loop TERMINATED at R0
+(`Verdict=AMBIGUOUS Grade=? threads=0`) and applied `state:skip` — the PR was never
+re-reviewed or implemented (this was the pre-#1112 false POLICY VIOLATION feeding the
+zero-thread-converge bug). Fix:
+
+1. A non-GO pass with NO posted threads (and nothing re-opened) no longer breaks — it
+   RE-REVIEWS on the next iteration (there are no threads to address, so the address step
+   is skipped via `continue`), bounded by `MAX_REVIEW_ITERATIONS`. GO still converges
+   immediately; a POSTED-THREAD NO-GO still runs the address step and still stops if the
+   address step resolves nothing (`if not addressed: break` — that path is unchanged and
+   correct).
+2. `state:skip` is applied ONLY on TRUE iteration exhaustion (`iterations_run >=
+   MAX_REVIEW_ITERATIONS and last_verdict != "GO"`), NOT on a single iteration-0
+   AMBIGUOUS/NO-GO. The previous code force-skipped on `is_ambiguous` after ONE iteration —
+   removed, because with fix (1) a persistent AMBIGUOUS now re-reviews to exhaustion and the
+   exhaustion gate catches it.
+
+A zero-thread non-GO pass must give the reviewer `MAX_REVIEW_ITERATIONS` chances (a
+transient/garbage review must not strand a fixable PR after R0); auto-skip belongs at TRUE
+exhaustion only. Distinguish the two zero-progress cases: (a) zero THREADS posted + non-GO
+→ re-review (the reviewer may be transiently broken); (b) threads posted but the ADDRESS
+step resolved nothing → break (genuine no-progress on real findings).
+
+Match prior threads for resolution on the thread `id`, NOT `(path, line)` — two threads
+can share a line (original + a re-open) and path normalization drifts across hunks. When
+editing an existing comment, FETCH+CONCATENATE its body first: `updatePullRequestReviewComment`
+REPLACES, it does not append. FENCE all untrusted comment text before interpolating into a
+prompt — first-line truncation is not injection-safe.
+
+#### Cross-run review-thread receipts
+
+An invocation boundary is not a human-review boundary. A restarted loop must continue work on a
+prior automation finding when GitHub still proves the same unresolved thread and the validator says
+it remains unaddressed. Reconstruct only a canonical receipt: durable thread and initial-comment
+identities, a complete participant/body snapshot, an automated parent review, and its reviewed
+commit. On every mutation, re-read the PR head and entire thread snapshot; require a changed head
+after the fix and stop if a reply, body, participant, or provenance fact differs.
+
+Route a validator-confirmed unaddressed canonical receipt through the same difficulty and address
+workflow used in the original run. Do not special-case external-bot receipts while handing off
+normal prior-loop receipts: that creates a retry-invariant terminal state even though the
+implementer has a concrete finding. Malformed, changed, replied-to, ambiguous, or validator-wont-fix
+receipts remain fail-closed handoffs.
+
+#### Batched implementation-review replies
+
+An implementation address pass owns one immutable response batch: exact PR head, complete thread
+snapshot, complete reply map, and a CSPRNG batch nonce persisted before the first GitHub mutation.
+Create at most one `PENDING` pull-request review for that batch, attach every thread reply to that
+review, verify every receipt from live GitHub state, then submit exactly that one review. The
+implementation actor replies but never resolves a thread; a fresh reviewer validates the submitted
+batch and is the sole resolver.
+
+The nonce identifies a proposed batch; it is not a GitHub lease. GitHub review writes have no
+compare-and-swap precondition, and a deterministic marker plus `viewerDidAuthor` cannot prove that
+an incomplete draft is safe to mutate. After create and before submit, re-inventory the current
+head. Preserve and diagnose every incomplete, stale, duplicate, or competing review rather than
+deleting it or compensating with more mutations. Stop the handoff before any thread resolution and
+begin a fresh review after manual cleanup or changed state.
+
+A host-only retry must retain the entire immutable batch. Never retain a nonce while filtering its
+thread or reply set: that changes the derived review body, turns the original draft into a conflict,
+and defeats recovery. Treat a mixed stale/ambiguous result as stale, or retry the exact full batch.
+
+Severity-tag every inline comment (`critical | major | minor | nitpick`) and SUPPRESS
+nitpick by default; a `--nitpick` flag opts back in. Per-comment dispatch: classify each
+comment's fix difficulty with a cheap sub-agent, render `@ <file> Line <#> - <difficulty> - <desc>`,
+dispatch ONE sub-agent per comment (SERIALIZE same-file comments), tier models simple→haiku /
+medium→sonnet / hard→opus. A `state:skip` label (name sourced from the single-source
+`state_labels` module, auto-provisioned, honored on issue OR PR) skips all phases — gate the
+auto-apply on TRUE iteration exhaustion, not on a single iteration-0 non-GO.
+
+#### Disposition of out-of-scope / non-blocking threads
+
+**Verified-local (observed in-session on ProjectHephaestus PR #1245 / issue #1216; CI
+not yet confirming this disposition).** The address-review coordinator's mandate "every
+one of these comments MUST be resolved before you finish" means *give every thread a
+DISPOSITION* — it does NOT mean "every thread must produce a code edit." Resolving ≠
+editing. A valid disposition is **"not addressable in code within this issue's scope →
+leave it out of the `addressed` set so the reviewer logs it as a follow-up issue."**
+
+Generalizable rules:
+
+1. "Every comment MUST be resolved" = every comment gets a disposition, NOT a code edit.
+   "Not addressable in code within this issue's scope → follow-up issue" is a valid
+   resolution; leave the thread out of `addressed` and change nothing.
+2. Recognize the non-actionable signal: the reviewer's OWN text classifying the thread.
+   Treat that classification as authoritative, not a directive to expand scope.
+3. The approved plan is the scope contract. If a thread asks for an edit the plan
+   EXPLICITLY scoped out (often guarded by a verification check like "count must not
+   increase"), making that edit BREACHES the plan, trips its own scope guard, and
+   re-introduces the scope-creep the plan was designed to prevent. Honor the scope
+   boundary over per-comment loop pressure.
+4. Distinguish the *redirect/anchor* (often correct) from the *redirect target's content*
+   (the actual complaint). A correct pointer to a doc whose downstream step is buggy is
+   not itself a defect in THIS PR.
+5. When no code change is warranted: dispatch ZERO fixer sub-agents, run no integration
+   gates beyond confirming a clean tree (untracked loop scratch files like
+   `.claude-address-review-*.md` are expected and must stay UNSTAGED), commit nothing,
+   and emit `{"addressed": []}`.
+
+Signal phrases to look for in the reviewer's own text (authoritative classification):
+"non-blocking", "pre-existing", "out of scope for #`<issue>`", "doesn't block merge",
+"worth a follow-up issue".
+
+Concrete case (PR #1245 / #1216): the sole thread was labelled "Non-blocking
+(pre-existing, out of scope for #1216)" and asked to fix `pixi shell -e dev` in
+`CONTRIBUTING.md:63` / `README.md:494`. The approved plan had EXPLICITLY scoped that
+pre-existing `-e dev` drift OUT and shipped a count-guard ("repo-wide `-e dev` occurrence
+count must not increase — stay at exactly 2"). Editing those lines would have exceeded
+the plan AND tripped its own guard. Correct action: dispatch no sub-agent, change no code,
+commit nothing, return `{"addressed": []}` — leaving the thread for the reviewer-recommended
+follow-up issue.
+
+#### Existing-PR handler: short-circuit on GO ONLY, and use the PR's real head branch
+
+The existing-PR handler (`_review_existing_pr`) must enforce two invariants that mirror the
+core "converge ONLY on `Verdict: GO`; a re-open OVERRIDES a stale GO" rule:
+
+1. **GO-ONLY short-circuit.** The idempotency guard must skip a PR ONLY when it already carries
+   the GO label — `if has_go: return` — NOT `if has_go or has_no_go: return`. A
+   `state:implementation-no-go` label is NOT terminal: it means the PR FAILED review and must
+   keep going. Treating NO-GO as settled is identical to the long-standing "zero threads != GO"
+   bug at the existing-PR layer. Symptom in a live 5-loop run: all 60 existing PRs carried a
+   terminal label (10 GO, 50 NO-GO), so every PR was skipped every loop (`Successful: 0 /
+   Skipped: 60`) AND the fallback `drive-green` phase was itself skipped, so NO-GO PRs were
+   NEVER re-implemented or re-reviewed. FIX: short-circuit on `has_go` only; a NO-GO PR then
+   falls through into `_run_impl_review_loop`, which already does NO-GO → address (resume the
+   implementer session) → re-review → converge-on-GO. Bound the re-run with
+   `MAX_REVIEW_ITERATIONS` and only re-implement when there are ACTIONABLE threads; the
+   documented defense against burning tokens on a genuinely-stuck PR is to gate a re-run on the
+   PR head SHA having advanced (same marker discipline as the no-commit forensics path).
+
+2. **Resolve the PR's REAL head branch — never assume `{issue}-auto-impl`.** `_review_existing_pr`
+   must NOT prepare the worktree with `branch_name = f"{issue_number}-auto-impl"`. That is an
+   ASSUMPTION, and `find_pr_for_issue` can match a PR via a PR-body `Closes #N` search
+   (strategy 2), so the PR's head branch may be named after a DIFFERENT issue or a bundle.
+   `sync_worktree_to_remote_branch` then runs `git fetch origin {assumed-branch}` which fails
+   `fatal: couldn't find remote ref ...; exit 128` whenever the real `headRefName` differs from
+   the convention (confirmed live: issue #725 → PR #996 whose real `headRefName` is
+   `708-auto-impl`). FIX: call `get_pr_head_branch(pr_number)` (`gh pr view <pr> --json
+   headRefName`; returns `None` on failure for a safe fallback) and use the resolved branch for
+   the worktree create + sync + review loop + `WorkerResult`; fall back to the assumed name ONLY
+   if the lookup returns `None`. The FRESH-implementation path (no existing PR) keeps the
+   `{issue}-auto-impl` convention because it CREATES the branch itself. This bug was LATENT —
+   before the GO-ONLY fix, NO-GO PRs short-circuited before reaching the fetch, so it never
+   fired for them; the GO-ONLY fix EXPOSED it. Test note: any test exercising this path MUST
+   mock `get_pr_head_branch` or it makes a real `gh` call (a test took 103s before mocking).
+
+#### Policy enforcement belongs in CI gates, not the in-loop LLM reviewer
+
+Do NOT make the in-loop LLM PR reviewer enforce repo PR policy (`Closes #N` body
+line, deferred auto-merge, signed commits). Those are enforced authoritatively by
+the GitHub CI gates `pr-policy` (required status check) and `auto-merge-policy`
+(advisory). Duplicating them in the reviewer is redundant AND fragile: LLM-context
+policy fetches fail OPEN TO "violation", so a transient/empty fetch fabricates a
+false NOGO that blocks a compliant PR.
+
+Concrete failure (PR #996): the reviewer prompt had a "Policy checks (MANDATORY)"
+block plus a strict-rubric "D1 — Policy compliance" NOGO gate, fed by
+`_fetch_signing_state()` (per-commit GraphQL) and an auto-merge state fetch.
+`_fetch_signing_state` returns `[]` on ANY error and the prompt treats an empty
+array as a signed-commits NOGO. On PR #996 the reviewer posted a FALSE `POLICY
+VIOLATION: Closes, auto-merge-premature, signed-commits` even though the body had
+`Closes #725` / `#726`, auto-merge was OFF, and the commit was signed
+(`verified=true`) — because a transient/empty fetch produced empty data blocks. The
+generic message also forced the human to guess which check "failed".
+
+Fix (PR #1112) — remove the in-loop policy enforcement entirely; let CI own it:
+
+- `prompts/pr_review.py`: delete the "Policy checks (MANDATORY)" section + the
+  `{auto_merge_state_block}` / `{commits_signing_block}` data blocks + the `POLICY
+  VIOLATION` summary contract; drop the `auto_merge_enabled` /
+  `commits_signing_state` params from `get_pr_review_analysis_prompt`. Keep the
+  `Verdict: GO/NOGO` + JSON contract (now code-quality only).
+- `prompts/_strict_rubric.py`: replace `D1 — Policy compliance (HIGHEST PRIORITY /
+  NOGO gate)` with `D1 — Correctness & completeness`; add a note that CI gates own
+  policy.
+- `pr_reviewer.py`: delete `_fetch_signing_state` + the signing GraphQL query;
+  stop populating `context["auto_merge_enabled"]` / `["commits_signing_state"]`;
+  drop `autoMergeRequest` from the `gh pr view --json` projection.
+
+KEY PRINCIPLE: when a hard gate already exists in CI (a required status check), an
+LLM re-implementation of the same gate is redundant and, because LLM-context
+fetches fail open to "violation", it produces false negatives that block good PRs.
+Enforce policy ONCE, in the deterministic CI gate; let the LLM reviewer judge code
+quality only.
+
+#### Inline-comment diff-hunk 422 validation
+
+GitHub rejects the ENTIRE review with HTTP 422 if ANY single inline comment points at a
+line not in the diff hunk; the in-loop reviewer then logs a spurious `Verdict=NOGO Grade=F`.
+Before POSTing:
+
+1. Fetch the FULL diff (`gh pr diff <n>`), not the truncated (8000-char) model context —
+   the model can cite real-but-out-of-hunk lines on large diffs.
+2. Parse the unified diff once into accepted `(line, side)` positions per file. `RIGHT` =
+   added (`+`) and context (` `) lines numbered in the NEW file; `LEFT` = removed (`-`) and
+   context lines numbered in the OLD file. Parse the hunk header defensively — the `,len`
+   part is optional (`@@ -1 +1 @@`).
+3. Keep comments whose `(path, line, side)` is in the accepted set; DROP + LOG the rest at
+   WARNING so the loss is visible.
+4. Still POST the summary review with whatever remains (empty `comments` array is fine).
+5. FAIL OPEN: if the diff is empty or could not be fetched, return comments UNCHANGED — a
+   possible 422 beats guaranteed silent feedback loss.
+
+Add tests the post-reviews path lacked: out-of-hunk filtered while in-hunk survives;
+all-out-of-hunk → summary-only POST; empty diff → fail open; pure hunk-parser unit tests
+for RIGHT/LEFT/context numbering.
+
+#### No-commit retry with thread injection
+
+Treat `no-commit + still-red required CI` as a force-engagement trigger, not a stop. Earn
+exactly ONE bounded same-session retry:
+
+1. Snapshot HEAD before invoking the agent (`pre_agent_sha = git -C <wt> rev-parse HEAD`).
+2. After the agent returns, gate the retry on BOTH: HEAD did not advance, AND
+   `gh pr checks <pr> --required` exits non-zero. If CI went green via concurrent activity,
+   do NOT retry (it would "fix" a green PR).
+3. Build the failing-check list from `gh pr checks <pr> --required --json name,bucket` —
+   `bucket` in `{fail, cancel, skipping}` is failing; `pass`/`pending` are not. Empty → abort.
+4. Compose a force-engagement prompt that: opens with `## Force-Engagement Retry — Previous
+   Turn Produced No Commit`, names the failing checks verbatim as a bullet list, states that
+   no-commit on red CI is itself a bug, restates the branch invariant (NEVER `git checkout -b`/
+   `git switch -c`; land on `{pr_head_branch}`), restates the signed-commit + no-`--no-verify`
+   invariant verbatim, and ends with `BLOCKED: <reason>` escape hatch.
+5. PREPEND the unresolved-review-thread block (via the existing `gh_pr_list_unresolved_threads`
+   GraphQL helper) into BOTH the initial AND the retry prompt — a bot/human review thread is
+   usually the real blocker the fix agent cannot otherwise see.
+6. Re-invoke on the SAME PR-scoped `session_uuid` (do NOT mint a new one — the retry agent
+   would lose the prior turn's context).
+7. Cap at exactly 1 retry. On the second no-commit, write `state_dir/repeated-no-commit-<pr>.json`
+   forensics marker and stop. NEVER loop, NEVER `gh pr create` — the fix must land on the
+   existing PR head branch.
+
+#### Agent-type selection
+
+The `feature-dev:code-reviewer` toolset is exactly Read, WebFetch, WebSearch, Grep, Glob,
+TaskStop — it has NO Bash/Edit/Write and CANNOT execute `gh pr review`. Detection signatures
+in sub-agent output: "I cannot run shell commands", "Available tools: Read, WebFetch,
+WebSearch, Grep, Glob, TaskStop", "the review body is composed below, ready for the
+orchestrator to post".
+
+- If write-back is required (post review, create issue, push): use `general-purpose`; the
+  prompt MUST include the explicit `gh pr review N --repo OWNER/NAME [--approve|--request-changes|--comment] --body "$BODY"`.
+- If analysis-only: use `feature-dev:code-reviewer`; the prompt MUST forbid `gh` syntax,
+  tell the agent it has no Bash, and require it to return `VERDICT:` + `BODY:` deterministically.
+  The orchestrator then wraps the body and posts it itself.
+
+Probe ONE agent's toolset before fanning out to N. A prompt cannot grant tools the agent
+type does not have — capability is enforced by the harness at registration. For comprehensive
+reviews, a `code-review-orchestrator`-style agent routes to specialist reviewers (test, language,
+implementation, docs, memory-safety, algorithm) and aggregates Priority 1/2/3 findings.
+
+#### GraphQL field validation
+
+A field selection or input argument has NO compile-time check; an invalid one ships
+silently and fails on EVERY call. Before shipping any raw `gh api graphql` PR-review
+query/mutation, introspect the LIVE schema:
+
+```bash
+gh api graphql -f query='{ __type(name: "TYPE") { fields { name } } }'          # output fields
+gh api graphql -f query='{ __type(name: "<Mutation>Input") { inputFields { name } } }'  # input args
+```
+
+Two distinct error signatures, one discipline:
+
+- Wrong OUTPUT field → `Field '<f>' doesn't exist on type '<T>'` (e.g. selecting
+  `pullRequestReviewThread` on a `PullRequestReviewComment` — that field does not exist;
+  return only `pullRequestReview { id }` and resolve threads via a separate
+  `pullRequest.reviewThreads` query).
+- Wrong mutation NAME → `InputObject '<Input>' doesn't accept argument '<arg>'` +
+  `Variable $X is declared by <Mutation> but not used` (e.g. `addPullRequestReviewComment`
+  has no `pullRequestReviewThreadId` — the correct reply mutation is
+  `addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId, body}) { comment { id } }`).
+
+Never assume a reverse child→parent edge exists; if `Child.parent` is absent, fetch via
+`Parent.children` and filter. Treat HTTP 200 with a top-level `errors` array as a FAILURE
+(a bare exit-code check misses it). Give every raw-query function a direct unit test that
+asserts the query string and parsing — boundary mocks are what let broken queries ship.
+
+For a SIMPLE one-line reply to a single existing review comment you do not need the GraphQL
+`addPullRequestReviewThreadReply` mutation at all — the REST replies endpoint is shorter and
+avoids resolving a thread node id:
+
+```bash
+gh api repos/OWNER/REPO/pulls/PR/comments/COMMENT_ID/replies --method POST -f body="..."
+```
+
+Use the GraphQL reply mutation only when you also need the returned `comment { id }` or are
+already operating on thread node ids; otherwise the REST `comments/{id}/replies` POST is the
+simpler path.
+
+#### Three-location posting for a comprehensive review
+
+To make a comprehensive review maximally visible, post it in THREE places: (1) the main PR
+review body (`gh pr review`), (2) one line-specific PR comment for each concrete finding, and
+(3) a tracking-issue comment via `gh issue comment <n> --body "..."` so the issue history
+records the review outcome. KEY takeaway: prefer plain line-specific PR comments
+(`gh pr comment` / `comments/{id}/replies`) over the inline REVIEW API — the inline review
+path requires validating every comment against a changed diff hunk (see the 422 section),
+which is complex and error-prone; a simple PR comment carries the same feedback without the
+hunk-position constraint.
+
+#### Self-cancelling review plan and pre-push diff scope
+
+When a `.claude-review-fix-*.md` file's outer wrapper says "implement all fixes" but the
+inner Fix Plan concludes "No fixes are required / the PR is correct and complete" (failing
+CI is pre-existing on `main`, `git status` clean, only the review file untracked), the plan
+is self-cancelling: make NO changes, do NOT manufacture a commit, and report that the branch
+is already up to date. Trust the inner plan, not the outer shell.
+
+Before pushing, run pre-commit/validation over the FULL PR diff from the merge-base
+(`git diff origin/main...HEAD`), not just the most-recently-edited files — a fix can be
+clean while an earlier-touched file in the same PR still fails the gate.
+
+#### Bash traps in review-automation scripts
+
+When the review loop or its helpers are shell scripts (e.g. gh-tidy-style wrappers), four
+recurring traps:
+
+- **Function-before-definition.** Do NOT call color/echo helper functions from the
+  argument-parsing block at the top of the script — that block runs before the helpers are
+  defined, so the call expands to nothing (or errors). Emit early diagnostics with a plain
+  `echo "..." >&2` instead, and only switch to the pretty helpers after their definitions.
+- **Value-flag consumes the next flag.** A flag that takes a value (`--branch X`) must guard
+  against an absent value, otherwise it silently swallows the following flag as its argument.
+  Guard with `if [[ -z "$1" || "$1" == --* ]]; then error "missing value for --branch"; fi`.
+- **Pipe-subshell loses array mutations.** `cmd | while read ...; do arr+=(...); done` runs
+  the loop body in a subshell, so array (and variable) mutations vanish after the pipe. Use
+  process substitution to keep the loop in the current shell: `while read ...; do ...; done < <(cmd)`.
+- **Helper that doesn't `exit` on error.** A `set_trunk_branch`-style helper that prints an
+  error but forgets `exit 1` lets the script continue past a fatal condition with bad state.
+  Every fatal branch in a helper MUST `exit 1` (or `return 1` + a checked caller).
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Resolve threads from the fixer's self-reported "addressed" list | Loop resolved threads whenever the fixer said it addressed them — even with a clean worktree and prose-only replies | Threads got resolved while NO commit was produced; the diff was unchanged | Gate resolution on a real commit: `made_progress = addressed and committed`. Never trust the model's self-report alone (PR #1084). |
+| Converge when the reviewer posts zero threads | Loop terminated on "zero new threads" regardless of verdict | Ended AMBIGUOUS/NO-GO too fast, before ever earning a GO | Require an explicit `Verdict: GO` to converge; zero threads != GO (PR #1084). |
+| Let the fixer agent resolve its own threads | Fixer both edited code AND called the resolve mutation | The fixer has every incentive to declare victory; not evidence-based | Move resolution to a fresh READ-ONLY reviewer on the next pass; fixer only edits+commits+pushes (PR #1084). |
+| Match prior threads on `(path, line)` | Validator paired a prior thread to the new diff by file+line | Two threads can share a line; path normalization drifts across hunks → wrong thread resolved | Match on the thread `id`; echo it back through the validation prompt and payload. |
+| Edit an existing comment via `updatePullRequestReviewComment` with only its node id | Fetched only the node id, then called the update mutation | The mutation REPLACES the body — it silently destroys the original comment | FETCH the existing body first and CONCATENATE; the comment index must return the body. |
+| Post inline comments unvalidated | Mapped LLM comment dicts straight into the `POST .../reviews` payload with no diff check | GitHub 422s the ENTIRE review if ANY comment is off-hunk; loop logged spurious `Verdict=NOGO Grade=F` | Validate every `(path, line, side)` against the FULL diff before POST (PR #1043). |
+| Validate against the truncated context diff | Reused the 8000-char model-context diff as the accepted-positions source | On large PRs truncation omits real hunks, wrongly dropping valid comments | Validate against the full `gh pr diff`, not the model's truncated context. |
+| Fail closed on empty diff | Dropped all comments when the diff was empty/unavailable to be "safe" | A transient fetch hiccup silently discarded all reviewer feedback | FAIL OPEN: return comments unchanged when the diff cannot be fetched. |
+| Give up after one no-commit | Logged "skipping push, iteration failed" and moved to the next PR | Same prompt on the same red CI reproduces the same no-commit run after run | Treat no-commit + red required CI as a force-engagement trigger; earn one bounded retry (PR #847). |
+| Retry on ANY no-commit | Always retried regardless of whether required checks were still red | Wasted tokens "fixing" PRs whose CI passed via concurrent activity, risking regressions | Gate the retry on `gh pr checks --required` exit code. |
+| Retry with the same prompt / a new session_uuid | Re-invoked the original prompt, or minted a fresh session id to "start over" | Same prompt+context → same no-commit; a new session loses the prior turn's context | Retry prompt must differ (name failing checks, restate invariants) and reuse the SAME PR-scoped session id. |
+| Ignore PR review threads in the prompt | Built the prompt from `ci_logs` alone | The real blocker is often an unresolved bot/human review thread the fix agent never sees | Inject unresolved `reviewThreads { isResolved, comments { body, path, line } }` verbatim into BOTH the initial and retry prompts. |
+| Open a new PR / loop the retry on second failure | Closed the stuck PR for a fresh one, or looped the retry until quota | Loses review history + `Closes #N` link; burns tokens on a genuinely stuck PR | Exactly ONE retry; on second no-commit write `repeated-no-commit-<pr>.json` and stop. Never `gh pr create` from the retry path. |
+| Prompt `feature-dev:code-reviewer` with `gh pr review` action verbs | Dispatched 11 read-only agents expecting them to post reviews | The type has NO Bash; all 11 returned "I cannot run shell commands"; orchestrator posted all 11 manually | Use `general-purpose` for write-back; probe one agent's toolset before fanning out to N. |
+| Tell `feature-dev:code-reviewer` to "use Bash anyway" | Added "you have Bash, use it" to the prompt | Toolset is harness-enforced at registration; the agent still reports no Bash | A prompt cannot grant tools the agent type lacks. |
+| Select a non-existent GraphQL output field | `addPullRequestReview` selected `pullRequestReviewThread { id isResolved }` on a `PullRequestReviewComment` | That output field does not exist; the mutation failed on EVERY call (219 identical failures); no in-loop review posted | Introspect `__type { fields { name } }` against the live schema; return only `pullRequestReview { id }` (PR #906). |
+| Reply with the wrong mutation name | `gh_pr_resolve_thread` used `addPullRequestReviewComment(input: {pullRequestReviewThreadId, body})` | `AddPullRequestReviewCommentInput` has no `pullRequestReviewThreadId` → `InputObject ... doesn't accept argument` + `Variable $threadId declared but not used` | Introspect the Input type's `inputFields`; the correct mutation is `addPullRequestReviewThreadReply` (PR #1006). |
+| Trust `gh api graphql` exit code alone | Relied on exit 0 to mean success | `gh api graphql` returns HTTP 200 with a top-level `errors` array on a failed op | Surface the `errors` array from the JSON; do not trust the exit code alone. |
+| Manufacture a commit for a self-cancelling plan | Considered committing a no-op when "implement all fixes" was the outer instruction | Would create spurious history and confuse reviewers; the inner plan said "no fixes required" | Read the entire plan body; if it cancels itself, do nothing and report the branch is already complete. |
+| `if git branch --list "$branch"; then` (bash review trap) | Used the exit code of `git branch --list` to test branch existence | `git branch --list` always exits 0; the exit code reflects execution, not a match | Test the OUTPUT: `[[ -n "$(git branch --list "$branch")" ]]`. |
+| Post every comprehensive-review finding through the inline review API | Mapped each finding into the `POST .../reviews` inline-comments payload | Inline comments must validate against a changed diff hunk (422 on any off-hunk line) — complex and error-prone for prose findings | Prefer a simple line-specific PR comment (`gh pr comment` / `comments/{id}/replies`); reserve the inline review API for true on-hunk annotations. Post comprehensively in THREE places: PR review body + line-specific PR comment + `gh issue comment` on the tracking issue. |
+| Reply to one review comment via the GraphQL thread-reply mutation | Resolved the thread node id then called `addPullRequestReviewThreadReply` for a one-line reply | Overkill — needed the thread node id and the full GraphQL round-trip for a trivial reply | For a single one-line reply use the REST endpoint `gh api repos/OWNER/REPO/pulls/PR/comments/COMMENT_ID/replies --method POST -f body="..."`; reserve the GraphQL mutation for when you need the returned `comment { id }`. |
+| Call color/echo helpers in the arg-parsing block (bash) | Invoked pretty-print helpers from the top-of-script flag parser | The parser runs before the helper definitions, so the call no-ops or errors | Emit early diagnostics with `echo "..." >&2`; only use the helpers after their definitions. |
+| Value-taking flag without an absent-value guard (bash) | `--branch X` read `$1` blindly as its value | A missing value silently swallows the next flag as the argument | Guard with `[[ -z "$1" \|\| "$1" == --* ]]` before consuming the value, else error out. |
+| Mutate an array inside a piped `while read` loop (bash) | Appended to an array inside `cmd \| while read` | The piped loop runs in a subshell; array mutations are lost after the pipe | Use process substitution: `while read ...; do arr+=(...); done < <(cmd)`. |
+| `set_trunk_branch`-style helper prints an error but doesn't exit (bash) | Helper logged the error and returned normally | The script continued past a fatal condition with bad trunk state | Every fatal branch in a helper MUST `exit 1` (or `return 1` + a checked caller). |
+| Short-circuit the existing-PR handler on GO **or** NO-GO | `_review_existing_pr` skipped re-review with `if has_go or has_no_go: return`, treating a `state:implementation-no-go` PR as terminal/settled | In a live 5-loop run all 60 existing PRs carried a terminal label (10 GO, 50 NO-GO), so every PR was skipped every loop (`Successful: 0 / Skipped: 60`) and the fallback `drive-green` phase was skipped too — NO-GO PRs were NEVER re-implemented or re-reviewed | Short-circuit on `has_go` ONLY; a NO-GO label is NOT terminal (it means review FAILED). Let NO-GO fall through into `_run_impl_review_loop` (NO-GO → resume implementer → re-review → converge-on-GO), bounded by `MAX_REVIEW_ITERATIONS`; gate a re-run on the PR head SHA advancing to avoid burning tokens on a stuck PR (PR #1104). |
+| Sync the existing-PR worktree to the assumed `{issue}-auto-impl` branch | `_review_existing_pr` set `branch_name = f"{issue_number}-auto-impl"` and called `sync_worktree_to_remote_branch` → `git fetch origin {issue}-auto-impl` | `find_pr_for_issue` can match a PR via a PR-body `Closes #N` search, so the PR head branch may belong to a DIFFERENT issue/bundle; the fetch failed `fatal: couldn't find remote ref …; exit 128` every loop (live: issue #725 → PR #996, real `headRefName` `708-auto-impl`). Latent until the GO-ONLY fix let NO-GO PRs reach the fetch | Resolve the PR's REAL head via `get_pr_head_branch(pr_number)` (`gh pr view <pr> --json headRefName`; `None` on failure) and use it for worktree create + sync + loop + result; fall back to the assumed name only on `None`. The fresh-impl path keeps the convention (it creates the branch). Tests MUST mock `get_pr_head_branch` (a real `gh` call took 103s) (PR #1106). |
+| Make the in-loop LLM reviewer enforce repo PR policy | Reviewer had a "Policy checks (MANDATORY)" prompt block + a strict-rubric `D1 — Policy compliance` NOGO gate that re-checked `Closes #N` / auto-merge / signed-commits, fed by a per-commit GraphQL signing fetch (`_fetch_signing_state`) + an auto-merge state fetch | The fetch returns `[]` on any error and the prompt treats empty = violation → fabricated false POLICY VIOLATIONs on compliant PRs. On PR #996 it posted `POLICY VIOLATION: Closes, auto-merge-premature, signed-commits` though the body had `Closes #725/#726`, auto-merge was OFF, and the commit was signed (`verified=true`) | Enforce PR policy ONCE in the deterministic CI gates (`pr-policy` required + `auto-merge-policy` advisory); the LLM reviewer judges code quality only — never duplicate a CI hard-gate in an LLM that fails open to violation. Removed the prompt block, the rubric D1 gate, `_fetch_signing_state`, and the auto-merge/signing context (PR #1112). |
+| Converge the in-loop review cycle on zero posted threads + force `state:skip` on a single AMBIGUOUS | `_run_impl_review_loop` had `if not posted_thread_ids and not reopened: break` (converge regardless of verdict) and force-applied `state:skip` after one iteration-0 non-GO via `is_ambiguous` | A malformed/transient review with 0 threads ended the loop at R0 and stranded a fixable PR with `state:skip` — observed on #725 / PR #996, fed by the pre-#1112 false POLICY VIOLATION (only a `POLICY VIOLATION:` line, no `Verdict:` → AMBIGUOUS, 0 threads) | Re-review on a zero-thread non-GO pass up to `MAX_REVIEW_ITERATIONS` (no threads → skip the address step via `continue`); converge ONLY on GO; auto-skip ONLY on TRUE exhaustion (`iterations_run >= MAX_REVIEW_ITERATIONS and last_verdict != "GO"`). Distinguish zero-threads-posted (re-review) from address-step-resolved-nothing (`break`) (PR #1114). |
+| Dispatch a fixer sub-agent for every review thread because the coordinator prompt says "every comment MUST be resolved" | Treating "resolve" as "must edit code", including for a thread the reviewer labelled non-blocking / pre-existing / out-of-scope | The requested edit (`pixi shell -e dev` in `CONTRIBUTING.md:63` / `README.md:494`) was pre-existing drift the approved plan EXPLICITLY scoped out behind a "count must not increase" guard; editing it would breach the plan and re-introduce scope-creep (PR #1245 / #1216) | Resolving a thread = giving it a disposition. "Not addressable in code within this issue's scope → follow-up issue" is a valid resolution; leave it out of `addressed` and change nothing (verified-local). |
+| Edit the redirect target's content because the anchor was correct | Saw a correct pointer to `CONTRIBUTING.md` / `README.md` and assumed the doc itself was THIS PR's defect to fix | A correct anchor to a doc whose downstream step is buggy is not a defect introduced by this PR; the reviewer themselves recommended a follow-up issue, not an in-PR fix | Distinguish the redirect/anchor (often correct) from the redirect target's content (the actual, out-of-scope complaint); honor the scope contract and emit `{"addressed": []}` (verified-local). |
+| Treat restart adoption as a terminal handoff | A later loop reconstructed a canonical prior automation receipt, but reconciliation allowed only external-bot receipts to reach remediation. | Validator-confirmed unaddressed normal receipts were labelled as requiring human resolution, so a fresh run could never make progress. | Provenance, head, reply, and readback checks protect the mutation; they do not justify an iteration boundary. Route all verified unaddressed automation receipts back to remediation. |
+| Retry a filtered subset of a nonce-bound implementation batch | A stale thread was removed while an ambiguous thread retained the original nonce. | The review body derives from the whole reply map, so the original full-batch draft no longer matches and is correctly preserved as a conflict instead of being retried. | Retry the exact immutable batch, or classify any mixed stale/ambiguous outcome as stale and start a fresh pass. Never use a nonce as a subset-retry token. |
+
+## Results & Parameters
+
+### Progress / convergence contract (SHIPPED, verified-ci)
+
+| Rule | Implementation | Why |
+|------|----------------|-----|
+| Progress requires a commit | `made_progress = addressed and committed`; `_commit_if_changes` returns bool (True iff HEAD advanced) | A clean worktree with prose replies is NOT progress |
+| Convergence requires explicit GO | parse reviewer output, require literal `Verdict: GO` (last line, not substring) | "zero threads" + AMBIGUOUS/NO-GO is not success |
+| Fixer never resolves | resolution mutation lives in the reviewer/validator on the next pass | evidence-based; fixer can't self-declare victory |
+| Reviewer resolution is diff-evidence-based, matched by thread `id` | resolve addressed threads, re-open (new thread) the rest | re-open OVERRIDES a stale GO; GitHub has no unresolve mutation |
+| Existing-PR short-circuit is GO-ONLY | `_review_existing_pr`: `if has_go: return` (NOT `has_go or has_no_go`) | a NO-GO label is NOT terminal; it must re-enter the loop (PR #1104) |
+| Existing-PR worktree uses the PR's real head branch | `get_pr_head_branch(pr)` → `headRefName`; fall back to `{issue}-auto-impl` only on `None` | the PR may have matched via `Closes #N`, so the head branch can differ from the issue number (PR #1106) |
+| Out-of-scope / non-blocking thread → resolve by NON-action | coordinator emits `{"addressed": []}`, dispatches ZERO sub-agents, commits nothing, leaves loop scratch file (`.claude-address-review-*.md`) UNTRACKED | "resolve" = give a disposition, not edit; editing a plan-scoped-out thread (e.g. behind a "count must not increase" guard) breaches the scope contract (verified-local, PR #1245 / #1216) |
+
+### Cross-run receipt remediation (verified locally)
+
+```text
+restart -> reconstruct canonical immutable receipt from live GitHub facts
+validator says unaddressed -> difficulty classification -> address implementation
+fresh reviewed head + unchanged receipt snapshot -> reply and resolve
+
+Do not hand off solely because the receipt was created by an earlier invocation.
+Do hand off on malformed provenance, a changed/replied-to thread, ambiguous validation,
+or a validator wont-fix disposition.
+```
+
+ProjectHephaestus regression evidence: a targeted stage test passed before and after the minimal
+transition fix; the complete unit suite then passed with 6,515 passed, 24 skipped, and 84.91%
+coverage. CI was pending when this learning was recorded.
+
+### One-review implementation reply batch (reviewed, CI-passing)
+
+```text
+complete address pass + persisted CSPRNG nonce
+  -> create at most one PENDING review
+  -> add every original-thread reply to that review
+  -> re-read head, review state, receipts, and competing reviews
+  -> submit one complete review
+  -> fresh reviewer validates and resolves only proven threads
+
+Any incomplete, stale, duplicate, or competing review -> preserve + diagnose;
+never delete it, resolve a thread, or replay a filtered subset of the batch.
+```
+
+ProjectHephaestus PR #2525 exercised the adapter and stage regressions (358 focused tests) and the
+locked full suite (6,892 collected tests), with required CI checks passing at the reviewed head. A
+strict review exposed the latent mixed stale/ambiguous subset-retry condition captured above; do not
+treat that recovery path as complete until it is corrected.
+
+### `--nitpick` severity model and per-comment dispatch
+
+```text
+Reviewer tags every inline comment: critical | major | minor | nitpick
+  Default:    suppress nitpick-severity comments
+  --nitpick:  re-enable them
+Per-comment dispatch:
+  1. cheap sub-agent classifies each comment's fix difficulty
+  2. todo list:  @ <file> Line <#> - <difficulty> - <description>
+  3. ONE sub-agent per comment; SERIALIZE same-file comments; parallelize across files
+  4. tier model:  simple -> haiku   medium -> sonnet   hard -> opus
+```
+
+### Inline-comment 422 validation
+
+```text
+Endpoint:   POST /repos/{owner}/{repo}/pulls/{n}/reviews   (gh api -X POST)
+Failure:    gh: Unprocessable Entity (HTTP 422)  (any one off-hunk comment poisons all)
+Side map:   RIGHT = '+'/context numbered in NEW file ;  LEFT = '-'/context in OLD file
+Hunk hdr:   @@ -oldStart[,oldLen] +newStart[,newLen] @@   (",len" optional — parse defensively)
+Invariant:  FAIL OPEN — never drop comments because the diff could not be fetched
+```
+
+### Force-engagement retry prompt template (verbatim from PR #847)
+
+```text
+## Force-Engagement Retry — Previous Turn Produced No Commit
+
+You just returned from a CI-fix session for PR {pr} (issue {issue}) WITHOUT
+producing a new commit on branch `{pr_head_branch}`. The required CI checks
+below are STILL failing on the remote:
+
+{failing_check_names_bulleted}
+
+Returning no commit when required checks are still red is itself a bug.
+
+Required behaviour:
+1. Re-read the failing check logs for the names listed above.
+2. Make the minimal change that addresses each failure.
+3. Run the local test + pre-commit gates to verify before committing.
+4. **Every commit MUST be cryptographically signed (`git commit -S`).**
+   NEVER use `--no-verify`.
+5. Do NOT run `git checkout -b` / `git switch -c` — the fix lands on `{pr_head_branch}`.
+
+If you still cannot produce a commit, reply with a single line
+`BLOCKED: <one-sentence reason>` and stop.
+```
+
+The `review_threads_block` from `_format_review_threads_block(pr_number)` is PREPENDED above
+this entire template. `_failing_required_check_names` parses `gh pr checks <pr> --required
+--json name,bucket` and returns names whose `bucket` ∈ `{fail, cancel, skipping}`.
+
+### Forensics marker JSON (`state_dir/repeated-no-commit-<pr>.json`)
+
+```json
+{
+  "issue_number": 41,
+  "pr_number": 83,
+  "pr_head_branch": "41-auto-impl",
+  "failing_required_checks": ["lint", "test-py310"],
+  "recorded_at": "2026-05-31T19:37:30Z"
+}
+```
+
+`_run_ci_fix_session` checks for this marker at entry and skips the PR if it exists AND the
+PR head SHA still matches — re-arming requires a new commit on the head branch.
+
+### Agent type capability matrix (verified 2026-05-31)
+
+| Agent type | Read | Grep | Glob | WebFetch | WebSearch | Bash | Edit | Write | TaskStop |
+|---|---|---|---|---|---|---|---|---|---|
+| `feature-dev:code-reviewer` | yes | yes | yes | yes | yes | NO | NO | NO | yes |
+| `general-purpose` | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+
+### GraphQL introspection + corrected PR-review mutations
+
+```bash
+gh api graphql -f query='{ __type(name: "PullRequestReviewComment") { fields { name } } }'
+gh api graphql -f query='{ __type(name: "AddPullRequestReviewThreadReplyInput") { inputFields { name } } }'
+gh api graphql -f query='{ __type(name: "AddPullRequestReviewThreadReplyPayload") { fields { name } } }'
+```
+
+```graphql
+# Reply to a review thread (right NAME + right Input + valid leaf):
+mutation AddReply($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: $threadId, body: $body
+  }) { comment { id } }
+}
+# resolveReviewThread(input: { threadId: $threadId }) is the follow-up (already correct).
+
+# Post a review (select ONLY a field that exists):
+mutation {
+  addPullRequestReview(input: {
+    pullRequestId: $prId, event: COMMENT, body: $body, comments: $comments
+  }) { pullRequestReview { id } }   # PullRequestReview has `id`, NOT `databaseId`
+}
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #1084 (closes #1083) | Commit-gated progress, `Verdict: GO` convergence, reviewer-side evidence-based resolution, `state:skip` vocabulary, `--nitpick` suppression, per-comment tiered dispatch |
+| ProjectHephaestus | PR #1043 (closes #1039) | Inline-comment diff-hunk 422 validation; full-diff hunk parser; fail-open on empty diff; new 422-path tests |
+| ProjectHephaestus | PR #847 | `_format_review_threads_block`, `_failing_required_check_names`, `_force_engagement_prompt`, `_retry_no_commit_once`; 18 new tests; forensics marker |
+| ProjectHephaestus | PR #906 (closes #905) / PR #1006 (closes #999) | GraphQL field + input-argument validation; corrected `addPullRequestReview` selection and `addPullRequestReviewThreadReply` mutation |
+| ProjectHephaestus | PR #1104 | Existing-PR handler short-circuits on GO ONLY; NO-GO PRs re-enter `_run_impl_review_loop` instead of being skipped as settled (`_review_existing_pr` in `implementer_phase_runner.py`) |
+| ProjectHephaestus | PR #1106 | `get_pr_head_branch(pr_number)` in `_review_utils`; `_review_existing_pr` uses the PR's real `headRefName` (not the assumed `{issue}-auto-impl`) for worktree create + sync + loop; fixes `git fetch … exit 128` |
+| ProjectHephaestus | PR #1114 | In-loop `_run_impl_review_loop` (`implementer_phase_runner.py`): a zero-thread non-GO pass (no re-opens) now RE-REVIEWS up to `MAX_REVIEW_ITERATIONS` instead of `break`ing on `if not posted_thread_ids and not reopened: break`; GO still converges immediately; a posted-thread NO-GO still runs the address step (`if not addressed: break` unchanged). `state:skip` is applied ONLY on TRUE iteration exhaustion (`iterations_run >= MAX_REVIEW_ITERATIONS and last_verdict != "GO"`), not on a single iteration-0 AMBIGUOUS/NO-GO. Fixes #725 → PR #996 being stranded at R0 with `state:skip` by a malformed 0-thread review. 81 implementer-suite tests pass, ruff + mypy 342 files clean; PR CLEAN/MERGEABLE |
+| ProjectHephaestus | PR #1112 | Removed in-loop policy enforcement from the LLM reviewer — deleted the "Policy checks (MANDATORY)" block + `POLICY VIOLATION` contract from `prompts/pr_review.py`, the `D1 — Policy compliance` rubric gate from `prompts/_strict_rubric.py`, and `_fetch_signing_state` + auto-merge/signing context from `pr_reviewer.py`. CI gates `pr-policy` (required) + `auto-merge-policy` (advisory) own policy; reviewer judges code quality only. Fixes false POLICY VIOLATION on compliant PR #996. Net +78/-345; prompt + pr_reviewer suites green, ruff + mypy 342 files clean |
+| ProjectHephaestus | PR #1245 (issue #1216) | Out-of-scope / non-blocking / pre-existing review-thread disposition: the sole address-review thread was reviewer-labelled "Non-blocking (pre-existing, out of scope for #1216)" and asked to edit `pixi shell -e dev` (`CONTRIBUTING.md:63` / `README.md:494`) — drift the approved plan explicitly scoped out behind a "count must not increase" guard. Coordinator dispatched zero sub-agents, changed no code, committed nothing, returned `{"addressed": []}`. verified-local (CI not yet confirming the disposition) |
+| ProjectHephaestus | Issue #2496 / prior-loop review-thread remediation | Verified locally: canonical restart receipt adoption already worked, but a later reconciliation branch incorrectly restricted remediation to external-bot receipts. A normal prior-loop receipt classified as unaddressed now returns to the difficulty/address workflow; malformed, changed, replied-to, ambiguous, and wont-fix paths remain fail-closed. |
+| ProjectHephaestus | PR #2525 (issue #2523) | One implementation response pass creates one pending review, associates every original-thread reply, verifies receipts, and submits one review. CSPRNG nonce-bound batches preserve incomplete, stale, duplicate, and competing drafts for diagnosis because GitHub lacks a write CAS; only a fresh reviewer can resolve threads. Required CI passed at the reviewed head; strict review identified a latent subset-retry correction. |
+| HomericIntelligence/AchaeanFleet | 11 Dependabot PRs, 2026-05-31 | `feature-dev:code-reviewer` read-only blocker discovered; agent-type selection rule |
+| ProjectOdyssey | PR #3343 (issue #3152) / PR #3109 (issue #3033) | Self-cancelling review plan no-op; comprehensive multi-specialist PR review orchestration |
+| gh-tidy (HaywardMorihara/gh-tidy) | PRs #63/#67/#68/#69 | Upstream bash PR review rounds; logic/safety traps (verified-local) |
+``````
+
+---
+
+
 ## v1.7.0 (2026-07-27)
 
 **Changed by:** ProjectHephaestus issue #2496 cross-run review-thread remediation.

--- a/skills/pr-review-loop-orchestration-agent-patterns.md
+++ b/skills/pr-review-loop-orchestration-agent-patterns.md
@@ -1,9 +1,9 @@
 ---
 name: pr-review-loop-orchestration-agent-patterns
-description: "Use when: (1) building or debugging a Python implement-review loop where an LLM sub-agent reviews a PR and a fixer agent addresses inline comments, (2) a review loop resolves threads even though no commit was produced — resolution must be gated on a real commit not the model self-report, (3) a loop ends AMBIGUOUS or NO-GO too fast before ever earning an explicit GO verdict, (4) LLM or agent-generated inline PR review comments are rejected by GitHub (HTTP 422) because they do not lie on a changed diff hunk, (5) an agent-driven CI-fix session produces no commit and the PR stays red; the correct response is a single bounded retry with unresolved review threads injected verbatim, (6) a review fix plan file concludes no changes are needed and the automation should self-cancel without opening a new PR, (7) a feature-dev:code-reviewer sub-agent cannot execute shell commands and cannot post gh pr review — wrong agent type was chosen, (8) a GitHub GraphQL PR-review mutation field selection is wrong and the automation loop fails on every call with Field X does not exist, (9) pre-commit must cover the full PR diff from the merge-base not just the most-recent-edit files before pushing, (10) an existing-PR review handler short-circuits NO-GO PRs as if they were settled (idempotency `if has_go or has_no_go: skip`) so a failed-review PR never re-enters the loop — short-circuit on GO ONLY, (11) an existing-PR worktree sync fails `git fetch origin {issue}-auto-impl` with exit 128 because the PR head branch was ASSUMED from the issue number instead of read from the PR's real `headRefName`, (12) an in-loop LLM PR reviewer posts a FALSE policy violation (e.g. `POLICY VIOLATION: Closes, auto-merge-premature, signed-commits` on a PR that actually has `Closes #N`, auto-merge OFF, and a signed commit) because its policy fetch failed open to violation, or you are tempted to make the reviewer re-check `Closes #N` / signed commits / auto-merge that a CI gate (`pr-policy` required, `auto-merge-policy` advisory) already enforces, (13) an in-loop implementer review cycle (`_run_impl_review_loop`) converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO instead of re-reviewing up to `MAX_REVIEW_ITERATIONS` and auto-skipping only on TRUE exhaustion, (14) the address-review coordinator is handed a review thread the reviewer itself labels non-blocking / pre-existing / out-of-scope / follow-up-worthy, or that asks for an edit the approved plan explicitly scoped out (e.g. behind a 'count must not increase' verification guard) — the correct disposition is to leave the thread UNADDRESSED (out of the `addressed` set) as a follow-up issue and make NO code change, because resolving a comment means giving it a disposition, not necessarily editing code, (15) a run parks EVERY pr_review item to state:skip via 'zero-thread NOGO retry cap exhausted' or 'exhausted at round N (automation unresolved 0 -> 0)' and you suspect the reviewer model or verdict parsing — check each PR's hephaestus-pr-review-zero-thread-nogo anomaly comment FIRST: a summary like 'NOGO: ... head unchanged (Nth round)' means by-design stale-PR triage (#2079: deterministic no-progress NOGOs escalate to skip instead of burning implement budget), NOT a reviewer failure; only a FRESHLY-implemented PR parked this way indicates a real defect"
+description: "Use when: (1) building or debugging a Python implement-review loop where an LLM sub-agent reviews a PR and a fixer agent addresses inline comments, (2) a review loop resolves threads even though no commit was produced — resolution must be gated on a real commit not the model self-report, (3) a loop ends AMBIGUOUS or NO-GO too fast before ever earning an explicit GO verdict, (4) LLM or agent-generated inline PR review comments are rejected by GitHub (HTTP 422) because they do not lie on a changed diff hunk, (5) an agent-driven CI-fix session produces no commit and the PR stays red; the correct response is a single bounded retry with unresolved review threads injected verbatim, (6) a review fix plan file concludes no changes are needed and the automation should self-cancel without opening a new PR, (7) a feature-dev:code-reviewer sub-agent cannot execute shell commands and cannot post gh pr review — wrong agent type was chosen, (8) a GitHub GraphQL PR-review mutation field selection is wrong and the automation loop fails on every call with Field X does not exist, (9) pre-commit must cover the full PR diff from the merge-base not just the most-recent-edit files before pushing, (10) an existing-PR review handler short-circuits NO-GO PRs as if they were settled (idempotency `if has_go or has_no_go: skip`) so a failed-review PR never re-enters the loop — short-circuit on GO ONLY, (11) an existing-PR worktree sync fails `git fetch origin {issue}-auto-impl` with exit 128 because the PR head branch was ASSUMED from the issue number instead of read from the PR's real `headRefName`, (12) an in-loop LLM PR reviewer posts a FALSE policy violation (e.g. `POLICY VIOLATION: Closes, auto-merge-premature, signed-commits` on a PR that actually has `Closes #N`, auto-merge OFF, and a signed commit) because its policy fetch failed open to violation, or you are tempted to make the reviewer re-check `Closes #N` / signed commits / auto-merge that a CI gate (`pr-policy` required, `auto-merge-policy` advisory) already enforces, (13) an in-loop implementer review cycle (`_run_impl_review_loop`) converges/`break`s when the reviewer posts zero threads even though the verdict is AMBIGUOUS or NO-GO, or applies `state:skip` after a single iteration-0 non-GO instead of re-reviewing up to `MAX_REVIEW_ITERATIONS` and auto-skipping only on TRUE exhaustion, (14) the address-review coordinator is handed a review thread the reviewer itself labels non-blocking / pre-existing / out-of-scope / follow-up-worthy, or that asks for an edit the approved plan explicitly scoped out (e.g. behind a 'count must not increase' verification guard) — the correct disposition is to leave the thread UNADDRESSED (out of the `addressed` set) as a follow-up issue and make NO code change, because resolving a comment means giving it a disposition, not necessarily editing code, (15) a run parks EVERY pr_review item to state:skip via 'zero-thread NOGO retry cap exhausted' or 'exhausted at round N (automation unresolved 0 -> 0)' and you suspect the reviewer model or verdict parsing — check each PR's hephaestus-pr-review-zero-thread-nogo anomaly comment FIRST: a summary like 'NOGO: ... head unchanged (Nth round)' means by-design stale-PR triage (#2079: deterministic no-progress NOGOs escalate to skip instead of burning implement budget), NOT a reviewer failure; only a FRESHLY-implemented PR parked this way indicates a real defect, (16) a remediation agent pushed a valid commit but its `addressed`/`replies` map fails exact thread-ID validation — post no replies, discard only the malformed agent output, and return the existing PR to fresh review; without a pushed commit keep the terminal fail-closed path"
 category: ci-cd
-date: 2026-07-30
-version: "1.8.0"
+date: 2026-08-04
+version: "1.9.0"
 user-invocable: false
 history: pr-review-loop-orchestration-agent-patterns.history
 tags:
@@ -56,6 +56,11 @@ tags:
   - one-review-per-pass
   - pending-review-ownership
   - preserve-review-conflicts
+  - malformed-reply-mapping
+  - exact-thread-id
+  - pushed-head-recovery
+  - fresh-review-routing
+  - no-commit-fail-closed
   - homericintelligence
 ---
 
@@ -65,11 +70,11 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-30 |
-| **Objective** | Build and debug a Python implement-review loop that drives LLM sub-agents to review a PR and fix its inline comments, converging on an EVIDENCE-BASED `Verdict: GO`. Covers: commit-gated thread resolution, inline-comment diff-hunk (422) validation, one-shot no-commit retry with unresolved review threads injected, agent-type selection for review tasks, GraphQL field/input validation for PR-review mutations, self-cancelling review plans, full merge-base pre-commit scope, the existing-PR short-circuit being GO-ONLY (NO-GO PRs MUST re-enter the loop), using the PR's real `headRefName` for the worktree instead of an assumed `{issue}-auto-impl`, and the "zero threads != GO" rule applying to the LOOP's TERMINATION condition (a zero-thread non-GO pass RE-REVIEWS up to `MAX_REVIEW_ITERATIONS`; `state:skip` only on TRUE exhaustion). |
-| **Outcome** | Merged across multiple ProjectHephaestus PRs (commit-gate + verdict-GO convergence #1084; inline-comment 422 validation #1043; no-commit retry + thread injection #847; GraphQL field/input validation #906/#1006; existing-PR NO-GO re-review #1104; real PR head-branch resolution #1106; in-loop policy enforcement removed in favor of CI gates #1112; in-loop zero-thread non-GO re-reviews + `state:skip` only on exhaustion #1114) plus ProjectOdyssey and gh-tidy upstream review rounds. |
-| **Verification** | verified-ci |
-| **Version** | 1.8.0 |
+| **Date** | 2026-08-04 |
+| **Objective** | Build and debug a Python implement-review loop that drives LLM sub-agents to review a PR and fix its inline comments, converges only on evidence, and preserves an independently verified pushed remediation commit when its reply map is malformed without posting unverified replies. |
+| **Outcome** | The established review-loop workflow is merged and CI-verified across multiple projects. The v1.9 malformed-map recovery is an implementation-ready design with exact-ID regression cases; execution and CI remain pending. |
+| **Verification** | verified-ci for the established workflow; the v1.9 malformed-map recovery is unverified and explicitly marked proposed below. |
+| **Version** | 1.9.0 |
 
 ## When to Use
 
@@ -88,6 +93,7 @@ tags:
 - The address-review coordinator is handed a review thread the reviewer ITSELF labels non-blocking / pre-existing / out-of-scope for #N / follow-up-worthy, or a thread that asks for an edit the approved plan explicitly scoped out (often behind a "count must not increase" verification guard), and the per-comment loop pressure ("every comment MUST be resolved") tempts a fixer-dispatch + code edit.
 - A fresh loop invocation reconstructs a canonical prior-run automated review thread, the validator marks it unaddressed, and reconciliation still hands it off instead of returning it to the normal remediation path.
 - One implementation pass posts a separate empty GitHub review for every addressed thread, or a transport failure leaves a pending review draft and the recovery path is tempted to delete, reuse, or partially replay it.
+- A remediation agent produced a valid pushed head, but its `addressed` and `replies` keys differ from the immutable thread snapshot by even one character; the commit should receive fresh review without any reply mutation, while the same malformed output with no pushed commit must remain terminal.
 
 ## Verified Workflow
 
@@ -228,6 +234,41 @@ begin a fresh review after manual cleanup or changed state.
 A host-only retry must retain the entire immutable batch. Never retain a nonce while filtering its
 thread or reply set: that changes the derived review body, turns the original draft into a conflict,
 and defeats recovery. Treat a mixed stale/ambiguous result as stale, or retry the exact full batch.
+
+#### Proposed malformed-reply recovery after a verified push
+
+> **Warning:** This recovery branch has not been validated end-to-end. Treat it as a hypothesis
+> until the implementation regressions and CI confirm it.
+
+Parsing reply evidence and proving a pushed commit are separate trust domains. Keep exact set
+comparison for the snapshot thread IDs; never guess that `thread-l` means `thread-1`, and never
+construct a reply handoff from malformed output. A malformed map invalidates every proposed reply,
+but it does not invalidate a commit that the trusted push-result parser independently proved was
+pushed with a full SHA.
+
+Recovery is allowed only when all three facts are already trusted: `pushed=True`, a full head SHA,
+and an existing PR. In ProjectHephaestus, obtain the first two facts only from
+`_remediation_reply_head()`, which already rejects a non-full SHA. Clear only
+`implementation_remediation` and `remediation_output`, create no reply handoff or journal record,
+perform no GitHub reply mutation, and let the existing
+`PR_CREATE -> ADVANCE -> PR_REVIEW` route send the new head through a fresh reviewer. The fresh
+reviewer can reconstruct findings from the new diff instead of trusting the malformed map.
+
+When `pushed=False`, the presence of a SHA-shaped string is not recovery evidence. Set the existing
+reply error and retain the terminal `implementation_reply_failed` transition. A missing PR is also
+terminal because there is nowhere to route the independently proven head for review.
+
+```python
+pushed, head_sha = remediation_reply_head(push_result)
+replies = parse_exact_reply_mapping(remediation_output, thread_snapshots)
+if replies is None:
+    if pushed and existing_pr:
+        clear("implementation_remediation", "remediation_output")
+        route("PR_CREATE", "ADVANCE", "PR_REVIEW")
+    else:
+        remediation_reply_error = True
+        finish_fail("implementation_reply_failed")
+```
 
 Severity-tag every inline comment (`critical | major | minor | nitpick`) and SUPPRESS
 nitpick by default; a `--nitpick` flag opts back in. Per-comment dispatch: classify each
@@ -538,6 +579,9 @@ recurring traps:
 | Edit the redirect target's content because the anchor was correct | Saw a correct pointer to `CONTRIBUTING.md` / `README.md` and assumed the doc itself was THIS PR's defect to fix | A correct anchor to a doc whose downstream step is buggy is not a defect introduced by this PR; the reviewer themselves recommended a follow-up issue, not an in-PR fix | Distinguish the redirect/anchor (often correct) from the redirect target's content (the actual, out-of-scope complaint); honor the scope contract and emit `{"addressed": []}` (verified-local). |
 | Treat restart adoption as a terminal handoff | A later loop reconstructed a canonical prior automation receipt, but reconciliation allowed only external-bot receipts to reach remediation. | Validator-confirmed unaddressed normal receipts were labelled as requiring human resolution, so a fresh run could never make progress. | Provenance, head, reply, and readback checks protect the mutation; they do not justify an iteration boundary. Route all verified unaddressed automation receipts back to remediation. |
 | Retry a filtered subset of a nonce-bound implementation batch | A stale thread was removed while an ambiguous thread retained the original nonce. | The review body derives from the whole reply map, so the original full-batch draft no longer matches and is correctly preserved as a conflict instead of being retried. | Retry the exact immutable batch, or classify any mixed stale/ambiguous outcome as stale and start a fresh pass. Never use a nonce as a subset-retry token. |
+| Terminalize every malformed reply map | Set the reply-error flag even after a trusted push result proved that a new full head SHA exists on an existing PR. | The malformed reply evidence blocked an independently valid commit from ever receiving fresh review. | Split reply-evidence failure from push-evidence failure: discard all replies, preserve the pushed head, and route the existing PR to a fresh reviewer. |
+| Fuzzy-match a mistyped thread ID | Guessed that an unknown key such as `thread-l` meant snapshot ID `thread-1`, then prepared a reply mutation. | A one-character typo is not evidence of author intent and can post an unverified response to the wrong thread. | Require exact set equality. On any mismatch post nothing and create no handoff or journal entry. |
+| Recover from `pushed=False` because a SHA-shaped value exists | Treated a returned head string as proof that remediation reached the remote. | The push-result contract explicitly says no commit was pushed; accepting the string would bypass the terminal no-commit safety path. | Recovery requires both `pushed=True` and a full SHA from the trusted parser. Preserve `implementation_reply_failed` otherwise. |
 
 ## Results & Parameters
 
@@ -552,6 +596,32 @@ recurring traps:
 | Existing-PR short-circuit is GO-ONLY | `_review_existing_pr`: `if has_go: return` (NOT `has_go or has_no_go`) | a NO-GO label is NOT terminal; it must re-enter the loop (PR #1104) |
 | Existing-PR worktree uses the PR's real head branch | `get_pr_head_branch(pr)` → `headRefName`; fall back to `{issue}-auto-impl` only on `None` | the PR may have matched via `Closes #N`, so the head branch can differ from the issue number (PR #1106) |
 | Out-of-scope / non-blocking thread → resolve by NON-action | coordinator emits `{"addressed": []}`, dispatches ZERO sub-agents, commits nothing, leaves loop scratch file (`.claude-address-review-*.md`) UNTRACKED | "resolve" = give a disposition, not edit; editing a plan-scoped-out thread (e.g. behind a "count must not increase" guard) breaches the scope contract (verified-local, PR #1245 / #1216) |
+
+### Malformed reply-map recovery decision table (proposed, unverified)
+
+| Exact map | `pushed` | Full SHA | Existing PR | Host action | Reply mutation |
+|-----------|----------|----------|-------------|-------------|----------------|
+| yes | any | validated as required | yes | Build the normal immutable reply batch. | Only through the normal verified batch handoff. |
+| no | true | yes | yes | Clear stale remediation-agent output and return the PR to fresh review. | None. |
+| no | false | any | any | Set the reply error and finish with `implementation_reply_failed`. | None. |
+| no | true | no | any | Reject the push result, set the reply error, and fail closed. | None. |
+| no | true | yes | no | Set the reply error because no existing PR can receive fresh review. | None. |
+
+Use a one-character identifier typo to prove the safety boundary without relying on malformed JSON:
+
+```python
+snapshots = [{"id": "thread-1", "path": "a.py", "line": 3}]
+output = {
+    "addressed": ["thread-l"],
+    "replies": {"thread-l": "[Response] Fixed the missing guard."},
+}
+
+# Pushed case: ADVANCE to fresh review, no reply error/handoff/mutation.
+# No-commit case: FINISH_FAIL implementation_reply_failed, no mutation.
+```
+
+The paired stage regressions must assert both routing and absence of the reply-post mutation. Keep
+the exact-ID parser unchanged so this test also proves that no fuzzy matching was introduced.
 
 ### Cross-run receipt remediation (verified locally)
 
@@ -702,6 +772,7 @@ mutation {
 | ProjectHephaestus | PR #1245 (issue #1216) | Out-of-scope / non-blocking / pre-existing review-thread disposition: the sole address-review thread was reviewer-labelled "Non-blocking (pre-existing, out of scope for #1216)" and asked to edit `pixi shell -e dev` (`CONTRIBUTING.md:63` / `README.md:494`) — drift the approved plan explicitly scoped out behind a "count must not increase" guard. Coordinator dispatched zero sub-agents, changed no code, committed nothing, returned `{"addressed": []}`. verified-local (CI not yet confirming the disposition) |
 | ProjectHephaestus | Issue #2496 / prior-loop review-thread remediation | Verified locally: canonical restart receipt adoption already worked, but a later reconciliation branch incorrectly restricted remediation to external-bot receipts. A normal prior-loop receipt classified as unaddressed now returns to the difficulty/address workflow; malformed, changed, replied-to, ambiguous, and wont-fix paths remain fail-closed. |
 | ProjectHephaestus | PR #2525 (issue #2523) | One implementation response pass creates one pending review, associates every original-thread reply, verifies receipts, and submits one review. CSPRNG nonce-bound batches preserve incomplete, stale, duplicate, and competing drafts for diagnosis because GitHub lacks a write CAS; only a fresh reviewer can resolve threads. Required CI passed at the reviewed head; strict review identified a latent subset-retry correction. |
+| ProjectHephaestus | Malformed remediation reply-map design, 2026-08-04 | Unverified implementation design: exact-ID typo regressions distinguish a valid pushed head routed to fresh review from malformed no-commit output that remains terminal, with no reply-post mutation in either case. |
 | HomericIntelligence/AchaeanFleet | 11 Dependabot PRs, 2026-05-31 | `feature-dev:code-reviewer` read-only blocker discovered; agent-type selection rule |
 | ProjectOdyssey | PR #3343 (issue #3152) / PR #3109 (issue #3033) | Self-cancelling review plan no-op; comprehensive multi-specialist PR review orchestration |
 | gh-tidy (HaywardMorihara/gh-tidy) | PRs #63/#67/#68/#69 | Upstream bash PR review rounds; logic/safety traps (verified-local) |


### PR DESCRIPTION
## Summary

Amends `pr-review-loop-orchestration-agent-patterns` from v1.8.0 to v1.9.0.

Documents the safe trust split when a remediation agent returns a malformed exact-thread reply mapping after a commit was independently proven pushed:

- post no unverified replies and create no reply handoff or journal entry
- preserve the trusted pushed head and return the existing PR to fresh review
- retain `implementation_reply_failed` for malformed no-commit or missing-PR responses
- keep exact thread-ID set comparison; never guess a one-character typo
- archive the complete v1.8.0 skill snapshot in history

## Verification Level

**unverified** for the newly documented Hephaestus recovery branch. The implementation and paired stage regressions are specified, but have not yet run in Hephaestus CI.

The Mnemosyne amendment itself passed all local repository gates.

## Key Findings

**What Worked**:

- Treat pushed-head evidence and reply-map evidence as independent trust domains.
- Route a valid pushed head through the existing fresh-review path without any reply mutation.
- Exercise exact-ID safety with `thread-l` versus `thread-1` and assert mutation absence.

**What Failed**:

- Terminalizing every malformed mapping strands a valid pushed commit.
- Fuzzy-matching a typo can post an unverified reply to the wrong thread.
- Treating a SHA-shaped value as proof when `pushed=False` bypasses the no-commit safety path.

## Test Plan

- [x] `uv run --locked python scripts/validate_plugins.py` — 723/723 skills valid
- [x] `just check` — 219 tests passed
- [x] targeted pre-commit hooks passed
- [x] markdownlint-cli2 reported zero errors
- [x] direct PII scan passed
- [ ] Hephaestus implementation regressions and CI (pending by design)

Co-Authored-By: Codex <noreply@openai.com>
