### PR TITLE
feat: amend coverage omit orchestration skill

### DIFF
--- a/skills/coverage-omit-orchestration-pure-function-testing.history
+++ b/skills/coverage-omit-orchestration-pure-function-testing.history
@@ -1,6 +1,216 @@
 <!-- markdownlint-disable MD024 -->
 # coverage-omit-orchestration-pure-function-testing — History
 
+## v2.0.0 (2026-08-05)
+
+**Changed by:** ProjectHephaestus issue #2371 reviewed implementation contract
+**Verification:** unverified
+
+### What changed
+
+- Replaced the core recommendation to keep whole orchestration modules omitted with a hermetic promotion workflow that measures their executable bodies.
+- Added explicit `line`, `branch`, and legacy `auto` metric semantics, including the zero-branch regression and metric-labelled diagnostics.
+- Added exact omit-list equality, retired-module reconciliation, canonical Cobertura validation, atomic configuration promotion, and rollback guidance.
+- Generalized agent, GitHub, Git, subprocess, clock, and terminal seams while retaining the issue #2371 twelve-module cohort as a concrete example.
+
+### Why
+
+The previous v1.1.0 guidance improved behavior confidence for pure helpers but deliberately left
+whole orchestration modules outside the coverage denominator. Issue #2371 identified that the
+import/test-name justification proxy could be satisfied without executing orchestration bodies,
+that automatic branch-to-line fallback could misapply an explicit future branch floor, and that
+prefix-based omit guards could be bypassed by alternate glob forms. The new workflow changes the
+core recommendation: exercise live boundaries through hermetic substitutes, select metrics
+explicitly, and remove whole-module omissions only when the canonical report proves every floor.
+
+### Previous version (v1.1.0) snapshot
+
+~~~~markdown
+---
+name: coverage-omit-orchestration-pure-function-testing
+description: "How to add behavioral test coverage for pure-function helpers in coverage-omitted orchestration modules (live CLI/TTY boundary). Use when: (1) modules are omitted from --cov due to live-session dependencies, (2) the omit list is frozen but pure helpers inside omitted modules have no behavioral tests, (3) a coverage audit flags untested orchestration logic."
+category: testing
+date: 2026-06-13
+version: "1.1.0"
+user-invocable: false
+verification: unverified
+tags: []
+history: coverage-omit-orchestration-pure-function-testing.history
+---
+
+# Coverage-Omit Orchestration Pure-Function Testing
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-13 |
+| **Objective** | Add behavioral test coverage for pure-function helpers inside coverage-omitted orchestration modules without removing modules from the omit list |
+| **Outcome** | Plan written (not yet implemented) |
+| **Verification** | unverified |
+
+## When to Use
+
+- Orchestration modules are omitted from `--cov` due to live `claude`/`gh` CLI or real TTY dependencies
+- A coverage audit flags that the 80% gate measures a reduced denominator
+- Pure helpers inside omitted modules (parsers, formatters, predicates) have no behavioral tests
+- You want to tighten the coverage gate without removing the omit entries
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```bash
+# Step 0: Verify actual filenames before adding any coverage.toml floor
+ls hephaestus/automation/ | grep -i arming
+grep -rn "class ArmingState" hephaestus/   # → arming_state.py:32
+
+# Step 1: Run coverage to get actual XML and confirm path format
+pixi run pytest tests/unit --cov=hephaestus --cov-report=xml:build/coverage.xml -q
+
+# Step 2: Confirm path format from actual XML (no hephaestus/ prefix)
+python3 -c "
+import defusedxml.ElementTree as ET
+tree = ET.parse('build/coverage.xml')
+for c in list(tree.findall('.//class'))[:5]:
+    print(c.get('filename'))
+"
+# Expected output: automation/models.py (NOT hephaestus/automation/models.py)
+
+# Step 3: Check actual branch-rate values for target modules before setting floors
+python3 -c "
+import defusedxml.ElementTree as ET
+tree = ET.parse('build/coverage.xml')
+targets = {'automation/models.py', 'automation/dependency_resolver.py', 'automation/arming_state.py'}
+for c in tree.findall('.//class'):
+    if c.get('filename') in targets:
+        print(c.get('filename'), 'line:', c.get('line-rate'), 'branch:', c.get('branch-rate'))
+"
+
+# Step 4: Set floors conservatively (70%) — CI enforcer uses branch_rate if > 0
+# coverage.toml format (verified working):
+# [coverage.modules]
+# "automation/models.py" = { minimum = 70 }
+
+# Step 5: Verify enforcement by running the actual CLI (not hand-rolled XML parse)
+pip install -e ".[xml]"
+hephaestus-check-coverage --coverage-file build/coverage.xml --config coverage.toml
+# Must exit 0 before committing floors
+```
+
+### Detailed Steps
+
+1. **Verify actual filenames before touching coverage.toml** — `ls hephaestus/automation/` and grep for the class name. Modules get renamed (e.g., `arming_state_store.py` → `arming_state.py` in commit cb33b509); any path in `[coverage.modules]` that is missing from the XML causes a hard CI fail (coverage.py:250-257).
+
+2. **Read actual function signatures** for every function you plan to test — do NOT assume from name alone. Key risk areas:
+   - `ci_driver._pr_is_failing`: checks `isDraft` first (line 85), then `mergeStateStatus == "BLOCKED"` (line 87), then rollup conclusions (line 89-90)
+   - `loop_runner._parse_repo_list`: empty string returns `[]` (not raises) per docstring at loop_runner.py:126
+   - `loop_runner._validate_phases`: raises `SystemExit`; valid phases are `{"plan", "implement", "drive-green"}` (`ALL_SELECTABLE` at loop_runner.py:108)
+   - `github_api._assert_body_has_closes`: raises `ValueError` exactly (github_api.py:541)
+   - `audit_reviewer._parse_coordinator_results`: returns `[]` on empty/whitespace (docstring at audit_reviewer.py:40-43); skips malformed JSON blocks without raising (audit_reviewer.py:44-48)
+
+3. **Create `tests/unit/automation/test_orchestration_pure_functions.py`** with one class per module, importing each pure helper directly:
+   ```python
+   from hephaestus.automation.loop_runner import _parse_repo_list
+   ```
+   Tests run fine even though the source is in the omit list — they exercise the logic and prove behavioral correctness; they just do not add to the coverage denominator.
+
+4. **Extend `coverage.toml`** with per-module floors for non-omitted automation modules. Set floors conservatively against branch-rate (CI enforcer uses `branch_rate if branch_rate > 0 else line_rate` — coverage.py:262). Verify via `hephaestus-check-coverage` CLI, not a hand-rolled XML parser.
+
+5. **Fix any docstring count discrepancies** in `tests/integration/test_orchestration_smoke.py` if the module comment says "4 console scripts" but 5 are listed.
+
+## Verified Workflow
+
+> This workflow is **unverified** — it has not been run end-to-end through CI. The steps below are the intended approach based on planning analysis of ProjectHephaestus issue #1197 (R1 iteration). Update this section to "verified" once the implementation passes CI.
+
+1. Verify filenames: `ls hephaestus/automation/` + `grep -rn "class <TargetClass>" hephaestus/` — confirm the exact `.py` filename before adding any floor.
+2. Read actual function signatures for each pure helper (grep `^def _` in the target module; read the docstring and body, not just the name).
+3. Create `tests/unit/automation/test_orchestration_pure_functions.py` with one class per omitted module; import helpers directly.
+4. Run the new test file in isolation (`pixi run pytest tests/unit/automation/test_orchestration_pure_functions.py -v`) — confirm all pass.
+5. Confirm the omit allowlist test still passes (`pixi run pytest tests/unit/validation/test_omit_allowlist.py -v`).
+6. Generate a Cobertura XML report (`pixi run pytest tests/unit --cov=hephaestus --cov-report=xml:build/coverage.xml`) and inspect `filename` attributes to confirm path format is `automation/<name>.py` (no `hephaestus/` prefix).
+7. Check branch-rate values for target modules from the XML before setting floors (CI enforcer uses branch-rate preferentially).
+8. Add per-module floors to `coverage.toml`; verify via `hephaestus-check-coverage --coverage-file build/coverage.xml --config coverage.toml` (exit 0). Set one test floor to 99% on a known-below-99% module → confirm exit 1 → restore real floor.
+9. Push and confirm CI green.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Assumed `_pr_is_failing` dict shape | Wrote tests using `{"statusCheckRollup": [...]}` without reading source | Dict key or nesting may differ — tests would fail immediately | Always read the function body, not just the name, before writing assertions |
+| Assumed `_parse_repo_list("")` raises | Wrote `pytest.raises((ValueError, SystemExit))` for empty input | Docstring at loop_runner.py:126 states "Empty input returns an empty list" — function returns `[]` not raise | Read the function docstring/body before writing edge-case assertions; empty-string behavior is often intentionally lenient |
+| Used full path in coverage.toml floors | `"hephaestus/automation/models.py" = { minimum = 80 }` | Cobertura XML uses relative paths without `hephaestus/` prefix; mismatch silently skips the floor check | Verify path format against actual XML output before committing floors |
+| Included `_evaluate_run_result` in approach but not tests | Identified it as pure at ci_driver.py:3224 but omitted from test class | Complex signature requires reading before stubbing; silently dropped | Either test it or explicitly note it as deferred in the plan |
+| Used `arming_state_store.py` as module path in coverage.toml | Prior plan added floor for `"automation/arming_state_store.py"` | File was renamed to `arming_state.py` by commit cb33b509 (extract ArmingStateStore from CIDriver) — causes hard CI fail (coverage.py:250-257: missing module fails loud) | Always verify filename against actual `ls hephaestus/automation/` before adding a floor; grep for class name: `grep -rn "class ArmingState" hephaestus/` |
+| Verified floors against line-rate in verification step | Plan's Criterion 5 used `xml.etree.ElementTree` to read line-rate from XML | CI enforcer (`_required.yml:592`) uses `hephaestus-check-coverage` which applies `branch_rate if branch_rate > 0 else line_rate` (coverage.py:262) — floor set vs line-rate could silently pass while branch-rate fails | Always verify floor enforcement by running the actual `hephaestus-check-coverage` CLI, not a hand-rolled XML parser |
+| Assumed `_parse_repo_list("")` raises on empty | Test used `pytest.raises((ValueError, SystemExit))` for empty string | Docstring at loop_runner.py:126 states "Empty input returns an empty list" — function returns `[]` not raise | Read the function docstring/body before writing edge-case assertions; empty-string behavior is often intentionally lenient |
+| Used shotgun exception tuples `raises((ValueError, SystemExit, AssertionError))` | Test accepted any of three unrelated exception types | Accepting three unrelated exception types is not a behavior contract — it's a guess wrapper (POLA violation) | Read the source to confirm the exact exception type; each `raises()` call must specify exactly one type |
+
+## Results & Parameters
+
+**Confirmed path format from live coverage run:**
+- XML `filename` attribute format: `automation/models.py` (no `hephaestus/` prefix) — verified via `pixi run pytest tests/unit/automation/test_models.py --cov=hephaestus --cov-report=xml:build/coverage_sample.xml`
+
+**Coverage floor safety invariants (verified R1):**
+
+1. **Path format**: `automation/<name>.py` — no `hephaestus/` prefix (confirmed from live XML)
+2. **Missing module = hard CI fail**: `coverage.py:250-257` — any path in `[coverage.modules]` missing from XML fails loudly; verify XML presence before committing a floor
+3. **Metric used**: `branch_rate if branch_rate > 0 else line_rate` (`coverage.py:262`) — floor values must be safe vs branch-rate, which is typically lower than line-rate
+4. **CI invocation**: `hephaestus-check-coverage --coverage-file coverage.xml --config coverage.toml` (`_required.yml:592`) — always verify via this CLI, not custom XML parsing
+5. **Verify floor enforcement**: Set test floor to 99% on a known-uncovered module → confirm exit 1 → restore real floor
+
+**Coverage.toml per-module floor format (verified path prefix):**
+```toml
+[coverage.modules]
+"automation/models.py" = { minimum = 70 }
+"automation/dependency_resolver.py" = { minimum = 70 }
+"automation/arming_state.py" = { minimum = 70 }   # not arming_state_store.py
+```
+
+**Confirmed function behaviors (R1, verified against source):**
+
+| Function | Module | Behavior | Source Location |
+|----------|--------|----------|-----------------|
+| `_validate_phases` | loop_runner.py | Raises `SystemExit`; valid phases: `{"plan", "implement", "drive-green"}` | loop_runner.py:537; `ALL_SELECTABLE` at loop_runner.py:108 |
+| `_assert_body_has_closes` | github_api.py | Raises `ValueError` exactly (not AssertionError or SystemExit) | github_api.py:541 |
+| `_parse_repo_list("")` | loop_runner.py | Returns `[]` not raises | docstring at loop_runner.py:126 |
+| `_parse_coordinator_results` | audit_reviewer.py | Returns `[]` on empty/whitespace; skips malformed JSON without raising | audit_reviewer.py:40-48 |
+| `_pr_is_failing` | ci_driver.py | Checks `isDraft` first (line 85), then `mergeStateStatus == "BLOCKED"` (line 87), then rollup conclusions (line 89-90) | ci_driver.py:85-90 |
+
+**Omit list is frozen by `test_omit_allowlist.py` — any addition fails CI:**
+- Do NOT add new modules to the omit list without updating the allowlist test
+- Tests for omitted modules can be written and run; they just don't count toward the denominator
+
+**Recommended test structure for omitted-module pure helpers:**
+```python
+class TestLoopRunnerPureFunctions:
+    def test_parse_repo_list_comma_separated(self) -> None:
+        from hephaestus.automation.loop_runner import _parse_repo_list
+        assert _parse_repo_list("a,b,c") == ["a", "b", "c"]
+
+    def test_parse_repo_list_empty_returns_empty_list(self) -> None:
+        from hephaestus.automation.loop_runner import _parse_repo_list
+        # Empty string returns [] not raises (confirmed loop_runner.py:126)
+        assert _parse_repo_list("") == []
+
+    def test_validate_phases_invalid_raises_system_exit(self) -> None:
+        from hephaestus.automation.loop_runner import _validate_phases
+        with pytest.raises(SystemExit):  # NOT ValueError or AssertionError
+            _validate_phases(["nonexistent"])
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #1197 planning R0 (2026-06-13) | Plan written; implementation pending |
+| ProjectHephaestus | Issue #1197 planning R1 (2026-06-13) | Second planning iteration; verified filenames, metrics, and function behaviors against source files |
+~~~~
+
+---
+
 ## v1.0.0 (2026-06-13)
 
 Initial skill created from planning analysis of ProjectHephaestus issue #1197.

--- a/skills/coverage-omit-orchestration-pure-function-testing.md
+++ b/skills/coverage-omit-orchestration-pure-function-testing.md
@@ -1,181 +1,167 @@
 ---
 name: coverage-omit-orchestration-pure-function-testing
-description: "How to add behavioral test coverage for pure-function helpers in coverage-omitted orchestration modules (live CLI/TTY boundary). Use when: (1) modules are omitted from --cov due to live-session dependencies, (2) the omit list is frozen but pure helpers inside omitted modules have no behavioral tests, (3) a coverage audit flags untested orchestration logic."
+description: "How to replace whole-module coverage omissions and import/test-name proxies with hermetic behavior tests plus explicit per-module coverage metrics. Use when: (1) orchestration modules are excluded because they touch agents, GitHub, Git, subprocesses, clocks, or terminals, (2) a proxy test proves only that a module was imported or named, (3) line and branch floors need unambiguous enforcement."
 category: testing
-date: 2026-06-13
-version: "1.1.0"
+date: 2026-08-05
+version: "2.0.0"
 user-invocable: false
 verification: unverified
-tags: []
+tags: [coverage, hermetic-tests, orchestration, cobertura]
 history: coverage-omit-orchestration-pure-function-testing.history
 ---
 
-# Coverage-Omit Orchestration Pure-Function Testing
+# Promoting Omitted Orchestration Modules to Executable Coverage
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-13 |
-| **Objective** | Add behavioral test coverage for pure-function helpers inside coverage-omitted orchestration modules without removing modules from the omit list |
-| **Outcome** | Plan written (not yet implemented) |
+| **Date** | 2026-08-05 |
+| **Objective** | Replace whole-module coverage omissions and import/test-name proxies with hermetic behavior tests and explicit per-module coverage floors |
+| **Outcome** | Reviewed implementation contract captured; execution and CI validation remain pending |
 | **Verification** | unverified |
+| **History** | [changelog](./coverage-omit-orchestration-pure-function-testing.history) |
 
 ## When to Use
 
-- Orchestration modules are omitted from `--cov` due to live `claude`/`gh` CLI or real TTY dependencies
-- A coverage audit flags that the 80% gate measures a reduced denominator
-- Pure helpers inside omitted modules (parsers, formatters, predicates) have no behavioral tests
-- You want to tighten the coverage gate without removing the omit entries
+- Coverage excludes complete orchestration modules because their normal path invokes live agents, GitHub, Git, subprocesses, a wall clock, or a terminal.
+- A validation test considers an omitted module justified when a test merely imports it or has a matching filename.
+- A coverage-floor checker automatically chooses branch coverage when positive and otherwise falls back to line coverage.
+- A migration cohort includes renamed or retired modules that must be reconciled with their current executable owners.
+- You need to remove omissions without weakening a repository-wide gate or depending on external services.
 
 ## Proposed Workflow
 
-> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms.
+> **Warning:** This workflow has not been validated end-to-end. Treat it as a hypothesis until the canonical coverage report and CI confirm it.
 
 ### Quick Reference
 
 ```bash
