### PR TITLE
docs(skills): add no-force DCO remediation

### DIFF
--- a/skills/git-dco-signoff-distinct-from-gpg-sign.md
+++ b/skills/git-dco-signoff-distinct-from-gpg-sign.md
@@ -1,9 +1,9 @@
 ---
 name: git-dco-signoff-distinct-from-gpg-sign
-description: "The DCO Signed-off-by trailer (git commit -s) is a SEPARATE requirement from GPG/SSH cryptographic signing (git commit -S); a commit can be -S signed yet still fail the pr-policy DCO check because it lacks the trailer. Use when: (1) a PR is BLOCKED and the pr-policy / required-checks-gate CI gate fails with 'missing Signed-off-by: Name <email> trailer' even though git log --show-signature shows a valid GPG signature, (2) automation/agent-generated commits (auto-impl branches) lack the DCO trailer because the generator ran `git commit -S` without `-s`, (3) you need to retroactively add Signed-off-by to every commit on a branch WITHOUT losing GPG signatures, (4) lint passes but required-checks-gate still fails — check pr-policy sub-checks (Check 4 is DCO), (5) you fixed only one blocker (mypy/lint) but the gate is still red on a second independent DCO failure, (6) `git log` shows TWO (or more) `Signed-off-by` trailers on the same commit after the retroactive fix-all recipe was run more than once — this is a DUPLICATE trailer, not a missing one, caused by `--exec ... -s -S` being run twice with different `user.name` config values, since `-s` dedups by literal string match on the whole trailer line, not by email, (7) you are about to run `git rebase --exec \"git commit --amend --no-edit -s -S\" origin/main` on a branch that may ALREADY carry a Signed-off-by trailer (e.g. a resumed/interrupted rebase session) — reconcile `git config user.name` first to avoid producing a duplicate trailer."
+description: "The DCO Signed-off-by trailer (git commit -s) is a SEPARATE requirement from GPG/SSH cryptographic signing (git commit -S); a commit can be -S signed yet still fail the pr-policy DCO check because it lacks the trailer. Use when: (1) a PR is BLOCKED and the pr-policy / required-checks-gate CI gate fails with 'missing Signed-off-by: Name <email> trailer' even though git log --show-signature shows a valid GPG signature, (2) automation/agent-generated commits (auto-impl branches) lack the DCO trailer because the generator ran `git commit -S` without `-s`, (3) you need to retroactively add Signed-off-by to every commit on a branch WITHOUT losing GPG signatures, (4) lint passes but required-checks-gate still fails — check pr-policy sub-checks (Check 4 is DCO), (5) you fixed only one blocker (mypy/lint) but the gate is still red on a second independent DCO failure, (6) `git log` shows TWO (or more) `Signed-off-by` trailers on the same commit after the retroactive fix-all recipe was run more than once — this is a DUPLICATE trailer, not a missing one, caused by `--exec ... -s -S` being run twice with different `user.name` config values, since `-s` dedups by literal string match on the whole trailer line, not by email, (7) you are about to run `git rebase --exec \"git commit --amend --no-edit -s -S\" origin/main` on a branch that may ALREADY carry a Signed-off-by trailer (e.g. a resumed/interrupted rebase session) — reconcile `git config user.name` first to avoid producing a duplicate trailer, (8) rewriting or force-pushing a legacy branch is disallowed, so you must reproduce only the intended change as one fresh `git commit -S -s` from current `origin/main`."
 category: ci-cd
-date: 2026-07-12
-version: "1.1.0"
+date: 2026-07-16
+version: "1.2.0"
 user-invocable: false
 verification: verified-ci
 history: git-dco-signoff-distinct-from-gpg-sign.history
