### PR TITLE
feat: add CI discovery and metric validation skills

### DIFF
--- a/skills/ci-workflow-discovery-yaml-suffix-parity.md
+++ b/skills/ci-workflow-discovery-yaml-suffix-parity.md
@@ -1,0 +1,159 @@
+---
+name: ci-workflow-discovery-yaml-suffix-parity
+description: "Unify GitHub Actions workflow discovery across .yml and .yaml. Use when: (1) inventory or checkout validation recognizes only one YAML suffix, (2) README parsing and pre-commit triggers drift from filesystem discovery, (3) compatibility helpers duplicate workflow glob logic."
+category: ci-cd
+date: 2026-08-06
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [github-actions, workflow-inventory, yaml, yml, discovery, pre-commit, pathlib]
+---
+
+# CI Workflow Discovery YAML Suffix Parity
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-08-06 |
+| **Objective** | Make one collector authoritative for GitHub Actions workflow discovery while keeping inventory documentation and trigger filters consistent for `.yml` and `.yaml`. |
+| **Outcome** | A reviewed implementation pattern and boundary-test matrix; implementation and CI validation are pending. |
+| **Verification** | unverified |
+
+GitHub Actions accepts both `.yml` and `.yaml`, so every layer that discovers, documents, or
+reacts to workflow files must share the same suffix contract. Fixing the filesystem glob alone
+leaves silent gaps if README parsing or pre-commit path filters still recognize only `.yml`.
+
+## When to Use
+
+- A repository inventory reports `.yml` workflows correctly but ignores `.yaml` files.
+- Checkout validation, documentation drift checks, and direct file validation use different
+  discovery helpers.
+- An exported suffix-specific helper cannot be removed without an avoidable compatibility break.
+- A pre-commit inventory hook does not run when a `.yaml` workflow changes.
+- A README workflow table parser matches filenames ending in `.yml` only.
+
+## Verified Workflow Status
+
+No end-to-end workflow has been verified. The design below comes from a reviewed
+ProjectHephaestus implementation plan and must remain a proposal until its focused and CI suites
+pass.
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat it as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```python
+import re
+import sys
+from pathlib import Path
+
+_WORKFLOW_GLOBS = ("*.yml", "*.yaml")
+_WORKFLOW_SUFFIXES = frozenset({".yml", ".yaml"})
+_TABLE_FILENAME_RE = re.compile(
+    r"\|\s*\[?([a-zA-Z0-9_.-]+\.ya?ml)\]?[^|]*\|"
+)
+
+
+def collect_workflow_files(paths: list[str]) -> list[Path]:
+    """Return deduplicated .yml and .yaml files from files or directories."""
+    files: list[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_file():
+            if path.suffix in _WORKFLOW_SUFFIXES:
+                files.append(path)
+        elif path.is_dir():
+            for pattern in _WORKFLOW_GLOBS:
+                files.extend(sorted(path.glob(pattern)))
+        else:
+            print(f"WARNING: Path not found: {path}", file=sys.stderr)
+
+    seen: set[Path] = set()
+    result: list[Path] = []
+    for workflow_file in files:
+        key = workflow_file.resolve()
+        if key not in seen:
+            seen.add(key)
+            result.append(workflow_file)
+    return result
+```
+
+Use one regex shape in path-trigger configuration as well:
+
+```yaml
+files: ^(\.pre-commit-config\.yaml|\.github/workflows/(README\.md|.*\.ya?ml))$
+```
+
+### Detailed Steps
+
+1. Define the accepted suffix set once for direct-file filtering and a small tuple of glob
+   patterns for directory scans. Do not use a broad `*.yaml*` pattern.
+2. Make one collector accept both files and directories. For files, reject unsupported suffixes;
+   for directories, scan both explicit patterns.
+3. Deduplicate with `Path.resolve()` keys so the same file supplied directly and through a
+   directory appears once. Preserve the original `Path` object and first-seen order in the
+   returned list.
+4. Keep an exported legacy helper when callers may import it, but turn it into a compatibility
+   wrapper over the canonical collector. It may reshape the result, such as returning basenames,
+   but must not own another glob.
+5. Route inventory comparison and checkout validation through the canonical collector. This
+   prevents one consumer from gaining suffix support while another remains stale.
+6. Update adjacent recognition layers in the same change:
+   - README table parsing: match `\.ya?ml`.
+   - Pre-commit selectors: match `.*\.ya?ml`.
+   - Help text and diagnostics: say `.yml and .yaml`, not `*.yml`.
+7. Add behavior-first tests for directory discovery, direct files, deduplication, README parsing,
+   documented inventory, undocumented `.yaml`, and the exact pre-commit selector contract.
+8. Run the focused workflow tests, then the surrounding CI-helper suite.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Independent suffix-specific helpers | Inventory used a `.yml` glob while checkout validation used a separate collector. | The two consumers could recognize different workflow sets and drift again after a local fix. | Discovery authority should live in one collector; compatibility helpers should delegate. |
+| Change only the filesystem glob | Add `*.yaml` discovery but leave README parsing and pre-commit selectors unchanged. | `.yaml` becomes discoverable but cannot be documented reliably and may not trigger the inventory hook. | Treat discovery, documentation parsing, triggers, and diagnostics as one suffix contract. |
+| Remove the old exported helper | Delete a helper after repository grep finds no internal callers. | Package exports are compatibility surfaces even when the current repository has no caller. | Preserve the export as a thin wrapper unless a breaking change is intentional. |
+| Deduplicate by raw path text | Compare `Path` objects exactly as supplied. | Relative, absolute, and directory-discovered references to the same file can survive as duplicates. | Deduplicate by resolved identity while returning the first original path. |
+
+## Results & Parameters
+
+Target contract:
+
+```yaml
+accepted_suffixes: [.yml, .yaml]
+directory_scan: non-recursive
+unsupported_direct_files: ignored
+missing_paths: warning_to_stderr
+deduplication_key: resolved_path
+result_order: first_seen
+legacy_exports: delegate_to_canonical_collector
+readme_filename_pattern: "\\.ya?ml"
+precommit_filename_pattern: ".*\\.ya?ml"
+```
+
+Boundary-test matrix:
+
+| Case | Expected result |
+|------|-----------------|
+| Directory contains `ci.yml` and `release.yaml` | Both files are returned. |
+| Same workflow passed directly and through its directory | One result is returned. |
+| Direct `README.md` or unrelated YAML-adjacent suffix | Ignored. |
+| README documents both suffixes | Inventory is in sync. |
+| Undocumented `.yaml` workflow | Reported as missing documentation. |
+| `.yaml` workflow changes | Inventory pre-commit hook selector matches. |
+
+Suggested verification commands:
+
+```bash
+<package-manager> pytest <workflow-test-path> -v
+<package-manager> pytest <ci-helper-test-directory> -v
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Reviewed implementation plan for shared workflow discovery and suffix parity | Not implemented; local and CI validation pending. |

--- a/skills/python-metric-validation-api-cli-domain-parity.md
+++ b/skills/python-metric-validation-api-cli-domain-parity.md
@@ -1,0 +1,216 @@
+---
+name: python-metric-validation-api-cli-domain-parity
+description: "Enforce explicit metric domains across Python APIs and argparse CLIs. Use when: (1) helpers accept negative counts or durations, (2) percentages permit NaN, infinity, or impossible ranges, (3) CLI inputs must exit 2 while programmatic callers receive documented ValueErrors."
+category: tooling
+date: 2026-08-06
+version: "1.0.0"
+user-invocable: false
+verification: unverified
+tags: [python, argparse, valueerror, metrics, validation, telemetry, finite, boundary-testing]
+---
+
+# Python Metric Validation API and CLI Domain Parity
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-08-06 |
+| **Objective** | Give metrics explicit domains, reject misleading telemetry programmatically with `ValueError`, and map invalid CLI inputs to standard `argparse` usage errors with exit code 2. |
+| **Outcome** | A reviewed validator and boundary-test pattern; implementation and CI validation are pending. |
+| **Verification** | unverified |
+
+Metric-rendering helpers often begin as permissive formatters. Once they are called directly by
+other Python code and through a CLI, permissiveness becomes ambiguity: negative counts,
+non-finite percentages, or unsupported status strings can render plausible but false telemetry.
+The two entry surfaces need different error presentation while enforcing the same domain.
+
+## When to Use
+
+- Public helpers accept elapsed times, counts, thresholds, percentages, or enumerated statuses.
+- Invalid programmatic values currently produce a fallback such as `0.0` or a misleading table.
+- A Python `bool` must not be accepted merely because `bool` is a subclass of `int`.
+- A CLI should emit standard usage text and `SystemExit(2)` for invalid arguments.
+- Negative deltas are meaningful but impossible upper bounds or non-finite values are not.
+- Values computed elsewhere can bypass validation unless rendering functions validate again.
+
+## Verified Workflow Status
+
+No end-to-end workflow has been verified. The design below comes from a reviewed
+ProjectHephaestus implementation plan and must remain a proposal until the focused tests and CI
+suite pass.
+
+## Proposed Workflow
+
+> **Warning:** This workflow has not been validated end-to-end. Treat it as a hypothesis until CI confirms.
+
+### Quick Reference
+
+```python
+import argparse
+import math
+
+_VALID_STATUSES = ("failed", "passed")
+
+
+def _require_non_negative_int(value: int, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+
+
+def _require_finite_percentage(value: float, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a finite percentage in 0..100")
+    if not math.isfinite(value) or not 0 <= value <= 100:
+        raise ValueError(f"{field_name} must be a finite percentage in 0..100")
+
+
+def _parse_non_negative_int(value: str) -> int:
+    parsed = int(value)
+    _require_non_negative_int(parsed, "value")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--elapsed", type=_parse_non_negative_int, required=True)
+    parser.add_argument("--files", type=_parse_non_negative_int, default=0)
+    parser.add_argument("--status", choices=_VALID_STATUSES, default="passed")
+    parser.add_argument("--threshold", type=_parse_non_negative_int, default=120)
+    return parser
+```
+
+Public functions validate and document their own contracts:
+
+```python
+def check_threshold(elapsed_s: int, threshold_s: int = 120) -> bool:
+    """Return whether elapsed time exceeds the threshold.
+
+    Raises:
+        ValueError: If either duration is not a non-negative integer.
+    """
+    _require_non_negative_int(elapsed_s, "elapsed_s")
+    _require_non_negative_int(threshold_s, "threshold_s")
+    return elapsed_s > threshold_s
+```
+
+### Detailed Steps
+
+1. Write each metric's domain before writing validation:
+   - Positive integer: denominators such as a cold-build duration.
+   - Non-negative integer: elapsed time, counts, warm duration, and thresholds.
+   - Closed percentage: finite value in `0..100`.
+   - Directional delta: finite value with a meaningful negative range and an upper bound such as
+     `<= 100`.
+   - Enumeration: exactly the states the renderer implements.
+2. Use small local validators when domains are module-specific. Reject `bool` explicitly before
+   `int` or `(int, float)` checks.
+3. Validate in every public programmatic function, including renderers that receive derived
+   values. Do not assume another helper computed the argument.
+4. Raise `ValueError` with the field name and domain, and add a Google-style `Raises:` section to
+   public docstrings.
+5. For CLI integer arguments, use an `argparse` type converter that calls the same domain
+   validator. `argparse` converts the resulting conversion failure into usage output and
+   `SystemExit(2)`.
+6. Use `choices=` for closed string domains. Avoid reproducing enumeration checks after parsing.
+7. Preserve semantically valid negative deltas. For a build reduction, a negative value can
+   accurately mean the warm build regressed; reject non-finite values and values above `100`, not
+   all negatives.
+8. Add boundary-first tests before implementation: zero where valid, one or another positive
+   value where required, exact `0` and `100` percentages, negative deltas, just-outside values,
+   `NaN`, infinities, booleans, unsupported statuses, and CLI exit code `2`.
+
+### Domain-Specific Example: Build Reduction
+
+```python
+def compute_reduction(cold_seconds: int, warm_seconds: int) -> float:
+    """Compute percentage reduction in build time.
+
+    Raises:
+        ValueError: If cold_seconds is not positive or warm_seconds is negative.
+    """
+    if isinstance(cold_seconds, bool) or not isinstance(cold_seconds, int) or cold_seconds <= 0:
+        raise ValueError("cold_seconds must be a positive integer")
+    _require_non_negative_int(warm_seconds, "warm_seconds")
+    return round((cold_seconds - warm_seconds) / cold_seconds * 100, 1)
+
+
+def _require_reduction(value: float) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("reduction must be a finite number no greater than 100")
+    if not math.isfinite(value) or value > 100:
+        raise ValueError("reduction must be a finite number no greater than 100")
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Return `0.0` for a zero or negative denominator | Treat invalid cold duration as a harmless reduction fallback. | It hides invalid input and emits plausible telemetry with no indication that the calculation was undefined. | Reject invalid denominators with a documented `ValueError`. |
+| Validate only in CLI parsing | Trust CLI validation to protect helpers. | Direct Python callers and tests can still supply invalid values. | Public helpers own programmatic contracts; CLI parsing adapts those contracts for operators. |
+| Validate only in the computation helper | Assume a renderer always receives values from the trusted calculator. | Renderers are public and can receive externally computed `NaN`, infinity, or impossible percentages. | Validate at every public boundary that promises a metric domain. |
+| Use `isinstance(value, int)` alone | Accept booleans as integer metrics. | In Python, `isinstance(True, int)` is true, but boolean durations and counts are misleading. | Reject `bool` before numeric type checks. |
+| Reject every negative percentage | Apply a generic `0..100` rule to directional reductions. | Negative reduction is valid telemetry for a regression or slower warm build. | Model each metric's semantics; finite and `<= 100` is the correct reduction domain. |
+| Raise ad hoc CLI exceptions | Let `ValueError` escape from the entrypoint or print a custom error and return an arbitrary code. | Operators receive a traceback or nonstandard exit behavior. | Use `type=` and `choices=` so `argparse` owns usage diagnostics and exit code 2. |
+
+## Results & Parameters
+
+Example domain table:
+
+| Metric | Valid domain | Invalid examples |
+|--------|--------------|------------------|
+| Cold duration denominator | Integer `> 0` | `0`, `-1`, `True` |
+| Warm duration, elapsed time, count, threshold | Integer `>= 0` | `-1`, `False`, `1.5` |
+| Acceptance threshold | Finite number in `0..100` | `-0.1`, `100.1`, `NaN`, infinity |
+| Reduction/directional improvement | Finite number `<= 100`; negatives allowed | `100.1`, `NaN`, infinity |
+| Hook status | Exact implemented states | Unknown strings, alternate casing |
+
+Boundary tests:
+
+```python
+import math
+import pytest
+
+
+def test_zero_boundaries_are_valid() -> None:
+    assert check_threshold(0, 0) is False
+    assert compute_reduction(100, 0) == 100.0
+
+
+def test_negative_reduction_is_preserved() -> None:
+    assert compute_reduction(100, 120) == -20.0
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf, 100.1])
+def test_reduction_rejects_invalid_values(value: float) -> None:
+    with pytest.raises(ValueError):
+        _require_reduction(value)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--elapsed", "-1"],
+        ["--elapsed", "1", "--files", "-1"],
+        ["--elapsed", "1", "--threshold", "-1"],
+        ["--elapsed", "1", "--status", "unknown"],
+    ],
+)
+def test_cli_rejects_invalid_inputs_with_usage_error(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(argv)
+    assert exc_info.value.code == 2
+```
+
+Suggested verification commands:
+
+```bash
+<package-manager> pytest <metric-helper-test-path> <cli-test-path> -v
+<package-manager> pytest <ci-helper-test-directory> -v
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Reviewed implementation plan for Docker timing and pre-commit benchmark metric validation | Not implemented; local and CI validation pending. |


### PR DESCRIPTION
## Summary

Adds two distinct skills extracted from a reviewed ProjectHephaestus implementation plan:

- Centralize GitHub Actions workflow discovery while keeping `.yml`/`.yaml` inventory, README parsing, and pre-commit triggers aligned.
- Enforce explicit Python metric domains with documented `ValueError` contracts for programmatic callers and standard `argparse` exit code 2 for invalid CLI inputs.

## Verification Level

**unverified**

The implementation plan was reviewed, but the underlying Hephaestus changes have not been executed or confirmed in CI. Both skills label their workflows as proposed and preserve this limitation explicitly.

## Key Findings

**What Worked**:

- One canonical collector can preserve compatibility through delegating wrappers while preventing suffix drift.
- Local domain validators keep public helper contracts explicit without a new dependency or shared abstraction.
- `argparse` type converters and `choices` map the same invalid domains to conventional CLI usage errors.

**What Failed**:

- Independent `.yml`-only discovery, README parsing, and hook filters create inconsistent workflow inventories.
- Numeric fallbacks and permissive rendering can turn invalid metrics into plausible telemetry.
- Generic percentage rules incorrectly reject meaningful negative directional reductions.

## Test Plan

- [x] Validate the full skill registry with `uv run python scripts/validate_plugins.py`
- [x] Run `uv run python -m pytest tests/test_validate_plugins.py -q`
- [x] Run pre-commit hooks for both new skill files
- [x] Pass the repository pre-push suite (`219 passed`)
- [ ] Confirm both skills appear in Mnemosyne search results after merge
- [ ] Promote verification after the underlying Hephaestus implementation passes CI

Co-Authored-By: Codex <noreply@openai.com>