-# Step 0: Verify actual filenames before adding any coverage.toml floor
-ls hephaestus/automation/ | grep -i arming
-grep -rn "class ArmingState" hephaestus/   # → arming_state.py:32
+# 1. Reconcile the planned cohort against the current tree.
+find <source-root> -type f -name '*.py' | sort
+rg '<retired-symbol>|<replacement-symbol>' <source-root> <docs-root> <tests-root>
 
-# Step 1: Run coverage to get actual XML and confirm path format
-pixi run pytest tests/unit --cov=hephaestus --cov-report=xml:build/coverage.xml -q
+# 2. Add hermetic behavior tests before changing coverage configuration.
+<package-manager> pytest <focused-behavior-tests> -v
 
-# Step 2: Confirm path format from actual XML (no hephaestus/ prefix)
-python3 -c "
-import defusedxml.ElementTree as ET
-tree = ET.parse('build/coverage.xml')
-for c in list(tree.findall('.//class'))[:5]:
-    print(c.get('filename'))
-"
-# Expected output: automation/models.py (NOT hephaestus/automation/models.py)
-
-# Step 3: Check actual branch-rate values for target modules before setting floors
-python3 -c "
-import defusedxml.ElementTree as ET
-tree = ET.parse('build/coverage.xml')
-targets = {'automation/models.py', 'automation/dependency_resolver.py', 'automation/arming_state.py'}
-for c in tree.findall('.//class'):
-    if c.get('filename') in targets:
-        print(c.get('filename'), 'line:', c.get('line-rate'), 'branch:', c.get('branch-rate'))
-"
-
-# Step 4: Set floors conservatively (70%) — CI enforcer uses branch_rate if > 0
-# coverage.toml format (verified working):
+# 3. Promote omissions and floors as one configuration change.
+# coverage.toml
 # [coverage.modules]