@@ -16,10 +16,10 @@ tags: []
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-26 |
-| **Objective** | Land 5 stranded auto-impl refactor PRs whose `required-checks-gate` was red because `pr-policy` Check 4 (DCO Signed-off-by trailer) failed independently of GPG signing |
-| **Outcome** | Successful — added the `Signed-off-by` trailer to every commit (including bot-authored ones) while preserving GPG signatures; pr-policy and required-checks-gate went green |
-| **Verification** | verified-ci — these commits actually merged in ProjectHephaestus on 2026-06-26 via this fix |
+| **Date** | 2026-07-16 |
+| **Objective** | Distinguish the DCO `Signed-off-by` trailer from GPG/SSH signing, including a no-rewrite remedy when legacy commits all lack DCO trailers |
+| **Outcome** | The added remedy recreated the intended change as one fresh signed-and-signed-off commit, avoiding legacy re-signing and force-pushing; its replacement PR passed required checks and merged |
+| **Verification** | verified-ci — both the historical rewrite remedy and the newer no-rewrite replacement workflow passed their repositories' required checks and merged |
 
 ## When to Use
 
@@ -30,6 +30,7 @@ tags: []
 - You fixed only one blocker (mypy/lint) but the gate is still red on a second, independent DCO failure.
 - `git log` shows TWO (or more) `Signed-off-by` trailers on the same commit after running the retroactive fix-all recipe more than once — a DUPLICATE trailer, not a missing one, caused by different `user.name` config between passes.
 - You are about to run the retroactive fix-all recipe on a branch from an interrupted/resumed session and are unsure whether a trailer is already present — reconcile `git config user.name` first to avoid producing a duplicate.
+- A no-rewrite/no-force remedy is required and every legacy commit on the old PR is cryptographically valid but lacks `Signed-off-by`; reproduce only the intended change as one fresh `git commit -S -s` from current `origin/main`.
 
 ## Verified Workflow
 
@@ -57,6 +58,15 @@ git log origin/main..HEAD \
 
 # 4. Find WHICH pr-policy sub-check failed (the gate aggregates):
 gh run view --job <id> --log   # grep for "Check 4: DCO Signed-off-by"
