### PR TITLE
docs(skills): record tag deployment policy debugging

### DIFF
--- a/skills/release-workflow-stagewise-failure-debugging.md
+++ b/skills/release-workflow-stagewise-failure-debugging.md
@@ -1,9 +1,9 @@
 ---
 name: release-workflow-stagewise-failure-debugging
-description: "A tag-triggered PyPI release workflow fails one job at a time — each fix only exposes the next latent bug, because a release is the first time the publish path actually runs end-to-end. Use when: (1) a release.yml / publish pipeline fails at type-check, test, publish-testpypi, or build-and-publish and you must fix stage-by-stage, (2) a fix you merged to main does NOT take effect in the release run — because resolve-release checks out the TAG's tree, not main's HEAD, so the fix must be AT the tagged commit (retag onto the fixed HEAD), (3) `uv run mypy` fails with 'Missing target module, package, files, or command' in the release but the required PR gate passes (the PR gate's pre-commit hook passes explicit targets), (4) tests fail on the release runner with 'No supported agent backend found on PATH' (claude/codex/pi) though they pass on dev/CI where an agent binary exists, (5) a PyPI/TestPyPI publish fails with `invalid-publisher: valid token, but no corresponding publisher` (a trusted-publisher config gap, not code), (6) deciding whether a TestPyPI staging gate earns its keep vs. having build-and-publish build its own dist."
+description: "A tag-triggered release workflow fails one job at a time — each fix only exposes the next latent bug, because a release is the first time the publish path actually runs end-to-end. Use when: (1) a release/publish pipeline fails at a verification or publish job and you must debug stage-by-stage, (2) a fix on the default branch does not take effect because the release checks out the tag's tree, (3) a release runner lacks a local-only dependency, (4) trusted publishing rejects a valid token, (5) deciding whether a staging gate earns its configuration cost, or (6) a tag-triggered deployment is rejected by an environment before any job step starts."
 category: ci-cd
-date: 2026-07-19
-version: "1.0.0"
+date: 2026-08-07
+version: "1.1.0"
 user-invocable: false
 verification: verified-ci
 tags:
@@ -20,6 +20,9 @@ tags:
   - agent-backend-on-path
   - conftest-stub
   - stagewise-failure
+  - environment-policy
+  - deployment-branch-policy
+  - tag-policy
   - homericintelligence
   - hephaestus
 ---
@@ -30,9 +33,9 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-19 |
+| **Date** | 2026-08-07 |
 | **Objective** | Get a tag-triggered PyPI release (Hephaestus v0.10.0) to publish after it failed repeatedly, each time at a later job than the last. |