-# "automation/models.py" = { minimum = 70 }
+# "orchestration/target.py" = { minimum = 70, metric = "line" }
 
-# Step 5: Verify enforcement by running the actual CLI (not hand-rolled XML parse)
-pip install -e ".[xml]"
-hephaestus-check-coverage --coverage-file build/coverage.xml --config coverage.toml
-# Must exit 0 before committing floors
+# 4. Generate the same Cobertura artifact CI consumes and run the real checker.
+mkdir -p build
+<package-manager> pytest <unit-tests> --cov=<package> \
+  --cov-report=xml:build/coverage.xml
+<package-manager> <coverage-checker> \
+  --coverage-file build/coverage.xml --config coverage.toml
 ```
 
 ### Detailed Steps
 
-1. **Verify actual filenames before touching coverage.toml** — `ls hephaestus/automation/` and grep for the class name. Modules get renamed (e.g., `arming_state_store.py` → `arming_state.py` in commit cb33b509); any path in `[coverage.modules]` that is missing from the XML causes a hard CI fail (coverage.py:250-257).
+1. **Reconcile the cohort against the current tree.** For every planned module, record whether its source still exists, moved, split, or was retired. A retired facade should stay absent; place the floor on the surviving executable owner and add an assertion that the obsolete source does not reappear.
 
-2. **Read actual function signatures** for every function you plan to test — do NOT assume from name alone. Key risk areas:
-   - `ci_driver._pr_is_failing`: checks `isDraft` first (line 85), then `mergeStateStatus == "BLOCKED"` (line 87), then rollup conclusions (line 89-90)
-   - `loop_runner._parse_repo_list`: empty string returns `[]` (not raises) per docstring at loop_runner.py:126
-   - `loop_runner._validate_phases`: raises `SystemExit`; valid phases are `{"plan", "implement", "drive-green"}` (`ALL_SELECTABLE` at loop_runner.py:108)
-   - `github_api._assert_body_has_closes`: raises `ValueError` exactly (github_api.py:541)
-   - `audit_reviewer._parse_coordinator_results`: returns `[]` on empty/whitespace (docstring at audit_reviewer.py:40-43); skips malformed JSON blocks without raising (audit_reviewer.py:44-48)
+2. **Write hermetic behavior tests before editing omissions.** Exercise orchestration bodies through injected seams rather than importing modules for side effects. Patch or inject all external boundaries:
 
-3. **Create `tests/unit/automation/test_orchestration_pure_functions.py`** with one class per module, importing each pure helper directly:
+   | Boundary | Hermetic substitute | Behavior to assert |
+   |----------|---------------------|--------------------|
+   | Agent provider | Fake result, raised provider error, or resume failure | Dispatch, normalization, fallback, bounded retry |
+   | GitHub API/CLI | Patched call returning structured fixtures | Scope, pagination, union, deduplication, per-item failure containment |
+   | Git/subprocess | Fake completed process and repository state | Branch selection, retry limits, no-commit outcome |
+   | Clock | Patched monotonic/time/sleep | Refresh and timeout behavior without wall-clock delay |
+   | Terminal | Fake screen plus patched curses functions | Rendering, unavailable dependency, resize recovery |
+
+3. **Make the enforced metric explicit.** New module floors should select `line` or `branch`; legacy entries may retain an `auto` mode during migration. Explicit branch selection must use a zero branch rate as zero, never as a signal to fall back to line coverage.
+
    ```python
