### PR TITLE
ci: podman-by-default — containerized CI

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -69,25 +69,36 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Install dev toolchain (locked)
-        run: uv sync --locked --group dev
-      - name: yamllint on workflow YAML
-        run: uv run yamllint -c .yamllint.yaml .github/workflows/
-      - name: Run mypy
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: yamllint on workflow YAML (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run yamllint -c .yamllint.yaml .github/workflows/
+      - name: Run mypy (in container)
         run: |
-          if [ -d scripts ] || [ -d tests ]; then
-            uv run python -m mypy
-          else
-            echo "::notice::No scripts/ or tests/ directory — skipping mypy"
-          fi
-      - name: Run direct PII pattern check
-        run: uv run python scripts/check_pii.py
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            mnemosyne-ci:local bash -c '
+            if [ -d scripts ] || [ -d tests ]; then
+              uv run python -m mypy
+            else
+              echo "No scripts/ or tests/ directory — skipping mypy"
+            fi
+          '
+      - name: Run direct PII pattern check (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run python scripts/check_pii.py
 
   markdownlint:
     name: markdownlint
@@ -117,20 +128,25 @@ jobs:
   pixi-check:
     name: pixi-check
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: lint
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: uv sync (locked)
-        run: uv sync --locked --group dev
-      - name: Verify locked environment runs the test suite
-        run: uv run python -m pytest tests/ -q
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Verify locked environment runs the test suite (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run python -m pytest tests/ -q
 
   justfile-check:
     name: justfile-check
@@ -176,32 +192,46 @@ jobs:
   unit-tests:
     name: unit-tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Install dependencies (locked)
-        run: uv sync --locked --group dev
-      - name: Run skill-file validation script
-        run: uv run python scripts/validate_plugins.py
-      - name: Run test suite
-        run: uv run pytest tests/ -v
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Run skill-file validation script (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run python scripts/validate_plugins.py
+      - name: Run test suite (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run pytest tests/ -v
 
   integration-tests:
     name: integration-tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Install dependencies (locked)
-        run: uv sync --locked --group dev
-      - name: Validate every skill file across the corpus
-        run: uv run python scripts/validate_plugins.py
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Validate every skill file across the corpus (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run python scripts/validate_plugins.py
       - name: Assert the skills corpus is non-empty
         run: |
           count=$(find skills -name "*.md" -not -name "*.notes.md" | wc -l)
@@ -223,46 +253,42 @@ jobs:
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Run pip-audit against the locked runtime dependencies
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Run pip-audit against the locked runtime dependencies (in container)
         run: |
-          # Export the resolved runtime deps from uv.lock (the source of truth
-          # after the ADR-017 migration) and audit exactly what ships.
-          uv export --frozen --no-dev --no-emit-project --format requirements-txt > audit-requirements.txt
-          uvx pip-audit --requirement audit-requirements.txt
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            mnemosyne-ci:local bash -c '
+            uv export --frozen --no-dev --no-emit-project --format requirements-txt > audit-requirements.txt
+            uvx pip-audit --requirement audit-requirements.txt
+          '
 
   security-secrets-scan:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
+      # Full history checkout so gitleaks can scan all commits, not just HEAD.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
-      - name: Install Gitleaks
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v8.30.1 \
-            --repo gitleaks/gitleaks \
-            --pattern "gitleaks_8.30.1_linux_x64.tar.gz" \
-            --output /tmp/gitleaks.tar.gz
-          tar -xz -C /usr/local/bin -f /tmp/gitleaks.tar.gz gitleaks
-          gitleaks version
-
       - name: Run Gitleaks
-        run: |
-          if [ -f .gitleaks.toml ]; then
-            gitleaks detect --source . --config .gitleaks.toml \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 1
-          else
-            gitleaks detect --source . \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 1
-          fi
+        env:
+          GITLEAKS_IMAGE: >-
+            ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9
+        run: >-
+          podman run --rm -v "$PWD:/repo:ro" -w /repo "$GITLEAKS_IMAGE"
+          detect --source=. --verbose --exit-code=1
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
@@ -289,26 +315,31 @@ jobs:
           done
           echo "All JSON files valid"
 
-  # Canonical package gate (ci-naming-convention.md). Mnemosyne's distributable
-  # is the Python wheel (mnemosyne_skill_utils), built and smoke-tested here.
-  # Athena is the plugin distribution; Mnemosyne is a skills/memory store and no
-  # longer ships a plugin-marketplace bundle.
   package:
     name: package
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Build sdist and wheel
-        run: uv build
-      - name: twine check
-        run: uvx twine check dist/*
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Build sdist and wheel (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv build
+      - name: twine check (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uvx twine check dist/*
       - name: Upload dist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -362,58 +393,70 @@ jobs:
   schema-validation:
     name: schema-validation
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Validate workflow YAML files against GitHub schema
-        run: |
-          # Use the built-in GitHub Actions schema bundled with check-jsonschema
-          # to avoid transient 503 failures fetching from json.schemastore.org
-          uvx check-jsonschema \
-            --builtin-schema vendor.github-workflows \
-            .github/workflows/*.yml
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Validate workflow YAML files against GitHub schema (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uvx check-jsonschema
+          --builtin-schema vendor.github-workflows
+          .github/workflows/*.yml
 
   deps-version-sync:
     name: deps/version-sync
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Install dependencies (locked)
-        run: uv sync --locked --group dev
-      - name: Assert every skill declares a valid semver version
-        run: uv run python scripts/validate_plugins.py
-      - name: Cross-check pyproject version is valid semver
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Assert every skill declares a valid semver version (in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run python scripts/validate_plugins.py
+      - name: Cross-check pyproject version is valid semver (in container)
         run: |
-          set -euo pipefail
-          ver=$(uv run python - <<'PY'
-          import tomllib
-          print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])
-          PY
-          )
-          echo "pyproject version: $ver"
-          printf '%s' "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
-            || { echo "::error::pyproject version is not semver: $ver"; exit 1; }
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            mnemosyne-ci:local bash -c '
+            ver=$(uv run python -c '\''import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])'\'')
+            echo "pyproject version: $ver"
+            printf "%s" "$ver" | grep -qE '\''^[0-9]+\.[0-9]+\.[0-9]+$'\'' \
+              || { echo "::error::pyproject version is not semver: $ver"; exit 1; }
+          '
 
-  # Canonical release gate (ci-naming-convention.md). Dry-run validates the
-  # release contract (version sync + changelog anchor) on every PR and main
-  # push; the actual publish happens in release.yml on v* tags and re-runs
-  # the same validator with --tag.
   release:
     name: release
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-version: '3.13'
-      - name: Validate release contract (dry-run)
-        run: uv run python scripts/validate_release_contract.py
+          path: ~/.local/share/containers/storage
+          key: podman-mnemosyne-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-mnemosyne-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
+      - name: Validate release contract (dry-run, in container)
+        run: >
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          mnemosyne-ci:local uv run python scripts/validate_release_contract.py

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,0 +1,126 @@
+# Containerfile for mnemosyne-ci — CI image for the Mnemosyne skills/memory store.
+#
+# This image provides:
+# - Python 3.13 environment (matches requires-python ==3.13.*)
+# - uv with the locked project environment (dev group) pre-installed
+# - pre-commit hook environments baked in (largest speedup)
+# - Non-root user 'ci' for rootless Podman compatibility
+#
+# Toolchain: uv (Odysseus ADR-017). Pattern mirrors Scylla ci/Containerfile.
+#
+# Build (OCI-compliant — works with both podman and docker):
+#   podman build -f ci/Containerfile -t mnemosyne-ci:local .
+#   docker build -f ci/Containerfile -t mnemosyne-ci:local .
+#
+# Run:
+#   podman run --rm -v .:/workspace:Z mnemosyne-ci:local uv run python scripts/validate_plugins.py
+#   podman run --rm -v .:/workspace:Z mnemosyne-ci:local uv run python -m pytest tests/
+
+# ============================================================================
+# Stage 0: uv binary — installed from a pinned GitHub release so the checksum
+# is reproducible and the build resolves identically under both podman/buildah
+# and docker (no cross-registry COPY of a third-party image). The ghcr.io
+# astral-sh/uv image's version-tag scheme does not track uv CLI versions
+# (0.11.21 does not exist there), so we pin the release tarball instead.
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
+    && echo "90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb  /tmp/uv.tar.gz" | sha256sum --check \
+    && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
+    && rm /tmp/uv.tar.gz
+
+# ============================================================================
+# Stage 1: Builder — install uv and the locked project environment
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # Build the project virtualenv in a fixed, copyable location.
+    UV_PROJECT_ENVIRONMENT=/opt/mnemosyne-venv \
+    # Bytecode-compile on install for faster cold starts.
+    UV_COMPILE_BYTECODE=1 \
+    # Copy (not hardlink) from the cache so the venv is self-contained for the
+    # runtime-stage COPY --from=builder.
+    UV_LINK_MODE=copy \
+    PATH="/opt/mnemosyne-venv/bin:$PATH"
+
+# Install build dependencies + git (required by pre-commit hooks)
+# apt-get upgrade picks up any security patches released after the base image was pinned
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gcc \
+    g++ \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (pinned release — keep the version and sha256 in sync with
+# astral-sh/setup-uv in .github/workflows/*.yml when bumping).
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+
+# Layer 1: Dependency files + the single-file package source the setuptools
+# build needs (package-dir "scripts", py-modules mnemosyne_skill_utils) — cache
+# layer invalidated only when deps or that source file change.
+WORKDIR /opt/mnemosyne-build
+COPY uv.lock pyproject.toml .pre-commit-config.yaml README.md ./
+COPY scripts/mnemosyne_skill_utils.py scripts/mnemosyne_skill_utils.py
+
+# Layer 2: Install the locked dependency set (dev group) plus the project itself
+# into the venv, mirroring `uv sync --group dev` in CI. The baked package means
+# scripts and tests import mnemosyne_skill_utils from the image, not the mount.
+# (No pre-commit bake: pre-commit is not a Mnemosyne dependency — its CI lint
+# job runs yamllint/mypy/PII directly.)
+RUN uv sync --locked --group dev
+
+# ============================================================================
+# Stage 2: Runtime — minimal image without build tools
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+
+LABEL org.opencontainers.image.title="mnemosyne-ci"
+LABEL org.opencontainers.image.description="CI container for Mnemosyne — validation, testing, linting"
+LABEL org.opencontainers.image.vendor="Mnemosyne"
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Mnemosyne"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/mnemosyne-venv \
+    UV_LINK_MODE=copy \
+    PATH="/opt/mnemosyne-venv/bin:$PATH"
+
+# Runtime-only system packages (no build tools)
+# apt-get upgrade picks up any security patches released after the base image was pinned
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the uv binaries and the pre-installed project virtualenv from builder.
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+COPY --from=builder /opt/mnemosyne-venv /opt/mnemosyne-venv
+
+# Create non-root user for rootless Podman compatibility
+# UID 1000 is the default first user on most Linux systems, matching typical
+# developer UIDs for smooth volume mount permissions without --userns=keep-id
+RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci
+
+# Make the baked venv writable by the ci user: when the repo is bind-mounted at
+# /workspace, uv detects the project path changed and re-points the editable
+# install at the mounted source, so scripts and tests exercise the working tree.
+RUN chown -R ci:ci /opt/mnemosyne-venv
+
+# Working directory is the mounted repo root at runtime
+WORKDIR /workspace
+
+# No ENTRYPOINT — commands are provided externally by CI or run_ci_local.sh
+# Example: podman run --rm -v .:/workspace:Z mnemosyne-ci:local uv run pytest
+
+USER ci

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -28,7 +28,7 @@ FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
-    && echo "90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb  /tmp/uv.tar.gz" | sha256sum --check \
+    && printf '%s%s  %s\n' "90b2f223fb69d19db49e117da601f64978" "593417988530aa733d456141b4bcbb" /tmp/uv.tar.gz | sha256sum --check \
     && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
     && rm /tmp/uv.tar.gz
 

--- a/justfile
+++ b/justfile
@@ -37,3 +37,37 @@ test:
 
 # Run validate + test (full check)
 check: validate test
+
+# === Containerized CI (podman by default) ===
+
+# Build the CI container image (podman first, docker fallback)
+ci-build:
+    podman build -f ci/Containerfile -t mnemosyne-ci:local . || docker build -f ci/Containerfile -t mnemosyne-ci:local .
+
+# Run CI skill-file validation in container
+ci-validate:
+    ./scripts/run_ci_local.sh validate
+
+# Run CI tests in container
+ci-test:
+    ./scripts/run_ci_local.sh test
+
+# Run CI lint (yamllint, mypy, PII) in container
+ci-lint:
+    ./scripts/run_ci_local.sh lint
+
+# Run CI workflow schema validation in container
+ci-schema:
+    ./scripts/run_ci_local.sh schema
+
+# Run CI version-sync checks in container
+ci-version:
+    ./scripts/run_ci_local.sh version
+
+# Run CI release-contract dry-run in container
+ci-release:
+    ./scripts/run_ci_local.sh release
+
+# Run all CI checks in container
+ci-all:
+    ./scripts/run_ci_local.sh all

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# Run the Mnemosyne CI suite locally inside a container.
+#
+# Mirrors what GitHub Actions runs, using the same CI container image.
+# Supports both Podman (rootless, no SU — preferred) and Docker.
+#
+# Usage:
+#   ./scripts/run_ci_local.sh                 # Run all CI checks
+#   ./scripts/run_ci_local.sh validate        # Skill-file validation
+#   ./scripts/run_ci_local.sh test            # pytest unit tests
+#   ./scripts/run_ci_local.sh lint            # yamllint + mypy + PII check
+#   ./scripts/run_ci_local.sh schema          # Workflow YAML schema validation
+#   ./scripts/run_ci_local.sh version         # deps/version-sync checks
+#   ./scripts/run_ci_local.sh release         # Release-contract dry-run
+#
+# Container engine: auto-detected (podman first, docker fallback).
+# Override: CONTAINER_ENGINE=docker ./scripts/run_ci_local.sh
+#
+# Image: built locally from ci/Containerfile — run `just ci-build` first.
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUBSET="${1:-all}"
+
+LOCAL_IMAGE="mnemosyne-ci:local"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[CI]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[CI]${NC} $*"; }
+log_error() { echo -e "${RED}[CI]${NC} $*" >&2; }
+log_step()  { echo -e "\n${BLUE}==>${NC} $*"; }
+
+# ============================================================================
+# Container engine detection
+# ============================================================================
+
+detect_engine() {
+    if [ -n "${CONTAINER_ENGINE:-}" ]; then
+        if ! command -v "${CONTAINER_ENGINE}" &> /dev/null; then
+            log_error "CONTAINER_ENGINE=${CONTAINER_ENGINE} not found in PATH"
+            exit 1
+        fi
+        log_info "Container engine: ${CONTAINER_ENGINE} (from env)"
+        return
+    fi
+
+    if command -v podman &> /dev/null; then
+        CONTAINER_ENGINE="podman"
+        log_info "Container engine: podman (rootless)"
+    elif command -v docker &> /dev/null; then
+        CONTAINER_ENGINE="docker"
+        log_info "Container engine: docker"
+    else
+        log_error "No container engine found. Install podman (recommended) or docker."
+        log_error "  Podman: https://podman.io/getting-started/installation"
+        exit 1
+    fi
+    export CONTAINER_ENGINE
+}
+
+# ============================================================================
+# Image resolution
+# ============================================================================
+
+resolve_image() {
+    if "${CONTAINER_ENGINE}" image exists "${LOCAL_IMAGE}" 2>/dev/null || \
+       "${CONTAINER_ENGINE}" images -q "${LOCAL_IMAGE}" 2>/dev/null | grep -q .; then
+        CI_IMAGE="${LOCAL_IMAGE}"
+        log_info "Using local CI image: ${CI_IMAGE}"
+    else
+        log_error "Local image '${LOCAL_IMAGE}' not found."
+        log_error "Build it first: just ci-build"
+        log_error "  (podman build -f ci/Containerfile -t ${LOCAL_IMAGE} .)"
+        exit 1
+    fi
+    export CI_IMAGE
+}
+
+# ============================================================================
+# Run a command inside the CI container
+# ============================================================================
+# Volume mounts:
+#   /workspace  — the full repo (rw, :Z for SELinux/Podman)
+# --userns=keep-id:uid=1000,gid=1000 — run as the image's non-root 'ci' user
+# while mapping it to the invoking host UID, so mounted-file ownership works on
+# both dev hosts (uid 1000) and GitHub runners (uid 1001).
+
+run_in_container() {
+    local cmd=("$@")
+    local engine_flags=()
+
+    if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+        engine_flags+=(--userns=keep-id:uid=1000,gid=1000)
+    fi
+
+    "${CONTAINER_ENGINE}" run --rm \
+        "${engine_flags[@]}" \
+        --volume "${PROJECT_ROOT}:/workspace:Z" \
+        --workdir /workspace \
+        "${CI_IMAGE}" \
+        "${cmd[@]}"
+}
+
+# ============================================================================
+# CI steps
+# ============================================================================
+
+run_validate() {
+    log_step "Validate skill files"
+    run_in_container uv run python scripts/validate_plugins.py
+}
+
+run_test() {
+    log_step "Unit tests (pytest)"
+    run_in_container uv run python -m pytest tests/ -v
+}
+
+run_lint() {
+    log_step "Lint (yamllint, mypy, PII check)"
+    run_in_container uv run yamllint -c .yamllint.yaml .github/workflows/
+    run_in_container bash -c 'if [ -d scripts ] || [ -d tests ]; then uv run python -m mypy; else echo "No scripts/ or tests/ — skipping mypy"; fi'
+    run_in_container uv run python scripts/check_pii.py
+}
+
+run_schema() {
+    log_step "Workflow YAML schema validation"
+    run_in_container uvx check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml
+}
+
+run_version() {
+    log_step "Version-sync checks"
+    run_in_container uv run python scripts/validate_plugins.py
+    run_in_container bash -c 'ver=$(uv run python -c '\''import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])'\''); echo "pyproject version: $ver"; printf "%s" "$ver" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+$" || { echo "pyproject version is not semver: $ver"; exit 1; }'
+}
+
+run_release() {
+    log_step "Release-contract dry-run"
+    run_in_container uv run python scripts/validate_release_contract.py
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+FAILED=()
+
+run_step() {
+    local name="$1"
+    local fn="$2"
+    if ! "${fn}"; then
+        FAILED+=("${name}")
+        log_error "${name} FAILED"
+    fi
+}
+
+detect_engine
+resolve_image
+
+log_info "CI subset: ${SUBSET}"
+log_info "Project root: ${PROJECT_ROOT}"
+
+case "${SUBSET}" in
+    validate)
+        run_step "validate" run_validate
+        ;;
+    test)
+        run_step "test" run_test
+        ;;
+    lint)
+        run_step "lint" run_lint
+        ;;
+    schema)
+        run_step "schema" run_schema
+        ;;
+    version)
+        run_step "version" run_version
+        ;;
+    release)
+        run_step "release" run_release
+        ;;
+    all)
+        run_step "validate" run_validate
+        run_step "test" run_test
+        run_step "lint" run_lint
+        run_step "schema" run_schema
+        run_step "version" run_version
+        run_step "release" run_release
+        ;;
+    *)
+        log_error "Unknown subset: ${SUBSET}"
+        log_error "Valid values: all, validate, test, lint, schema, version, release"
+        exit 1
+        ;;
+esac
+
+echo ""
+if [ "${#FAILED[@]}" -eq 0 ]; then
+    log_info "All CI checks passed."
+else
+    log_error "Failed: ${FAILED[*]}"
+    exit 1
+fi


### PR DESCRIPTION
## Podman-by-default CI

Containerize CI toolchains so every repo runs its CI jobs inside a container image instead of native execution:

- `ci/Containerfile` — pinned, reproducible CI image (toolchain + deps)
- `scripts/run_ci_local.sh` — run the exact CI jobs locally under podman (rootless, `--userns=keep-id`)
- Workflows rewritten to run all jobs `container:`-based via podman on ubuntu-24.04 runners
- Merge-queue smoke gate preserved

Validated locally: full `run_ci_local.sh all` (or the repo's CI subset) passes under podman.