-| **Outcome** | Each stage-specific latent bug was fixed and verified by the release progressing to the next job: type-check → test → (removed) publish-testpypi → build-and-publish. The decisive insight was that the fixes had to be present AT THE TAGGED COMMIT, not merely on main. |
+| **Outcome** | Each stage-specific latent bug was fixed and verified by the release progressing to the next job. The decisive insight was that fixes must be present at the tagged commit, and environment authorization must match the ref type before a deployment can start. |
 | **Verification** | verified-ci (each fix was confirmed by the live release run clearing the previously-failing job; every fix was also reproduced/verified locally under the release's exact condition). |
 
 ## When to Use
@@ -115,6 +118,35 @@ Reusing a version is only safe if it was never published — confirm:
    the tag tree carries the fix.
 4. Re-run and watch the NEXT job — expect a new, later failure; repeat.
 
+### Pre-step environment-policy rejections
+
+A deployment job that fails before executing any step may have been rejected by
+the environment rather than the workflow code. Inspect the check-run annotations
+and the environment policy; job logs can be absent in this failure mode.
+
+Deployment patterns are typed: a branch rule with a matching glob does not
+authorize a tag-triggered workflow. Preserve existing restrictions, then add the
+smallest matching rule for the release tag convention and read it back before
+retrying.
+
+```bash
+OWNER_REPO="OWNER/REPO"
+ENVIRONMENT="environment-name"
+
+gh api "repos/$OWNER_REPO/environments/$ENVIRONMENT/deployment-branch-policies"
+gh api --method POST \
+  "repos/$OWNER_REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+  -f name='v*' \
+  -f type=tag
+gh api "repos/$OWNER_REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+  --jq '.branch_policies[] | {name, type}'
+gh run rerun <run-id> --failed --repo "$OWNER_REPO"
+```
+
+Only retry after readback proves that the intended `type: tag` policy exists.
+Do not disable selected deployment rules merely to make one release pass; retain
+the branch rules needed by ordinary or recovery workflows.
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
@@ -124,6 +156,7 @@ Reusing a version is only safe if it was never published — confirm:
 | 3 | Assumed the repeated release failures were GitHub runner starvation (as an earlier phase genuinely was) | Runners had recovered; the failures were real latent bugs surfacing one stage at a time | Read the completed job log and reproduce locally before blaming infra. |
 | 4 | Tried to fix `invalid-publisher` in the workflow / retag | It is a PyPI ACCOUNT trusted-publisher config, not code or tag state — no repo change resolves it | Distinguish PyPI-side config gaps from code bugs; escalate account config to the project owner (or remove the gate that needs it). |
 | 5 | `git tag -d` / retag from the agent shell | Local safety nets block tag deletion | Hand the retag commands to the human; verify the target SHA carries every fix first. |
+| 6 | Added a version glob as a branch deployment rule, then retried a tag-triggered job | The pattern name matched, but the rule type did not match the workflow ref; the job was rejected before it started | Diagnose pre-step failures from annotations and add a least-privilege `type=tag` policy with readback before retrying. |
 
 ## Results & Parameters
 
@@ -139,6 +172,8 @@ Reusing a version is only safe if it was never published — confirm:
   (`pypi` / `testpypi`). `invalid-publisher` == no matching publisher.
 - **Job logs are only downloadable after the whole run completes**, not while a
   sibling job is still in progress.
+- **Environment deployment rules are ref-typed:** a release tag requires a
+  `type=tag` rule even when the same glob also appears in an allowed branch rule.
 
 ### Related skills (cross-links)
 
@@ -150,3 +185,4 @@ Reusing a version is only safe if it was never published — confirm:
   patterns (hatch-vcs versioning, PyPI publish steps).
 - `rebase-stale-automation-pr-onto-refactored-main` — the sibling "a fix must be
   present at the exact evaluated tree" theme for stale-base PR rebases.
+- [GitHub deployment environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)


### PR DESCRIPTION
## Summary

- extend the canonical release-debugging lesson with environment-policy rejection diagnosis
- document distinct branch and tag deployment policy types with safe readback before retry
- retain least-privilege deployment rules during release recovery

## Validation

- Validating 741 skill files...

[92m✓[0m academic-paper-accuracy-and-citation-audit.md
[92m✓[0m academic-paper-validation-and-publication.md
[92m✓[0m academic-paper-writing-and-publication-workflow.md
[92m✓[0m actions-cache-restore-save-split-on-success.md
[92m✓[0m address-review-preexisting-unrelated-precommit-failure.md
[92m✓[0m adr-authoring-indexing-and-maintenance.md
[92m✓[0m advise-before-planning.md
[92m✓[0m agent-background-task-failure-recovery.md
[92m✓[0m agent-config-validation-and-integrity.md
[92m✓[0m agents-pr-review-evidence-discipline.md
[92m✓[0m ai-blog-generator.md
[92m✓[0m architecture-agents-md-contract-from-codebase.md
[92m✓[0m architecture-claude-md-agents-md-single-source-ecosystem-migration.md
[92m✓[0m architecture-claude-permission-bypass-removal-planning.md
[92m✓[0m architecture-compose-resource-limit-env-substitution.md
[92m✓[0m architecture-container-secret-cmdline-leak-fix.md
[92m✓[0m architecture-cross-repo-migration-verify-issue-inventory.md
[92m✓[0m architecture-ctx-github-guard-blind-spot.md
[92m✓[0m architecture-defer-env-coercion-lazy-resolver.md
[92m✓[0m architecture-dip-constructor-injection-planning-risks.md
[92m✓[0m architecture-executable-convention-guard-pattern.md
[92m✓[0m architecture-getattr-delegate-collapse-mypy-regressions.md
[92m✓[0m architecture-github-labels-as-state-vocabulary.md
[92m✓[0m architecture-god-function-decomposition-planning-risks.md
[92m✓[0m architecture-import-time-assert-anti-pattern.md
[92m✓[0m architecture-mcp-server-dispatcher-seam.md
[92m✓[0m architecture-meta-repo-config-hardening-planning.md
[92m✓[0m architecture-metaclass-threadlocal-thread-safety.md
[92m✓[0m architecture-migration-freeze-import-debt-baseline.md
[92m✓[0m architecture-ocp-dip-abc-protocol-planning-risks.md
[92m✓[0m architecture-pipeline-durable-state-ac3.md
[92m✓[0m architecture-pipeline-stage-implementation.md
[92m✓[0m architecture-pipeline-stage-order-is-semantic.md
[92m✓[0m architecture-pre-discovery-worker-guard-pattern.md
[92m✓[0m architecture-python-src-layout-migration.md
[92m✓[0m architecture-serial-depends-on-chain-code-serial.md
[92m✓[0m architecture-shared-cache-repo-key-lock-vs-threadlocal.md
[92m✓[0m architecture-threadsafe-cache-per-key-locks.md
[92m✓[0m argparse-tristate-optional-flag.md
[92m✓[0m argparse-version-action-crash-scope.md
[92m✓[0m asymptotic-safety-quantum-gravity-refs.md
[92m✓[0m atlas-dashboard-dockerfile-embed-distroless.md
[92m✓[0m atlas-go-dashboard-milestone-delivery.md
[92m✓[0m audit-doc-consistency-fix-verify-coordinates-on-disk.md
[92m✓[0m audit-driven-remediation-workflow.md
[92m✓[0m audit-driven-remediation.md
[92m✓[0m audit-epic-sequencing-milestone-attachment.md
[92m✓[0m audit-finding-read-adr-before-planning.md
[92m✓[0m audit-orphan-source-sweep-to-find-omissions.md
[92m✓[0m audit-remediation-verify-evidence-before-planning.md
[92m✓[0m audit-stale-version-comment-version-agnostic-fix.md
[92m✓[0m auto-init-py-generation.md
[92m✓[0m auto-review-loop-per-artifact.md
[92m✓[0m automation-529-overload-not-retried-classifier-gap.md
[92m✓[0m automation-agent-commit-type-must-match-pr-policy-allowlist.md
[92m✓[0m automation-agent-tool-scopes-least-privilege.md
[92m✓[0m automation-ambient-cwd-repo-resolution-breaker-cascade.md
[92m✓[0m automation-ci-driver-blocked-poll-early-exit.md
[92m✓[0m automation-clean-checkout-intermediate-artifacts.md
[92m✓[0m automation-constructor-injection-test-migration.md
[92m✓[0m automation-god-package-shim-first-decomposition.md
[92m✓[0m automation-graphql-batch-comment-fetch.md
[92m✓[0m automation-graphql-parameterisation-prevent-injection.md
[92m✓[0m automation-log-path-helper-planning-risks.md
[92m✓[0m automation-loop-backlog-cost-scaling.md
[92m✓[0m automation-loop-early-exit-zero-work-convergence.md
[92m✓[0m automation-loop-exclude-epic-roadmap-issues.md
[92m✓[0m automation-loop-gating-removal.md
[92m✓[0m automation-loop-log-driven-layered-debug.md
[92m✓[0m automation-loop-phase-major-to-issue-major.md
[92m✓[0m automation-loop-post-loop-filter-omission.md
[92m✓[0m automation-moot-issue-regression-guard-pattern.md
[92m✓[0m automation-multi-repo-pr-sweep-rebase-resolve.md
[92m✓[0m automation-parser-state-refactor-planning-risks.md
[92m✓[0m automation-pipeline-observability-and-dryrun.md
[92m✓[0m automation-plan-review-journal-bounded-liveness.md
[92m✓[0m automation-planner-learn-record-writing-robustness.md
[92m✓[0m automation-pola-poll-helper-none-sentinel.md
[92m✓[0m automation-prefix-match-plan-detection.md
[92m✓[0m automation-reuse-repo-clone-with-worktree-per-pr.md
[92m✓[0m automation-review-authorization-ci-boundary.md
[92m✓[0m automation-review-loop-unpushed-fix-oscillates.md
[92m✓[0m automation-session-naming-pr-scoped-not-commit-scoped.md
[92m✓[0m autoscaling-template-promotion-evidence.md
[92m✓[0m babylonjs-havok-vite-wasm.md
[92m✓[0m backoff-jitter-clamp-after-not-before-max-delay.md
[92m✓[0m baseten-miles-grpo-external-inference.md
[92m✓[0m bash-command-substitution-eval-silent-failure-untestable.md
[92m✓[0m bash-mock-gh-python-subprocess-export-f.md
[92m✓[0m bash-script-and-jq-failure-modes.md
[92m✓[0m bash-stderr-jq-separation.md
[92m✓[0m bash-stderr-mktemp-trap-return.md
[92m✓[0m bash-trap-process-group-tree-kill.md
[92m✓[0m batch-loss-averaging-with-partial-batches.md
[92m✓[0m batch-retry-errors-checkpoint-reset.md
[92m✓[0m bats-shell-test-patterns.md
[92m✓[0m benchmark-artifact-triage-pr-splitting.md
[92m✓[0m bf16-monokernel-sol-profiling.md
[92m✓[0m blocked-deletion-issue-unbuilt-prerequisites.md
[92m✓[0m blog-writer.md
[92m✓[0m btrfs-enospc-inheriting-props-metadata-pressure.md
[92m✓[0m campaign-handoff-prompt-authoring.md
[92m✓[0m canonical-config-env-var-expansion.md
[92m✓[0m checkout-other-ref-silent-file-clobber.md
[92m✓[0m checkpoint-recovery.md
[92m✓[0m checkpoint-state-machine-resume.md
[92m✓[0m ci-cd-achaean-fleet-ci-cascade-patterns.md
[92m✓[0m ci-cd-canonical-check-nonlibrary-repo.md
[92m✓[0m ci-cd-codeql-default-to-advanced-canonical-names.md
[92m✓[0m ci-cd-codex-plugin-listing-ci-drift.md
[92m✓[0m ci-cd-cpp-asan-gtest-discovery-branch-protection.md
[92m✓[0m ci-cd-distributed-dependency-license-compatibility-gate.md
[92m✓[0m ci-cd-git-boundary-merge-conflict-staged-handoff.md
[92m✓[0m ci-cd-github-code-quality-findings-no-api.md
[92m✓[0m ci-cd-load-bearing-filename-nitpick-document-dont-rename.md
[92m✓[0m ci-cd-non-required-precommit-strict-false-breaks-main.md
[92m✓[0m ci-cd-opencode-asset-arch-naming.md
[92m✓[0m ci-cd-pixi-lock-version-skew-regeneration.md
[92m✓[0m ci-cd-pixi-macos-runner-integration-test-gotcha.md
[92m✓[0m ci-cd-stage-shared-backoff-cap-constant.md
[92m✓[0m ci-cd-verify-merged-prs-end-to-end.md
[92m✓[0m ci-config-validators-binary-free-python.md
[92m✓[0m ci-coverage-path-remapping.md
[92m✓[0m ci-driver-silent-filter-missing-login-observability.md
[92m✓[0m ci-failure-triage-and-diagnosis.md
[92m✓[0m ci-gate-verify-artifact-is-consumed-before-guarding.md
[92m✓[0m ci-gha-dead-guard-removal.md
[92m✓[0m ci-gitignore-claude-coordinator-files.md
[92m✓[0m ci-gitleaks-pixi-managed-secrets-scan-planning.md
[92m✓[0m ci-hygiene-and-validation-gates.md
[92m✓[0m ci-library-migration-audit-pip-install-coverage.md
[92m✓[0m ci-manifest-platform-fixes.md
[92m✓[0m ci-markdownlint-all-files-repo-wide-blocks-prs.md
[92m✓[0m ci-matrix-yaml-multiformat-regex-fallback.md
[92m✓[0m ci-merge-preview-script-count-drift.md
[92m✓[0m ci-pip-install-user-pep668.md
[92m✓[0m ci-podman-containerized-validation.md
[92m✓[0m ci-precommit-whole-dir-format-drift-blocks-unrelated-commits.md
[92m✓[0m ci-readme-blockquote-markdownlint-break.md
[92m✓[0m ci-release-pipeline-must-mirror-required-pr-gate.md
[92m✓[0m ci-required-check-path-filter-pitfall.md
[92m✓[0m ci-required-checks-gate-superseded-run-false-failure.md
[92m✓[0m ci-ruff-format-collapses-handwrapped-comprehensions.md
[92m✓[0m ci-shell-grep-case-mismatch.md
[92m✓[0m ci-transient-flake-and-environment-failures.md
[92m✓[0m ci-workflow-discovery-yaml-suffix-parity.md
[92m✓[0m cifar10-one-hot-label-encoding.md
[92m✓[0m clang-tidy-conda-sysroot-isystem-pairing.md
[92m✓[0m claude-code-scheduled-tasks-lockfile-gitignore.md
[92m✓[0m claude-code-slash-command-discovery.md
[92m✓[0m claude-code-v21-adoption.md
[92m✓[0m claude-config-branch-audit.md
[92m✓[0m clear-open-issue-backlog-myrmidon-swarm.md
[92m✓[0m cli-adapter-implementation.md
[92m✓[0m cli-argparse-nargs-optional-required-pattern.md
[92m✓[0m cli-audit-subcommand.md
[92m✓[0m cli-flag-validation-prevent-silent-noop.md
[92m✓[0m cli-format-output-pola-silent-fallback.md
[92m✓[0m cli-input-file-prevalidation.md
[92m✓[0m cli-json-flag-emitter-selection-status-vs-data.md
[92m✓[0m cli-json-report-format-implementation.md
[92m✓[0m cli-main-refactor-plan-risk-checklist.md
[92m✓[0m cli-rate-limit-deferral-safe-retry.md
[92m✓[0m cli-validator-cross-section-blind-spot.md
[92m✓[0m cli-visualize-subcommand.md
[92m✓[0m cluster-endpoint-incident-reproducer-validation.md
[92m✓[0m cmd-visualize-filter-format-coverage.md
[92m✓[0m code-quality-audit-principles.md
[92m✓[0m code-quality-bot-ignores-noqa.md
[92m✓[0m code-quality-enforcement-gates.md
[92m✓[0m code-review-before-merge-workflow.md
[92m✓[0m codebase-analysis-generic-tier2-tools.md
[92m✓[0m codeowners-stale-entry-removal.md
[92m✓[0m codeql-action-family-version-alignment.md
[92m✓[0m codeql-exclude-vendored-deps-false-criticals.md
[92m✓[0m codeql-protocol-ellipsis-false-positive.md
[92m✓[0m codex-terminal-ctrl-z-shell-unusable.md
[92m✓[0m communication-redaction-avoid-internal-leaks.md
[92m✓[0m computation-hard-walls-analysis.md
[92m✓[0m conan-cmakeuserpresets-duplicate-preset-collision.md
[92m✓[0m concurrency-and-process-reliability-patterns.md
[92m✓[0m config-default-model-drift.md
[92m✓[0m config-explicit-path-fail-closed.md
[92m✓[0m config-governance-fix-scope-all-variant-files.md
[92m✓[0m config-validation-and-schema-alignment.md
[92m✓[0m console-scripts-exit-code-discipline.md
[92m✓[0m console-wrapper-removal-ci-reference-drift.md
[92m✓[0m container-ci-uid-permissions-rootless.md
[92m✓[0m container-runtime-dependency-linkage-audit.md
[92m✓[0m contributing-md-structure-sync.md
[92m✓[0m coverage-omit-orchestration-pure-function-testing.md
[92m✓[0m cpp-build-and-runtime-bug-patterns.md
[92m✓[0m cpp-cmake-ci-build-and-test-fixes.md
[92m✓[0m cpp-http-client-wrapper-lifetime-equals-object-not-per-call.md
[92m✓[0m cpp-httplib-inflight-cap-planning-assumptions.md
[92m✓[0m cpp-httplib-prerouting-audit-event-planning.md
[92m✓[0m cpp-logger-init-race.md
[92m✓[0m cpp-rate-limiter-test-fixture-burst-capacity-trap.md
[92m✓[0m create-reusable-utilities-hephaestus-port.md
[92m✓[0m create-review-checklist.md
[92m✓[0m cross-repo-boundary-and-ecosystem-audit.md
[92m✓[0m cross-repo-script-and-library-porting.md
[92m✓[0m cyclomatic-complexity-noqa-suppression-planning.md
[92m✓[0m cytoscape-edge-visibility-optimization.md
[92m✓[0m cytoscape-filter-compose.md
[92m✓[0m cytoscape-frontend-rewrite.md
[92m✓[0m cytoscape-interaction-patterns.md
[92m✓[0m dataset-pickle-stage-verify-convert-cleanup.md
[92m✓[0m dead-abstraction-investigate-before-removing.md
[92m✓[0m debian-apt-kernel-headers-repo-gap-diagnosis.md
[92m✓[0m debug-external-reachability-not-local-dns.md
[92m✓[0m debugging-blog-bug-validation-methodology.md
[92m✓[0m debugging-diagnose-before-fixing-stale-blocker-claims.md
[92m✓[0m debugging-gpg-agent-key-crack-export-barrier.md
[92m✓[0m debugging-openai-chat-null-content-reasoning-shape.md
[92m✓[0m debugging-podman-wsl2-netavark-hostnetwork-workaround.md
[92m✓[0m debugging-prefix-cache-nsight-kernel-evidence.md
[92m✓[0m debugging-silent-pipeline-stage-via-argparse-required-grep.md
[92m✓[0m debugging-ufw-systemd-active-status-misleading.md
[92m✓[0m debugging-wsl-host-hang-oom-forensic-diagnosis.md
[92m✓[0m deduplicate-issues.md
[92m✓[0m defensive-analysis-patterns.md
[92m✓[0m dependabot-lockfile-rebase-regenerate-resign.md
[92m✓[0m dependency-floor-near-tested-version.md
[92m✓[0m dependency-manifest-single-source-of-truth.md
[92m✓[0m dependency-resolver-public-api-seam.md
[92m✓[0m dependency-update-automation-bot-prs.md
[92m✓[0m deprecated-api-removal-plan-review.md
[92m✓[0m deprecation-warning-migration.md
[92m✓[0m depthwise-separable-forward-backward.md
[92m✓[0m derived-default-map-canonical-keys.md
[92m✓[0m doc-comment-count-drift-verify-frozen-test.md
[92m✓[0m doc-issue-readme.md
[92m✓[0m doc-update-blog.md
[92m✓[0m docker-apt-runc-conflict-removes-docker-ce.md
[92m✓[0m docker-compose-v1-v2-naming-cascading-recreate.md
[92m✓[0m docker-conan-cache-mount-vs-layer-ssl-not-found.md
[92m✓[0m docker-container-writable-layer-log-bloat.md
[92m✓[0m docker-dns-fallback-tailscale-magicdns.md
[92m✓[0m docker-traefik-network-loss-on-recreation.md
[92m✓[0m docker-ufw-published-ports-bypass-forward-chain.md
[92m✓[0m dockerhub-digest-check-null-guard.md
[92m✓[0m dockerized-mariadb-version-upgrade.md
[92m✓[0m dockerized-nextcloud-major-upgrade.md
[92m✓[0m docs-readme-subpackage-drift-regression.md
[92m✓[0m docstring-api-doc-generation-and-comment-hygiene.md
[92m✓[0m documentation-field-provenance-metadata-generation.md
[92m✓[0m documentation-github-issue-final-report-live-body.md
[92m✓[0m documentation-planning-stage-plan-comment-docstring.md
[92m✓[0m documentation-state-machine-consistency-review.md
[92m✓[0m documentation-table-from-frontmatter-drift-safe-edit.md
[92m✓[0m dry-refactoring-plan-assumption-audit.md
[92m✓[0m dry-refactoring-workflow.md
[92m✓[0m dryrun-process-metrics-assertions.md
[92m✓[0m e2e-crosshost-doctor-prerequisite-checker.md
[92m✓[0m e2e-experiment-run-triage-completion.md
[92m✓[0m e2e-experiment-runner-bug-patterns.md
[92m✓[0m env-manager-migration-python-version-drift.md
[92m✓[0m error-message-consistency-optional-dependency-pola.md
[92m✓[0m evaluate-model.md
[92m✓[0m evaluation-analysis-pipeline-reporting.md
[92m✓[0m evaluation-baseline-parity-cross-matrix.md
[92m✓[0m evaluation-paper-rewrite-after-data-fix.md
[92m✓[0m exception-discriminator-enums-state-machine-pola.md
[92m✓[0m experiment-checkpoint-resume-state-bugs.md
[92m✓[0m explicit-false-schema-fixture-tests.md
[92m✓[0m external-codebase-pattern-integration.md
[92m✓[0m external-request-boundary-invariants.md
[92m✓[0m extract-test-failures.md
[92m✓[0m fastapi-testing-get-settings-direct-call-patch.md
[92m✓[0m finish-branch-delivery-workflow.md
[92m✓[0m fix-altair-facet-layering.md
[92m✓[0m fix-default-value-test-mismatch.md
[92m✓[0m fix-flaky-glob-ordering.md
[92m✓[0m fix-hardcoded-target-path.md
[92m✓[0m fix-yaml-config-propagation.md
[92m✓[0m fixme-todo-cleanup.md
[92m✓[0m gcovr-lcov-excl-region-exclusion.md
[92m✓[0m generate-boilerplate.md
[92m✓[0m generate-changelog.md
[92m✓[0m generate-fix-suggestions.md
[92m✓[0m gh-create-pr-linked.md
[92m✓[0m gh-issue-author-or-assignee-union.md
[92m✓[0m gh-token-env-shadows-keyring.md
[92m✓[0m gha-dedup-jobs-trigger-scope-vs-workflow-call.md
[92m✓[0m gha-release-package-workflow-patterns.md
[92m✓[0m gha-required-checks-branch-protection.md
[92m✓[0m gha-security-scanning-supply-chain.md
[92m✓[0m gha-slsa-docker-build-attestation.md
[92m✓[0m gha-trigger-paths-filter-planning-checklist.md
[92m✓[0m gha-workflow-authoring-pitfalls.md
[92m✓[0m gha-workflow-concurrency-controls.md
[92m✓[0m git-branch-state-triage-and-recovery.md
[92m✓[0m git-commit-signing-failures-and-setup.md
[92m✓[0m git-dco-signoff-distinct-from-gpg-sign.md
[92m✓[0m git-rebase-signing-ci.md
[92m✓[0m git-rebase-skip-duplicate-merged-commits.md
[92m✓[0m git-stacked-prs-rebase-merge-worktree-orchestration.md
[92m✓[0m git-submodule-cd-persists-wrong-repo.md
[92m✓[0m git-trailer-human-identity-vs-model-provenance.md
[92m✓[0m git-unmerged-branch-file-access.md
[92m✓[0m git-workflow-rebase-worktree-signing.md
[92m✓[0m git-worktree-parallel-execution-lifecycle.md
[92m✓[0m git-worktree-sys-path-precedence-issue.md
[92m✓[0m gitattributes-setup.md
[92m✓[0m gitea-large-version-jump-upgrade-doctor-verify.md
[92m✓[0m github-actions-cli-required-env-var-guard.md
[92m✓[0m github-actions-python-required-checks.md
[92m✓[0m github-actions-workflow-paths-filter-completeness.md
[92m✓[0m github-api-label-parsing-splitlines-not-split.md
[92m✓[0m github-api-secondary-rate-limit-backoff.md
[92m✓[0m github-auto-merge-ci-gating-merge-method.md
[92m✓[0m github-cli-pr-body-api-edit.md
[92m✓[0m github-default-branch-standardization-ecosystem-verification.md
[92m✓[0m github-graphql-batch-query-optimization.md
[92m✓[0m github-graphql-pagination-fail-closed-complete-reads.md
[92m✓[0m github-issue-forms-cannot-auto-apply-labels-from-fields.md
[92m✓[0m github-issue-stale-plan-comment-cleanup.md
[92m✓[0m github-issue-state-label-rank-at-or-past.md
[92m✓[0m github-issue-workflow-and-preflight-gates.md
[92m✓[0m github-label-mass-mislabel-forensics.md
[92m✓[0m github-pr-review-head-bound-check-evidence.md
[92m✓[0m github-relative-doc-links-resolve-to-file-location.md
[92m✓[0m github-ruleset-enforcement-drift.md
[92m✓[0m github-ruleset-required-status-checks-management.md
[92m✓[0m github-ruleset-review-count-governance.md
[92m✓[0m github-ruleset-write-scope-404.md
[92m✓[0m gitignored-scratch-dir-regression-guard.md
[92m✓[0m googlenet-backward-pass-inception-gradients.md
[92m✓[0m grpo-external-vllm.md
[92m✓[0m haiku-batch-worktree-agents.md
[92m✓[0m hardened-verifier-self-consistency-and-benign-allowlist.md
[92m✓[0m harness-protected-file-edit-block-silently-defeats-precommit-deliverable.md
[92m✓[0m hephaestus-agent-timeout-refactor-planning-risks.md
[92m✓[0m hephaestus-automation-loop-branch-sync-drive-green.md
[92m✓[0m hephaestus-default-state-dir-planning-risk-capture.md
[92m✓[0m hephaestus-env-var-fallback-path-resolution.md
[92m✓[0m hephaestus-implement-issues-bulk-implementer.md
[92m✓[0m hephaestus-planning-review-risk-capture.md
[92m✓[0m hephaestus-slurm-verification-shared-worktree.md
[92m✓[0m hephaestus-write-secure-planning-guardrails.md
[92m✓[0m holographic-adscft-mechanism-design.md
[92m✓[0m homelab-nextcloud-data-dir-nfs-migration.md
[92m✓[0m homeric-crosshost-deployment-and-mesh-topology.md
[92m✓[0m hypothesis-property-fuzz-llm-output-parsers.md
[92m✓[0m implementation-plan-process-helper-risk-capture.md
[92m✓[0m inference360-dynamic-serving-capacity.md
[92m✓[0m issue-validation-workflow.md
[92m✓[0m justfile-and-local-build-verification.md
[92m✓[0m lazy-clone-dependency.md
[92m✓[0m library-product-import-boundary-enforcement-test.md
[92m✓[0m license-compatibility-ci-gate-pip-licenses.md
[92m✓[0m license-scan-marker-excluded-fallback.md
[92m✓[0m linux-bbr-fq-network-tuning.md
[92m✓[0m linux-cpu-governor-persist-without-cpupower.md
[92m✓[0m linux-diagnose-unclean-reboot-dead-cmos.md
[92m✓[0m linux-workstation-harden-preserve-bambu-avahi-mdns.md
[92m✓[0m liza-go-tests-embedded-cache.md
[92m✓[0m llm-baseline-spec-verification.md
[92m✓[0m llm-corruption-repro-artifact-review.md
[92m✓[0m llm-judge-rubric-design-patterns.md
[92m✓[0m llm-output-verdict-parse-last-line-not-substring.md
[92m✓[0m lockfile-and-release-pipeline-management.md
[92m✓[0m log-watch-subagent-streaming-triage.md
[92m✓[0m logging-contextvars-ambient-state.md
[92m✓[0m logging-downgrade-noisy-happy-path.md
[92m✓[0m logging-subprocess-context-tracking.md
[92m✓[0m logical-model-family-rename-with-storage-exceptions.md
[92m✓[0m luks-encrypted-drive-readonly-recovery.md
[92m✓[0m machine-local-container-artifact-validation-lane.md
[92m✓[0m manifests-config-derived-limits-digest-hardening.md
[92m✓[0m mass-figure-documentation.md
[92m✓[0m mcp-boundary-missing-argument-keyerror-translation.md
[92m✓[0m mcp-config-deliberate-absence-posture.md
[92m✓[0m merged-project-specialized-reviewer.md
[92m✓[0m mesh-dispatch-pipeline-debugging.md
[92m✓[0m meta-repo-build-root-pattern.md
[92m✓[0m mkdocs-markdown-doc-site-build-and-pr-workflow.md
[92m✓[0m mnemosyne-skill-pr-ci-gate-first-pass-green.md
[92m✓[0m mobilenetv1-epoch-training-validation.md
[92m✓[0m model-config-explicit-model-id.md
[92m✓[0m mojo-build-compilation-and-linker-error-patterns.md
[92m✓[0m mojo-ci-runtime-crash-diagnosis-and-mitigation.md
[92m✓[0m mojo-comptime-gate-skip-dead-gradient-block.md
[92m✓[0m mojo-example-script-execution-with-precompiled-packages.md
[92m✓[0m mojo-package-build-and-distribution.md
[92m✓[0m mojo-parallelize-worker-stash-parity-testing.md
[92m✓[0m mojo-planning-verify-type-semantics-and-source-counts.md
[92m✓[0m mojo-srp-module-split-bottom-import.md
[92m✓[0m mojo-tensor-design-view-semantics-numeric-correctness.md
[92m✓[0m mojo-tensor-ownership-training-loops.md
[92m✓[0m mojo-tensor-unit-test-and-gradient-checking.md
[92m✓[0m mojo-type-api-migration-and-import-patterns.md
[92m✓[0m monorepo-subproject-gitignore-and-github-template-gotchas.md
[92m✓[0m move-loose-test-files.md
[92m✓[0m multi-agent-dual-blind-validation-adjudication.md
[92m✓[0m multi-language-judge-pipelines.md
[92m✓[0m multi-pr-issue-triage.md
[92m✓[0m multi-repo-governance-and-ecosystem-setup.md
[92m✓[0m multi-repo-pr-automation-loop-orchestration.md
[92m✓[0m mypy-incremental-cache-scope.md
[92m✓[0m mypy-narrow-cast-not-assert-ruff-s101.md
[92m✓[0m mypy-shutil-which-optional-narrowing.md
[92m✓[0m myrmidon-one-agent-per-item-portfolio-research-pattern.md
[92m✓[0m myrmidon-research-grounding-swarm-with-counterfactual-track.md
[92m✓[0m nas-nfs-write-throughput-diagnosis.md
[92m✓[0m nats-jetstream-jserrcode-stream-exists-misclassification.md
[92m✓[0m nats-leaf-multi-account-remote-bridging.md
[92m✓[0m nats-server-auth-authz-hardening.md
[92m✓[0m nats-subscriber-ack-atmost-once-design.md
[92m✓[0m nats-verify-and-map-san-dns-identity.md
[92m✓[0m natsc-fetchcontent-cpp20-integration.md
[92m✓[0m newton-schulz-fixed-iteration-test-contract.md
[92m✓[0m nextcloud-appapi-harp-deploy-daemon.md
[92m✓[0m nextcloud-slow-storage-upload-failure.md
[92m✓[0m nextcloud-talk-hpb-standalone-deploy.md
[92m✓[0m nfs-no-root-squash-client-cache-flush.md
[92m✓[0m nfs-root-squash-systemd-service-user.md
[92m✓[0m nfs-server-oom-recursive-metadata-ops.md
[92m✓[0m nomad-hcl-variable-sensitive.md
[92m✓[0m notice-dependency-license-inventory-completeness.md
[92m✓[0m objective-collapse-compute-diosi-penrose-gates.md
[92m✓[0m observability-logging-and-process-monitoring.md
[92m✓[0m observability-readiness-closed-status-local-alert-recovery.md
[92m✓[0m odysseus-multi-branch-submodule-pin-management.md
[92m✓[0m odyssey-audit-migration-coverage.md
[92m✓[0m odyssey-functional-optimizer-step-api.md
[92m✓[0m openai-agentic-serving-parser-flags.md
[92m✓[0m optimizer-shampoo-matrix-form-api.md
[92m✓[0m optional-cli-dependency-layered-degradation.md
[92m✓[0m optional-scoped-discovery-pola-gate.md
[92m✓[0m orphan-config-detection.md
[92m✓[0m parallel-agent-myrmidon-swarm-orchestration.md
[92m✓[0m parallel-agent-research-and-swarm-orchestration.md
[92m✓[0m parallel-agent-swarm-dispatch-patterns.md
[92m✓[0m parallel-pr-worktree-workflow.md
[92m✓[0m pcp-pmlogger-unbounded-archive-growth.md
[92m✓[0m persistence-backing-store-test-harness-driven-choice.md
[92m✓[0m phase-implement.md
[92m✓[0m phase-plan-generate.md
[92m✓[0m phase-skip-semantics-already-done-success.md
[92m✓[0m pi-integration-epic-planning-and-package-parity.md
[92m✓[0m pil-grayscale-method-flag.md
[92m✓[0m pip-audit-policy-file-over-inline-ignores.md
[92m✓[0m pipeline-auxiliary-lane-capacity-isolation.md
[92m✓[0m pipeline-budget-tracking-fail-back-exits.md
[92m✓[0m pipeline-routing-budget-terminal-vs-retry-paths.md
[92m✓[0m pixi-env-task-config.md
[92m✓[0m pixi-pip-dep-floor-cap-pinning.md
[92m✓[0m pixi-runtime-env-gotchas.md
[92m✓[0m placeholder-config-deploy-render-footgun.md
[92m✓[0m plan-authoring-ci-justfile-fix-risk-surfacing.md
[92m✓[0m plan-mode-blocks-subagent-writes.md
[92m✓[0m plan-review-interview.md
[92m✓[0m plan-review-strict-rubric-iteration.md
[92m✓[0m plan-test-must-match-repo-runner.md
[92m✓[0m planning-absorb-existing-module-into-unmerged-stage.md
[92m✓[0m planning-against-unmerged-dependency-chain.md
[92m✓[0m planning-audit-doc-nitpick-stamp-and-document.md
[92m✓[0m planning-audit-finding-premise-verification.md
[92m✓[0m planning-backward-compat-config-primitive-extension.md
[92m✓[0m planning-bash-eval-to-positional-args-injection-fix.md
[92m✓[0m planning-bounded-queue-eviction-durability-ordering.md
[92m✓[0m planning-check-already-shipped-before-planning.md
[92m✓[0m planning-code-block-is-the-contract.md
[92m✓[0m planning-container-image-build-publish-meta-repo.md
[92m✓[0m planning-container-image-digest-pinning.md
[92m✓[0m planning-cpp-sibling-submodule-test-mirroring.md
[92m✓[0m planning-cross-pr-interface-dependency.md
[92m✓[0m planning-default-state-dir-centralization.md
[92m✓[0m planning-defer-tracking-via-append-only-adr.md
[92m✓[0m planning-dependent-issue-unverified-upstream.md
[92m✓[0m planning-doc-systematization-onboarding-nitpick.md
[92m✓[0m planning-env-var-to-typed-cli-option-migration.md
[92m✓[0m planning-epic-first-doc-issue-against-adr-guard.md
[92m✓[0m planning-epic-verify-live-child-state.md
[92m✓[0m planning-follow-up-issue-line-number-drift.md
[92m✓[0m planning-follower-issue-unmerged-dependency-assumptions.md
[92m✓[0m planning-frozen-registry-guard-co-update.md
[92m✓[0m planning-generated-doc-from-source-headers.md
[92m✓[0m planning-hephaestus-atomic-parser-risk-review.md
[92m✓[0m planning-implementation-from-issue.md
[92m✓[0m planning-mechanize-dod-convention-gate.md
[92m✓[0m planning-mirror-existing-training-template.md
[92m✓[0m planning-mirror-sibling-pattern-thread-all-consumers.md
[92m✓[0m planning-mismatched-issue-surfaces-review-risks.md
[92m✓[0m planning-normalize-liveness-at-fetch-layer.md
[92m✓[0m planning-parser-prompt-refactor-risk-review.md
[92m✓[0m planning-parser-refactor-metadata-mismatch-risk-checklist.md
[92m✓[0m planning-pr-body-extract-sibling-artifact-at-runtime.md
[92m✓[0m planning-pr-body-numeric-claims-source-derived.md
[92m✓[0m planning-pr-open-file-scope-via-git-diff.md
[92m✓[0m planning-pr-open-load-bearing-assumption-hygiene.md
[92m✓[0m planning-pr-review-go-gate-severity-round-trip.md
[92m✓[0m planning-pydantic-options-refactor-risk-checklist.md
[92m✓[0m planning-reuse-existing-public-env-reader.md
[92m✓[0m planning-revising-after-nogo-verify-impl-not-signature.md
[92m✓[0m planning-roadmap-tracking-issue-reconciliation.md
[92m✓[0m planning-self-identified-defects-must-be-fixed-not-noted.md
[92m✓[0m planning-shared-state-io-helper-refactor-risks.md
[92m✓[0m planning-slo-sla-adr-meta-repo.md
[92m✓[0m planning-state-dir-centralization-risk-audit.md
[92m✓[0m planning-test-coverage-verify-premise-and-mock-targets.md
[92m✓[0m planning-unmerged-dep-pure-classifier-extraction.md
[92m✓[0m planning-unmerged-parent-contract-compile-smoke-gate.md
[92m✓[0m planning-validator-ci-gate-tasks.md
[92m✓[0m planning-validator-false-assurance-flatten-duplicate-guard.md
[92m✓[0m planning-verify-issue-premise-before-implementing.md
[92m✓[0m png-jpeg-to-idx-conversion.md
[92m✓[0m podman-from-source-install.md
[92m✓[0m pola-consolidate-duplicated-silent-default-resolver.md
[92m✓[0m port-feature-branch-impl.md
[92m✓[0m pr-ci-failure-triage-preexisting-vs-introduced.md
[92m✓[0m pr-compliance-dco-and-rebase-fix.md
[92m✓[0m pr-enumeration-discovery-idempotency.md
[92m✓[0m pr-rebase-conflict-resolution-patterns.md
[92m✓[0m pr-review-loop-orchestration-agent-patterns.md
[92m✓[0m pr-review-thread-coordination-sub-agent-serialization.md
[92m✓[0m pr-review-threadless-nogo-verdict-retry-wedge.md
[92m✓[0m pr-review-two-dot-vs-three-dot-diff.md
[92m✓[0m pre-commit-hooks-and-linting-config.md
[92m✓[0m pre-implementation-plan-review-wave.md
[92m✓[0m prepare-dataset.md
[92m✓[0m process-metrics-pipeline-integration.md
[92m✓[0m projecthephaestus-d103-test-docstrings.md
[92m✓[0m projecthephaestus-finished-stage-pr-worktree-preservation.md
[92m✓[0m projecthephaestus-queue-pipeline-strict-review-remediation.md
[92m✓[0m prometheus-json-api-exporter-sidecar.md
[92m✓[0m prompt-fencing-refactor-plan-risks.md
[92m✓[0m prompt-string-syntax-raw-vs-plain.md
[92m✓[0m pydantic-basemodel-to-dataclass-behavioral-parity.md
[92m✓[0m pydantic-frozen-models-testing-pattern.md
[92m✓[0m pydantic-json-schema-dual-validation.md
[92m✓[0m pydantic-none-coercion-pattern.md
[92m✓[0m pydantic-options-base-class-refactor-planning-risks.md
[92m✓[0m pytest-async-mock-isolation-patterns.md
[92m✓[0m pytest-configuration-discovery-and-ci-pitfalls.md
[92m✓[0m pytest-coverage-threshold-and-enforcement.md
[92m✓[0m pytest-fixture-patterns-and-deduplication.md
[92m✓[0m pytest-nested-marker-walk-up-contract.md
[92m✓[0m pytest-patch-decorator-to-shared-fixture-conversion.md
[92m✓[0m pytest-test-file-placement-subpackage-enforcement.md
[92m✓[0m pytest-test-splitting-matrix-and-parametrization.md
[92m✓[0m python-automation-god-package-shim-antipattern.md
[92m✓[0m python-cli-cwd-github-repo-detect.md
[92m✓[0m python-cli-dry-run-and-entrypoint-patterns.md
[92m✓[0m python-import-patterns-and-compatibility-guards.md
[92m✓[0m python-import-time-forward-reference-lambda-guard.md
[92m✓[0m python-logging-and-silent-error-patterns.md
[92m✓[0m python-metric-validation-api-cli-domain-parity.md
[92m✓[0m python-module-decomposition-and-refactor-patterns.md
[92m✓[0m python-module-move-all-surface-sweep.md
[92m✓[0m python-packaging-pyproject-editable-install.md
[92m✓[0m python-path-resolution-cwd-resolve-contract.md
[92m✓[0m python-protocol-stub-ellipsis-not-pass.md
[92m✓[0m python-repo-modernization-workflow.md
[92m✓[0m python-repo-modernization.md
[92m✓[0m python-sca-pip-audit-update-transitive-lock.md
[92m✓[0m python-testing-coverage-xml-gitignore.md
[92m✓[0m python-type-hints-and-mypy-patterns.md
[92m✓[0m readme-badges-live-sources-and-count-drift-prevention.md
[92m✓[0m rebase-stale-automation-pr-onto-refactored-main.md
[92m✓[0m recurring-tier-label-fix.md
[92m✓[0m recursive-plan-multi-month-projects.md
[92m✓[0m refactor-extraction-plan-unverified-assumptions.md
[92m✓[0m regex-value-strip-before-finite-check.md
[92m✓[0m regression-test-from-issue-plan.md
[92m✓[0m release-auto-tag-token-trigger-and-doc-guard-traps.md
[92m✓[0m release-tag-drift-recut-on-fixed-commit.md
[92m✓[0m release-workflow-planning-assumptions-and-risks.md
[92m✓[0m release-workflow-stagewise-failure-debugging.md
[92m✓[0m rename-propagation-unexercised-paths-break-later.md
[92m✓[0m repo-audit-scoping-superproject-git-ls-files.md
[92m✓[0m repo-audit-triage-fix-and-issue-workflow.md
[92m✓[0m required-check-noop-fix-via-tested-script.md
[92m✓[0m rescue-broken-prs.md
[92m✓[0m research-charter-amendment-governance-workflow.md
[92m✓[0m resilience-circuit-breaker-error-translation.md
[92m✓[0m resilience-circuit-breaker-per-target-vs-service-failure.md
[92m✓[0m retry-cap-after-jitter-hard-ceiling-clamp.md
[92m✓[0m review-coordination-parallel-serial-subagent-dispatch.md
[92m✓[0m review-worker-defaults-options-alignment.md
[92m✓[0m rubric-conflict-detection.md
[92m✓[0m ruff-format-preexisting-files-precommit.md
[92m✓[0m ruff-specific-rule-fixes.md
[92m✓[0m run-tests.md
[92m✓[0m sampling-degeneration-seed-token-debugging.md
[92m✓[0m sata-drive-bus-disconnect-diagnosis.md
[92m✓[0m sbom-syft-preserve-native-dependency-graph.md
[92m✓[0m scan-vulnerabilities.md
[92m✓[0m scanner-alerts-to-github-issues-pipeline.md
[92m✓[0m scifi-mechanism-pr-box-trivial-communication-complexity.md
[92m✓[0m scifi-mechanism-single-device-design.md
[92m✓[0m security-md-version-sync.md
[92m✓[0m security-pep508-parser-replaces-regex.md
[92m✓[0m service-validation-fresh-isolated-allocation.md
[92m✓[0m sgd-momentum-initialization-convergence.md
[92m✓[0m sglang-moe-nsys-profile-preflight.md
[92m✓[0m sglang-v2-source-build-runtime-dependency-validation.md
[92m✓[0m shared-default-fallback-single-source.md
[92m✓[0m shared-predicate-gate-discovery-parity.md
[92m✓[0m shell-negation-exit-status-capture.md
[92m✓[0m shell-script-integration-test-tier-coverage.md
[92m✓[0m shell-wrapper-container-detection.md
[92m✓[0m sibling-pr-mutually-exclusive-design-conflict.md
[92m✓[0m silent-boundary-observability-exception-classification.md
[92m✓[0m skill-advisor-task-routing.md
[92m✓[0m skill-cli-deep-audit-and-fix.md
[92m✓[0m skill-consolidation-nuance-audit-workflow.md
[92m✓[0m skill-corpus-count-excludes-notes-and-history-files.md
[92m✓[0m skill-corpus-merge-consolidation-workflow.md
[92m✓[0m skill-file-format-frontmatter-and-validation.md
[92m✓[0m skill-teaching-stale-practices-contradicting-canonical-docs.md
[92m✓[0m skill-unify-config-structure.md
[92m✓[0m skills-to-plugins-migration.md
[92m✓[0m slurm-shared-storage-artifact-relocation.md
[92m✓[0m slurm-wrap-shell-contract.md
[92m✓[0m spec-driven-experimentation.md
[92m✓[0m split-figure-per-tier.md
[92m✓[0m stale-background-bash-tasks-audit.md
[92m✓[0m stale-documentation-audit-and-broken-reference-repair.md
[92m✓[0m stale-plan-already-resolved.md
[92m✓[0m stale-version-comment-version-agnostic-fix.md
[92m✓[0m state-file-persistence-refactor-planning-risks.md
[92m✓[0m state-machine-and-resource-lifecycle-patterns.md
[92m✓[0m statistical-claim-verification.md
[92m✓[0m stdlib-json-decoder-raw-decode-string-extraction.md
[92m✓[0m subprocess-embedded-null-byte-sanitize.md
[92m✓[0m swarm-agent-status-misread-as-premature-exit.md
[92m✓[0m symbol-scoped-import-exemptions.md
[92m✓[0m systemd-docker-compose-restart-storm-fix.md
[92m✓[0m systemd-inapplicable-failed-units-mask.md
[92m✓[0m tailscale-maestro-setup.md
[92m✓[0m tailscale-split-dns-dnsmasq-restricted-nameserver.md
[92m✓[0m targeted-port-audit-parallel-reviewers.md
[92m✓[0m tdd-workflow-and-test-coverage-expansion.md
[92m✓[0m tech-debt-discovery-grep-self-match.md
[92m✓[0m template-migration.md
[92m✓[0m test-diff-analyzer.md
[92m✓[0m test-fixtures-tz-aware-datetime-production-invariant.md
[92m✓[0m test-implementation-gap-analysis.md
[92m✓[0m test-state-machine-docstring-accuracy.md
[92m✓[0m test-worktree-parents-path-resolves-wrong-tree.md
[92m✓[0m testing-autouse-default-patch-for-new-batched-call.md
[92m✓[0m testing-cli-mock-subprocess-http.md
[92m✓[0m testing-dead-parametrize-short-circuit-tautology.md
[92m✓[0m testing-deterministic-clock-vs-thread-sleep-classification.md
[92m✓[0m testing-doc-guard-markdown-linewrap-substring.md
[92m✓[0m testing-dynamic-import-sys-path-resolution.md
[92m✓[0m testing-env-gated-live-broker-gtest-suite.md
[92m✓[0m testing-env-leak-local-fail-ci-pass.md
[92m✓[0m testing-gtest-skip-inside-helper-keeps-test-running.md
[92m✓[0m testing-guard-clause-environment-satisfaction.md
[92m✓[0m testing-integration-fake-binary-on-path.md
[92m✓[0m testing-jetstream-flaky-stream-state-leak.md
[92m✓[0m testing-local-wheel-install-content-test.md
[92m✓[0m testing-mock-print-stdout-patch-target.md
[92m✓[0m testing-module-patch-target-after-extraction.md
[92m✓[0m testing-non-vacuous-regression-guards-behavior-unchanged.md
[92m✓[0m testing-notice-cross-check-value-scoping.md
[92m✓[0m testing-oserror-swallow-nonfatal-patch-pattern.md
[92m✓[0m testing-parametrized-console-script-test-incomplete-implementation.md
[92m✓[0m testing-pipeline-crash-matrix-real-stage-durability.md
[92m✓[0m testing-pragma-no-cover-error-path-coverage.md
[92m✓[0m testing-python-constants-module.md
[92m✓[0m testing-real-server-fault-test-recovery.md
[92m✓[0m testing-semantic-enum-order-guard.md
[92m✓[0m testing-source-line-number-assertions-are-churn-engines.md
[92m✓[0m testing-source-package-asset-contract-mirroring.md
[92m✓[0m testing-stale-issue-dedup-inline-pattern.md
[92m✓[0m testing-subprocess-helper-mocks-during-refactor.md
[92m✓[0m testing-verification-gate-zero-test-false-pass.md
[92m✓[0m tiered-skill-migration-tests.md
[92m✓[0m timeout-centralization-plan-risk-review.md
[92m✓[0m timeout-refactor-env-var-to-cli-pitfalls.md
[92m✓[0m toml-section-bounded-regex-dotall-bug.md
[92m✓[0m tone-matched-documentation.md
[92m✓[0m tooling-ansible-core-upgrade-legacy-playbooks.md
[92m✓[0m tooling-build-john-jumbo-gpg-no-sudo.md
[92m✓[0m tooling-bulk-rename-relative-path-trap.md
[92m✓[0m tooling-cmake-version-grep-minimum-required-trap.md
[92m✓[0m tooling-codex-plugin-symlink-empty-cache-fix.md
[92m✓[0m tooling-config-placeholder-grep-guard.md
[92m✓[0m tooling-cross-repo-git-history-format-patch-replay.md
[92m✓[0m tooling-csv-merchant-normalization-regex-rules.md
[92m✓[0m tooling-dagger-sdk-v020-breaking-changes.md
[92m✓[0m tooling-docker-headless-build-credential-helper.md
[92m✓[0m tooling-dry-run-smoke-full-profile-dispatcher.md
[92m✓[0m tooling-edit-denied-bash-python-line-replace.md
[92m✓[0m tooling-edit-templated-config-at-source.md
[92m✓[0m tooling-force-push-blocked-reopen-as-fresh-branch.md
[92m✓[0m tooling-git-recover-stashed-work-after-concurrent-branch-reset.md
[92m✓[0m tooling-gitignore-broad-pattern-swallows-new-files.md
[92m✓[0m tooling-hephaestus-implementer-no-changes-state-skip.md
[92m✓[0m tooling-make-wrapper-skips-image-rebuild.md
[92m✓[0m tooling-parallel-gpg-passphrase-trial.md
[92m✓[0m tooling-pipeline-invalid-jobrequest.md
[92m✓[0m tooling-pixi-lockfile-churn-self-reference.md
[92m✓[0m tooling-plan-artifact-delivery-nogo.md
[92m✓[0m tooling-plugin-command-codebase-rename.md
[92m✓[0m tooling-portable-shared-repo-fork-resolution.md
[92m✓[0m tooling-precommit-check-convention-to-invariant.md
[92m✓[0m tooling-repo-rename-stale-remote-and-tag-refspec-push-failure.md
[92m✓[0m tooling-sonnet-content-filter-contributor-covenant.md
[92m✓[0m tooling-stage-only-your-own-files-in-shared-worktree.md
[92m✓[0m tooling-state-skip-label-recovers-skip-capped-prs.md
[92m✓[0m tooling-wave-b-pr-fix-mesh-playbook.md
[92m✓[0m tooling-wipe-claude-code-session-secrets.md
[92m✓[0m track-implementation-progress.md
[92m✓[0m tracking-doc-checkbox-sync-regression-guard.md
[92m✓[0m traefik-middleware-cross-provider-reference-suffix.md
[92m✓[0m train-model.md
[92m✓[0m training-diagnosis-loss-accuracy-decoupling-overfitting.md
[92m✓[0m training-grokking-preconditions-and-vision-recipe.md
[92m✓[0m training-hyperparam-lr-scale-depth-transfer.md
[92m✓[0m training-log-parsing-exit-codes.md
[92m✓[0m training-multi-metric-best-checkpoint-min-after-max.md
[92m✓[0m training-smoke-mechanism-ci-gate.md
[92m✓[0m ufw-firewalld-dual-manager-conflict.md
[92m✓[0m unison-systemd-home-env-required.md
[92m✓[0m validate-tier-id-filename-consistency.md
[92m✓[0m validation-cli-parser-root-resolution-planning.md
[92m✓[0m valuation-private-securities-platform-data-beats-web-research.md
[92m✓[0m variance-estimator-ddof-contract.md
[92m✓[0m verification-evidence-audit.md
[92m✓[0m verify-audit-issue-reproduces-before-fixing.md
[92m✓[0m verify-delegated-agent-claims-run-full-suite.md
[92m✓[0m verify-infrastructure-tracking.md
[92m✓[0m verify-issue-premise-against-code-before-planning.md
[92m✓[0m verify-pr-ready.md
[92m✓[0m vite-wasm-havok-fix.md
[92m✓[0m warden-hot-upgrade-api-wire-compatibility.md
[92m✓[0m warden-hot-upgrade-listener-isolation.md
[92m✓[0m warn-on-existing-dest-subdir.md
[92m✓[0m workaround-demolition-wave-strategy.md
[92m✓[0m workflow-batched-validation-resume-rate-limits.md
[92m✓[0m workflow-github-issues-individual-per-fix-for-automation-loop.md
[92m✓[0m worktree-deleted-mid-session-recovery.md
[92m✓[0m xterm-plan-mode-fix.md
[92m✓[0m yaml-long-line-refactor.md
[92m✓[0m zero-count-division-guard.md

============================================================
Validation Summary:
  [92mValid[0m: 741/741
============================================================
- ........................................................................ [ 32%]
........................................................................ [ 65%]
........................................................................ [ 98%]
...                                                                      [100%]
================================ tests coverage ================================
______________ coverage: platform darwin, python 3.13.11-final-0 _______________

Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
scripts/check_pii.py                      90     27    70%   51, 58, 84-85, 89-92, 96-105, 109-120, 124
scripts/fix_md_tables.py                 111    111     0%   17-173
scripts/fix_remaining_warnings.py         95      8    92%   48, 66, 99, 110, 114, 126, 130, 209
scripts/migrate_ecosystem_skills.py      292      9    97%   330, 396, 440, 604-609, 622-624
scripts/mnemosyne_skill_utils.py          26      0   100%
scripts/validate_plugins.py              137     32    77%   118, 168, 175, 223-244, 249-284, 288
scripts/validate_release_contract.py      66      3    95%   64-65, 128
--------------------------------------------------------------------
TOTAL                                    817    190    77%
219 passed in 1.85s