### PR TITLE
feat: amend reusable workflow identity skills

### DIFF
--- a/skills/gha-workflow-authoring-pitfalls.history
+++ b/skills/gha-workflow-authoring-pitfalls.history
@@ -5,6 +5,493 @@
 This file preserves the full verbatim content of the skills consolidated into
 `gha-workflow-authoring-pitfalls`, kept for provenance and reference.
 
+## v1.4.0 (2026-08-07)
+
+**Changed by:** ProjectHephaestus dual-trigger `auto-label-needs-plan.yml` learning
+**Verification:** verified-local (contract and shell boundary exercised locally; hosted CI pending)
+
+### What changed
+
+- Added pitfall #9 for workflows supporting both a native entity event and `workflow_call`.
+- Replaced the per-issue `github.run_id` fallback with a required typed caller input and the
+  shared `${{ github.event.issue.number || inputs.issue_number }}` expression.
+- Documented why `run_id` prevents an empty global bucket but destroys per-issue grouping.
+- Required both triggers to enter one ungated job and use the same resolved identity in
+  `concurrency.group` and the step environment.
+- Added positive-decimal shell validation before `gh api`, plus documentation and regression
+  contracts using `yaml.BaseLoader`, a parsed caller example, and a fake `gh` executable.
+- Added five failed-attempt lessons and bumped version 1.3.0 → 1.4.0.
+
+### Why
+
+The prior advice treated `github.run_id` as a universal fallback when `workflow_call` lacks the
+native `issues` payload. That only makes each call unique: it cannot serialize two runs for the
+same issue, cannot identify the API target, and masks an event-only job guard that skips the
+reusable path. A required numeric input preserves the stable issue identity across both triggers;
+the runtime guard then narrows the numeric type to the positive-integer domain required by the
+GitHub issue endpoint.
+
+### Previous version (v1.3.0) snapshot
+
+````markdown
+---
+name: gha-workflow-authoring-pitfalls
+description: "Use when: (1) a workflow file is silently ignored or produces 0 jobs due to invalid YAML job IDs (forward slashes), (2) a composite-action input description contains ${{ }} expressions that get evaluated unexpectedly, (3) a security hook blocks editing a workflow run: block because of a ${{ }} injection sink — and you need the env-var-lift pattern, (4) documenting platform asymmetries (Linux-only, macOS-skipped) in workflow header comments, (5) a WorkflowDispatch or PreToolUse hook fires on an edit to .github/workflows/*.yml, (6) a workflow step fails with 'GitHub Actions is not permitted to create or approve pull requests' and you need to diagnose repo-vs-org policy and choose org-toggle vs PAT/App-token vs direct-commit, (7) adding labeled/unlabeled/auto_merge_* event types to a pull_request trigger re-runs ALL jobs (the trigger is workflow-wide) when you wanted only specific policy jobs to run on label events — and you need the changes-gate needs/if pattern, (8) an event-driven workflow (issues, schedule, workflow_dispatch, push:tags) lacks a concurrency: block — and you need to choose the right group key and cancel-in-progress semantics based on side-effect profile (idempotent label/scan = true; non-idempotent tag-push/publish = false)."
+category: ci-cd
+date: 2026-06-23
+version: "1.3.0"
+verification: verified-ci
+user-invocable: false
+history: gha-workflow-authoring-pitfalls.history
+tags:
+  - github-actions
+  - workflow-authoring
+  - yaml
+  - job-id
+  - parse-failure
+  - composite-action
+  - template-expression
+  - workflow-injection
+  - security-hook
+  - env-var-lift
+  - platform-scope
+  - documentation
+  - pretooluse
+  - edit-tool
+  - create-pull-request
+  - org-policy
+  - github-token-permissions
+  - pull-request-trigger
+  - event-types
+  - label-event
+  - job-gating
+  - changes-gate
+  - branch-protection
+  - concurrency
+  - cancel-in-progress
+  - event-driven
+  - idempotent
+  - publisher
+---
+
+# GitHub Actions: Workflow-Authoring Pitfalls
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-23 |
+| **Objective** | Consolidate the recurring GitHub Actions workflow-authoring traps: invalid job IDs, expression evaluation in composite-action descriptions, the env-var-lift fix for injection hooks, platform-scope header documentation, editing path-blocked workflow files, the org create-PR policy block, the workflow-wide `pull_request` trigger re-running all jobs on label/auto-merge events, and choosing the right `concurrency:` group key and `cancel-in-progress` semantics for event-driven workflows |
+| **Outcome** | One reference covering the distinct gotchas, each with a copy-paste fix and the failed approaches that do NOT work |
+| **Verification** | verified-ci |
+
+## When to Use
+
+- A workflow looks syntactically valid (passes local YAML linters) but shows **0 jobs** in the Actions UI; PRs stuck at `mergeStateStatus=BLOCKED` with required check contexts **absent** (never ran). → slash-in-job-id.
+- A composite action you authored fails to load with `Unrecognized named-value: 'runner'` (or `'github'`, `'env'`) pointing into an `inputs.<name>.description` block. → expression-in-description.
+- A `PreToolUse:Edit` hook (or `actionlint` / `zizmor` / CodeQL workflow-injection query) rejects a `run:` block change because the block contains a `${{ … }}` expression — even a trusted `steps.*.outputs.*`. → env-var-lift.
+- A CI workflow intentionally targets only some platforms (e.g. Linux-only matrix) and you need to document why without making misleading "cross-platform" claims. → platform-scope header.
+- A `PreToolUse:Edit` hook blocks the `Edit` tool on `.github/workflows/*.yml` **by path alone** (no `${{` involved). → edit-tool-blocked workaround.
+- Adding `labeled`/`unlabeled`/`auto_merge_enabled`/`auto_merge_disabled` to a `pull_request` trigger (so a policy job converges on label/auto-merge state) re-runs **ALL** jobs because the trigger is workflow-wide — you wanted only specific jobs to run on label events. → changes-gate `needs:`/`if:` pattern.
+- An event-driven workflow (`issues:`, `push: tags:`, `schedule:`, `workflow_dispatch:`) currently lacks a `concurrency:` block and overlapping triggers are stacking redundant in-flight runs — you need to choose the right group key and `cancel-in-progress` value based on the workflow's side-effect profile. → concurrency controls.
+
+## Verified Workflow
+
+### Quick Reference
+
+| Pitfall | Symptom | Fix |
+| --------- | --------- | --------- |
+| Slash in job ID | 0 jobs in Actions UI; required checks "never run"; whole file silently rejected | Rename YAML job-ID keys to hyphens; keep slashes only in `name:` |
+| `${{ }}` in composite-action description | `Unrecognized named-value: 'runner'` / `TemplateValidationException` at action-load; every consuming job fails at the `uses:` step | Remove `${{ }}` from the docstring; use plain `<runner.os>` pseudo-syntax |
+| `${{ }}` in `run:` blocks hook | `PreToolUse:Edit` / actionlint / zizmor rejects the diff | Lift expr into a step-scoped `env:` block; reference as quoted `"$VAR"` |
+| Undocumented platform scope | Audit flags "misleading cross-platform claims" | 14-line header comment block before `name:` with Scope/CAPABILITY/EXPAND TRIGGER |
+| Edit tool path-blocked on workflows | `PreToolUse:Edit` hook error on `.github/workflows/*.yml` by path | Use `python3 -c` surgical replace via Bash, or full rewrite via `Write` |
+| Actions blocked from creating PRs | `GitHub Actions is not permitted to create or approve pull requests` at the create-PR step | Org admin enables "Allow Actions to create and approve PRs"; or pass a fine-grained PAT/App token to checkout + create-PR step; or commit direct to main |
+| Label/auto-merge event re-runs ALL jobs | Added `labeled`/`unlabeled`/`auto_merge_*` to `pull_request` `types:` so a policy job converges, but every label toggle re-runs the full matrix | Add a `changes-gate` job that emits `code_event=false` for those actions; gate heavy jobs on `needs: changes-gate` + `if: …code_event == 'true'`; leave policy jobs ungated |
+| Missing concurrency block | Overlapping runs race or stack; publishers can double-publish or push duplicate tags | Add top-level `concurrency:` block with group key scoped to the event (issue number, ref, workflow) and cancel-in-progress matching side-effect profile |
+
+```bash
+# Detection one-liners
+grep -n "^  [a-zA-Z].*\/.*:" .github/workflows/*.yml            # slash job IDs
+yq '.inputs[]? | .description'  .github/actions/*/action.yml 2>/dev/null | grep -nE '\$\{\{'  # expr in descriptions
+yq '.outputs[]? | .description' .github/actions/*/action.yml 2>/dev/null | grep -nE '\$\{\{'
+```
+
+### Detailed Steps
+
+#### 1. Forward slash in a job ID → silent whole-file parse failure
+
+GitHub Actions enforces job IDs (the YAML mapping key under `jobs:`) to match `[a-zA-Z_][a-zA-Z0-9_-]*`. A forward slash in **any** job ID makes GitHub **silently reject the entire workflow file** — no UI error, no runs, no check contexts. Local YAML parsers (`yamllint`, `yaml.safe_load`) accept the file because slashes are valid YAML keys; GitHub imposes a stricter character set. The `name:` field has **no** restrictions and is what GitHub reports as the check-context name, so move the slashes there.
+
+```yaml
+# BROKEN — job IDs with slashes; 0 jobs run:
+jobs:
+  security/dependency-scan:        # ← invalid job ID
+    name: security/dependency-scan
+    runs-on: ubuntu-latest
+
+# FIXED — hyphens in IDs, slashes preserved in name::
+jobs:
+  security-dependency-scan:        # ← valid job ID
+    name: security/dependency-scan # ← display name + check context (slashes OK)
+    runs-on: ubuntu-latest
+```
+
+Steps: (a) detect with the grep above; (b) replace slashes in YAML keys with hyphens; (c) keep the slash form in `name:` if branch rulesets reference it; (d) update any `needs:` references to the new hyphenated IDs; (e) push and confirm the expected job count appears.
+
+```yaml
+# Update needs: references after renaming
+needs: [security-dependency-scan, security-secrets-scan]  # was security/dependency-scan, ...
+```
+
+Org-wide audit (a repo emitting 0 of N required contexts while peers emit all N is the tell):
+
+```bash
+REQUIRED=(lint unit-tests integration-tests "security/dependency-scan" "security/secrets-scan" build schema-validation "deps/version-sync")
+for r in $(gh repo list <ORG> --json name,isArchived --limit 100 \
+    --jq '.[] | select(.isArchived==false) | .name'); do
+  SHA=$(gh api "repos/<ORG>/$r/commits/main" --jq .sha 2>/dev/null)
+  emitted=$(gh api "repos/<ORG>/$r/commits/$SHA/check-runs" \
+    --paginate --jq '[.check_runs[].name] | unique | join(",")' 2>/dev/null)
+  for c in "${REQUIRED[@]}"; do
+    [[ ",$emitted," == *",$c,"* ]] || echo "MISS $r $c"
+  done
+done
+```
+
+#### 2. `${{ … }}` in a composite-action input description gets evaluated
+
+GitHub Actions parses every `description` field in a composite action's `action.yml` through the same template parser as `run:`/`if:`. There is no "documentation mode": it sees `${{ … }}` and resolves it at action-load time, when the only valid context is `inputs.<name>` (`runner`, `github`, `env`, `steps`, `secrets`, `matrix` are all undefined). So `${{ runner.os }}` in a docstring fails the whole action to load, and **every consuming job fails at the `uses:` step**, not where `runner.os` is actually needed.
+
+```yaml
+# BAD — fails to load: "Unrecognized named-value: 'runner'"
+inputs:
+  cache-key-prefix:
+    description: >-
+      The full key becomes `<prefix>-${{ runner.os }}-${{ hashFiles('pixi.lock') }}`.
+
+# GOOD — plain angle-bracket pseudo-syntax
+inputs:
+  cache-key-prefix:
+    description: >-
+      The full key is composed as <prefix>-<runner.os>-<hashFiles(pixi.lock)>.
+```
+
+Backticks, single-quote YAML escapes, and `>-`/`|-` block scalars do **NOT** escape it — the parser scans the raw string for `${{` regardless. The only reliable fix is to not use `${{ … }}` syntax in descriptions at all. Same parser applies to `outputs.<name>.description`. Interpolation in `runs.steps[].name` and `runs.steps[].run` is intended and works fine. Verbatim error to grep for:
+
+```
+(Line: 35, Col: 18): Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.os
+GitHub.DistributedTask.ObjectTemplating.TemplateValidationException: The template is not valid.
+Failed to load /…/.github/actions/setup-pixi-env/action.yml
+```
+
+#### 3. Env-var lift for the workflow-injection hook on `run:` blocks
+
+A `PreToolUse` `security_reminder_hook` (and actionlint / zizmor / CodeQL) rejects a `run:` block that contains any `${{ … }}` expression. The hook scans the whole new file region, not just changed bytes, so a pre-existing trusted `steps.*.outputs.*` or `inputs.*` trips it even when your edit is unrelated. **Do not bypass it** — interpolating `${{ … }}` directly into a shell command is a real injection sink (the value is spliced before the shell parses quotes, so YAML/backtick quoting does not help). The fix that is correct regardless of source trust: lift the expression into a step-scoped `env:` block and reference it as a double-quoted shell variable.
+
+```yaml
+# BEFORE — vulnerable and hook-blocked:
+- name: Run README command validation
+  run: |
+    python3 scripts/validate_readme_commands.py \
+      --level ${{ steps.validation-level.outputs.level }} \
+      --output validation-report.md README.md
+
+# AFTER — env-var lift, hook-accepted, injection-safe:
+- name: Run README command validation
+  env:
+    VALIDATION_LEVEL: ${{ steps.validation-level.outputs.level }}
+  run: |
+    pixi run python3 scripts/validate_readme_commands.py \
+      --level "$VALIDATION_LEVEL" \
+      --output validation-report.md README.md
+```
+
+Recipe: (a) for each `${{ … }}` in the block, add an `UPPER_SNAKE_CASE` entry to a step `env:` with the expression verbatim; (b) replace each inline `${{ … }}` with `"$NAME"` — always double-quoted, even for numeric-looking values; (c) re-attempt the edit. Multi-expression example:
+
+```yaml
+- name: Comment on issue
+  env:
+    ISSUE_NUMBER: ${{ github.event.issue.number }}
+    ISSUE_TITLE: ${{ github.event.issue.title }}
+  run: |
+    gh issue comment "$ISSUE_NUMBER" --body "Triaged: $ISSUE_TITLE"
+```
+
+Especially-dangerous attacker-controllable sources the hook targets: `github.event.issue.title/.body`, `github.event.pull_request.title/.body`, `github.event.comment.body`, `github.event.review.body`, `github.event.head_commit.message`, `github.event.commits.*.message/.author.*`, `github.event.pull_request.head.ref/.label`, `github.head_ref`. Caveats: never prefix env names with `GITHUB_` (reserved); `env:` is per-step; heredocs (`cat <<EOF`) still splice `${{ … }}` so lift to `env:` there too.
+
+#### 4. Document platform scope in a workflow header comment
+
+When a workflow intentionally targets only some platforms, add a header comment block **before** the `name:` field (highest visibility — scope is a workflow-wide property, not job/matrix-specific). Include both the limitation AND the capability that still works, use `#NNN` issue links instead of doc paths (links survive refactors), and give an explicit EXPAND TRIGGER.
+
+```yaml
+# Platform Scope: Linux Only (CI)
+#
+# This workflow exercises tests only on Linux (ubuntu-latest) due to pixi environment
+# constraints that target linux-64 exclusively. macOS and Windows support is out of scope
+# for this test matrix and tracked separately per #539.
+#
+# CAPABILITY: Despite this CI limitation, the package remains pure-Python importable
+# on all platforms and wheels are generated in GitHub Actions with platform-specific tags.
+# Unit tests are platform-agnostic and designed to pass on any POSIX-compatible environment.
+#
+# EXPAND TRIGGER: When #539 lands with cross-platform pixi environment support, expand
+# matrix.os to include [ubuntu-latest, macos-latest, windows-latest] and verify all
+# tests pass on each platform before merging.
+#
+# See also: CONTRIBUTING.md (platform asymmetry rationale)
+---
+name: Test
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest  # Linux-only per scope above
+```
+
+#### 5. Edit tool path-blocked on `.github/workflows/*.yml`
+
+`security_reminder_hook.py` can block the `Edit` tool on any `.github/workflows/*.yml` by **path** (not content) — there is no way to satisfy it with `Edit`. This is distinct from pitfall #3 (which is `${{ }}`-content driven); if the block is path-only with no `${{` involved, use one of these workarounds:
+
+```bash
+# Workaround A — surgical replace via python3 -c (best for a few lines)
+python3 -c "
+import pathlib
+p = pathlib.Path('.github/workflows/ci.yml')
+text = p.read_text()
+text = text.replace('old-a', 'new-a')
+text = text.replace('old-b', 'new-b')
+p.write_text(text)
+"
+```
+
+Workaround B (larger restructuring): `Read` the file, build the full updated content, write it back with the `Write` tool. The `Write` tool may **also** be blocked if content trips the scanner (e.g. an identifier like `validate_eval`); fall back to Workaround A and rename the offending identifier in the replacement. **Never use `--no-verify`** to bypass pre-commit hooks.
+
+#### 6. GitHub Actions blocked from creating PRs by org policy
+
+A workflow step using `peter-evans/create-pull-request` (or `gh pr create`) fails with:
+
+```
+##[error]GitHub Actions is not permitted to create or approve pull requests.
+```
+
+The workflow's own `permissions:` block being correct (`contents: write`, `pull-requests: write`) is **NOT** enough — there is a **separate repo/org toggle** that gates PR creation by Actions. The permissions block governs token scope, not whether Actions is *allowed* to open PRs at all.
+
+**Diagnose which layer is the blocker:**
+
+```bash
+# Repo level — inspect default workflow permissions + PR-approval toggle
+gh api repos/OWNER/REPO/actions/permissions/workflow
+#   → look at default_workflow_permissions and can_approve_pull_request_reviews
+
+# Try to raise repo level; a 409 means the ORG is the blocker (repo can't exceed org)
+gh api --method PUT repos/OWNER/REPO/actions/permissions/workflow \
+  -f default_workflow_permissions=write
+#   → HTTP 409 Conflict: "Write permissions for workflows are disabled by the organization"
+
+# Org level (needs admin:org scope; 403 otherwise)
+gh api orgs/ORG/actions/permissions/workflow
+```
+
+**Two distinct org settings — easy to confuse:**
+
+1. **"Allow GitHub Actions to create and approve pull requests"** — the PR-creation toggle. This is the one you usually need.
+2. **"Default workflow permissions: read vs write"** (`default_workflow_permissions`) — separate. A workflow's own `permissions:` block **overrides** this default, so you often do **NOT** need to flip it.
+
+The 409 "Write permissions disabled by org" complains about **#2**, which is a **red herring** if your workflow already declares its own `permissions:` block. The actual blocker for `create-pull-request` is **#1**.
+
+**Fixes (ascending blast radius):**
+
+1. **Org admin enables setting #1** (UI: org Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"; or API):
+
+   ```bash
+   gh api --method PUT orgs/ORG/actions/permissions/workflow \
+     -F can_approve_pull_request_reviews=true
+   ```
+
+   Caveat: org-wide, and the SAME toggle also lets Actions **approve** PRs (self-approval / required-review bypass risk) across every repo.
+
+2. **Scoped alternative (no org change):** pass a fine-grained PAT or GitHub App installation token (Contents + PullRequests: write) to **BOTH** the `actions/checkout` `token:` and the create-PR step's `token:`, instead of `${{ secrets.GITHUB_TOKEN }}`. Limits PR-creation to that one workflow.
+
+   ```yaml
+   - uses: actions/checkout@v4
+     with:
+       token: ${{ secrets.PR_BOT_TOKEN }}
+   - uses: peter-evans/create-pull-request@v6
+     with:
+       token: ${{ secrets.PR_BOT_TOKEN }}
+   ```
+
+3. **Drop the PR step and commit directly to main** (needs only `contents: write`, which orgs usually allow) — loses the review-PR gate.
+
+**How to VALIDATE the fix definitively:** a green workflow run is **NOT** proof. If the generated artifact is unchanged, the create-PR step is skipped by its `if:` and the run shows success without creating anything. Force a real change so the step fires, then confirm a PR was actually created:
+
+```bash
+# Deliberately desync the artifact on a branch, dispatch, then check a PR exists
+gh workflow run update-marketplace.yml --ref <branch>
+gh pr list --head <branch> --json author   # author.login == "app/github-actions" → real PR created
+```
+
+This session proved it by deliberately desyncing `marketplace.json` on a branch, dispatching, and confirming the workflow opened a real PR. Also note: the scheduled/auto regeneration job **silently goes stale** when this block is in effect — every push-triggered run fails at the PR step, but the failure is easy to miss.
+
+#### 7. A `pull_request` trigger is workflow-wide — adding label/auto-merge event types to converge ONE job re-runs EVERY job
+
+A GitHub Actions `on: pull_request: types:` list applies to the **whole workflow**, not to individual jobs. So when you add label-related event types only to make ONE job re-converge, **every** job re-runs on those events.
+
+Concrete case (`.github/workflows/_required.yml` in ProjectHephaestus): the trigger was
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review,
+            labeled, unlabeled, auto_merge_enabled, auto_merge_disabled]
+```
+
+The `labeled`/`unlabeled`/`auto_merge_*` types were added **only** so two lightweight policy jobs (`pr-policy`, `auto-merge-policy`) re-converge on the PR's true label / auto-merge state. But because the trigger is workflow-wide, every label change re-ran **all 18 jobs** — the full unit+integration test matrix (py3.10-3.13), security scans, build, lint. An automation loop that constantly toggles `state:*` labels made this very expensive.
+
+**Fix** — add a tiny `changes-gate` job that decides whether the event is a "code event", and gate the heavy jobs on it:
+
+```yaml
+  changes-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      code_event: ${{ steps.decide.outputs.code_event }}
+    steps:
+      - id: decide
+        env:
+          ACTION: ${{ github.event.action }}   # passed via env:, NEVER interpolated into run: (injection-safe)
+        run: |
+          set -euo pipefail
+          case "$ACTION" in
+            labeled | unlabeled | auto_merge_enabled | auto_merge_disabled)
+              echo "code_event=false" >> "$GITHUB_OUTPUT" ;;   # push has empty action → default → true
+            *) echo "code_event=true" >> "$GITHUB_OUTPUT" ;;
+          esac
+```
+
+Each heavy job then gets `needs: changes-gate` + `if: needs.changes-gate.outputs.code_event == 'true'`. Jobs that already had `needs: lint` become `needs: [lint, changes-gate]`. The policy jobs (`pr-policy`, `auto-merge-policy`) are left **UNGATED** so they still run on label / auto-merge events.
+
+**Why this is safe (the correctness facts that make it work):**
+
+- A required job that is **SKIPPED via `if:`** still reports a neutral/success status, and GitHub **keeps the SHA's prior real result**, so branch-protection required checks (the `homeric-main-baseline` ruleset: `lint`, `unit-tests`, `integration-tests`, `security/*`, `build`, `schema-validation`, `deps/version-sync`, `pr-policy`) **stay satisfied**. Verified live: the PR stayed CLEAN/MERGEABLE after the heavy jobs skipped on the label event.
+- `github.event.action` is **empty on `push` events** → the `case` default returns `code_event=true` → push to main still runs everything.
+- Pass `github.event.action` via `env:`, **never interpolate it into the `run:` script** (workflow-injection safety — pitfall #3; a security hook flags this).
+
+**Self-test method** (how this was verified-ci): after the PR's initial CI runs once on the code event, **ADD then REMOVE** a throwaway label and inspect `gh run view <id> --json jobs`; the label-event run shows the 16 heavy jobs `skipped` and only `changes-gate` / `pr-policy` / `auto-merge-policy` `success`. Done live on PR #1108 — the 16 heavy jobs showed `skipped`, the PR stayed CLEAN/MERGEABLE.
+
+#### 8. Missing concurrency controls on event-driven workflows
+
+Event-driven workflows (triggered by `issues:`, `push: tags:`, `schedule:`, `workflow_dispatch:`) can receive overlapping triggers — rapid issue reopen storms, double tag pushes, back-to-back manual dispatches. Without a top-level `concurrency:` block, GitHub queues and runs all instances concurrently. The correct semantics depend on the workflow's side-effect profile:
+
+**cancel-in-progress: true** — idempotent / read-only side effects (newest run supersedes):
+
+- Label POSTs (adding a label the issue already has is a no-op)
+- Security/dependency scans (only the latest result matters)
+
+**cancel-in-progress: false** — non-idempotent / must-not-interrupt side effects:
+
+- Tag push (`git push origin vX.Y.Z`) — two runs computing the same next version can race on the push
+- PyPI publish + GitHub release creation — cancelling mid-publish leaves a broken half-published state
+
+**Group key patterns** (copy-paste ready):
+
+```yaml
+# Per-issue idempotent label — run_id fallback for workflow_call path (no issue context)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+# Per-workflow serializer for single-writer dispatches (tag push)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.workflow }}
+  cancel-in-progress: false
+
+# Per-ref serializer for publishers (PyPI publish, GitHub release)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# Per-branch scan — head_ref collapses PR pushes; falls back to ref for schedule/dispatch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+```
+
+**Critical detail — workflow_call fallback**: When a workflow has both a direct trigger (e.g. `issues:`) and a `workflow_call:` trigger, `github.event.issue.number` is empty on the `workflow_call` path. Without `|| github.run_id`, ALL `workflow_call` invocations share one group and serialize globally — even unrelated calls from different repos. Always add `|| github.run_id` as the fallback for any per-entity key that may be absent on some trigger paths.
+
+**Placement**: Insert the `concurrency:` block after `permissions:` and before `jobs:` — it is a top-level workflow property, not a job property.
+
+```yaml
+# WRONG — job-level (only governs that job):
+jobs:
+  my-job:
+    concurrency:
+      group: ...
+
+# CORRECT — workflow-level (governs all jobs):
+permissions:
+  contents: read
+concurrency:
+  group: ...
+  cancel-in-progress: true
+jobs:
+  my-job:
+```
+
+**Note**: `${{ github.* }}` in `concurrency.group:` is a YAML-key context expression evaluated by the Actions runner — it is NOT `run:` shell interpolation. The env-var-lift rule (pitfall #3) does NOT apply to `group:` values; they introduce no injection sink.
+
+See also: `gha-workflow-concurrency-controls` skill for the full decision framework.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Re-triggering CI / arming auto-merge for a slash-job-ID workflow | Empty commits, UI re-runs, `gh pr merge --auto` | No new runs created — GitHub rejects the file at parse time; required checks stay "never run", so auto-merge waits forever | The failure is at parse time, not run time; fix the job IDs, don't re-trigger |
+| Validating slash-job-ID YAML locally | `yamllint`, `python -c "import yaml; yaml.safe_load(...)"` | Local parsers accept slashes as valid YAML keys | GitHub adds a stricter job-ID character set beyond the YAML spec |
+| Backtick / YAML-quote / block-scalar escape of `${{ }}` in a description | `` `${{ runner.os }}` ``, single quotes, `>-` | The template parser scans the raw string for `${{` regardless of markdown/YAML context | Only removing `${{ }}` syntax works; markdown/YAML escapes don't apply to GHA expressions |
+| Moving a composite-action description into a YAML comment | Sidestep the parser via comments | Comments aren't surfaced in published metadata / tooltips | Lose discoverability; use plain text in the description field |
+| Editing a `run:` block in place leaving a trusted `${{ }}` untouched | Direct `Edit` adding a `pixi run` prefix | Hook scans the whole new file region; any `${{` in the block trips it | Lift the expression into `env:`; the hook is positional, not diff-scoped |
+| Bypassing the injection hook ("steps.*.outputs.* is trusted") | Offered skip / argued trust | The hook flags a real sink class; even trusted sources can transitively carry attacker input | Apply the env-var lift uniformly — it's correct for trusted sources too |
+| Inline / job-level comment for platform scope | Comment next to `matrix.os` or inside the job | Readers skip it as job-specific and miss the workflow-wide scope | Put scope at the top before `name:`; reference issues with `#NNN`, not doc paths |
+| Single-sentence scope note ("Linux-only due to pixi") | Terse one-liner | Didn't say what still works cross-platform → ambiguous "what's broken" | Include both limitation AND capability for honesty |
+| Declaring `permissions: pull-requests: write` in the workflow to let Actions open a PR | Added the permissions block, expected create-PR to succeed | Still got `GitHub Actions is not permitted to create or approve pull requests` | The workflow `permissions:` block sets token scope, not the separate repo/org create-PR toggle; it does not override that policy |
+| Raising repo create-PR permission via API | `gh api --method PUT repos/OWNER/REPO/actions/permissions/workflow -f default_workflow_permissions=write` | HTTP 409 `Conflict: "Write permissions for workflows are disabled by the organization"` | Repo can't exceed org policy; and `default_workflow_permissions` is a DIFFERENT toggle than create-PR — chasing it is a red herring |
+| Treating a green workflow run as proof the create-PR fix worked | Dispatched the workflow, saw a successful run | The create-PR step was skipped by its `if:` (no artifact change), so success was a no-op — no PR ever created | Force a real change so the step fires, then confirm a PR was actually created (`gh pr list --head <branch>` shows `app/github-actions`) |
+| Adding label/auto-merge event types to the `pull_request` trigger so policy jobs converge | Added `labeled, unlabeled, auto_merge_enabled, auto_merge_disabled` to `on.pull_request.types` so `pr-policy`/`auto-merge-policy` re-run on label/auto-merge changes | The trigger is workflow-wide → every label change re-ran all 18 jobs incl. the full test matrix (py3.10-3.13), security scans, build, lint; an automation loop toggling `state:*` labels made it very expensive | Gate heavy jobs on a `changes-gate` job that returns `code_event=false` for label/auto-merge actions (`needs:` + `if:`); leave policy jobs ungated; skipped required checks keep the SHA's prior status so branch protection stays satisfied |
+| Missing run_id fallback on workflow_call path | Used `group: label-${{ github.event.issue.number }}` without fallback | On `workflow_call`, `issue.number` is undefined → all callers share one group → global serialization of unrelated calls | Always add `|| github.run_id` fallback for per-entity keys that may be absent on some trigger paths |
+| Placed concurrency: inside a job | `jobs.my-job.concurrency:` instead of top-level | Only governs that single job; other jobs in the workflow can still overlap | `concurrency:` must be a top-level key, sibling of `jobs:`, not nested inside it |
+
+## Results & Parameters
+
+- **Job-ID valid character set**: `[a-zA-Z_][a-zA-Z0-9_-]*` (letters, digits, `_`, `-`). Forbidden: `/`, `.`, spaces. `name:` has no restrictions. A single invalid job ID rejects the **entire** file, silently — no UI error, no webhook event. Required checks referencing the workflow stay "pending/never run", permanently blocking PRs.
+- **Composite-action descriptions**: only `${{ inputs.<name> }}` resolves at action-load time; all other context names raise `Unrecognized named-value`. Failure surfaces at the consuming job's `uses:` step.
+- **Env-var lift**: ~3 added YAML lines per expression, no CI runtime cost; runtime behavior identical; security posture strictly improved. Always double-quote `"$VAR"`; never use a `GITHUB_` prefix; `env:` is per-step.
+- **Platform-scope header**: 14-line comment block before `name:`. Parameters to fill: `REASON`, `EXCLUDED_PLATFORMS`, `ISSUE_REF`, `CAPABILITY_CLAIM`, `EXPANSION_CONDITION`, `EXPANDED_MATRIX`, `DOC_REFERENCE`. Validate with `pre-commit run --all-files` and confirm YAML still parses.
+- **Edit-tool path block**: Workaround A (`python3 -c` replace) for targeted edits; Workaround B (`Read` + `Write`) for restructures; rename scanner-tripping identifiers if `Write` is also blocked.
+- **Actions-create-PR block**: TWO independent toggles — `can_approve_pull_request_reviews` (the create/approve-PR gate, the one you usually need) vs `default_workflow_permissions` (read/write default, overridden by a workflow's own `permissions:` block). A repo-level 409 means the ORG is the blocker. Fix order: org toggle (org-wide, also enables PR self-approval) → scoped PAT/App token on checkout + create-PR steps → direct commit to main (`contents: write` only). Validate by forcing a real artifact change so the create-PR step fires, then `gh pr list --head <branch> --json author` to confirm `app/github-actions` opened a PR — a green run alone is not proof (skipped step shows success).
+- **Workflow-wide trigger / changes-gate**: `on: pull_request: types:` applies to the ENTIRE workflow, so label/auto-merge event types added for one job re-run all jobs. Gate heavy jobs with a `changes-gate` job (`needs: changes-gate` + `if: needs.changes-gate.outputs.code_event == 'true'`); leave policy jobs (`pr-policy`, `auto-merge-policy`) ungated. Correctness invariants: a required job SKIPPED via `if:` reports neutral/success and GitHub keeps the SHA's prior real result → branch protection stays satisfied; `github.event.action` is empty on `push` → `case` default = `code_event=true` → push still runs everything; pass `github.event.action` via `env:`, never interpolate into `run:`. Validate by adding then removing a throwaway label and checking `gh run view <id> --json jobs` shows the heavy jobs `skipped` while `changes-gate`/policy jobs `success`, with the PR still CLEAN/MERGEABLE.
+- **Reference**: <https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/>
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| HomericIntelligence/ProjectCharybdis | `_required.yml` had `security/dependency-scan`, `security/secrets-scan`, `deps/version-sync` as job IDs | Deployed for weeks with 0 jobs ever running; fixed in PR #50 (2026-04-29) |
+| HomericIntelligence/ProjectScylla | PR #1901 (2026-05-03) — `_required.yml` slash job IDs; was the supposed "reference implementation" yet the only broken repo among 15 | Renamed 3 job IDs to dashed forms, kept `name:` verbatim; org audit confirmed 14/15 emitted all 8 contexts, Scylla emitted 0 |
+| ProjectHephaestus | PR #608 — `setup-pixi-env` composite action | Three jobs (lint, shell-tests, security/dependency-scan) failed at `uses:` with `TemplateValidationException`; fix commit `229591e` (description `${{ runner.os }}` → `<runner.os>`) flipped them green |
+| HomericIntelligence/ProjectOdyssey | PR #5445 (commit `702a5a2e`) — `.github/workflows/docs.yml` env-var lift | `validate-readme-commands` check went FAILURE → SUCCESS after lifting `steps.validation-level.outputs.level` into `env:` |
+| ProjectHephaestus | Issue #794 / PR #977 — `.github/workflows/test.yml` platform-scope header | 14-line header comment block added; pre-commit passed; workflow executed successfully (verified-local) |
+| HomericIntelligence/ProjectScylla | PR #1455 / Issue #1429 — Edit-tool path block | Workarounds documented in `.claude/shared/error-handling.md` |
+| Mnemosyne | 2026-06-07: `update-marketplace.yml` create-PR step 403, diagnosed org block, validated org-toggle fix by live dispatch | PR #2261 |
+| ProjectHephaestus | PR #1108 (2026-06-08) — `_required.yml` label-event re-ran all 18 jobs; added a `changes-gate` job and gated the 16 heavy jobs on `needs: changes-gate` + `if: …code_event == 'true'`, left `pr-policy`/`auto-merge-policy` ungated | SELF-TESTED live: adding then removing a label re-ran only the gate + 2 policy jobs; the 16 heavy jobs showed `skipped`; PR stayed CLEAN/MERGEABLE |
+| ProjectHephaestus | Issue #1548 — added concurrency blocks to auto-label-needs-plan.yml, auto-tag.yml, release.yml, security.yml | verified-local (YAML parse + structural assertions; CI pending) |
+````
+
+---
+
 ## v1.3.0 (2026-06-23)
 
 **Changed by:** Issue #1548 (ProjectHephaestus) — concurrency controls on event-driven workflows

--- a/skills/gha-workflow-authoring-pitfalls.md
+++ b/skills/gha-workflow-authoring-pitfalls.md
@@ -1,10 +1,10 @@
 ---
 name: gha-workflow-authoring-pitfalls
-description: "Use when: (1) a workflow file is silently ignored or produces 0 jobs due to invalid YAML job IDs (forward slashes), (2) a composite-action input description contains ${{ }} expressions that get evaluated unexpectedly, (3) a security hook blocks editing a workflow run: block because of a ${{ }} injection sink — and you need the env-var-lift pattern, (4) documenting platform asymmetries (Linux-only, macOS-skipped) in workflow header comments, (5) a WorkflowDispatch or PreToolUse hook fires on an edit to .github/workflows/*.yml, (6) a workflow step fails with 'GitHub Actions is not permitted to create or approve pull requests' and you need to diagnose repo-vs-org policy and choose org-toggle vs PAT/App-token vs direct-commit, (7) adding labeled/unlabeled/auto_merge_* event types to a pull_request trigger re-runs ALL jobs (the trigger is workflow-wide) when you wanted only specific policy jobs to run on label events — and you need the changes-gate needs/if pattern, (8) an event-driven workflow (issues, schedule, workflow_dispatch, push:tags) lacks a concurrency: block — and you need to choose the right group key and cancel-in-progress semantics based on side-effect profile (idempotent label/scan = true; non-idempotent tag-push/publish = false)."
+description: "Use when: (1) a workflow file is silently ignored or produces 0 jobs due to invalid YAML job IDs (forward slashes), (2) a composite-action input description contains ${{ }} expressions that get evaluated unexpectedly, (3) a security hook blocks editing a workflow run: block because of a ${{ }} injection sink — and you need the env-var-lift pattern, (4) documenting platform asymmetries (Linux-only, macOS-skipped) in workflow header comments, (5) a WorkflowDispatch or PreToolUse hook fires on an edit to .github/workflows/*.yml, (6) a workflow step fails with 'GitHub Actions is not permitted to create or approve pull requests' and you need to diagnose repo-vs-org policy and choose org-toggle vs PAT/App-token vs direct-commit, (7) adding labeled/unlabeled/auto_merge_* event types to a pull_request trigger re-runs ALL jobs when you wanted only specific policy jobs to run, (8) an event-driven workflow lacks concurrency controls, (9) one workflow supports both a native entity event and workflow_call, so callers must supply the missing entity identifier through a required typed input and both paths must share one validated job."
 category: ci-cd
-date: 2026-06-23
-version: "1.3.0"
-verification: verified-ci
+date: 2026-08-07
+version: "1.4.0"
+verification: verified-local
 user-invocable: false
 history: gha-workflow-authoring-pitfalls.history
 tags:
@@ -36,6 +36,11 @@ tags:
   - event-driven
   - idempotent
   - publisher
+  - workflow-call
+  - reusable-workflow
+  - typed-input
+  - issue-number
+  - contract-testing
 ---
 
 # GitHub Actions: Workflow-Authoring Pitfalls
@@ -44,10 +49,10 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-06-23 |
-| **Objective** | Consolidate the recurring GitHub Actions workflow-authoring traps: invalid job IDs, expression evaluation in composite-action descriptions, the env-var-lift fix for injection hooks, platform-scope header documentation, editing path-blocked workflow files, the org create-PR policy block, the workflow-wide `pull_request` trigger re-running all jobs on label/auto-merge events, and choosing the right `concurrency:` group key and `cancel-in-progress` semantics for event-driven workflows |
+| **Date** | 2026-08-07 |
+| **Objective** | Consolidate recurring GitHub Actions workflow-authoring traps, including how dual-trigger native-event/`workflow_call` workflows carry a stable entity identifier through a required typed input, one shared job, concurrency, and a validated shell boundary |
 | **Outcome** | One reference covering the distinct gotchas, each with a copy-paste fix and the failed approaches that do NOT work |
-| **Verification** | verified-ci |
+| **Verification** | verified-local — prior pitfalls retain their cited CI evidence; pitfall #9's YAML contract and shell boundary were exercised locally, while hosted GitHub Actions validation is pending |
 
 ## When to Use
 
@@ -58,6 +63,7 @@ tags:
 - A `PreToolUse:Edit` hook blocks the `Edit` tool on `.github/workflows/*.yml` **by path alone** (no `${{` involved). → edit-tool-blocked workaround.
 - Adding `labeled`/`unlabeled`/`auto_merge_enabled`/`auto_merge_disabled` to a `pull_request` trigger (so a policy job converges on label/auto-merge state) re-runs **ALL** jobs because the trigger is workflow-wide — you wanted only specific jobs to run on label events. → changes-gate `needs:`/`if:` pattern.
 - An event-driven workflow (`issues:`, `push: tags:`, `schedule:`, `workflow_dispatch:`) currently lacks a `concurrency:` block and overlapping triggers are stacking redundant in-flight runs — you need to choose the right group key and `cancel-in-progress` value based on the workflow's side-effect profile. → concurrency controls.
+- A workflow supports both a native entity event (for example, `issues`) and `workflow_call`, but the reusable invocation has no native event payload, the job is gated to the native event, or concurrency falls back to `run_id`. → required typed entity input + one event-or-input expression.
 
 ## Verified Workflow
 
@@ -73,6 +79,7 @@ tags:
 | Actions blocked from creating PRs | `GitHub Actions is not permitted to create or approve pull requests` at the create-PR step | Org admin enables "Allow Actions to create and approve PRs"; or pass a fine-grained PAT/App token to checkout + create-PR step; or commit direct to main |
 | Label/auto-merge event re-runs ALL jobs | Added `labeled`/`unlabeled`/`auto_merge_*` to `pull_request` `types:` so a policy job converges, but every label toggle re-runs the full matrix | Add a `changes-gate` job that emits `code_event=false` for those actions; gate heavy jobs on `needs: changes-gate` + `if: …code_event == 'true'`; leave policy jobs ungated |
 | Missing concurrency block | Overlapping runs race or stack; publishers can double-publish or push duplicate tags | Add top-level `concurrency:` block with group key scoped to the event (issue number, ref, workflow) and cancel-in-progress matching side-effect profile |
+| Reusable path has no native event entity | `workflow_call` runs lack `github.event.issue.number`; an event-only job guard silently skips the reusable path, and a `run_id` fallback loses per-issue serialization | Declare a required numeric `workflow_call` input, resolve `${{ github.event.issue.number || inputs.issue_number }}` everywhere, remove the event-only job guard, and reject non-positive integers before the API call |
 
 ```bash
 # Detection one-liners
@@ -363,9 +370,9 @@ Event-driven workflows (triggered by `issues:`, `push: tags:`, `schedule:`, `wor
 **Group key patterns** (copy-paste ready):
 
 ```yaml
-# Per-issue idempotent label — run_id fallback for workflow_call path (no issue context)
+# Per-issue idempotent label — caller supplies the missing issue identity
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
 
 # Per-workflow serializer for single-writer dispatches (tag push)
@@ -384,7 +391,7 @@ concurrency:
   cancel-in-progress: true
 ```
 
-**Critical detail — workflow_call fallback**: When a workflow has both a direct trigger (e.g. `issues:`) and a `workflow_call:` trigger, `github.event.issue.number` is empty on the `workflow_call` path. Without `|| github.run_id`, ALL `workflow_call` invocations share one group and serialize globally — even unrelated calls from different repos. Always add `|| github.run_id` as the fallback for any per-entity key that may be absent on some trigger paths.
+**Critical detail — preserve the entity identity across `workflow_call`**: When a workflow has both a direct trigger (for example, `issues:`) and `workflow_call:`, `github.event.issue.number` is empty on the reusable path. If the operation is per entity, require the caller to pass that entity's stable identifier and use it as the fallback. `github.run_id` is unique per invocation, so it prevents an empty global bucket but also prevents two runs for the same issue from sharing a concurrency group. Use `run_id` only when there is no meaningful stable entity key and uniqueness—not per-entity serialization—is the intended behavior. See pitfall #9.
 
 **Placement**: Insert the `concurrency:` block after `permissions:` and before `jobs:` — it is a top-level workflow property, not a job property.
 
@@ -409,6 +416,90 @@ jobs:
 
 See also: `gha-workflow-concurrency-controls` skill for the full decision framework.
 
+#### 9. A dual-trigger reusable workflow must receive missing event context explicitly
+
+`workflow_call` does not recreate the caller's native event payload inside the called workflow. A
+callee triggered by both `issues` and `workflow_call` therefore cannot assume
+`github.event.issue.number` exists on both paths. The caller must pass the missing identity through
+the reusable interface. For an issue-label mutation, make the input required and numeric, then use
+one event-or-input expression in every place that depends on issue identity:
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: Positive issue number to label
+        required: true
+        type: number
+  issues:
+    types: [opened, reopened]
+
+concurrency:
+  group: auto-label-needs-plan-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  needs-plan:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Add state:needs-plan label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          case "$ISSUE_NUMBER" in
+            ''|0|0*|*[!0-9]*)
+              echo "::error::Unexpected ISSUE_NUMBER value (not a positive integer)"
+              exit 1
+              ;;
+          esac
+          gh api \
+            --method POST \
+            "repos/$REPO/issues/$ISSUE_NUMBER/labels" \
+            -f "labels[]=state:needs-plan"
+```
+
+The caller binds its own server-controlled event field explicitly:
+
+```yaml
+jobs:
+  call:
+    uses: OWNER/REPO/.github/workflows/auto-label-needs-plan.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+```
+
+The interface and runtime checks do different jobs. `required: true` plus `type: number` rejects
+missing or non-numeric caller values during workflow validation. The shell guard rejects empty,
+zero, negative, fractional, leading-zero, or malformed values before `gh api` executes. Keep the
+expression in `env:` and quote `"$ISSUE_NUMBER"` in shell; do not splice caller data directly into
+`run:` source.
+
+Do not leave `if: github.event_name == 'issues'` on the job. With exactly the two declared
+triggers above, that condition disables the reusable path the interface claims to support. Both
+triggers should enter the same job so the API behavior and validation cannot drift.
+
+**Regression-contract pattern (verified locally only — hosted CI pending):**
+
+1. Parse workflow YAML with `yaml.BaseLoader`, because PyYAML's YAML 1.1 resolver otherwise
+   coerces the unquoted key `on` to boolean `True`.
+2. Assert `workflow_call.inputs.issue_number` is required and typed `number`; `issues` declares
+   the expected event types; there is one ungated label job; and both `concurrency.group` and the
+   step's `ISSUE_NUMBER` use the identical event-or-input expression.
+3. Extract and parse the documented caller's fenced YAML example, and assert its `with:` block
+   passes `${{ github.event.issue.number }}`. This keeps documentation executable as a contract.
+4. Execute the embedded shell body with a temporary fake `gh` earlier on `PATH`. Assert `42`
+   reaches exactly `repos/<owner>/<repo>/issues/42/labels`, while empty, `0`, negative,
+   fractional, leading-zero, and non-numeric inputs exit nonzero without invoking `gh`.
+
+This pattern was exercised locally against the proposed ProjectHephaestus
+`auto-label-needs-plan.yml` contract. The reusable workflow has not yet run in hosted GitHub
+Actions, so treat hosted behavior as pending until its implementation PR is green.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -425,7 +516,11 @@ See also: `gha-workflow-concurrency-controls` skill for the full decision framew
 | Raising repo create-PR permission via API | `gh api --method PUT repos/OWNER/REPO/actions/permissions/workflow -f default_workflow_permissions=write` | HTTP 409 `Conflict: "Write permissions for workflows are disabled by the organization"` | Repo can't exceed org policy; and `default_workflow_permissions` is a DIFFERENT toggle than create-PR — chasing it is a red herring |
 | Treating a green workflow run as proof the create-PR fix worked | Dispatched the workflow, saw a successful run | The create-PR step was skipped by its `if:` (no artifact change), so success was a no-op — no PR ever created | Force a real change so the step fires, then confirm a PR was actually created (`gh pr list --head <branch>` shows `app/github-actions`) |
 | Adding label/auto-merge event types to the `pull_request` trigger so policy jobs converge | Added `labeled, unlabeled, auto_merge_enabled, auto_merge_disabled` to `on.pull_request.types` so `pr-policy`/`auto-merge-policy` re-run on label/auto-merge changes | The trigger is workflow-wide → every label change re-ran all 18 jobs incl. the full test matrix (py3.10-3.13), security scans, build, lint; an automation loop toggling `state:*` labels made it very expensive | Gate heavy jobs on a `changes-gate` job that returns `code_event=false` for label/auto-merge actions (`needs:` + `if:`); leave policy jobs ungated; skipped required checks keep the SHA's prior status so branch protection stays satisfied |
-| Missing run_id fallback on workflow_call path | Used `group: label-${{ github.event.issue.number }}` without fallback | On `workflow_call`, `issue.number` is undefined → all callers share one group → global serialization of unrelated calls | Always add `|| github.run_id` fallback for per-entity keys that may be absent on some trigger paths |
+| No fallback for missing native event context | Used `github.event.issue.number` on both native and reusable paths | On `workflow_call`, the issue payload is absent, leaving concurrency and the API target without an issue identity | Define a required typed reusable input and use `github.event.issue.number || inputs.issue_number` consistently |
+| `github.run_id` as a universal reusable fallback | Used `group: label-${{ github.event.issue.number || github.run_id }}` for a per-issue mutation | Every call gets a distinct run ID, so concurrent runs for the same issue no longer share a group; it also does not supply the issue number needed by the API job | Pass the stable issue number from the caller; reserve `run_id` for workflows with no meaningful entity key |
+| Event-only job guard in a dual-trigger workflow | Kept `if: github.event_name == 'issues'` after declaring `workflow_call` | Reusable invocations validate and start but silently skip the only job | With exactly the supported triggers declared, route both through one ungated job |
+| Trusted numeric input without a shell domain check | Relied only on `workflow_call` input type `number` | Numeric still includes unusable values such as zero, negatives, and fractions | Fail closed on the operation's actual domain—positive decimal integers—before invoking `gh` |
+| `yaml.safe_load` for GitHub workflow contract tests | Indexed parsed data through `workflow["on"]` | PyYAML's YAML 1.1 resolver can coerce unquoted `on` to boolean `True`, making the test fail for the wrong reason | Load workflow contracts with `yaml.BaseLoader` so GitHub's `on` key remains a string |
 | Placed concurrency: inside a job | `jobs.my-job.concurrency:` instead of top-level | Only governs that single job; other jobs in the workflow can still overlap | `concurrency:` must be a top-level key, sibling of `jobs:`, not nested inside it |
 
 ## Results & Parameters
@@ -437,6 +532,7 @@ See also: `gha-workflow-concurrency-controls` skill for the full decision framew
 - **Edit-tool path block**: Workaround A (`python3 -c` replace) for targeted edits; Workaround B (`Read` + `Write`) for restructures; rename scanner-tripping identifiers if `Write` is also blocked.
 - **Actions-create-PR block**: TWO independent toggles — `can_approve_pull_request_reviews` (the create/approve-PR gate, the one you usually need) vs `default_workflow_permissions` (read/write default, overridden by a workflow's own `permissions:` block). A repo-level 409 means the ORG is the blocker. Fix order: org toggle (org-wide, also enables PR self-approval) → scoped PAT/App token on checkout + create-PR steps → direct commit to main (`contents: write` only). Validate by forcing a real artifact change so the create-PR step fires, then `gh pr list --head <branch> --json author` to confirm `app/github-actions` opened a PR — a green run alone is not proof (skipped step shows success).
 - **Workflow-wide trigger / changes-gate**: `on: pull_request: types:` applies to the ENTIRE workflow, so label/auto-merge event types added for one job re-run all jobs. Gate heavy jobs with a `changes-gate` job (`needs: changes-gate` + `if: needs.changes-gate.outputs.code_event == 'true'`); leave policy jobs (`pr-policy`, `auto-merge-policy`) ungated. Correctness invariants: a required job SKIPPED via `if:` reports neutral/success and GitHub keeps the SHA's prior real result → branch protection stays satisfied; `github.event.action` is empty on `push` → `case` default = `code_event=true` → push still runs everything; pass `github.event.action` via `env:`, never interpolate into `run:`. Validate by adding then removing a throwaway label and checking `gh run view <id> --json jobs` shows the heavy jobs `skipped` while `changes-gate`/policy jobs `success`, with the PR still CLEAN/MERGEABLE.
+- **Dual native/reusable trigger identity**: `workflow_call` lacks the caller's `github.event.issue` payload. For a per-issue side effect, declare `workflow_call.inputs.issue_number` with `required: true` and `type: number`; use `${{ github.event.issue.number || inputs.issue_number }}` in both concurrency and the step environment; remove event-only job gates; and reject `''|0|0*|*[!0-9]*` before the API boundary. A `run_id` fallback is unique per run, not stable per issue. Contract-test the workflow, documented caller, and embedded shell with `yaml.BaseLoader` plus a fake `gh` executable.
 - **Reference**: <https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/>
 
 ## Verified On
@@ -452,3 +548,4 @@ See also: `gha-workflow-concurrency-controls` skill for the full decision framew
 | Mnemosyne | 2026-06-07: `update-marketplace.yml` create-PR step 403, diagnosed org block, validated org-toggle fix by live dispatch | PR #2261 |
 | ProjectHephaestus | PR #1108 (2026-06-08) — `_required.yml` label-event re-ran all 18 jobs; added a `changes-gate` job and gated the 16 heavy jobs on `needs: changes-gate` + `if: …code_event == 'true'`, left `pr-policy`/`auto-merge-policy` ungated | SELF-TESTED live: adding then removing a label re-ran only the gate + 2 policy jobs; the 16 heavy jobs showed `skipped`; PR stayed CLEAN/MERGEABLE |
 | ProjectHephaestus | Issue #1548 — added concurrency blocks to auto-label-needs-plan.yml, auto-tag.yml, release.yml, security.yml | verified-local (YAML parse + structural assertions; CI pending) |
+| ProjectHephaestus | Proposed `auto-label-needs-plan.yml` dual `issues`/`workflow_call` contract (2026-08-07) | Required numeric issue input, one ungated label job, shared event-or-input identity, positive-integer shell guard, documented caller, and fake-`gh` regression pattern exercised locally; hosted CI pending |

--- a/skills/gha-workflow-concurrency-controls.history
+++ b/skills/gha-workflow-concurrency-controls.history
@@ -1,5 +1,211 @@
 # gha-workflow-concurrency-controls — History
 
+## v3.0.0 (2026-08-07)
+
+**Changed by:** ProjectHephaestus dual-trigger `auto-label-needs-plan.yml` learning
+**Verification:** verified-local (corrected reusable-path contract exercised locally; hosted CI pending)
+
+### What changed
+
+- Replaced the recommended per-issue `github.run_id` fallback with a required typed
+  `workflow_call.inputs.issue_number` and stable event-or-input group identity.
+- Clarified that `run_id` is valid only for intentional per-invocation uniqueness when no
+  meaningful entity key exists; it cannot implement per-issue serialization.
+- Reclassified PR #1590's old `run_id` key as historical direct-event CI evidence because the
+  workflow's event-only job guard made its reusable path inert.
+- Added the dual-trigger use case, a failed-attempt row, local verification evidence, and a
+  cross-reference to the full authoring contract.
+- Bumped version 2.0.0 → 3.0.0 because this changes a core group-key recommendation.
+
+### Why
+
+A concurrency fallback must preserve the identity of the work being serialized. `github.run_id`
+is unique for every invocation, so two reusable calls targeting the same issue never collide and
+cannot cancel or queue as one per-issue stream. Requiring callers to pass the issue number keeps
+native and reusable paths semantically equivalent and also supplies the downstream API target.
+
+### Previous version (v2.0.0) snapshot
+
+````markdown
+---
+name: gha-workflow-concurrency-controls
+description: "Choosing GitHub Actions `concurrency:` controls when ADDING them to event-driven workflows that currently lack them — selecting the `group` key and `cancel-in-progress` value per the workflow's trigger and its side-effect idempotency. The ONE decision rule: `cancel-in-progress: true` for idempotent / supersede-able runs (tests, scans, idempotent label POSTs — newest event wins), `cancel-in-progress: false` for non-idempotent publishers that must not be interrupted mid-flight (git tag push, PyPI publish, GitHub release creation). Group-key selection scopes the serialization: `github.event.issue.number` (+ `github.run_id` fallback) for per-issue, `github.ref` for per-tag (distinct tags publish in parallel, same tag never double-publishes), `github.head_ref || github.ref` (NOT `github.sha`) for PR scans so successive pushes collapse. Bare group keys (without `${{ github.workflow }}-` prefix) work correctly for single-workflow repos — the workflow-prefix is defensive but optional when cross-workflow collision is not a concern. Use when: (1) a workflow has no `concurrency:` block and you must pick `group`/`cancel-in-progress` by trigger, (2) deciding whether cancelling a run is safe — gate it on side-effect idempotency not convenience, (3) a publish/release workflow needs serialization without over- or under-serializing across tags, (4) PR-scan concurrency must collapse rapid successive pushes (use head_ref, NOT sha), (5) confirming `${{ github.* }}` in a `concurrency.group` does NOT introduce a workflow-injection sink (it is a YAML-key context expr, not a `run:` interpolation), (6) confirming a workflow you are editing is NOT a pinned required status-check context before assuming branch-protection interaction."
+category: ci-cd
+date: 2026-06-24
+version: "2.0.0"
+user-invocable: false
+verification: verified-ci
+history: gha-workflow-concurrency-controls.history
+tags:
+  - github-actions
+  - concurrency
+  - cancel-in-progress
+  - concurrency-group
+  - idempotency
+  - publish-workflow
+  - pypi-publish
+  - git-tag-push
+  - github-release
+  - github-ref
+  - github-head-ref
+  - github-sha
+  - pr-scan
+  - per-issue-serialization
+  - per-tag-serialization
+  - workflow-injection
+  - context-expression
+  - required-status-checks
+  - branch-protection
+  - side-effect-idempotency
+  - verified-ci
+---
+
+# GitHub Actions Workflow Concurrency Controls (Group Key + Cancel-in-Progress Selection)
+
+**History:** [changelog](./gha-workflow-concurrency-controls.history)
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-06-24 |
+| **Objective** | Capture the durable decision rules for adding a `concurrency:` block to event-driven GitHub Actions workflows that lack one — how to choose the `group` key and the `cancel-in-progress` value from the workflow's trigger and the idempotency of its side effects. Surfaced while planning (ProjectHephaestus, issue #1548) the addition of `concurrency:` to four workflows: a per-issue automation workflow, a release/publish workflow, an auto-tag workflow, and a PR-scan workflow. |
+| **Outcome** | Implemented and CI-verified. PR #1590 applied concurrency blocks to all four workflows (`auto-label-needs-plan.yml`, `auto-tag.yml`, `release.yml`, `security.yml`) and all required CI checks passed (test, integration, pr-policy, lint). The decision rules and group-key patterns were confirmed correct in practice. The actual implementation used simpler bare group keys (without `${{ github.workflow }}-` prefix) — valid for single-workflow repos where cross-workflow group collision is not a concern. |
+| **Verification** | verified-ci (PR #1590 passed all required CI checks on 2026-06-24) |
+| **Files Amended** | `auto-label-needs-plan.yml`, `auto-tag.yml`, `release.yml`, `security.yml` |
+
+## When to Use
+
+Reach for this when you are ADDING a `concurrency:` block to a workflow that currently has none, and you must justify both the group key and the cancel semantics rather than copy-pasting a template. Specifically:
+
+- A workflow runs on a high-frequency event (issue activity, PR pushes, label changes) and stacks redundant in-flight runs because it has no `concurrency:` block — and you need to decide whether the newest run should CANCEL the older one or QUEUE behind it.
+- You are tempted to reflexively set `cancel-in-progress: true` everywhere "to save runner minutes" and must first check whether the workflow has a non-idempotent side effect (tag push, PyPI upload, release creation) that a mid-flight cancel would corrupt.
+- A publish/release workflow needs serialization so the SAME tag never double-publishes, but DIFFERENT tags should still proceed in parallel — you need the right group key (`github.ref`), not an over-broad one (`github.workflow`) that blocks unrelated tags.
+- A PR-scan workflow re-runs on every push to a PR branch and you want successive pushes to the same PR to collapse to one run — you must use `github.head_ref || github.ref`, because `github.sha` makes every push a distinct group and collapses NOTHING.
+- A security/edit hook or reviewer flags `${{ github.* }}` inside a `concurrency.group:` as a possible injection sink — you need to know it is a YAML-key context expression, not `run:` shell interpolation, so the env-var-lift rule does not apply.
+- You are about to add `concurrency:` to a workflow in a branch-protected repo and must confirm the target is NOT a pinned required status-check context before assuming any merge-queue interaction.
+
+## Verified Workflow
+
+### Quick Reference
+
+The single decision rule, then the group-key map:
+
+| Workflow side effect | Idempotent / supersede-able? | `cancel-in-progress` | Group key | Why |
+| - | - | - | - | - |
+| Tests / scans / lint on a PR | Yes — newest commit's result is the only one that matters | `true` | `github.head_ref \|\| github.ref` | Successive pushes to the same PR collapse to one run; matches the repo's existing `test.yml` convention |
+| Idempotent label POST on an issue | Yes — re-POSTing the same label is a no-op | `true` | `github.event.issue.number \|\| github.run_id` | Per-issue serialization; newest event wins; `run_id` fallback keeps a `workflow_call`/no-issue path uniquely grouped |
+| git tag push | NO — a cancelled run can leave a tag pushed but its release uncreated | `false` | `github.ref` | Serialize same-ref runs; never interrupt a half-done tag operation |
+| PyPI publish | NO — a cancel can leave a partial/duplicate upload | `false` | `github.ref` (the tag) | Same tag never double-publishes; distinct tags publish in parallel |
+| GitHub release creation | NO — half-created release is worse than serializing | `false` | `github.ref` | Same as PyPI — gate on idempotency, not convenience |
+
+**The rule in one line:** set `cancel-in-progress` from the idempotency of the side effect, NOT from a desire to save minutes. Cancelling a half-finished publish is worse than letting it run.
+
+### Actual Group Keys Used (CI-Verified)
+
+The four workflows amended in PR #1590 used these exact concurrency blocks — notably WITHOUT the `${{ github.workflow }}-` prefix, which is optional for single-workflow repos:
+
+| Workflow | Trigger | Group key used | `cancel-in-progress` | Rationale |
+| -------- | ------- | -------------- | -------------------- | --------- |
+| `auto-label-needs-plan.yml` | `issues` events | `auto-label-needs-plan-${{ github.event.issue.number \|\| github.run_id }}` | `true` | Per-issue idempotent label POST; newest event wins |
+| `auto-tag.yml` | `workflow_dispatch` only | `auto-tag-${{ github.workflow }}` | `false` | Non-idempotent tag push; `workflow_dispatch`-only means only one meaningful run at a time anyway |
+| `release.yml` | tag push (`refs/tags/v*`) | `release-${{ github.ref }}` | `false` | Non-idempotent release publish; per-ref so different tags run in parallel |
+| `security.yml` | `pull_request`, `push` | `security-${{ github.head_ref \|\| github.ref }}` | `true` | Idempotent security scan; collapses successive pushes per PR branch |
+
+**Bare-key vs. workflow-prefixed key:** The planned snippets used `${{ github.workflow }}-${{ github.ref }}` style; the actual implementation used simpler bare keys (`release-${{ github.ref }}` etc.). Both are correct. The workflow-prefix prevents cross-workflow collision if two workflows accidentally share a group name; the bare form is more readable and sufficient for repos where this is not a concern.
+
+### Detailed Steps
+
+**1. Classify the workflow's side effect before touching the keys.**
+Ask only one question: *if a run is killed at an arbitrary point, can the system be left in a corrupt or half-applied state?*
+- No (tests, scans, idempotent label POST) → the run is supersede-able → `cancel-in-progress: true`. The newest event's result is the only one that matters; killing the older run is free.
+- Yes (git tag push, PyPI publish, GitHub release creation) → the run must NOT be interrupted → `cancel-in-progress: false`. New runs QUEUE behind the in-flight one instead of cancelling it.
+
+**2. Choose the group key to scope serialization to the right unit of work.**
+
+```yaml
+# Per-issue automation (idempotent label POST): serialize per issue,
+# but keep a unique group on a workflow_call / no-issue path so it isn't
+# all collapsed into one empty-string group.
+# Bare-key form (no workflow prefix) — sufficient for single-workflow repos.
+concurrency:
+  group: auto-label-needs-plan-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+# Auto-tag (workflow_dispatch only — non-idempotent tag push):
+# Use github.workflow as the bare key; only one dispatch can run at a time.
+concurrency:
+  group: auto-tag-${{ github.workflow }}
+  cancel-in-progress: false
+
+# Release / publish (tag push, PyPI, release): serialize per TAG so the
+# same tag never double-publishes, while DIFFERENT tags proceed in parallel.
+# Do NOT cancel — a half-done publish must finish or queue.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+# PR scan (tests/security): collapse successive pushes to the SAME PR.
+# Use head_ref (the PR branch), NOT github.sha — each sha is a distinct
+# group and would collapse nothing. Matches the repo's test.yml convention.
+concurrency:
+  group: security-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+```
+
+Key facts:
+- `github.ref` per-tag: distinct tags get distinct groups (parallel), the same tag re-run serializes (never double-publishes).
+- `github.head_ref || github.ref`: `head_ref` is only set on `pull_request`; the `|| github.ref` keeps push/non-PR events grouped. Successive pushes to one PR share the branch ref → they collapse.
+- `github.sha` is WRONG for "collapse successive pushes": every commit is a new SHA → every push is a new group → no collapse ever happens.
+- `github.event.issue.number || github.run_id`: `run_id` is unique per run, so a path with no issue (e.g. `workflow_call`) still gets a unique group instead of falling into a shared empty group.
+- Bare keys vs. workflow-prefixed: `${{ github.workflow }}-` prefix is defensive but optional. Use it if cross-workflow collision is a realistic concern; omit it for readability in repos with clear event-to-workflow mapping.
+
+**3. Confirm the group expression is NOT an injection sink.**
+`concurrency.group:` is a workflow-level YAML KEY whose value is a context expression evaluated by the Actions runner — it is NOT `run:` shell that splices attacker-controllable text into a command. The workflow-injection / env-var-lift mitigation (lift `${{ github.* }}` into `env:` before using in `run:`) applies to shell interpolation, NOT to a `group:` key. So `${{ github.head_ref }}` or `${{ github.event.issue.number }}` in a group key introduces no injection sink. (Contrast: the SAME `github.head_ref` IS a dangerous source inside `run:` — see `gha-workflow-authoring-pitfalls`.)
+
+**4. Confirm no branch-protection interaction before assuming one.**
+Adding `concurrency:` to a workflow that is NOT a pinned required status-check context cannot brick the merge queue — there is no required context whose cancellation/serialization would leave a PR un-mergeable. Before assuming any interaction, enumerate the repo/org ruleset required contexts and confirm the target workflow's jobs are not among them. (For issue #1548, none of the four target workflows were required contexts — confirmed by enumerating ruleset contexts.)
+
+**5. Verify per-file specifics against the live files before assuming line numbers.**
+The group-key decision rules are durable. Exact insertion lines in any specific workflow file may drift — always re-read the live file and confirm the insertion point (top-level, after `on:`/`permissions:`, before `jobs:`) before editing.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| ------- | -------------- | ------------- | -------------- |
+| Universal cancel | Assume `cancel-in-progress: true` is universally safe "to save minutes" | WRONG for publishers: a cancelled tag-push/PyPI/release run can leave a tag pushed but release uncreated, or a partial PyPI upload | Gate cancel semantics on side-effect IDEMPOTENCY, not convenience; publishers get `cancel-in-progress: false` |
+| Key publish on `github.workflow` alone | Group a release/publish workflow on just `github.workflow` | Over-serializes (blocks unrelated tags) or under-serializes depending on form — wrong granularity | For `release.yml` prefer `github.ref` (the tag): same-tag races serialize while DISTINCT tags proceed in parallel |
+| Key PR scan on `github.sha` | Use `github.sha` for PR-scan concurrency group | Each SHA is a distinct group, so rapid successive pushes to the same PR branch do NOT collapse | Use `github.head_ref \|\| github.ref` so successive pushes to one PR share a group and collapse |
+| Treat `${{ github.* }}` in group as injection | Apply env-var-lift to `${{ github.head_ref }}` inside `concurrency.group:` | The mitigation is for `run:` shell splicing; a `group:` key is a context-expr YAML key, not a shell sink | No env-var-lift needed in a `concurrency.group:`; it introduces no injection sink |
+| Assume branch-protection interaction | Assume adding `concurrency:` could brick the merge queue | A non-required workflow's serialization can't leave a PR un-mergeable; the assumption was unchecked | Enumerate ruleset required contexts FIRST; only a pinned required context could interact |
+| Using `github.workflow-` prefix in group key | Plan proposed `${{ github.workflow }}-${{ github.ref }}` etc. to prevent cross-workflow collisions | Not incorrect but unnecessary — simpler bare keys work fine in repos where workflows don't accidentally share a concurrency group name; the actual implementation used the shorter form | For single-repo, single-workflow-per-event scenarios, the workflow-prefix is defensive but optional; use bare event-scoped keys for readability, add prefix if cross-workflow collision is a real concern |
+
+## Results & Parameters
+
+| Parameter | Value |
+| --------- | ----- |
+| **Verification level** | verified-ci (PR #1590, ProjectHephaestus issue #1548; all required CI checks passed on 2026-06-24) |
+| **Decision rule** | `cancel-in-progress: true` ⇔ idempotent/supersede-able side effect; `false` ⇔ non-idempotent publisher (tag/PyPI/release) |
+| **Per-issue group (confirmed)** | `auto-label-needs-plan-${{ github.event.issue.number \|\| github.run_id }}`, `cancel-in-progress: true` |
+| **Per-tag (publish) group (confirmed)** | `release-${{ github.ref }}`, `cancel-in-progress: false` |
+| **Auto-tag group (confirmed)** | `auto-tag-${{ github.workflow }}`, `cancel-in-progress: false` (workflow_dispatch-only) |
+| **PR-scan group (confirmed)** | `security-${{ github.head_ref \|\| github.ref }}`, `cancel-in-progress: true` |
+| **Anti-pattern** | `github.sha` for PR-scan collapse (each sha = distinct group, no collapse) |
+| **Bare vs. prefixed keys** | Bare keys (no `github.workflow-` prefix) are sufficient for single-workflow repos; prefixed form is defensive but optional |
+| **Injection** | `${{ github.* }}` in `concurrency.group:` is a context-expr key, NOT a `run:` sink — no env-var-lift needed |
+| **Branch protection** | Only a pinned required status-check context can interact — none of the four amended workflows are required contexts (confirmed) |
+| **auto-tag.yml trigger** | `workflow_dispatch`-only (confirmed) — validates the planning assumption |
+| **label POST idempotency** | `auto-label-needs-plan.yml` uses add-label (idempotent) — confirms `cancel-in-progress: true` is safe (confirmed) |
+
+### Verified On
+
+| Repo | Context | Status |
+| ---- | ------- | ------ |
+| ProjectHephaestus | issue #1548 / PR #1590 — added `concurrency:` to auto-label-needs-plan.yml, auto-tag.yml, release.yml, security.yml | verified-ci (all required CI checks passed: test, integration, pr-policy, lint; 2026-06-24) |
+````
+
+---
+
 ## v2.0.0 (2026-06-24)
 
 **Changed by:** ProjectHephaestus issue #1548 / PR #1590 — CI-verified after all required checks passed.

--- a/skills/gha-workflow-concurrency-controls.md
+++ b/skills/gha-workflow-concurrency-controls.md
@@ -1,11 +1,11 @@
 ---
 name: gha-workflow-concurrency-controls
-description: "Choosing GitHub Actions `concurrency:` controls when ADDING them to event-driven workflows that currently lack them — selecting the `group` key and `cancel-in-progress` value per the workflow's trigger and its side-effect idempotency. The ONE decision rule: `cancel-in-progress: true` for idempotent / supersede-able runs (tests, scans, idempotent label POSTs — newest event wins), `cancel-in-progress: false` for non-idempotent publishers that must not be interrupted mid-flight (git tag push, PyPI publish, GitHub release creation). Group-key selection scopes the serialization: `github.event.issue.number` (+ `github.run_id` fallback) for per-issue, `github.ref` for per-tag (distinct tags publish in parallel, same tag never double-publishes), `github.head_ref || github.ref` (NOT `github.sha`) for PR scans so successive pushes collapse. Bare group keys (without `${{ github.workflow }}-` prefix) work correctly for single-workflow repos — the workflow-prefix is defensive but optional when cross-workflow collision is not a concern. Use when: (1) a workflow has no `concurrency:` block and you must pick `group`/`cancel-in-progress` by trigger, (2) deciding whether cancelling a run is safe — gate it on side-effect idempotency not convenience, (3) a publish/release workflow needs serialization without over- or under-serializing across tags, (4) PR-scan concurrency must collapse rapid successive pushes (use head_ref, NOT sha), (5) confirming `${{ github.* }}` in a `concurrency.group` does NOT introduce a workflow-injection sink (it is a YAML-key context expr, not a `run:` interpolation), (6) confirming a workflow you are editing is NOT a pinned required status-check context before assuming branch-protection interaction."
+description: "Choosing GitHub Actions `concurrency:` controls for event-driven workflows from trigger identity and side-effect idempotency. Use `cancel-in-progress: true` for idempotent or supersede-able runs and `false` for non-idempotent publishers. Scope groups with stable work identity: a native issue number or required typed `workflow_call` input for per-issue work, `github.ref` for per-tag publishing, and `github.head_ref || github.ref` (not `github.sha`) for PR scans. Use `github.run_id` only when no stable entity key exists and unique per-run grouping is intentional. Use when adding concurrency, supporting both native and reusable triggers, reviewing cancellation safety, or checking branch-protection interaction."
 category: ci-cd
-date: 2026-06-24
-version: "2.0.0"
+date: 2026-08-07
+version: "3.0.0"
 user-invocable: false
-verification: verified-ci
+verification: verified-local
 history: gha-workflow-concurrency-controls.history
 tags:
   - github-actions
@@ -28,7 +28,10 @@ tags:
   - required-status-checks
   - branch-protection
   - side-effect-idempotency
-  - verified-ci
+  - workflow-call
+  - typed-input
+  - stable-entity-key
+  - verified-local
 ---
 
 # GitHub Actions Workflow Concurrency Controls (Group Key + Cancel-in-Progress Selection)
@@ -39,10 +42,10 @@ tags:
 
 | Field | Value |
 | ------- | ------- |
-| **Date** | 2026-06-24 |
+| **Date** | 2026-08-07 |
 | **Objective** | Capture the durable decision rules for adding a `concurrency:` block to event-driven GitHub Actions workflows that lack one — how to choose the `group` key and the `cancel-in-progress` value from the workflow's trigger and the idempotency of its side effects. Surfaced while planning (ProjectHephaestus, issue #1548) the addition of `concurrency:` to four workflows: a per-issue automation workflow, a release/publish workflow, an auto-tag workflow, and a PR-scan workflow. |
-| **Outcome** | Implemented and CI-verified. PR #1590 applied concurrency blocks to all four workflows (`auto-label-needs-plan.yml`, `auto-tag.yml`, `release.yml`, `security.yml`) and all required CI checks passed (test, integration, pr-policy, lint). The decision rules and group-key patterns were confirmed correct in practice. The actual implementation used simpler bare group keys (without `${{ github.workflow }}-` prefix) — valid for single-workflow repos where cross-workflow group collision is not a concern. |
-| **Verification** | verified-ci (PR #1590 passed all required CI checks on 2026-06-24) |
+| **Outcome** | The cancellation and ref/head-ref rules remain CI-verified by PR #1590. The per-issue rule is corrected for reusable workflows: callers provide a required numeric issue input so native and called runs share stable per-issue identity; `run_id` is not a per-issue fallback. The corrected contract and shell boundary are verified locally; hosted CI is pending. |
+| **Verification** | verified-local — PR #1590 retains CI evidence for the original direct-event controls; the corrected reusable per-issue contract was exercised locally on 2026-08-07, with hosted CI pending |
 | **Files Amended** | `auto-label-needs-plan.yml`, `auto-tag.yml`, `release.yml`, `security.yml` |
 
 ## When to Use
@@ -55,6 +58,7 @@ Reach for this when you are ADDING a `concurrency:` block to a workflow that cur
 - A PR-scan workflow re-runs on every push to a PR branch and you want successive pushes to the same PR to collapse to one run — you must use `github.head_ref || github.ref`, because `github.sha` makes every push a distinct group and collapses NOTHING.
 - A security/edit hook or reviewer flags `${{ github.* }}` inside a `concurrency.group:` as a possible injection sink — you need to know it is a YAML-key context expression, not `run:` shell interpolation, so the env-var-lift rule does not apply.
 - You are about to add `concurrency:` to a workflow in a branch-protected repo and must confirm the target is NOT a pinned required status-check context before assuming any merge-queue interaction.
+- One workflow supports both a native entity trigger and `workflow_call`, and you need both paths for the same issue or entity to land in the same concurrency group instead of falling back to a unique `run_id`.
 
 ## Verified Workflow
 
@@ -65,20 +69,20 @@ The single decision rule, then the group-key map:
 | Workflow side effect | Idempotent / supersede-able? | `cancel-in-progress` | Group key | Why |
 | - | - | - | - | - |
 | Tests / scans / lint on a PR | Yes — newest commit's result is the only one that matters | `true` | `github.head_ref \|\| github.ref` | Successive pushes to the same PR collapse to one run; matches the repo's existing `test.yml` convention |
-| Idempotent label POST on an issue | Yes — re-POSTing the same label is a no-op | `true` | `github.event.issue.number \|\| github.run_id` | Per-issue serialization; newest event wins; `run_id` fallback keeps a `workflow_call`/no-issue path uniquely grouped |
+| Idempotent label POST on an issue | Yes — re-POSTing the same label is a no-op | `true` | `github.event.issue.number \|\| inputs.issue_number` | Per-issue serialization across native and reusable runs; the required typed caller input preserves stable identity |
 | git tag push | NO — a cancelled run can leave a tag pushed but its release uncreated | `false` | `github.ref` | Serialize same-ref runs; never interrupt a half-done tag operation |
 | PyPI publish | NO — a cancel can leave a partial/duplicate upload | `false` | `github.ref` (the tag) | Same tag never double-publishes; distinct tags publish in parallel |
 | GitHub release creation | NO — half-created release is worse than serializing | `false` | `github.ref` | Same as PyPI — gate on idempotency, not convenience |
 
 **The rule in one line:** set `cancel-in-progress` from the idempotency of the side effect, NOT from a desire to save minutes. Cancelling a half-finished publish is worse than letting it run.
 
-### Actual Group Keys Used (CI-Verified)
+### Historical Group Keys Used (Direct-Event Path CI-Verified)
 
 The four workflows amended in PR #1590 used these exact concurrency blocks — notably WITHOUT the `${{ github.workflow }}-` prefix, which is optional for single-workflow repos:
 
 | Workflow | Trigger | Group key used | `cancel-in-progress` | Rationale |
 | -------- | ------- | -------------- | -------------------- | --------- |
-| `auto-label-needs-plan.yml` | `issues` events | `auto-label-needs-plan-${{ github.event.issue.number \|\| github.run_id }}` | `true` | Per-issue idempotent label POST; newest event wins |
+| `auto-label-needs-plan.yml` | `issues` events plus an inert reusable declaration | `auto-label-needs-plan-${{ github.event.issue.number \|\| github.run_id }}` | `true` | PR #1590 verified the native `issues` path only; the job's event-only guard skipped `workflow_call`, so this is historical evidence, not the reusable-path recommendation |
 | `auto-tag.yml` | `workflow_dispatch` only | `auto-tag-${{ github.workflow }}` | `false` | Non-idempotent tag push; `workflow_dispatch`-only means only one meaningful run at a time anyway |
 | `release.yml` | tag push (`refs/tags/v*`) | `release-${{ github.ref }}` | `false` | Non-idempotent release publish; per-ref so different tags run in parallel |
 | `security.yml` | `pull_request`, `push` | `security-${{ github.head_ref \|\| github.ref }}` | `true` | Idempotent security scan; collapses successive pushes per PR branch |
@@ -95,12 +99,20 @@ Ask only one question: *if a run is killed at an arbitrary point, can the system
 **2. Choose the group key to scope serialization to the right unit of work.**
 
 ```yaml
-# Per-issue automation (idempotent label POST): serialize per issue,
-# but keep a unique group on a workflow_call / no-issue path so it isn't
-# all collapsed into one empty-string group.
+# Per-issue automation (idempotent label POST): preserve one stable issue
+# identity on both the native event and reusable call paths.
 # Bare-key form (no workflow prefix) — sufficient for single-workflow repos.
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        required: true
+        type: number
+  issues:
+    types: [opened, reopened]
+
 concurrency:
-  group: auto-label-needs-plan-${{ github.event.issue.number || github.run_id }}
+  group: auto-label-needs-plan-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
 
 # Auto-tag (workflow_dispatch only — non-idempotent tag push):
@@ -128,8 +140,13 @@ Key facts:
 - `github.ref` per-tag: distinct tags get distinct groups (parallel), the same tag re-run serializes (never double-publishes).
 - `github.head_ref || github.ref`: `head_ref` is only set on `pull_request`; the `|| github.ref` keeps push/non-PR events grouped. Successive pushes to one PR share the branch ref → they collapse.
 - `github.sha` is WRONG for "collapse successive pushes": every commit is a new SHA → every push is a new group → no collapse ever happens.
-- `github.event.issue.number || github.run_id`: `run_id` is unique per run, so a path with no issue (e.g. `workflow_call`) still gets a unique group instead of falling into a shared empty group.
+- `github.event.issue.number || inputs.issue_number`: a reusable workflow does not inherit the caller's native issue payload. Require the caller to pass the stable issue identifier so native and called runs for the same issue share a group.
+- `github.run_id` is unique per invocation, not stable per entity. It is appropriate only when uniqueness is the desired fallback because no meaningful entity key exists. It prevents an empty shared group, but it cannot provide per-issue serialization and cannot supply the issue number required by downstream API work.
 - Bare keys vs. workflow-prefixed: `${{ github.workflow }}-` prefix is defensive but optional. Use it if cross-workflow collision is a realistic concern; omit it for readability in repos with clear event-to-workflow mapping.
+
+For the complete dual-trigger contract—including one ungated job, positive-integer shell
+validation, caller documentation, `yaml.BaseLoader`, and fake-`gh` regression tests—see pitfall #9
+in `gha-workflow-authoring-pitfalls`.
 
 **3. Confirm the group expression is NOT an injection sink.**
 `concurrency.group:` is a workflow-level YAML KEY whose value is a context expression evaluated by the Actions runner — it is NOT `run:` shell that splices attacker-controllable text into a command. The workflow-injection / env-var-lift mitigation (lift `${{ github.* }}` into `env:` before using in `run:`) applies to shell interpolation, NOT to a `group:` key. So `${{ github.head_ref }}` or `${{ github.event.issue.number }}` in a group key introduces no injection sink. (Contrast: the SAME `github.head_ref` IS a dangerous source inside `run:` — see `gha-workflow-authoring-pitfalls`.)
@@ -147,6 +164,7 @@ The group-key decision rules are durable. Exact insertion lines in any specific 
 | Universal cancel | Assume `cancel-in-progress: true` is universally safe "to save minutes" | WRONG for publishers: a cancelled tag-push/PyPI/release run can leave a tag pushed but release uncreated, or a partial PyPI upload | Gate cancel semantics on side-effect IDEMPOTENCY, not convenience; publishers get `cancel-in-progress: false` |
 | Key publish on `github.workflow` alone | Group a release/publish workflow on just `github.workflow` | Over-serializes (blocks unrelated tags) or under-serializes depending on form — wrong granularity | For `release.yml` prefer `github.ref` (the tag): same-tag races serialize while DISTINCT tags proceed in parallel |
 | Key PR scan on `github.sha` | Use `github.sha` for PR-scan concurrency group | Each SHA is a distinct group, so rapid successive pushes to the same PR branch do NOT collapse | Use `github.head_ref \|\| github.ref` so successive pushes to one PR share a group and collapse |
+| Use `github.run_id` as a per-issue reusable fallback | Group on `github.event.issue.number \|\| github.run_id` | Every reusable invocation receives a different group, including two runs targeting the same issue; the value also cannot identify the issue for the API call | Require a typed `workflow_call` issue input and group on `github.event.issue.number \|\| inputs.issue_number`; reserve `run_id` for intentional per-run uniqueness |
 | Treat `${{ github.* }}` in group as injection | Apply env-var-lift to `${{ github.head_ref }}` inside `concurrency.group:` | The mitigation is for `run:` shell splicing; a `group:` key is a context-expr YAML key, not a shell sink | No env-var-lift needed in a `concurrency.group:`; it introduces no injection sink |
 | Assume branch-protection interaction | Assume adding `concurrency:` could brick the merge queue | A non-required workflow's serialization can't leave a PR un-mergeable; the assumption was unchecked | Enumerate ruleset required contexts FIRST; only a pinned required context could interact |
 | Using `github.workflow-` prefix in group key | Plan proposed `${{ github.workflow }}-${{ github.ref }}` etc. to prevent cross-workflow collisions | Not incorrect but unnecessary — simpler bare keys work fine in repos where workflows don't accidentally share a concurrency group name; the actual implementation used the shorter form | For single-repo, single-workflow-per-event scenarios, the workflow-prefix is defensive but optional; use bare event-scoped keys for readability, add prefix if cross-workflow collision is a real concern |
@@ -155,9 +173,9 @@ The group-key decision rules are durable. Exact insertion lines in any specific 
 
 | Parameter | Value |
 | --------- | ----- |
-| **Verification level** | verified-ci (PR #1590, ProjectHephaestus issue #1548; all required CI checks passed on 2026-06-24) |
+| **Verification level** | verified-local for the corrected reusable per-issue rule; PR #1590 remains verified-ci evidence for direct-event cancellation and the other group-key patterns |
 | **Decision rule** | `cancel-in-progress: true` ⇔ idempotent/supersede-able side effect; `false` ⇔ non-idempotent publisher (tag/PyPI/release) |
-| **Per-issue group (confirmed)** | `auto-label-needs-plan-${{ github.event.issue.number \|\| github.run_id }}`, `cancel-in-progress: true` |
+| **Per-issue group** | `auto-label-needs-plan-${{ github.event.issue.number \|\| inputs.issue_number }}`, `cancel-in-progress: true`; declare `workflow_call.inputs.issue_number` as required `number` and pass the same resolved value to the job |
 | **Per-tag (publish) group (confirmed)** | `release-${{ github.ref }}`, `cancel-in-progress: false` |
 | **Auto-tag group (confirmed)** | `auto-tag-${{ github.workflow }}`, `cancel-in-progress: false` (workflow_dispatch-only) |
 | **PR-scan group (confirmed)** | `security-${{ github.head_ref \|\| github.ref }}`, `cancel-in-progress: true` |
@@ -173,3 +191,4 @@ The group-key decision rules are durable. Exact insertion lines in any specific 
 | Repo | Context | Status |
 | ---- | ------- | ------ |
 | ProjectHephaestus | issue #1548 / PR #1590 — added `concurrency:` to auto-label-needs-plan.yml, auto-tag.yml, release.yml, security.yml | verified-ci (all required CI checks passed: test, integration, pr-policy, lint; 2026-06-24) |
+| ProjectHephaestus | proposed dual-trigger `auto-label-needs-plan.yml` contract | verified-local (typed input, shared identity expression, positive-integer shell guard, and fake-`gh` boundary exercised on 2026-08-07); hosted CI pending |


### PR DESCRIPTION
## Summary

Amends `gha-workflow-authoring-pitfalls` from v1.3.0 to v1.4.0 and `gha-workflow-concurrency-controls` from v2.0.0 to v3.0.0.

Documents the durable identity contract for workflows that support both native entity events and reusable calls.

- require a typed caller-supplied issue number
- route native and reusable paths through one stable event-or-input identity
- validate positive decimal integers before the API boundary
- contract-test workflow YAML, documented caller YAML, and embedded shell behavior
- archive exact pre-amendment snapshots in both history files

## Verification Level

**verified-local**

The YAML contract and shell boundary were exercised locally. Hosted GitHub Actions validation of the proposed Hephaestus workflow remains pending.

## Key Findings

**What Worked**:

- A required numeric reusable input preserves the same issue identity used by the native event.
- One resolved identity expression can drive both concurrency and the job environment.
- A fake `gh` executable proves valid endpoint construction and fail-closed invalid-input behavior.

**What Failed**:

- A `run_id` fallback prevents an empty global bucket but assigns every invocation a different group, so it cannot serialize work per issue.
- An event-only job condition makes a declared reusable trigger silently inert.
- Numeric typing alone does not reject zero, negative, or fractional values from the API domain.

## Test Plan

- [x] `python3 scripts/validate_plugins.py` via the locked `uv` environment (740/740 valid)
- [x] `just check` (219 tests passed)
- [x] Ruff, mypy, and direct PII checks
- [x] markdownlint-cli2 on both amended Markdown skills
- [x] Exact history snapshot hash checks
- [x] Fake-`gh` positive and invalid-input shell checks
- [ ] Hosted CI

Co-authored-by: Codex <noreply@openai.com>