-   from hephaestus.automation.loop_runner import _parse_repo_list
+   def select_metric(metric: str, line_rate: float, branch_rate: float) -> tuple[str, float]:
+       if metric == "line":
+           return "line", line_rate
+       if metric == "branch":
+           return "branch", branch_rate
+       if metric == "auto":
+           return ("branch", branch_rate) if branch_rate > 0 else ("line", line_rate)
+       raise ValueError(f"unsupported coverage metric: {metric!r}")
    ```
-   Tests run fine even though the source is in the omit list — they exercise the logic and prove behavioral correctness; they just do not add to the coverage denominator.
 
-4. **Extend `coverage.toml`** with per-module floors for non-omitted automation modules. Set floors conservatively against branch-rate (CI enforcer uses `branch_rate if branch_rate > 0 else line_rate` — coverage.py:262). Verify via `hephaestus-check-coverage` CLI, not a hand-rolled XML parser.
+4. **Test metric boundaries through the public checker.** A 70% line floor needs regressions proving 69% fails and 70% passes. Also prove that an explicit branch floor fails at 0% branch coverage even if line coverage is 99%. Assert that diagnostics name the selected metric.
 
-5. **Fix any docstring count discrepancies** in `tests/integration/test_orchestration_smoke.py` if the module comment says "4 console scripts" but 5 are listed.
+5. **Freeze omissions by exact equality.** Compare the configured omit list with the complete allowed list, including order when configuration stability matters. Prefix checks and substring checks are bypassable by alternate glob spellings. An exact contract rejects every extra whole-module pattern regardless of how the coverage engine interprets it.
+
+6. **Promote configuration atomically.** In one change, remove the whole-module omissions, add explicit floors for every reconciled source, replace the proxy tests with behavior/floor contracts, and update documentation. Do not leave a state where measured modules lack floors or floors target still-omitted files.
+
+7. **Use the canonical Cobertura pipeline.** Generate coverage with the same test selection, source root, branch setting, and XML path as required CI. Run the repository's coverage-checker CLI rather than a custom XML script. Confirm every configured filename appears in the XML; a missing path is a configuration error, not zero coverage.
+
+8. **Rollback configuration as a unit if a floor cannot be met hermetically.** Restore the prior omit list, module-floor entries, and omit-contract tests together. Keep useful behavior tests. Do not lower the agreed floor merely to finish the migration.
 
 ## Verified Workflow
 
-> This workflow is **unverified** — it has not been run end-to-end through CI. The steps below are the intended approach based on planning analysis of ProjectHephaestus issue #1197 (R1 iteration). Update this section to "verified" once the implementation passes CI.
-
-1. Verify filenames: `ls hephaestus/automation/` + `grep -rn "class <TargetClass>" hephaestus/` — confirm the exact `.py` filename before adding any floor.
-2. Read actual function signatures for each pure helper (grep `^def _` in the target module; read the docstring and body, not just the name).
-3. Create `tests/unit/automation/test_orchestration_pure_functions.py` with one class per omitted module; import helpers directly.
-4. Run the new test file in isolation (`pixi run pytest tests/unit/automation/test_orchestration_pure_functions.py -v`) — confirm all pass.
-5. Confirm the omit allowlist test still passes (`pixi run pytest tests/unit/validation/test_omit_allowlist.py -v`).
-6. Generate a Cobertura XML report (`pixi run pytest tests/unit --cov=hephaestus --cov-report=xml:build/coverage.xml`) and inspect `filename` attributes to confirm path format is `automation/<name>.py` (no `hephaestus/` prefix).
-7. Check branch-rate values for target modules from the XML before setting floors (CI enforcer uses branch-rate preferentially).
-8. Add per-module floors to `coverage.toml`; verify via `hephaestus-check-coverage --coverage-file build/coverage.xml --config coverage.toml` (exit 0). Set one test floor to 99% on a known-below-99% module → confirm exit 1 → restore real floor.
-9. Push and confirm CI green.
+No end-to-end workflow is verified yet. The executable procedure is intentionally documented under **Proposed Workflow** until the canonical report and CI pass. This explicit placeholder is retained because Mnemosyne's current skill validator requires the `Verified Workflow` heading even for `verification: unverified` skills.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Assumed `_pr_is_failing` dict shape | Wrote tests using `{"statusCheckRollup": [...]}` without reading source | Dict key or nesting may differ — tests would fail immediately | Always read the function body, not just the name, before writing assertions |
-| Assumed `_parse_repo_list("")` raises | Wrote `pytest.raises((ValueError, SystemExit))` for empty input | Docstring at loop_runner.py:126 states "Empty input returns an empty list" — function returns `[]` not raise | Read the function docstring/body before writing edge-case assertions; empty-string behavior is often intentionally lenient |
-| Used full path in coverage.toml floors | `"hephaestus/automation/models.py" = { minimum = 80 }` | Cobertura XML uses relative paths without `hephaestus/` prefix; mismatch silently skips the floor check | Verify path format against actual XML output before committing floors |
-| Included `_evaluate_run_result` in approach but not tests | Identified it as pure at ci_driver.py:3224 but omitted from test class | Complex signature requires reading before stubbing; silently dropped | Either test it or explicitly note it as deferred in the plan |
-| Used `arming_state_store.py` as module path in coverage.toml | Prior plan added floor for `"automation/arming_state_store.py"` | File was renamed to `arming_state.py` by commit cb33b509 (extract ArmingStateStore from CIDriver) — causes hard CI fail (coverage.py:250-257: missing module fails loud) | Always verify filename against actual `ls hephaestus/automation/` before adding a floor; grep for class name: `grep -rn "class ArmingState" hephaestus/` |
-| Verified floors against line-rate in verification step | Plan's Criterion 5 used `xml.etree.ElementTree` to read line-rate from XML | CI enforcer (`_required.yml:592`) uses `hephaestus-check-coverage` which applies `branch_rate if branch_rate > 0 else line_rate` (coverage.py:262) — floor set vs line-rate could silently pass while branch-rate fails | Always verify floor enforcement by running the actual `hephaestus-check-coverage` CLI, not a hand-rolled XML parser |
-| Assumed `_parse_repo_list("")` raises on empty | Test used `pytest.raises((ValueError, SystemExit))` for empty string | Docstring at loop_runner.py:126 states "Empty input returns an empty list" — function returns `[]` not raise | Read the function docstring/body before writing edge-case assertions; empty-string behavior is often intentionally lenient |
-| Used shotgun exception tuples `raises((ValueError, SystemExit, AssertionError))` | Test accepted any of three unrelated exception types | Accepting three unrelated exception types is not a behavior contract — it's a guess wrapper (POLA violation) | Read the source to confirm the exact exception type; each `raises()` call must specify exactly one type |
+| Import/test-name proxy | Treated a test import and a matching test function name as evidence that an omitted module was covered | Imports can execute none of the orchestration body and do not contribute measurable behavior while the source remains omitted | Replace naming proxies with Cobertura floors plus assertions over observable behavior |
+| Pure helpers while keeping whole modules omitted | Tested parsers and predicates but left orchestration sources outside the denominator | The tests improved correctness but could not prove or enforce execution of the omitted modules | Inject live boundaries and measure the complete source module |
+| Automatic zero-branch fallback | Used branch coverage when positive and line coverage when branch rate was zero | An explicit branch floor could pass using a high line rate even though no branches executed | Distinguish explicit `branch` from legacy `auto`; zero is a real branch measurement |
+| Prefix-based omit guard | Rejected only omit entries beginning with a known source prefix | Alternate globs such as `*/orchestration/target.py` bypassed the check | Require exact equality with the complete allowed omit list |
+| Floor on retired source | Carried a historical module name into the coverage configuration | Retired files never appear in Cobertura XML, so the floor cannot measure current behavior | Map retired facades to the surviving owner and assert the retired path remains absent |
+| Hand-rolled XML verification | Parsed selected XML attributes outside the real coverage-checker CLI | It can diverge from production path matching, threshold conversion, and diagnostics | Generate the canonical artifact and invoke the same checker CI uses |
+| Lowered floor to complete migration | Reduced a below-floor threshold after removing omissions | It changes the acceptance contract instead of improving behavior coverage | Roll back the promotion unit and retain the new tests until the agreed floor is met |
 
 ## Results & Parameters
 
-**Confirmed path format from live coverage run:**
-- XML `filename` attribute format: `automation/models.py` (no `hephaestus/` prefix) — verified via `pixi run pytest tests/unit/automation/test_models.py --cov=hephaestus --cov-report=xml:build/coverage_sample.xml`
+### Generic configuration contracts
 
-**Coverage floor safety invariants (verified R1):**
-
-1. **Path format**: `automation/<name>.py` — no `hephaestus/` prefix (confirmed from live XML)
-2. **Missing module = hard CI fail**: `coverage.py:250-257` — any path in `[coverage.modules]` missing from XML fails loudly; verify XML presence before committing a floor
-3. **Metric used**: `branch_rate if branch_rate > 0 else line_rate` (`coverage.py:262`) — floor values must be safe vs branch-rate, which is typically lower than line-rate
-4. **CI invocation**: `hephaestus-check-coverage --coverage-file coverage.xml --config coverage.toml` (`_required.yml:592`) — always verify via this CLI, not custom XML parsing
-5. **Verify floor enforcement**: Set test floor to 99% on a known-uncovered module → confirm exit 1 → restore real floor
-
-**Coverage.toml per-module floor format (verified path prefix):**
 ```toml