+
+# 5. No-rewrite/no-force remedy: begin at current main and make ONE commit.
+git switch --create <replacement-branch> origin/main
+# Reproduce only the intended change, then stage its paths:
+git add <paths>
+git commit -S -s -m "feat(scope): replacement"
+
+# 6. Require an acceptable signature (G or U) and a non-empty DCO trailer:
+git log -1 --format="%H gpg:%G? signoff:[%(trailers:key=Signed-off-by,valueonly)]"
 ```
 
 ### Detailed Steps
@@ -80,6 +90,25 @@ gh run view --job <id> --log   # grep for "Check 4: DCO Signed-off-by"
    FINE — GitHub verifies server-side, and both `U` and `G` satisfy
    crypto-signing.
 5. **Push.** `git push --force-with-lease` (safer than `--force`).
+
+### No-rewrite/no-force DCO remediation
+
+When rewriting the old branch or force-pushing is disallowed, do **not** try to
+repair every legacy commit. Start a replacement branch from current
+`origin/main`, reproduce only the intended change, and create **one** commit with
+`git commit -S -s`. Verify both independent properties: `%G?` is `G` or `U`
+for the SSH/GPG signature, and the commit body has a non-empty `Signed-off-by`
+trailer.
+
+This was verified in a replacement-PR exercise where every old commit had a
+good cryptographic signature but no DCO trailer. A fresh branch from current
+`origin/main` recreated the intended change in one commit satisfying both
+checks; the replacement passed its required CI checks and merged.
+
+Fresh single-commit remediation avoids re-signing every legacy commit and avoids
+force-pushing. For the generic replacement-PR sequence, see
+[Force-Push Blocked by Sandbox: Fast-Forward via Merge, or Reopen as Fresh Branch](./tooling-force-push-blocked-reopen-as-fresh-branch.md);
+this skill records only the DCO-specific remediation and verification gate.
 
 ### Duplicate trailers from re-signing with different user.name
 
@@ -161,6 +190,7 @@ git log origin/main..HEAD --format='%h %(trailers:key=Signed-off-by)'
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
 | Committed with `git commit -S` only (no -s) | Assumed GPG signing satisfied the policy | pr-policy Check 4 failed: missing Signed-off-by trailer; required-checks-gate then failed downstream | DCO trailer is a separate text requirement from crypto signing — always pass both -s and -S |
+| Treated a cryptographically signed legacy branch as policy-complete | Every old commit had `%G?` = `G`, but none had a `Signed-off-by` trailer | DCO validates the text trailer independently of SSH/GPG signature status, so a good signature alone still fails DCO | Require both `%G?` = `G` or `U` and a non-empty trailer; use one fresh `git commit -S -s` when rewriting is disallowed |
 | Fixed the mypy/lint error and assumed the gate would pass | Treated required-checks-gate as a single-cause failure | Gate still red — a second independent DCO failure remained | A required-checks-gate failure can aggregate multiple independent causes; enumerate ALL failing pr-policy sub-checks before re-pushing |
 | Re-signed only the new commit, left the original auto-impl commit untouched | Thought only my own commit needed the trailer | Check 4 validates EVERY commit on the PR, including bot/automation-authored ones | Use `git rebase --exec ... -s -S origin/main` to cover every commit, not just HEAD |
 | Ran `--exec "git commit --amend --no-edit -s -S" origin/main` twice with different `user.name` between passes | Expected `-s` to dedupe an already-present trailer on the second pass | Produced duplicate `Signed-off-by` trailers instead of deduping — `-s` matches the whole trailer line literally, not just the email | Reconcile `user.name` (local + global) to one canonical value before the first pass; recover via a message-rewrite `--exec` pass keeping only the first trailer |
@@ -196,6 +226,16 @@ git log origin/main..HEAD --format='%h %(trailers:key=Signed-off-by)'
 - **Interpreting `%G?`**: `G` = good signature, `U` = signed but
   locally-untrusted key (FINE — GitHub verifies server-side). Both satisfy
   crypto-signing; neither implies the DCO trailer is present.
+- **No-rewrite/no-force remedy**: start from current `origin/main`, reproduce
+  the intended change in exactly one `git commit -S -s`, then require both
+  `%G?` = `G` or `U` and a non-empty `Signed-off-by` before creating a
+  replacement PR. This avoids re-signing legacy commits and avoids
+  force-pushing.
+- **Verification boundary**: the replacement branch passed all required CI
+  checks and merged, so the no-rewrite remedy is verified-ci.
+- **Generic PR sequencing**: use
+  [tooling-force-push-blocked-reopen-as-fresh-branch](./tooling-force-push-blocked-reopen-as-fresh-branch.md)
+  instead of duplicating the general replacement-PR workflow here.
 - **Duplicate-trailer dedup mechanism**: `-s`/`--signoff` dedups by a LITERAL
   STRING match on the whole `Signed-off-by: Name <email>` line, not by email
   alone. Running the retroactive fix-all recipe twice with different
@@ -228,4 +268,5 @@ git log origin/main..HEAD --format='%h %(trailers:key=Signed-off-by)'
 
   | PR | Repo | Context |
   |----|------|---------|
+  | Merged replacement PR | Generic Git repository | Fresh replacement commit from current main had `%G?` = `G` and a non-empty `Signed-off-by`; all required checks passed and the PR merged |
   | [#2056](https://github.com/HomericIntelligence/ProjectHephaestus/pull/2056) | `HomericIntelligence/ProjectHephaestus` | `[Critical] Fail closed autonomous auto-merge paths`, branch `2054-auto-impl`, 17 commits; encountered during a large rebase (~38 commits forward onto `origin/main`) that required two separate `--exec ... -s -S` re-signing passes because of an interrupted/resumed session with different `user.name` config between passes. Verified LOCALLY — the recovery script was run and observed (via `git log --format='%(trailers:key=Signed-off-by)'`) to produce exactly one clean trailer per commit. Not yet verified against this Mnemosyne skill PR's own CI at authoring time. |


### PR DESCRIPTION
## Summary

- amend the canonical DCO skill with a no-rewrite/no-force replacement-branch workflow
- require both an acceptable cryptographic signature (`G` or `U`) and a non-empty `Signed-off-by` trailer
- record the replacement workflow as verified-ci after its required checks passed and it merged

## Root cause

An intentional but unpublished skill amendment was left in a shared default-branch checkout. That dirty worktree correctly caused `gh tidy` to fail closed. This PR preserves the durable learning in an isolated branch and generalizes the evidence before publication.

## Validation

- `just check`: 737/737 skills valid; 219 tests passed
- `just package`: wheel and sdist built successfully
- `git verify-commit HEAD`: good ED25519 signature
- commit contains one `Signed-off-by` trailer

