### PR TITLE
feat: amend automation-prefix-match-plan-detection skill

### DIFF
--- a/skills/automation-prefix-match-plan-detection.history
+++ b/skills/automation-prefix-match-plan-detection.history
@@ -1,0 +1,313 @@
+# automation-prefix-match-plan-detection — History
+
+## v2.0.0 (2026-08-06)
+
+**Changed by:** ProjectHephaestus exact canonical plan/review marker design.
+**Verification:** unverified.
+
+### What changed
+
+- Replaced display-heading prefix identity with an exact opaque marker at byte zero.
+- Generalized the shared predicate across recognition, mutation, append, admission, and crash reconstruction.
+- Added inert-data rules for leading whitespace, same-line suffixes, and historical headings.
+- Added create-beside-legacy rollout behavior, outgoing-body validation, and fail-closed paired-artifact recovery.
+- Reclassified the v2 workflow as unverified until its Hephaestus implementation and acceptance suites run.
+
+### Why
+
+The v1 substring-to-prefix fix correctly stopped reviews that quoted a plan from counting as plans,
+but its human-readable heading still acted as identity and its recommended `startswith()` check did
+not require an exact first line. The v2 design makes identity opaque, raw-body-sensitive, and shared
+by every read/write/recovery path so trimming or legacy fallbacks cannot make historical audit text
+mutable. This changes the core recommendation and therefore requires a major version bump.
+
+### Previous version (v1.0.0) snapshot
+
+````markdown
+---
+name: automation-prefix-match-plan-detection
+description: "Fix substring-match anti-pattern in plan detection by delegating to canonical helpers or inlining proven prefix-match logic with shared constants. Use when: (1) fixing a substring-match bug in comment detection (like _has_plan), (2) after fixing a prefix-match bug in one automation module, grep sibling modules for the same anti-pattern, (3) implementing plan detection across multiple modules, (4) test regressions show Plan Review comments quoting the plan are miscounted as 'having a plan'."
+category: debugging
+date: 2026-06-05
+version: "1.0.0"
+verification: verified-ci
+tags: [automation, prefix-match, substring-match, anti-pattern, plan-detection, comment-parsing, comment-filters, canonical-helpers, sibling-modules, test-regression]
+---
+
+# Automation: Prefix-Match Plan Detection
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-05 |
+| **Objective** | Fix substring-match anti-pattern in implementer_phase_runner._has_plan that was reintroducing bug class fixed in #455/#468/#484 |
+| **Outcome** | Success — _has_plan delegated to canonical helper; _fetch_plan_and_review uses inlined prefix-match logic; regression test added; 1085 tests pass (verified-ci) |
+| **Verification** | verified-ci |
+| **Context** | Issue #715 — ProjectHephaestus automation module |
+
+## When to Use
+
+**Trigger conditions:**
+
+- A bug fix in one automation module involves comment detection (prefix-match vs substring-match)
+- You've just fixed a substring-match bug in one module and need to audit sibling modules
+- Test regressions show Plan Review comments (which quote the plan) are miscounted as 'having a plan'
+- Comment-filtering logic is duplicated across _planner_state, _plan_reviewer, and _implementer modules
+- You're implementing a new plan-detection variant across multiple modules and need a proven pattern
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# Pattern 1: Delegate to canonical helper (preferred when available)
+from hephaestus.automation.planner_state import _comments_contain_plan
+
+def _has_plan(comments: list[dict]) -> bool:
+    """Check if any comment contains a plan (POLA: single responsibility)."""
+    return _comments_contain_plan(comments)
+
+# Pattern 2: Inline prefix-match logic using shared constant (when return type differs)
+from hephaestus.automation.planner_state import PLAN_COMMENT_MARKER
+
+def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None]:
+    """Fetch plan and review comment from comments.
+
+    Return: (plan_text, review_comment) or (None, None) if no plan found.
+    """
+    for comment in comments:
+        body = comment.get("body", "")
+        # PREFIX-MATCH: only comments starting with marker count
+        if body.startswith(PLAN_COMMENT_MARKER):
+            return (body[len(PLAN_COMMENT_MARKER):].strip(), None)
+    return (None, None)
+```
+
+### Detailed Steps
+
+**Step 1: Identify the bug pattern**
+
+Substring-match anti-pattern (BROKEN):
+```python
+def _has_plan(comments):
+    for comment in comments:
+        if "plan:" in comment.get("body", ""):  # BROKEN: matches "review: plan:" too
+            return True
+    return False
+```
+
+Why it's broken:
+- Plan Review comments have format: `## Review:\n\nThe plan:\n...` (the word "plan" appears after review text)
+- Substring match catches "The plan:" from review comments, not just actual plan comments
+- Original plan comments start with `## Plan\n` (the marker is at the start)
+
+Prefix-match fix (CORRECT):
+```python
+# Correct: check if comment STARTS with the marker
+if comment.get("body", "").startswith(PLAN_COMMENT_MARKER):
+    return True
+```
+
+**Step 2: Search for canonical helper (delegation pattern)**
+
+```bash
+# In the module with the bug:
+grep -rn "def _has_plan\|def _comments_contain_plan" hephaestus/automation/
+
+# Check if planner_state has the proven implementation:
+grep -A 10 "_comments_contain_plan" hephaestus/automation/planner_state.py
+grep "PLAN_COMMENT_MARKER" hephaestus/automation/planner_state.py
+```
+
+Expected output from planner_state:
+```python
+PLAN_COMMENT_MARKER = "## Plan\n"  # shared constant
+
+def _comments_contain_plan(comments: list[dict]) -> bool:
+    """Canonical implementation: prefix-match only."""
+    for comment in comments:
+        if comment.get("body", "").startswith(PLAN_COMMENT_MARKER):
+            return True
+    return False
+```
+
+**Step 3: Apply the fix**
+
+**If return type matches** (both return bool) → **delegate**:
+
+```python
+# Before (implementer_phase_runner.py, BROKEN)
+def _has_plan(comments: list[dict]) -> bool:
+    for comment in comments:
+        if "## Plan" in comment.get("body", ""):
+            return True
+    return False
+
+# After (implementer_phase_runner.py, FIXED)
+from hephaestus.automation.planner_state import _comments_contain_plan
+
+def _has_plan(comments: list[dict]) -> bool:
+    return _comments_contain_plan(comments)  # delegate to canonical
+```
+
+**If return type differs** (e.g., need to extract the plan text) → **inline prefix-match**:
+
+```python
+# Before (implementer_phase_runner.py, BROKEN)
+def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None]:
+    for comment in comments:
+        if "## Plan" in comment.get("body", ""):  # substring match — BROKEN
+            return (comment["body"], None)
+    return (None, None)
+
+# After (implementer_phase_runner.py, FIXED)
+from hephaestus.automation.planner_state import PLAN_COMMENT_MARKER
+
+def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None]:
+    for comment in comments:
+        body = comment.get("body", "")
+        # Prefix-match: only comments STARTING with marker count as plans
+        if body.startswith(PLAN_COMMENT_MARKER):
+            return (body[len(PLAN_COMMENT_MARKER):].strip(), None)
+    return (None, None)
+```
+
+**Step 4: Add regression test**
+
+```python
+# tests/unit/automation/test_implementer.py
+
+def test_has_plan_prefix_match():
+    """Regression: Plan Review comments quoting the plan should NOT count as having a plan.
+
+    Issue #715: substring-match was broken because Review comments contain 'The plan:' text.
+    """
+    # Plan comment (starts with marker)
+    plan_comment = {
+        "body": "## Plan\n\n1. Implement foo\n2. Test bar"
+    }
+    assert _has_plan([plan_comment]) is True
+
+    # Review comment (contains word 'plan' but doesn't start with marker) — MUST be False
+    review_comment = {
+        "body": "## Review:\n\nThe plan is good, implementation is correct."
+    }
+    assert _has_plan([review_comment]) is False
+
+    # Both comments: only plan comment counts
+    assert _has_plan([plan_comment, review_comment]) is True
+```
+
+**Step 5: Grep sibling modules for the same pattern**
+
+```bash
+# After landing the fix in implementer_phase_runner.py, check all sibling modules:
+cd hephaestus/automation
+
+# Search for the broken pattern in all files
+grep -rn "in .*\.get(\"body\"\|if \".*\" in.*body\|startswith.*Plan" *.py | grep -v planner_state | grep -v test
+
+# Expected: no matches (all modules either delegate or use prefix-match)
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| 1 | Patching `IssueImplementer._impl_module` in test to mock `_has_plan` behavior | `IssueImplementer` doesn't have `_impl_module`; the attribute is on `phase_runner` which is a different class | Always check class structure before patching; patch at the correct module level (`patch('implementer_phase_runner.run')` not `patch('IssueImplementer._impl_module')`) |
+| 2 | Using substring match ("## Plan" in body) for plan detection | Plan Review comments contain the string "The plan:" after review text, triggering false positives on substring match | Prefix-match is the only safe pattern for start-of-comment markers; use `startswith(PLAN_COMMENT_MARKER)` not `in` or `find()` |
+| 3 | Inline prefix-match in each module without a shared constant | Maintenance burden: if marker format changes, all inline locations must be updated; test fixtures may mask the invariant | Define the constant in the canonical module (planner_state.py) and import everywhere; prefer delegation when return types match |
+
+## Results & Parameters
+
+### Code Locations
+
+| File | Function | Change |
+|------|----------|--------|
+| `hephaestus/automation/implementer_phase_runner.py` | `_has_plan` | Delegated to `_comments_contain_plan` from planner_state |
+| `hephaestus/automation/implementer_phase_runner.py` | `_fetch_plan_and_review` | Inlined prefix-match using `PLAN_COMMENT_MARKER` constant |
+| `tests/unit/automation/test_implementer.py` | `TestHasPlanPrefixMatch` | Added regression test for Plan Review comment false positive |
+
+### Shared Constants
+
+```python
+# hephaestus/automation/planner_state.py
+PLAN_COMMENT_MARKER = "## Plan\n"  # Anchor for prefix-match
+
+# Usage:
+def _comments_contain_plan(comments: list[dict]) -> bool:
+    for comment in comments:
+        if comment.get("body", "").startswith(PLAN_COMMENT_MARKER):
+            return True
+    return False
+```
+
+### Test Regression Pattern
+
+```python
+# Regression test: Review comments with quoted plan should NOT count as having plan
+review_with_quoted_plan = {
+    "body": "## Review:\n\nThe plan is well-designed. Implementation follows the design."
+}
+assert _has_plan([review_with_quoted_plan]) is False
+
+# Only comments STARTING with marker count
+plan_comment = {"body": "## Plan\n\n1. Do X\n2. Do Y"}
+assert _has_plan([plan_comment]) is True
+```
+
+### Verification Commands
+
+```bash
+# Run affected tests
+pixi run pytest tests/unit/automation/test_implementer.py::TestHasPlanPrefixMatch -v
+
+# Run full automation test suite
+pixi run pytest tests/unit/automation/ -v
+
+# Grep for sibling-module anti-patterns (all should be negative)
+grep -rn "in .*body.*Plan\|if \"Plan\" in" hephaestus/automation/*.py | grep -v planner_state
+```
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | Issue #715 — implementer_phase_runner prefix-match bug fix | [PR #1085](https://github.com/HomericIntelligence/ProjectHephaestus/pull/1085) — 1085 tests pass |
+
+## Key References
+
+- **Related Issues**: #455, #468, #484 (earlier substring-match bugs in other modules)
+- **Similar Pattern**: See `audit-driven-remediation-workflow` skill for post-fix grep workflow
+- **Canonical Helper Location**: `hephaestus/automation/planner_state.py:_comments_contain_plan`
+- **Shared Constant**: `PLAN_COMMENT_MARKER = "## Plan\n"`
+
+## Architecture Notes
+
+**Why delegation is preferred over duplication:**
+
+- `_comments_contain_plan` in planner_state is the authoritative implementation
+- Delegating ensures single source of truth for the prefix-match logic
+- If marker format changes (e.g., to `## Implementation Plan`), only one location needs update
+- Tests automatically pass the regression (Plan Review comment false positive)
+
+**Why inline prefix-match is acceptable for different return types:**
+
+- `_fetch_plan_and_review` returns `(plan_text, review_comment)` tuple, not bool
+- Can't delegate to `_comments_contain_plan` without wrapping
+- Inlining with shared `PLAN_COMMENT_MARKER` constant keeps the logic identical
+- Import the constant to maintain single source of truth
+
+**Anti-pattern to avoid (substring match):**
+
+- ❌ `if "## Plan" in body:` — catches partial matches
+- ❌ `if body.find("Plan") >= 0:` — catches word anywhere in comment
+- ✅ `if body.startswith(PLAN_COMMENT_MARKER):` — prefix-anchored, canonical format only
+````
+
+---
+
+## v1.0.0 (2026-06-05)
+
+**Initial version.**

--- a/skills/automation-prefix-match-plan-detection.md
+++ b/skills/automation-prefix-match-plan-detection.md
@@ -1,280 +1,193 @@
 ---
 name: automation-prefix-match-plan-detection
-description: "Fix substring-match anti-pattern in plan detection by delegating to canonical helpers or inlining proven prefix-match logic with shared constants. Use when: (1) fixing a substring-match bug in comment detection (like _has_plan), (2) after fixing a prefix-match bug in one automation module, grep sibling modules for the same anti-pattern, (3) implementing plan detection across multiple modules, (4) test regressions show Plan Review comments quoting the plan are miscounted as 'having a plan'."
-category: debugging
-date: 2026-06-05
-version: "1.0.0"
-verification: verified-ci
-tags: [automation, prefix-match, substring-match, anti-pattern, plan-detection, comment-parsing, comment-filters, canonical-helpers, sibling-modules, test-regression]
+description: "Recognize mutable automation-owned GitHub comments only by an exact opaque marker at byte zero, with headings and malformed lookalikes left inert. Use when: (1) fixing substring or permissive-prefix comment detection, (2) an owned-comment upsert can fall back to a display heading, (3) caller-side trimming can broaden identity, or (4) a durable plan/review journal must reconstruct safely after crashes."
+category: architecture
+date: 2026-08-06
+version: "2.0.0"
+user-invocable: false
+verification: unverified
+history: automation-prefix-match-plan-detection.history
+tags:
+  - automation
+  - github-comments
+  - plan-detection
+  - canonical-marker
+  - exact-match
+  - actor-ownership
+  - durable-journal
+  - crash-recovery
+  - fail-closed
+  - migration-safety
 ---
 
-# Automation: Prefix-Match Plan Detection
+# Automation Plan Detection: Exact Leading Marker Boundary
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-05 |
-| **Objective** | Fix substring-match anti-pattern in implementer_phase_runner._has_plan that was reintroducing bug class fixed in #455/#468/#484 |
-| **Outcome** | Success — _has_plan delegated to canonical helper; _fetch_plan_and_review uses inlined prefix-match logic; regression test added; 1085 tests pass (verified-ci) |
-| **Verification** | verified-ci |
-| **Context** | Issue #715 — ProjectHephaestus automation module |
+| **Date** | 2026-08-06 |
+| **Objective** | Make an actor-owned mutable comment identifiable only when its raw body begins at byte zero with an exact opaque marker line, while preserving display headings and inert historical comments. |
+| **Outcome** | v1's verified substring-to-prefix correction is retained as history. v2 generalizes the boundary across plan/review recognition, mutation, admission, and recovery, and replaces display-heading identity with an opaque canonical marker. The v2 implementation was not executed in this session. |
+| **Verification** | unverified — the v2 workflow is based on an implementation-ready ProjectHephaestus plan, but its production changes and acceptance suites have not run. |
+| **History** | [changelog](./automation-prefix-match-plan-detection.history) |
 
 ## When to Use
 
-**Trigger conditions:**
+- Automation edits or replaces a GitHub issue comment that acts as the current pointer to a plan, review, report, lease, or other durable record.
+- A substring or broad prefix check can confuse quoted text, a display heading, or a marker extension with a canonical record.
+- Human-readable headings were historically used as identity and must become display-only without rewriting old comments.
+- A shared predicate is called from queries, mutations, cached state, admission checks, and restart reconstruction.
+- Leading whitespace or caller-side `.strip()` / `.lstrip()` could accidentally grant mutation authority to malformed or historical text.
+- Archive-first publication must recover after a crash only when the canonical current artifacts form a valid pair.
 
-- A bug fix in one automation module involves comment detection (prefix-match vs substring-match)
-- You've just fixed a substring-match bug in one module and need to audit sibling modules
-- Test regressions show Plan Review comments (which quote the plan) are miscounted as 'having a plan'
-- Comment-filtering logic is duplicated across _planner_state, _plan_reviewer, and _implementer modules
-- You're implementing a new plan-detection variant across multiple modules and need a proven pattern
+## Proposed Workflow
 
-## Verified Workflow
+> **Warning:** This workflow has not been validated end-to-end. Treat it as a hypothesis until the implementation and focused crash-recovery tests pass, preferably in CI.
 
 ### Quick Reference
 
 ```python
-# Pattern 1: Delegate to canonical helper (preferred when available)
-from hephaestus.automation.planner_state import _comments_contain_plan
+def has_exact_leading_marker(body: str, marker: str) -> bool:
+    """Return whether marker is the exact first raw line of body."""
+    return bool(marker) and (
+        body == marker or body.startswith(f"{marker}\n")
+    )
+```
 
-def _has_plan(comments: list[dict]) -> bool:
-    """Check if any comment contains a plan (POLA: single responsibility)."""
-    return _comments_contain_plan(comments)
+```text
+Recognized:
+  <marker>
+  <marker>\n<display heading>\n<payload>
 
-# Pattern 2: Inline prefix-match logic using shared constant (when return type differs)
-from hephaestus.automation.planner_state import PLAN_COMMENT_MARKER
-
-def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None]:
-    """Fetch plan and review comment from comments.
-
-    Return: (plan_text, review_comment) or (None, None) if no plan found.
-    """
-    for comment in comments:
-        body = comment.get("body", "")
-        # PREFIX-MATCH: only comments starting with marker count
-        if body.startswith(PLAN_COMMENT_MARKER):
-            return (body[len(PLAN_COMMENT_MARKER):].strip(), None)
-    return (None, None)
+Inert:
+  <display heading>\n<payload>
+   <marker>\n<payload>
+  \n<marker>\n<payload>
+  <marker> suffix\n<payload>
 ```
 
 ### Detailed Steps
 
-**Step 1: Identify the bug pattern**
+1. **Define one public raw-body identity primitive.** Accept only `body == marker` or `body.startswith(f"{marker}\n")`; reject an empty marker. The primitive must not trim, normalize, decode, or otherwise transform the raw stored body.
 
-Substring-match anti-pattern (BROKEN):
-```python
-def _has_plan(comments):
-    for comment in comments:
-        if "plan:" in comment.get("body", ""):  # BROKEN: matches "review: plan:" too
-            return True
-    return False
-```
+2. **Separate identity from presentation and ownership.** The opaque marker grants record identity only when it occupies the exact first raw line. A display heading may remain on the second line for people, but it must never select a mutable record. Separately require authenticated-actor ownership before editing or deduplicating a matching comment.
 
-Why it's broken:
-- Plan Review comments have format: `## Review:\n\nThe plan:\n...` (the word "plan" appears after review text)
-- Substring match catches "The plan:" from review comments, not just actual plan comments
-- Original plan comments start with `## Plan\n` (the marker is at the start)
+3. **Route every identity decision through the primitive.** Use the shared helper in comment queries, cached plan/review presence checks, standalone and coordinator upserts, post-create reconciliation, immutable append deduplication, admission, reviewer lookup, and journal reconstruction. Pass raw bodies to these predicates; remove caller-side `.strip()` and `.lstrip()`.
 
-Prefix-match fix (CORRECT):
-```python
-# Correct: check if comment STARTS with the marker
-if comment.get("body", "").startswith(PLAN_COMMENT_MARKER):
-    return True
-```
+4. **Validate outgoing bodies before any write.** An upsert or immutable append should raise before calling GitHub unless its outgoing body satisfies the same exact-leading-marker rule. This keeps read and write identity symmetric and prevents creating records that the next run cannot reconstruct.
 
-**Step 2: Search for canonical helper (delegation pattern)**
+5. **Anchor immutable history records at byte zero too.** Match the whole first marker line and require either newline or end-of-body after it. For example:
 
-```bash
-# In the module with the bug:
-grep -rn "def _has_plan\|def _comments_contain_plan" hephaestus/automation/
+   ```python
+   HISTORY_RE = re.compile(
+       r"^<!-- journal-history:revision=(?P<revision>\d+):"
+       r"kind=(?P<kind>plan|review) -->(?:\n|$)"
+   )
+   ```
 
-# Check if planner_state has the proven implementation:
-grep -A 10 "_comments_contain_plan" hephaestus/automation/planner_state.py
-grep "PLAN_COMMENT_MARKER" hephaestus/automation/planner_state.py
-```
+6. **Remove legacy identity parameters end to end.** Delete `legacy_marker` from production implementations, protocols, stage interfaces, call sites, and test fakes. A heading-only or whitespace-prefixed comment is audit text, not a migration source and not a fallback mutation target.
 
-Expected output from planner_state:
-```python
-PLAN_COMMENT_MARKER = "## Plan\n"  # shared constant
+7. **Preserve visible canonical rendering.** Render current records as `opaque marker -> display heading -> revision metadata -> payload`. Tightening identity should not remove the heading humans use to scan an issue timeline.
 
-def _comments_contain_plan(comments: list[dict]) -> bool:
-    """Canonical implementation: prefix-match only."""
-    for comment in comments:
-        if comment.get("body", "").startswith(PLAN_COMMENT_MARKER):
-            return True
-    return False
-```
+8. **Leave residual legacy data untouched.** When only inert historical comments exist, create a separate canonical pointer beside them. Do not patch, delete, or migrate those records. This preserves audit history and supports rollback when an older implementation already prioritizes a canonical match before any legacy fallback.
 
-**Step 3: Apply the fix**
+9. **Keep recovery archive-first and fail closed.** Reconstruct from unmodified stored bodies. Ignore noncanonical current pointers and refuse to advance an interrupted publication unless the required canonical paired artifact is present. A heading-only or whitespace-prefixed review must never satisfy the paired-review recovery gate.
 
-**If return type matches** (both return bool) → **delegate**:
+10. **Test every boundary across layers.** Cover marker-only validity, marker-plus-newline validity, same-line suffix rejection, heading-only rejection, space/tab/newline prefixes, raw-start history matching, canonical rendering headings, create-beside-inert upserts, no PATCH/DELETE of inert comments, admission rejection, and idempotent crash recovery with a valid canonical pair.
 
-```python
-# Before (implementer_phase_runner.py, BROKEN)
-def _has_plan(comments: list[dict]) -> bool:
-    for comment in comments:
-        if "## Plan" in comment.get("body", ""):
-            return True
-    return False
+## Verified Workflow
 
-# After (implementer_phase_runner.py, FIXED)
-from hephaestus.automation.planner_state import _comments_contain_plan
-
-def _has_plan(comments: list[dict]) -> bool:
-    return _comments_contain_plan(comments)  # delegate to canonical
-```
-
-**If return type differs** (e.g., need to extract the plan text) → **inline prefix-match**:
-
-```python
-# Before (implementer_phase_runner.py, BROKEN)
-def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None]:
-    for comment in comments:
-        if "## Plan" in comment.get("body", ""):  # substring match — BROKEN
-            return (comment["body"], None)
-    return (None, None)
-
-# After (implementer_phase_runner.py, FIXED)
-from hephaestus.automation.planner_state import PLAN_COMMENT_MARKER
-
-def _fetch_plan_and_review(comments: list[dict]) -> tuple[str | None, str | None]:
-    for comment in comments:
-        body = comment.get("body", "")
-        # Prefix-match: only comments STARTING with marker count as plans
-        if body.startswith(PLAN_COMMENT_MARKER):
-            return (body[len(PLAN_COMMENT_MARKER):].strip(), None)
-    return (None, None)
-```
-
-**Step 4: Add regression test**
-
-```python
-# tests/unit/automation/test_implementer.py
-
-def test_has_plan_prefix_match():
-    """Regression: Plan Review comments quoting the plan should NOT count as having a plan.
-
-    Issue #715: substring-match was broken because Review comments contain 'The plan:' text.
-    """
-    # Plan comment (starts with marker)
-    plan_comment = {
-        "body": "## Plan\n\n1. Implement foo\n2. Test bar"
-    }
-    assert _has_plan([plan_comment]) is True
-
-    # Review comment (contains word 'plan' but doesn't start with marker) — MUST be False
-    review_comment = {
-        "body": "## Review:\n\nThe plan is good, implementation is correct."
-    }
-    assert _has_plan([review_comment]) is False
-
-    # Both comments: only plan comment counts
-    assert _has_plan([plan_comment, review_comment]) is True
-```
-
-**Step 5: Grep sibling modules for the same pattern**
-
-```bash
-# After landing the fix in implementer_phase_runner.py, check all sibling modules:
-cd hephaestus/automation
-
-# Search for the broken pattern in all files
-grep -rn "in .*\.get(\"body\"\|if \".*\" in.*body\|startswith.*Plan" *.py | grep -v planner_state | grep -v test
-
-# Expected: no matches (all modules either delegate or use prefix-match)
-```
+> **Warning:** The marketplace validator currently requires this heading. No v2 workflow is verified yet; use the proposed workflow above until implementation tests and CI confirm it. The archived v1 workflow remains verified only for its older substring-to-heading-prefix bug fix.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| 1 | Patching `IssueImplementer._impl_module` in test to mock `_has_plan` behavior | `IssueImplementer` doesn't have `_impl_module`; the attribute is on `phase_runner` which is a different class | Always check class structure before patching; patch at the correct module level (`patch('implementer_phase_runner.run')` not `patch('IssueImplementer._impl_module')`) |
-| 2 | Using substring match ("## Plan" in body) for plan detection | Plan Review comments contain the string "The plan:" after review text, triggering false positives on substring match | Prefix-match is the only safe pattern for start-of-comment markers; use `startswith(PLAN_COMMENT_MARKER)` not `in` or `find()` |
-| 3 | Inline prefix-match in each module without a shared constant | Maintenance burden: if marker format changes, all inline locations must be updated; test fixtures may mask the invariant | Define the constant in the canonical module (planner_state.py) and import everywhere; prefer delegation when return types match |
+| Substring-match plan text | Used `marker in body` or searched for the word "plan" anywhere in a comment. | Reviews that quoted a plan were misclassified as active plans. | Identity must be anchored at the beginning of the record, never inferred from content. |
+| Treat a display-heading prefix as canonical | Used `body.startswith(PLAN_COMMENT_MARKER)` where the marker was a human-readable heading. | Historical heading-only audit text remained mutable and reconstructable. | Use a separate opaque marker for identity and keep the heading on the second line for display only. |
+| Trim before classification | Called `.lstrip()` or `.strip()` before testing a canonical marker. | Leading spaces, tabs, or newlines became invisible, so malformed text acquired canonical identity and mutation authority. | Identity checks must receive the raw stored body and preserve byte-zero significance. |
+| Use unrestricted `startswith(marker)` | Accepted any body beginning with the marker bytes. | Same-line extensions such as `<marker> appendix` collided with the canonical namespace. | Require the marker to be the entire first line: exact body or marker followed by `\n`. |
+| Duplicate first-line parsing in each caller | Queries, mutation helpers, state managers, and reviewers each interpreted markers independently. | Semantics drifted: some callers trimmed, some recognized headings, and some used raw bodies, breaking retry consistency. | Centralize one public predicate and route all identity decisions through it. |
+| Tighten reads but keep legacy mutation parameters | Recognition became strict while upsert protocols still accepted `legacy_marker`. | A supposedly inert comment could still be selected by a write path, so the safety boundary was incomplete. | Remove legacy identity from implementations, protocols, call sites, and fakes together. |
+| Recover from a noncanonical paired artifact | Archive-first recovery treated a heading-only or whitespace-prefixed review as the current paired review. | The state machine could advance from ambiguous durable evidence after a crash. | Recovery must reconstruct raw canonical records and stop when the canonical pair is incomplete. |
 
 ## Results & Parameters
 
-### Code Locations
+### Identity Truth Table
 
-| File | Function | Change |
-|------|----------|--------|
-| `hephaestus/automation/implementer_phase_runner.py` | `_has_plan` | Delegated to `_comments_contain_plan` from planner_state |
-| `hephaestus/automation/implementer_phase_runner.py` | `_fetch_plan_and_review` | Inlined prefix-match using `PLAN_COMMENT_MARKER` constant |
-| `tests/unit/automation/test_implementer.py` | `TestHasPlanPrefixMatch` | Added regression test for Plan Review comment false positive |
+| Raw body | Result | Reason |
+|----------|--------|--------|
+| `marker` | canonical | Marker-only records are valid. |
+| `marker + "\n" + payload` | canonical | Marker is the exact first raw line. |
+| `" " + marker + "\n" + payload` | inert | Marker does not begin at byte zero. |
+| `"\t" + marker + "\n" + payload` | inert | Marker does not begin at byte zero. |
+| `"\n" + marker + "\n" + payload` | inert | Marker does not begin at byte zero. |
+| `marker + " appendix\n" + payload` | inert | Marker has a same-line suffix. |
+| `display_heading + "\n" + payload` | inert | A display heading does not establish identity. |
 
-### Shared Constants
+### Required Mutation Invariants
 
-```python
-# hephaestus/automation/planner_state.py
-PLAN_COMMENT_MARKER = "## Plan\n"  # Anchor for prefix-match
-
-# Usage:
-def _comments_contain_plan(comments: list[dict]) -> bool:
-    for comment in comments:
-        if comment.get("body", "").startswith(PLAN_COMMENT_MARKER):
-            return True
-    return False
+```text
+editable = exact-leading-marker(raw_body, marker) AND owned-by-current-actor
+outgoing-valid = exact-leading-marker(outgoing_body, marker)
+legacy-lookalike = never edit, never delete, never migrate
+no canonical match = create canonical record
+multiple canonical matches = reconcile only canonical actor-owned records
 ```
 
-### Test Regression Pattern
+### Acceptance Matrix
 
-```python
-# Regression test: Review comments with quoted plan should NOT count as having plan
-review_with_quoted_plan = {
-    "body": "## Review:\n\nThe plan is well-designed. Implementation follows the design."
-}
-assert _has_plan([review_with_quoted_plan]) is False
+| Surface | Required evidence |
+|---------|-------------------|
+| Shared journal | Direct helper tests plus raw reconstruction tests for current and history records. |
+| Queries and cache | Heading-only and whitespace-prefixed bodies do not count as an existing current pointer. |
+| Coordinator and standalone upserts | Inert actor-owned records receive no PATCH or DELETE; a canonical record is created and returned. |
+| Immutable append | Deduplication recognizes only an exact first marker line. |
+| Admission and reviewer lookup | Noncanonical plan bodies are ignored even when authored by the automation actor. |
+| Rendering | Canonical marker remains first and the display heading remains second. |
+| Crash recovery | Noncanonical paired artifacts cannot advance recovery; valid canonical crash matrices converge idempotently. |
 
-# Only comments STARTING with marker count
-plan_comment = {"body": "## Plan\n\n1. Do X\n2. Do Y"}
-assert _has_plan([plan_comment]) is True
-```
-
-### Verification Commands
+### ProjectHephaestus Acceptance Commands
 
 ```bash
-# Run affected tests
-pixi run pytest tests/unit/automation/test_implementer.py::TestHasPlanPrefixMatch -v
+uv run pytest \
+  tests/unit/automation/test_review_journal.py \
+  tests/unit/automation/test_pipeline_github.py \
+  tests/unit/automation/test_github_api.py \
+  tests/unit/automation/state/test_planner.py \
+  tests/unit/automation/state/test_review.py \
+  tests/unit/automation/test_plan_reviewer.py -v
 
-# Run full automation test suite
-pixi run pytest tests/unit/automation/ -v
+uv run pytest \
+  tests/unit/automation/pipeline/test_admission.py \
+  tests/unit/automation/pipeline/test_plan_journal.py \
+  tests/unit/automation/pipeline/stages/test_stage_planning.py \
+  tests/unit/automation/pipeline/stages/test_stage_plan_review.py -v
 
-# Grep for sibling-module anti-patterns (all should be negative)
-grep -rn "in .*body.*Plan\|if \"Plan\" in" hephaestus/automation/*.py | grep -v planner_state
+uv run pytest tests/unit/automation -v
+uv run ruff check hephaestus/automation tests/unit/automation
+uv run mypy hephaestus/automation tests/unit/automation
 ```
+
+### Related Skills
+
+- `automation-plan-review-journal-bounded-liveness` — bounded agent context and no-progress termination for the same durable journal domain.
+- `testing-pipeline-crash-matrix-real-stage-durability` — reconstructing pipeline state from durable stage-owned evidence after restart.
+- `github-graphql-pagination-fail-closed-complete-reads` — complete comment inventory before making authoritative GitHub decisions.
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | Issue #715 — implementer_phase_runner prefix-match bug fix | [PR #1085](https://github.com/HomericIntelligence/ProjectHephaestus/pull/1085) — 1085 tests pass |
-
-## Key References
-
-- **Related Issues**: #455, #468, #484 (earlier substring-match bugs in other modules)
-- **Similar Pattern**: See `audit-driven-remediation-workflow` skill for post-fix grep workflow
-- **Canonical Helper Location**: `hephaestus/automation/planner_state.py:_comments_contain_plan`
-- **Shared Constant**: `PLAN_COMMENT_MARKER = "## Plan\n"`
+| ProjectHephaestus | Issue #715 / PR #1085 | v1's narrower substring-to-heading-prefix correction was verified in CI with 1,085 tests. It is retained in history, not presented as evidence for the v2 opaque-marker boundary. |
+| ProjectHephaestus | Exact raw marker identity across plan/review journal queries, mutations, admission, and recovery | Unverified. The plan named the affected production and test surfaces and supplied acceptance commands, but no Hephaestus implementation or test run occurred in this session. |
 
 ## Architecture Notes
 
-**Why delegation is preferred over duplication:**
+- Identity answers which raw record automation is authorized to treat as canonical.
+- Ownership answers whether the current actor may mutate that canonical record.
+- Presentation answers what humans see after the opaque marker.
+- Recovery answers whether durable canonical evidence is complete enough to advance.
 
-- `_comments_contain_plan` in planner_state is the authoritative implementation
-- Delegating ensures single source of truth for the prefix-match logic
-- If marker format changes (e.g., to `## Implementation Plan`), only one location needs update
-- Tests automatically pass the regression (Plan Review comment false positive)
-
-**Why inline prefix-match is acceptable for different return types:**
-
-- `_fetch_plan_and_review` returns `(plan_text, review_comment)` tuple, not bool
-- Can't delegate to `_comments_contain_plan` without wrapping
-- Inlining with shared `PLAN_COMMENT_MARKER` constant keeps the logic identical
-- Import the constant to maintain single source of truth
-
-**Anti-pattern to avoid (substring match):**
-
-- ❌ `if "## Plan" in body:` — catches partial matches
-- ❌ `if body.find("Plan") >= 0:` — catches word anywhere in comment
-- ✅ `if body.startswith(PLAN_COMMENT_MARKER):` — prefix-anchored, canonical format only
+Keeping these concerns separate prevents a convenience normalization or display-heading change from silently widening mutation authority.


### PR DESCRIPTION
## Summary

Amends `automation-prefix-match-plan-detection` from v1.0.0 to v2.0.0.

Documents the exact byte-zero opaque-marker boundary for automation-owned plan and review comments:

- centralize raw-body identity in one exact-first-line predicate;
- keep display headings and malformed or historical lookalikes inert;
- apply the same rule to recognition, mutation, append, admission, and crash recovery;
- create canonical pointers beside residual legacy audit text without migration or deletion.

The previous v1.0.0 skill is archived byte-for-byte in the new history file.

## Verification Level

**unverified**

The Mnemosyne skill file and repository checks pass locally, but the underlying ProjectHephaestus implementation and its acceptance suites have not run. The skill therefore labels the v2 workflow as proposed and does not inherit v1's CI verification.

## Key Findings

**What Worked**:

- Exact `body == marker` or `body.startswith(marker + "\n")` semantics preserve byte-zero and first-line identity.
- Separating opaque identity, actor ownership, and human-readable presentation keeps mutation authority narrow.
- Archive-first recovery remains fail closed when only a noncanonical paired artifact exists.

**What Failed**:

- Caller-side trimming makes whitespace-prefixed records appear canonical.
- Display-heading fallback and unrestricted prefix checks make historical or same-line-suffixed comments mutable.
- Tightening reads without removing legacy mutation parameters leaves an inconsistent safety boundary.

## Test Plan

- [x] `uv run python scripts/validate_plugins.py` — 729/729 valid
- [x] `just check` — 219 tests passed
- [x] Pre-push locked test hook — 219 tests passed
- [x] Confirm the archived v1 snapshot matches the prior skill byte-for-byte
- [ ] Validate the ProjectHephaestus implementation and acceptance suites before upgrading verification

## Checklist

- [x] Skill file follows the required frontmatter format
- [x] Failed attempts are documented
- [x] No machine-specific paths were added
- [x] Existing skill was amended instead of creating a duplicate search surface

Co-Authored-By: Codex <noreply@openai.com>