+[tool.coverage.run]
+branch = true
+source = ["<package>"]
+omit = [
+    "*/tests/*",
+    "*/__init__.py",
+]
+
 [coverage.modules]
-"automation/models.py" = { minimum = 70 }
-"automation/dependency_resolver.py" = { minimum = 70 }
-"automation/arming_state.py" = { minimum = 70 }   # not arming_state_store.py
+"orchestration/target.py" = { minimum = 70, metric = "line" }
+"orchestration/branchy_target.py" = { minimum = 70, metric = "branch" }
 ```
 
-**Confirmed function behaviors (R1, verified against source):**
-
-| Function | Module | Behavior | Source Location |
-|----------|--------|----------|-----------------|
-| `_validate_phases` | loop_runner.py | Raises `SystemExit`; valid phases: `{"plan", "implement", "drive-green"}` | loop_runner.py:537; `ALL_SELECTABLE` at loop_runner.py:108 |
-| `_assert_body_has_closes` | github_api.py | Raises `ValueError` exactly (not AssertionError or SystemExit) | github_api.py:541 |
-| `_parse_repo_list("")` | loop_runner.py | Returns `[]` not raises | docstring at loop_runner.py:126 |
-| `_parse_coordinator_results` | audit_reviewer.py | Returns `[]` on empty/whitespace; skips malformed JSON without raising | audit_reviewer.py:40-48 |
-| `_pr_is_failing` | ci_driver.py | Checks `isDraft` first (line 85), then `mergeStateStatus == "BLOCKED"` (line 87), then rollup conclusions (line 89-90) | ci_driver.py:85-90 |
-
-**Omit list is frozen by `test_omit_allowlist.py` — any addition fails CI:**
-- Do NOT add new modules to the omit list without updating the allowlist test
-- Tests for omitted modules can be written and run; they just don't count toward the denominator
-
-**Recommended test structure for omitted-module pure helpers:**
 ```python
-class TestLoopRunnerPureFunctions:
-    def test_parse_repo_list_comma_separated(self) -> None:
-        from hephaestus.automation.loop_runner import _parse_repo_list
-        assert _parse_repo_list("a,b,c") == ["a", "b", "c"]
+ALLOWED_OMITS = ["*/tests/*", "*/__init__.py"]
 
-    def test_parse_repo_list_empty_returns_empty_list(self) -> None:
-        from hephaestus.automation.loop_runner import _parse_repo_list
-        # Empty string returns [] not raises (confirmed loop_runner.py:126)
-        assert _parse_repo_list("") == []
-
-    def test_validate_phases_invalid_raises_system_exit(self) -> None:
-        from hephaestus.automation.loop_runner import _validate_phases
-        with pytest.raises(SystemExit):  # NOT ValueError or AssertionError
-            _validate_phases(["nonexistent"])
+assert configured_omits == ALLOWED_OMITS
+assert module_floors["orchestration/target.py"] == {
+    "minimum": 70,
+    "metric": "line",
+}
 ```
+
+### Metric regression matrix
+
+| Floor | Line rate | Branch rate | Expected |
+|-------|-----------|-------------|----------|
+| `minimum = 70, metric = "line"` | 69% | 99% | Fail |
+| `minimum = 70, metric = "line"` | 70% | 0% | Pass |
+| `minimum = 70, metric = "branch"` | 99% | 0% | Fail |
+| `minimum = 70` (legacy auto) | 99% | 0% | Pass on line; migrate deliberately |
+
+### ProjectHephaestus issue #2371 reconciliation example
+
+Eleven historical sources remain executable and should receive 70% line floors: `implementer.py`, `planner.py`, `ci_driver.py`, `pr_discovery.py`, `ci_check_inspector.py`, `ci_fix_orchestrator.py`, `post_merge_processor.py`, `loop_runner.py`, `loop_repo_manager.py`, `curses_ui.py`, and `audit_reviewer.py`. The retired twelfth facade, `address_review.py`, maps to `address_review_core.py`, whose parsing behavior remains executable.
+
+The migration contract is:
+
+- Every surviving source is present and every configured module path appears in Cobertura XML.
+- The retired facade is absent and its current owner is present.
+- Every cohort entry has `{ minimum = 70, metric = "line" }`.
+- The coverage omit list equals only the generic test and package-initializer exclusions.
+- Agent, GitHub, Git, subprocess, clock, and terminal behavior is exercised through injected substitutes.
+- The canonical unit-test XML and coverage checker pass before the migration is called complete.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | Issue #1197 planning R0 (2026-06-13) | Plan written; implementation pending |
-| ProjectHephaestus | Issue #1197 planning R1 (2026-06-13) | Second planning iteration; verified filenames, metrics, and function behaviors against source files |
+| ProjectHephaestus | Issue #2371 reviewed implementation contract (2026-08-05) | Unverified: implementation, canonical coverage report, and CI remain pending |


### PR DESCRIPTION
## Summary

Amends coverage-omit-orchestration-pure-function-testing from v1.1.0 to v2.0.0.

Documents how to replace whole-module coverage omissions and import/test-name proxies with hermetic behavior tests and explicit per-module metrics.

- Exercises agent, GitHub, Git, subprocess, clock, and terminal boundaries through injected substitutes
- Defines line, branch, and legacy auto semantics, including the zero-branch regression
- Requires exact omit-list equality, retired-module reconciliation, canonical Cobertura validation, and atomic rollback

## Verification Level

**unverified**

This captures the reviewed ProjectHephaestus issue #2371 implementation contract. The Hephaestus implementation, canonical coverage report, and CI validation are still pending, so the skill labels the executable steps as a proposed workflow.

## Key Findings

**What Worked**:
- Consolidating into the existing canonical coverage-omit skill instead of creating a duplicate
- Treating explicit line and branch selection separately from legacy automatic fallback
- Coupling omission removal, module floors, and executable contracts as one migration unit

**What Failed**:
- Import/test-name proxies do not prove orchestration body execution
- Prefix-based omit guards can be bypassed by alternate glob patterns
- Zero branch rate must not trigger line fallback for an explicit branch floor

## Test Plan

- [x] Validate all 723 skills with `uv run python scripts/validate_plugins.py`
- [x] Run 219 repository tests with `just check`
- [x] Run file-scoped pre-commit hooks
- [ ] Verify skill discovery and CI on the pull request

Co-Authored-By: Codex <noreply@openai.com>
