### PR TITLE
feat(skills): amend Python import patterns skill

### DIFF
--- a/skills/python-import-patterns-and-compatibility-guards.history
+++ b/skills/python-import-patterns-and-compatibility-guards.history
@@ -2,6 +2,909 @@
 
 # History: python-import-patterns-and-compatibility-guards
 
+## v2.0.0 (2026-08-08)
+
+**Changed by:** Reviewed ProjectHephaestus implementation plan to make the
+`hephaestus.automation` runtime module graph acyclic while preserving public
+imports and adapter behavior.
+**Verification:** `unverified` — the implementation, focused suites, and CI
+were not executed in this `/learn` session.
+
+### What changed
+
+- Corrected the core recommendation: a function-local import can defer a
+  partial-initialization failure, but it remains a runtime dependency edge and
+  does not prove structural acyclicity.
+- Added section I, a proposed workflow for building a complete AST runtime
+  graph, handling positive and negated `TYPE_CHECKING` guards, retaining both
+  package and resolvable-child edges, parsing assigned and annotated lazy-export
+  maps, normalizing only intentional facade components, and detecting cycles
+  with an in-test Tarjan implementation.
+- Added the dependency-neutral leaf extraction pattern: move only shared
+  low-level execution, identity, cache, and formatting behavior; keep
+  higher-level orchestration with existing owners.
+- Added explicit re-export identity/signature pins, direct-module import
+  guidance, adapter lookup-site testing, scoped/unscoped parity, subprocess
+  import-order checks, synthetic false-negative fixtures, and before/after
+  cache isolation.
+- Added nine planning-failure rows, proposed graph parameters, expected failure
+  and success shapes, and a plan-only ProjectHephaestus verification record.
+- Bumped `1.8.0` to `2.0.0` because the amendment changes the skill's core
+  circular-import recommendation rather than merely extending it.
+
+### Why
+
+Successful import order is a weaker contract than an acyclic runtime module
+graph. Module-local deferral, package-attribute resolution, PEP 562 lazy maps,
+and intentional patch facades can hide dependencies from top-level import
+smoke tests. The prior skill conflated import-time repair with structural cycle
+removal. This major update makes that distinction explicit and supplies a
+guard design that preserves public and adapter seams instead of allowlisting
+cycles.
+
+### Previous version (v1.8.0) snapshot
+
+The exact previous skill body follows.
+
+````markdown
+---
+name: python-import-patterns-and-compatibility-guards
+description: "Use when: (1) a child module would create circular dependencies by importing the parent at module level — use function-local imports to defer the lookup and keep the import graph acyclic; (2) extending a public SDK surface with peer classes using lazy-loading __init__.py infrastructure (lazy exports pattern via __getattr__) to prevent eager-load regressions when adding new peers to __all__; (3) code uses a stdlib module added in a later Python version (tomllib in 3.11+, ExceptionGroup in 3.11+) and the CI matrix includes older Python — add a version-gated try/except import guard so the module remains importable; (4) adding cross-OS CI matrix and Windows jobs fail with ModuleNotFoundError for POSIX-only stdlib modules (curses, fcntl, grp, tzdata) — add conditional import guards and ensure tzdata is listed as an optional Windows dependency; (5) a hardcoded surface-pinning test (set(__all__) == literal) fails on CI with 'Extra items in the left set' because a peer export landed on main via an independent PR while your branch was open — fix the stale test literal, not the (correct) source, and use env -i / git stash / grep-the-CI-log to separate real failures from live-session environment noise; (6) a branch widening a lazy SDK surface (_LAZY_EXPORTS/__all__/__getattr__ in __init__.py) goes DIRTY/CONFLICTING on rebase because a sibling PR already landed the identical export — resolve by keeping ONE copy of the shared entry, and FIRST check mergeStateStatus=DIRTY when a PR reads as CI-failing but no test actually failed; (7) adding a DeprecationWarning at ACCESS time (not just call time) for a deprecated lazy shim exposed via a PEP 562 package __getattr__ loader — grep the named symbol against the source first because the issue may misname the mechanism (in _LAZY_IMPORTS vs __all__), keep access-time and call-time warnings as complementary layers (both needed for different access paths), force a fresh resolve in the regression test via module.__dict__.pop(name) because PEP 562 caches into globals, rewrite any stale-tolerant test that documents the current silent behavior, use stacklevel=2 inside __getattr__ (verified: user line → __getattr__ → warn, so stacklevel=2 attributes to user's access line), and update the prose deprecation doc (COMPATIBILITY.md) in the same PR (verified-local, ProjectHephaestus issue #1545); (8) EXECUTING an audit-finding fix that PROMOTES existing public-looking symbols into a package's declared __all__ — scope creep is intentional: when the issue names a subset of affected symbols but the same defect class applies to sibling symbols in the same module, fix ALL of them in one PR (e.g. issue #1511 named add_dry_run_arg + DRY_RUN_HELP_CAVEAT but add_github_throttle_args + configure_github_throttle_from_args had the identical gap; fixing all four so set(utils.__all__) == set(cli.__all__) prevents re-triggering the same audit finding); choose EAGER re-export (plain 'from … import (…)' in __init__.py) when the source module pulls only stdlib — no need for _LAZY_EXPORTS infrastructure; NO COMPATIBILITY.md change is needed when the package has no per-symbol table (only a tier entry); pin the test with a SUBSET ASSERTION (set(submodule.__all__) - set(pkg.__all__) must be empty, not strict equality) so parallel PRs adding new symbols cannot break the pin; do NOT guess the COMPATIBILITY.md 'Added' version from the latest git tag (check RELEASING.md/milestones/roadmap or flag for reviewer), grep the WHOLE test tree (not just the obvious file) for a strict-equality surface pin before widening __all__ because the breakage is non-local, verify the audit's stability-tier premise on disk (audit findings can be factually wrong), assert re-export IDENTITY (pkg.sym is submodule.sym) and grep for existing patch(\"pkg.submodule...\") usages, and include test_import_surface.py/test_automation_boundary.py in the verification set for any __init__.py widening (verified-local, executed end-to-end for ProjectHephaestus issue #1511; planning-guidance for COMPATIBILITY.md version-stamping derived from plan for issue #1513 remains unverified); (9) PLANNING the companion module-level __dir__() for a PEP 562 lazy-loader package whose __getattr__ lazily resolves symbols but whose dir(pkg) shows only eagerly-bound names — define __dir__() returning sorted(set(_LAZY_IMPORTS) | set(__all__) | set(globals())) so the entire lazy public API is discoverable to IPython tab-completion / IDEs / doc generators; CRITICAL: a custom __dir__ REPLACES (does not merge with) the default listing, so you MUST fold set(globals()) in or you silently REMOVE today-visible names (__version__, __author__, dunders, already-cached lazy names); __dir__ returns names only and performs NO attribute access, so a deprecated lazy shim can be listed without firing its DeprecationWarning; pin the contract by SUBSET INVARIANT (set(_LAZY_IMPORTS) <= set(dir(pkg))) not a hardcoded count (the audit's '35 symbols' was already stale at 40); regression-test that dir() does not SHRINK the visible set; extend the existing surface test file, do not create a parallel one (unverified planning-guidance, derived from a plan for ProjectHephaestus issue #1512); (10) EXECUTING a fix that adds a single public symbol to a package __all__ in a repo that has a per-symbol COMPATIBILITY.md API table guarded by a live-tree-scanning validation test (e.g. hephaestus tests/unit/validation/test_api_table_docs.py — TestLiveTreeAlignment::test_real_compatibility_md_is_aligned / TestMain::test_main_returns_zero_on_real_repo) — adding the name to __all__ (and re-exporting it from the package __init__.py __all__) WITHOUT adding a matching COMPATIBILITY.md row fails with '[missing-from-docs] <pkg>.<name> is in __all__ but has no row in COMPATIBILITY.md'; the FIX is to add an ALPHABETICAL row to the right '### <pkg>' section with a 'since' version column resolved from sibling helpers added in the same release cycle (NOT blindly from `git describe --tags --abbrev=0` — verify against siblings, e.g. configure_cli_logging took 0.9.8 because create_validation_parser/resolve_repo_root in the same cycle used 0.9.8 even though the latest tag was v0.9.7). CRITICAL FULL-SUITE-ONLY HAZARD: this live-tree alignment test scans the actual on-disk __all__ + COMPATIBILITY.md at scan time, so it can PASS when run in ISOLATION (`pytest …::test_real_compatibility_md_is_aligned` alone) yet reliably FAIL only when you run the WHOLE module / the broad tests/unit/validation suite WITH the change applied — an isolated green run is a FALSE NEGATIVE. After editing ANY package __all__ or [project.scripts]/public-export surface, run the full module that owns the live-tree alignment check (here `pixi run python -m pytest tests/unit/validation/test_api_table_docs.py -q --no-cov`) before claiming green; never trust an isolated test run for live-tree-scanning validation tests (verified-local, ProjectHephaestus issue #1419). This UPGRADES the previously-unverified COMPATIBILITY.md per-symbol version-stamping guidance from issue #1513 to verified-local: issue #1419 executed the per-symbol-row addition end-to-end and confirmed the version column is resolved from same-cycle siblings, not the latest tag. SECONDARY (cross-link, not its own skill): the issue #1419 body + approved plan predated sibling PR #1637 which had ALREADY merged most of the work with a WIDER create_validation_parser API (kept include_repo_root/prog/usage/epilog/formatter_class that the plan said to drop) — do NOT reverse merged code to satisfy a stale plan; grep the CURRENT state and implement only the genuinely-unimplemented slice (reinforces dry-refactoring-workflow's 'issue bodies/plans go stale')."
+category: architecture
+date: 2026-06-29
+version: "1.8.0"
+user-invocable: false
+history: python-import-patterns-and-compatibility-guards.history
+tags:
+  - import-strategy
+  - circular-dependency
+  - coupling-avoidance
+  - lazy-loading
+  - sdk-surface
+  - version-guard
+  - cross-platform
+  - windows-ci
+  - stdlib
+  - tomllib
+  - curses
+  - fcntl
+  - tzdata
+  - compatibility
+  - surface-pinning
+  - branch-divergence
+  - merge-skew
+  - test-vs-source
+  - environment-noise
+  - merge-conflict
+  - rebase
+  - mergestate-dirty
+  - deprecation-warning
+  - access-time-warning
+  - pep-562
+  - getattr
+  - stale-tolerant-test
+  - doc-drift
+  - stacklevel
+  - warnings-warn
+  - audit-finding
+  - surface-promotion
+  - version-stamping
+  - stability-docs
+  - re-export-identity
+  - import-surface-boundary
+  - dir
+  - __dir__
+  - discoverability
+  - introspection
+  - compatibility-md
+  - api-table
+  - missing-from-docs
+  - live-tree-scan
+  - full-suite-only
+  - false-negative-isolation
+  - version-column
+  - same-cycle-siblings
+---
+
+# Python Import Patterns and Compatibility Guards
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-06-29 |
+| **Objective** | Manage the Python import graph and import compatibility across versions and platforms: avoid circular dependencies with function-local imports, extend public SDK surfaces via lazy exports without eager-load regressions, guard stdlib imports that vary by Python version or OS, keep hardcoded surface-pinning tests from going stale when peers land via parallel PRs, emit an access-time `DeprecationWarning` across the PEP 562 lazy-loader seam, and — when adding a public symbol to a package `__all__` in a repo with a per-symbol `COMPATIBILITY.md` API table guarded by a live-tree-scanning validation test — add the matching alphabetical table row (with a version column resolved from same-cycle siblings) AND run the full validation module, because the live-tree alignment check is a FALSE NEGATIVE when run in isolation |
+| **Outcome** | Acyclic import graphs, Windows-importable packages, CI matrices green on older Python and POSIX-only stdlib, lazy SDK surfaces that scale to new peer classes, a decision procedure for fixing stale pinned-`__all__` tests (test vs source) without chasing live-session environment noise, a verified workflow for emitting a deprecation warning at `__getattr__` access time, and a verified workflow for keeping a per-symbol `COMPATIBILITY.md` API table aligned with a widened `__all__` — confirming the `missing-from-docs` failure surfaces only in the FULL validation module (isolated runs are false negatives), that the row goes alphabetically into the right `### <pkg>` section, and that the "since" version is read off same-cycle sibling helpers (not `git describe --tags`) |
+| **Verification** | verified-ci (function-local / version-guard / Windows-guard / lazy-exports); verified-local (surface-pin-stale fix, access-time deprecation-warning implementation — section F executed end-to-end with all tests passing locally; section G — __all__ alignment / eager re-export / subset-assertion pin executed end-to-end for ProjectHephaestus issue #1511, all tests passing locally; section G′ — per-symbol COMPATIBILITY.md API-table row alignment + the full-suite-only live-tree-scan false-negative hazard executed end-to-end for ProjectHephaestus issue #1419, all affected tests passing locally including `tests/unit/validation/test_api_table_docs.py`, ruff/mypy/markdownlint clean; this also UPGRADES the COMPATIBILITY.md per-symbol version-stamping guidance — previously `unverified` from issue #1513 — to `verified-local` (the version column is resolved from same-cycle siblings, confirmed on disk: `configure_cli_logging` = 0.9.8, matching `create_validation_parser`/`resolve_repo_root`, even though the latest tag was `v0.9.7`); CI pending after the ProjectHephaestus PR merges); **unverified** planning-guidance (section H — adding the companion `__dir__()` to a PEP 562 lazy-loader package; derived from a plan for ProjectHephaestus issue #1512, not yet executed in CI) |
+
+## When to Use
+
+- **Function-local imports (coupling avoidance)**: A child module needs ambient state from a parent module (e.g., `logging.utils` already imports `utils.helpers`), and a module-level child-to-parent import would create a circular dependency or import-graph bloat. The import is used in only one or two functions.
+- **Lazy exports (SDK surface)**: Extending a public package `__all__` with peer classes from submodules, adding `TYPE_CHECKING` imports, preventing eager-load regressions, or avoiding architectural restructuring when widening the public surface.
+- **Version-gated stdlib guard**: A CI matrix includes Python 3.10 and code does a bare import of a 3.11+ stdlib module (`tomllib`, `ExceptionGroup`); `pytest` collection fails with `ModuleNotFoundError` on the lowest Python in the matrix.
+- **Windows / POSIX-only stdlib guard**: Adding a cross-OS CI matrix where Windows jobs fail with `ModuleNotFoundError` for `curses`/`fcntl`/`termios`/`grp`/`pwd`, or `zoneinfo.ZoneInfo` raises `ZoneInfoNotFoundError` on Windows (needs `tzdata`).
+- **Lazy-export add/add rebase conflict**: A branch widens the lazy SDK surface (`_LAZY_EXPORTS` + `__all__` + `__getattr__`) and goes `DIRTY`/`CONFLICTING` because a *sibling PR already landed the identical export* on main. The PR reads as "CI failing" but the logs show only runner/setup steps and **no test actually failed** — the merge conflict itself is the blocker. Resolve by keeping ONE copy of the shared entry.
+- **Stale surface-pin test (branch-divergence / merge-skew)**: A hardcoded surface-pinning test (`assert set(__all__) == {literal}`) fails on CI with `Extra items in the left set: '<Symbol>'`, where `<Symbol>` is a *legitimate* peer export that landed on `main` via an independent PR while your feature branch was open. The production `__init__.py` is correct; the test literal went stale. You need to decide whether the test or the source is wrong, then fix only the stale party — and to do that you must separate the real CI failure from environment noise that only appears when the local suite runs inside a live automation session.
+- **Access-time deprecation warning across the lazy-loader seam (verified-local)**: You need to make a deprecated lazy shim (e.g. `retry_with_jitter`) warn at *attribute-access* time, not only when called, by adding a `warnings.warn(...)` inside the package `__getattr__` / `_LAZY_IMPORTS` resolver. Key verified facts: the issue may misname *where* the symbol lives (`_LAZY_IMPORTS` vs `__all__`) — grep first; the existing call-time warning is a *different* layer covering a different access path (keep both); PEP 562 caches the resolved name into module globals so the access warning fires once per process — the test must `module.__dict__.pop(name, None)` to re-trigger `__getattr__`; `stacklevel=2` IS correct inside `__getattr__` (call stack: user access line → `__getattr__` → `warnings.warn`); an existing regression test that documents the current silent resolve must be *rewritten*, not supplemented; and a prose doc (`COMPATIBILITY.md`) describing the warning as firing "when called" must be updated in the same PR.
+- **Promoting undeclared public-looking symbols to the package surface — audit-finding fix (verified-local for __all__ alignment; unverified for COMPATIBILITY.md version-stamping)**: One or more existing, public-looking functions are present in a submodule but absent from the package `__init__.py`'s `__all__`, so `from pkg import sym` fails for external users while internal callers work around it by importing from the submodule directly. Key verified patterns from ProjectHephaestus issue #1511 (`hephaestus/cli/__init__.py` aligned with `hephaestus/cli/utils.py`): **expand scope** from the named symbols to ALL missing symbols when the same defect class applies — fixing all four (`DRY_RUN_HELP_CAVEAT`, `add_dry_run_arg`, `add_github_throttle_args`, `configure_github_throttle_from_args`) prevented re-triggering the same audit finding; choose **eager re-export** (`from hephaestus.cli.utils import (…)` in `__init__.py`) when the source module pulls only stdlib — no `_LAZY_EXPORTS` infrastructure needed; **no COMPATIBILITY.md change** is needed when the package has no per-symbol table (only a tier-level entry at the package level); pin the test with a **subset assertion** (`set(utils.__all__) - set(cli.__all__)`) so parallel PRs adding new symbols cannot break it; always include `test_import_surface.py`/`test_automation_boundary.py` in the verification set. Additional planning traps (from a plan for ProjectHephaestus issue #1513 — still unverified): stamping the COMPATIBILITY.md "Added" version by guessing from the latest git tag; missing a non-local strict-equality surface-pin test; building on an unverified stability-tier premise; getting the re-export binding wrong for `monkeypatch`/`mock.patch` paths. See section G.
+- **Adding a public symbol to `__all__` in a repo with a per-symbol `COMPATIBILITY.md` API table + a live-tree-scanning validation test (verified-local)**: You add one name to a package `__all__` (e.g. `configure_cli_logging` to `hephaestus/cli/utils.py:__all__` and re-export it from `hephaestus/cli/__init__.py:__all__`), and a validation test that scans the LIVE repo (`tests/unit/validation/test_api_table_docs.py` — `TestLiveTreeAlignment::test_real_compatibility_md_is_aligned` and `TestMain::test_main_returns_zero_on_real_repo`) fails with `[missing-from-docs] hephaestus.cli.configure_cli_logging is in __all__ but has no row in COMPATIBILITY.md`. The fix is to add an ALPHABETICAL row to the matching `### hephaestus.cli` section, with the "since" version resolved from same-cycle sibling helpers (NOT from `git describe --tags`). The DANGEROUS part (section G′): this test scans the on-disk `__all__` + `COMPATIBILITY.md` at scan time, so it can PASS when run in ISOLATION yet FAIL only when you run the WHOLE module / broad `tests/unit/validation` suite — an isolated green run is a FALSE NEGATIVE. After editing ANY `__all__` or `[project.scripts]`/public-export surface, run the full validation module before claiming green. See section G′. (Verified-local for ProjectHephaestus issue #1419; this upgrades the issue #1513 COMPATIBILITY.md version-stamping guidance from `unverified` to `verified-local`.)
+- **Adding the companion `__dir__()` to a PEP 562 lazy-loader package — discoverability fix (unverified planning-guidance)**: A package defines a module-level `__getattr__` for lazy loading (PEP 562), but defines no module-level `__dir__()`, so `dir(pkg)` shows only the eagerly-bound names (~4: `__version__`, `__author__`, dunders) and the entire lazy public API (everything in `_LAZY_IMPORTS` / `__all__`) is invisible to IPython tab-completion, IDEs, and doc generators. This is a POLA/discoverability defect, not a correctness bug. The fix adds `def __dir__() -> list[str]: return sorted(set(_LAZY_IMPORTS) | set(__all__) | set(globals()))` and pins it with a surface test. The planning traps: a custom `__dir__` REPLACES the default listing (it does not auto-union module globals), so you MUST fold `set(globals())` in or you silently SHRINK the visible set; `__dir__` returns names only (no attribute access), so listing a deprecated lazy shim does NOT fire its `DeprecationWarning`; pin by a SUBSET INVARIANT (`set(_LAZY_IMPORTS) <= set(dir(pkg))`), never a hardcoded count (the audit's "35 symbols" was already stale at 40 on disk); and regression-test that `dir()` does not SHRINK vs today (`__version__`/`__author__` must remain). See section H. (Derived from a plan for ProjectHephaestus issue #1512; this guidance is `unverified` — the plan has not been executed in CI.)
+
+## Verified Workflow
+
+### Quick Reference
+
+```python
+# (1) FUNCTION-LOCAL IMPORT — break a circular dep child→parent
+# child module (utils/helpers.py); parent (logging/utils.py) already imports this child
+def run_subprocess(cmd):
+    from hephaestus.logging.utils import get_current_correlation_id  # local, not top-level
+    cid = get_current_correlation_id()
+    ...
+```
+
+```python
+# (2) LAZY EXPORTS — extend public SDK surface without eager load
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from hephaestus.automation.ci_driver import CIDriver, CIDriverOptions
+
+__all__ = ["Automation", "CIDriver", "CIDriverOptions"]  # alphabetical, case-sensitive
+
+_LAZY_EXPORTS = {"CIDriver": "hephaestus.automation.ci_driver",
+                 "CIDriverOptions": "hephaestus.automation.ci_driver"}
+_PHASE_ENTRYPOINTS = ("hephaestus.automation.ci_driver",)  # guards eager-load preload
+```
+
+```python
+# (3) VERSION-GATED STDLIB GUARD — 3.11+ module on a 3.10 matrix
+import sys
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+```
+
+```python
+# (4) POSIX-ONLY STDLIB GUARD — keep package importable on Windows
+try:
+    import fcntl
+except ModuleNotFoundError:  # Windows: fcntl is POSIX-only
+    fcntl = None  # type: ignore[assignment]
+```
+
+```toml
+# Conditional dependencies for the guards above (pyproject.toml)
+[project]
+dependencies = [
+    "tomli; python_version < '3.11'",       # backport for (3)
+    "tzdata; platform_system == 'Windows'", # zoneinfo data for (4)
+]
+```
+
+```bash
+# Audit for unguarded imports before patching
+grep -rn "^import tomllib" hephaestus/ scripts/ tests/   # expect 0 after fix
+grep -rn "^import \(curses\|fcntl\|termios\|grp\|pwd\)" hephaestus/  # each needs a guard
+```
+
+```bash
+# (6) LAZY-EXPORT ADD/ADD REBASE CONFLICT — "CI failing" but no test failed
+gh pr view <N> --json mergeStateStatus --jq .mergeStateStatus   # DIRTY → conflict, not a test
+git fetch origin main && git rebase origin/main                 # conflict localises to __init__.py
+git show origin/main:hephaestus/automation/__init__.py | grep PRReviewer  # confirm main has it
+#   → keep ONE copy of the shared _LAZY_EXPORTS entry; key ORDER is irrelevant (set()-based tests)
+git rebase --continue
+pixi run python -m pytest tests/ && pre-commit run --all-files  # ruff-format may reflow old lines
+git commit -S -m "..."                                          # GPG (not SSH); key-email committer
+git push --force-with-lease origin HEAD:<branch>                # rebase rewrote history
+```
+
+```bash
+# (10) ADDED A SYMBOL TO __all__ → per-symbol COMPATIBILITY.md API-table test breaks (section G′)
+# Failure: [missing-from-docs] hephaestus.cli.configure_cli_logging is in __all__ but has no row in COMPATIBILITY.md
+
+# a) Find the package section in COMPATIBILITY.md (the per-symbol table header)
+grep -n "### hephaestus.cli" COMPATIBILITY.md            # locate the right '### <pkg>' section
+
+# b) See the alphabetical neighbours so you insert in the RIGHT position
+grep -nA40 "### hephaestus.cli" COMPATIBILITY.md | grep '^[0-9].*| `'   # rows are ALPHABETICAL by symbol
+#   → configure_cli_logging goes between add_version_arg and configure_github_throttle_from_args
+
+# c) Resolve the "since" version from SAME-CYCLE SIBLINGS, not the latest tag
+git describe --tags --abbrev=0                            # e.g. v0.9.7 — do NOT just use 0.9.8 from this
+grep -nE "create_validation_parser|resolve_repo_root" COMPATIBILITY.md  # siblings added this cycle → 0.9.8
+#   → row: | configure_cli_logging | 0.9.8 | Configure standard stderr-safe logging for a CLI |
+
+# d) AUTHORITATIVE check — run the WHOLE module (isolated run is a FALSE NEGATIVE):
+pixi run python -m pytest tests/unit/validation/test_api_table_docs.py -q --no-cov
+#   NOT: pytest …::test_real_compatibility_md_is_aligned alone (can pass with the bug present)
+
+# e) markdownlint the doc you edited
+markdownlint-cli2 COMPATIBILITY.md
+```
+
+### Detailed Steps
+
+#### A. Function-local imports to avoid coupling / circular deps
+
+1. **Diagnose the cycle.** Confirm the parent already imports the child:
+   ```bash
+   grep -r "^from hephaestus.utils" hephaestus/logging/   # parent imports child?
+   grep -r "^from hephaestus.logging" hephaestus/utils/   # child imports parent at top-level? → cycle
+   ```
+2. **Move the import into the function** that needs the ambient state:
+   ```python
+   def run_subprocess(cmd: list[str]) -> str:
+       """Run subprocess, injecting correlation ID into environment.
+
+       Note: import is inside the function to avoid a circular dependency
+       with hephaestus.logging (which imports from hephaestus.utils).
+       """
+       from hephaestus.logging.utils import get_current_correlation_id
+       env = os.environ.copy()
+       if cid := get_current_correlation_id():
+           env["GH_TRACE_ID"] = cid
+       ...
+   ```
+3. **Keep the function where it semantically belongs** — move the *import*, not the function. Do not relocate `get_current_correlation_id()` into `utils` just to dodge the edge (that creates a god-module / SRP violation).
+4. **Accept the cost.** First call pays an import lookup (~1–5µs); subsequent calls hit `sys.modules` (negligible). For subprocess spawning the import is ~1,000,000x cheaper than the spawn itself.
+5. **Prefer function-local imports over threading a parameter** through intermediate functions that don't use it — that is what ambient context (contextvars/logging/config) is for. Reserve parameters for true call-level arguments.
+
+#### B. Lazy exports to widen an SDK surface safely
+
+1. **Identify peer classes** in submodules that belong in the public SDK but are missing from `__all__` (follow `PeerClass` + `PeerClassOptions` naming).
+2. **Extend the `TYPE_CHECKING` block** with conditional imports (alphabetical; import class + Options together) so type hints resolve without eager loading.
+3. **Update `__all__`** — add every entry, sorted alphabetically case-sensitively (uppercase first), each appearing exactly once.
+4. **Extend `_LAZY_EXPORTS`** — map each name → module path string; the package `__getattr__` resolves these on first access. Keep keys alphabetically sorted.
+5. **Guard new phase modules in `_PHASE_ENTRYPOINTS`** — add the module path to the tuple so `_auto_import_on_access()` skips eager preload, preventing eager-load regressions and import-time bloat.
+6. **Add a surface-pinning test** (extend the existing `test_package_imports.py`, do not create a parallel file):
+   ```python
+   def test_public_surface_pins_expected_symbols() -> None:
+       from hephaestus.automation import __all__
+       expected = {"AddressReviewer", "AddressReviewerOptions", "CIDriver",
+                   "CIDriverOptions", "PlanReviewer", "PlanReviewerOptions"}
+       missing = expected - set(__all__)
+       assert not missing, f"Missing peer classes in __all__: {missing}"
+   ```
+7. **Validate**: `pixi run pytest tests/unit/automation/ -v && pixi run ruff check ... && pixi run mypy ...`.
+8. **Prefer a subset assertion (`expected - set(__all__)`) over strict equality (`set(__all__) == expected`)** for the pin. A subset assertion (`missing = expected - set(__all__); assert not missing`) catches *removed* peers (the regression you care about) but tolerates a new peer being added on `main` via an independent PR. A strict-equality pin breaks every open branch the moment any peer lands elsewhere (see section B′). If you must keep strict equality, treat the literal as a manifest that has to be re-synced on rebase.
+
+#### B2. Resolving a lazy-export add/add rebase conflict (sibling PR landed the same widening first)
+
+Symptom: the PR reads as "CI failing", but `gh run view` shows only runner/setup steps and **no test failure**. The real blocker is a merge conflict, not a test.
+
+1. **Diagnose before touching CI.** When a PR is reported CI-failing with no failing test in the logs, run `gh pr view <N> --json mergeStateStatus` FIRST. `DIRTY` (or `CONFLICTING`) means a merge conflict — not a test — blocks the merge. Don't re-run CI; rebase.
+2. **Fetch and rebase** onto the advanced main: `git fetch origin main && git rebase origin/main`. The conflict localises to `__init__.py`'s `_LAZY_EXPORTS` dict where both branches added the *same* export line (e.g. both added `"PRReviewer": "hephaestus.automation.pr_reviewer"`).
+3. **Keep ONE copy.** Both sides want the identical line — delete the duplicate, keep a single entry. Verify main already carries it: `git show origin/main:hephaestus/automation/__init__.py | grep PRReviewer`.
+4. **Don't fight dict key ORDER.** The surface-pinning tests use `set()` equality and `<=` subset checks (see `test_public_surface_pins_expected_symbols`), so `_LAZY_EXPORTS` / `__all__` key order does not affect pass/fail. A richer branch-side `EXPECTED_PUBLIC_SYMBOLS` identity test coexists with main's test — no dedup needed.
+5. **Continue and re-verify**: `git rebase --continue`, then run the FULL suite (`pixi run python -m pytest tests/`) — a surface change can ripple. Then `pre-commit run --all-files`: **ruff-format may reformat a line that was fine on the old base** (e.g. collapse a multi-line f-string assertion). Re-run pre-commit until clean and commit the format fix with `git commit -S` (committer email MUST be the GPG key's email, e.g. `4211002+mvillmow@users.noreply.github.com`, or pr-policy signing fails; use the default GPG format, NOT SSH — SSH-signed commits can trip a false-NOGO in the automation reviewer when local git can't verify them without an `allowedSignersFile`).
+6. **Push needs `--force-with-lease`** because the rebase rewrote history.
+7. **Stale/duplicate-issue smell**: if main *already* contains the change your branch was trying to make, the branch may be partly redundant — but its test improvements can still be worth keeping. Keep the richer tests, drop only the now-duplicate production change.
+
+#### B′. Repairing a stale surface-pin test after a parallel-PR peer landed
+
+A strict-equality surface pin (`assert set(automation.__all__) == expected`) fails on CI with `Extra items in the left set: '<Symbol>'` when `<Symbol>` was added to `__all__` on `main` by an independent PR while your branch was open. The source is correct; the *test literal* is the stale party. Procedure:
+
+1. **Confirm the failure is real and isolate the symbol.** `gh pr view <pr> --json state,statusCheckRollup` to confirm OPEN + which checks fail (here: `unit-tests` on every Python leg). Then `gh run view --job <id> --log-failed | grep -iE "FAILED|AssertionError"` to find the single failing test among thousands. The pytest set-diff (`Extra items in the left set: '<Symbol>'`) names the exact symbol.
+2. **Decide test-vs-source before editing either** — the critical step. Prove whether `<Symbol>` is a legitimate export or an accidental addition:
+   ```bash
+   git log --oneline -- hephaestus/automation/__init__.py     # when/how did <Symbol> enter __all__?
+   git log -p -1 -- hephaestus/automation/__init__.py          # the landing commit + its PR/message
+   ```
+   If `<Symbol>` landed via a separate, legitimate feature PR on `main` (e.g. `AuditReviewer` via #1067), the **test is stale, not the source**. Do NOT remove `<Symbol>` from `__all__` — that would silently shrink the public surface.
+3. **Fix the test literal only.** Add `<Symbol>` to the `expected` set, alphabetically placed. Zero production code changes.
+4. **Discriminate real CI failures from live-session environment noise.** A full *local* suite run inside a live Claude Code automation session can show extra failures that CI does not. Two cheap discriminators:
+   ```bash
+   # (a) env-var leakage (e.g. HEPH_*_MODEL set in the live session):
+   env -i HOME="$HOME" PATH="$PATH" pixi run pytest <path>::<test> -q   # PASS under env -i ⇒ environmental
+   # (b) your-change-vs-pre-existing: stash your diff, re-run on the clean base:
+   git stash && pixi run pytest <path> -q ; git stash pop            # still fails ⇒ pre-existing, not yours
+   ```
+   Decisive tiebreaker: `gh run view --job <id> --log | grep <testname>` — if the test **PASSED in CI**, the local failure is environment-only (CI has no live `gh` auth and no `HEPH_*_MODEL` env vars). Lesson: when the local suite shows MORE failures than CI, verify each against the CI log before attributing any of them to your change.
+5. **Harden the pin** so the next parallel PR doesn't re-break it: switch the assertion to a subset check (step 8 above), or accept that the strict literal is a manifest requiring a rebase-time re-sync.
+
+#### C. Version-gated stdlib import guard (newer-Python module on older matrix)
+
+1. **Audit**: `grep -rn "^import tomllib" hephaestus/ scripts/ tests/`.
+2. **Replace each bare import** with a `sys.version_info` guard (mypy narrows on this; a bare `try/except` does not):
+   ```python
+   import sys
+   if sys.version_info >= (3, 11):
+       import tomllib
+   else:
+       import tomli as tomllib  # type: ignore[no-redef]
+   ```
+3. **Declare the backport** as a conditional dependency in `pyproject.toml` (`"tomli; python_version < '3.11'"`) and, if used, `pixi.toml` (`tomli = { version = ">=2.0", python = "<3.11" }`).
+4. **Run** `pixi run pytest tests/unit` and confirm collection succeeds on both the lowest and highest Python in the matrix.
+5. **If mypy on 3.11+ flags the redefinition or an unused ignore**, use `# type: ignore[no-redef, unused-ignore]` on the `else`-branch import.
+
+General pattern + known backports:
+
+| Module | Added in | Backport package |
+|--------|----------|-----------------|
+| `tomllib` | 3.11 | `tomli` |
+| `ExceptionGroup` | 3.11 | `exceptiongroup` |
+| `importlib.resources` (new API) | 3.9 | `importlib_resources` |
+| `zoneinfo` | 3.9 | `backports.zoneinfo` |
+| `graphlib` | 3.9 | `graphlib_backport` |
+
+#### D. POSIX-only stdlib guards for Windows CI
+
+1. **Find every POSIX-only import**: `curses`, `fcntl`, `termios`, `grp`, `pwd`, `resource`, `syslog`, `readline`. Each needs a guard.
+2. **Wrap at module top-level** with `try/except ModuleNotFoundError` (only this exception — never bare `except:`) and assign `None`:
+   ```python
+   try:
+       import curses
+   except ModuleNotFoundError:  # Windows: curses not bundled with CPython
+       curses = None  # type: ignore[assignment]
+   ```
+3. **Move the "unavailable" error to runtime** (class `__init__` / function entry), not import time, so the package imports cleanly on Windows and only the POSIX path raises.
+4. **Guard every call site** with `if <module> is not None:`; treat absent locks as best-effort no-ops:
+   ```python
+   def _acquire_lock(fp) -> None:
+       if fcntl is not None:
+           fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+       # else: cross-process locking is a best-effort no-op on Windows
+   ```
+5. **For `zoneinfo`**: add `"tzdata; platform_system == 'Windows'"` to `[project].dependencies`; `ZoneInfo` discovers the wheel automatically.
+6. **Scope tests honestly**: runtime guards make the package *importable* on Windows, not the POSIX-only CLIs *functional*. Skip those tests on Windows via `pytest.skip(...)` rather than scattering inline `if sys.platform == "win32"` assertions.
+7. **Track the full cross-OS port as a separate issue** (file-mode bits, path encoding, coredump handlers). Keep the matrix ubuntu-only until that lands; keep the import guards so downstream consumers stay Windows-importable.
+
+#### F. Verified Workflow — adding an access-time DeprecationWarning across the PEP 562 lazy-loader seam (verified-local)
+
+> **Verification:** This workflow was executed end-to-end for ProjectHephaestus issue #1545 (warn at *access* time, not only call time, for the deprecated `retry_with_jitter` shim exposed via `hephaestus/__init__.py`'s PEP 562 `__getattr__` loader). All steps below are verified locally — tests pass, ruff and mypy clean. CI confirmation pending after the ProjectHephaestus PR merges. Verification level = `verified-local`.
+
+1. **Grep the named symbol against the source BEFORE trusting the issue's structural claim.** Issue #1545 said the shim was "in `__all__`", but `retry_with_jitter` is actually only in `_LAZY_IMPORTS` (the lazy resolver map), not `__all__`. The fix location — the `__getattr__` lazy-loader seam — is the same either way, but you must understand where the symbol actually lives before editing.
+   ```bash
+   grep -n "retry_with_jitter" hephaestus/__init__.py   # is it in _LAZY_IMPORTS or __all__? (here: _LAZY_IMPORTS only)
+   grep -rn "def retry_with_jitter" hephaestus/         # where the real impl + any call-time warning lives
+   ```
+
+2. **Treat access-time and call-time warnings as COMPLEMENTARY layers, not duplicates — keep both.** A deprecated shim may already warn *inside its function body* (fires on `hephaestus.utils.X` direct call). Adding a warning in the package `__getattr__` covers a *different* access path — binding `hephaestus.X` via attribute lookup, even if the symbol is never called. Different users hit different paths; do NOT "dedup" them.
+
+3. **Add a `_DEPRECATED_LAZY` dict alongside `_LAZY_IMPORTS` and check it inside `__getattr__`.** The warning message should name the canonical replacement. Defer the `import warnings` inside the condition — it is stdlib, safe, and does not breach the automation boundary (`test_automation_boundary.py` confirmed):
+   ```python
+   # hephaestus/__init__.py — add after _LAZY_IMPORTS closes
+   _DEPRECATED_LAZY: dict[str, str] = {
+       "retry_with_jitter": (
+           "hephaestus.retry_with_jitter is deprecated; use "
+           "retry_with_backoff(jitter=True, max_delay=...) instead. "
+           "It will be removed no earlier than the next major version after 1.0."
+       ),
+   }
+
+   def __getattr__(name: str) -> Any:
+       """Lazy-load public symbols on first access (PEP 562)."""
+       if name in _LAZY_IMPORTS:
+           if name in _DEPRECATED_LAZY:
+               import warnings
+               warnings.warn(_DEPRECATED_LAZY[name], DeprecationWarning, stacklevel=2)
+           module_name, attr = _LAZY_IMPORTS[name]
+           import importlib
+           module = importlib.import_module(module_name)
+           value = getattr(module, attr)
+           globals()[name] = value
+           return value
+       raise AttributeError(f"module 'hephaestus' has no attribute {name!r}")
+   ```
+
+4. **`stacklevel=2` IS correct for `__getattr__` — verified.** The call stack when a user writes `hephaestus.retry_with_jitter` is: (1) user's access line → (2) `__getattr__` → (3) `warnings.warn`. `stacklevel=2` skips `__getattr__` (frame 2) and attributes the warning to frame 1 (the user's line). Confirmed by asserting `access_warnings[0].filename == __file__` in the test.
+
+5. **Force a fresh resolve in the regression test — PEP 562 `__getattr__` caches into module globals.** After the first `hephaestus.retry_with_jitter` access, the resolved name is written into the module's `__dict__`, so `__getattr__` (and the access warning) never runs again that process. A prior test that already touched the symbol makes the warning assertion a false-negative. Pop it first:
+   ```python
+   def test_retry_with_jitter_access_emits_deprecation_warning(self) -> None:
+       import hephaestus
+
+       # Bust PEP 562 cache — force __getattr__ to re-run
+       hephaestus.__dict__.pop("retry_with_jitter", None)
+
+       with warnings.catch_warnings(record=True) as caught:
+           warnings.simplefilter("always")
+           symbol = hephaestus.retry_with_jitter  # ACCESS only, do not call
+
+       assert callable(symbol)
+       access_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+       assert access_warnings, "Accessing hephaestus.retry_with_jitter must emit DeprecationWarning"
+       assert "retry_with_jitter" in str(access_warnings[0].message)
+       # stacklevel=2 must attribute the warning to the caller's file
+       assert access_warnings[0].filename == __file__, (
+           f"DeprecationWarning should be attributed to the caller's file "
+           f"({__file__}); got {access_warnings[0].filename}. Check stacklevel."
+       )
+   ```
+
+6. **Grep for stale-tolerant tests that ASSERT the about-to-change behavior, then REWRITE them — a change is not "additive" if a passing test documents the old contract.** The existing test `test_retry_with_jitter_reachable_from_top_level_lazy_loader` explicitly documented and tolerated the silent lazy resolve ("the lazy resolve itself is silent; only CALLING warns"). It had to be replaced, not supplemented — its docstring said the old behavior was intentional.
+   ```bash
+   grep -rn "silent\|lazy resolve\|only CALLING\|does not warn" tests/ | grep -i deprecat
+   ```
+
+7. **Update the prose deprecation doc in the SAME PR — behavior/doc drift is a review trap.** `COMPATIBILITY.md` had a bullet stating the warning fires "when called". Update it to reflect that the warning now fires both when accessed via `hephaestus.retry_with_jitter` AND when called.
+
+8. **Re-confirm the import-surface boundary still holds.** Adding `import warnings` inside `__getattr__` is low-risk (`warnings` is stdlib, deferred inside the condition), but run `test_import_surface.py` and `test_automation_boundary.py` after the change — both passed for issue #1545.
+
+#### G. Promoting undeclared public-looking symbols to the package surface (audit-finding fix) — verified-local for __all__ alignment; unverified for COMPATIBILITY.md version-stamping
+
+> **Verification:** `verified-local` for `__all__` alignment, eager re-export, subset-assertion pin, and import-surface/boundary boundary checks — these steps were executed end-to-end for ProjectHephaestus issue #1511 (`hephaestus/cli/__init__.py` aligned with `hephaestus/cli/utils.py`; 79 tests passed; mypy/ruff/test_import_surface/test_automation_boundary all clean). COMPATIBILITY.md version-stamping guidance remains `unverified` — derived from a plan for ProjectHephaestus issue #1513, not yet executed in CI.
+
+When you fix a defect where symbols are declared in a submodule `__all__` but not re-exported from the package `__init__.py`, the symbol-level diff is tiny but the verification blast radius is not. Work through these checks BEFORE writing the plan as fact:
+
+**Verified concrete example (ProjectHephaestus issue #1511 — `hephaestus/cli/__init__.py`):**
+
+```python
+# hephaestus/cli/__init__.py — BEFORE (missing 4 symbols from utils.py __all__)
+from hephaestus.cli.utils import (
+    Colors,
+    add_json_arg,
+    # ... other symbols already present
+)
+__all__ = ["Colors", "add_json_arg", ...]
+
+# hephaestus/cli/__init__.py — AFTER (eager re-export; stdlib-only module → no lazy machinery)
+from hephaestus.cli.utils import (
+    Colors,
+    DRY_RUN_HELP_CAVEAT,          # string constant
+    add_dry_run_arg,               # argparse helper
+    add_github_throttle_args,      # argparse helper
+    add_json_arg,
+    configure_github_throttle_from_args,  # argparse helper
+    # ... other symbols
+)
+__all__ = [
+    "Colors",
+    "DRY_RUN_HELP_CAVEAT",
+    "add_dry_run_arg",
+    "add_github_throttle_args",
+    "add_json_arg",
+    "configure_github_throttle_from_args",
+    # ...
+]
+```
+
+```python
+# tests/unit/cli/test_utils.py — AFTER: subset-assertion pin + identity check
+import hephaestus.cli as cli
+import hephaestus.cli.utils as utils
+
+def test_cli_all_covers_module_all() -> None:
+    """Subset assertion: every symbol in utils.__all__ must appear in cli.__all__."""
+    missing = set(utils.__all__) - set(cli.__all__)
+    assert not missing, f"cli.__all__ is missing symbols from utils.__all__: {missing}"
+
+def test_dry_run_symbols_reexport_identity() -> None:
+    """Re-exported symbols must be the SAME object (identity, not just equality)."""
+    assert cli.add_dry_run_arg is utils.add_dry_run_arg
+    assert cli.DRY_RUN_HELP_CAVEAT is utils.DRY_RUN_HELP_CAVEAT
+```
+
+Key verified decisions from issue #1511:
+
+- **Scope expansion is intentional**: the issue named 2 symbols; audit found the SAME defect class applied to 4. Fix all 4 so `set(utils.__all__) == set(cli.__all__)` — a partial fix re-triggers the same audit finding for the skipped symbols.
+- **Eager re-export beats lazy when the module is stdlib-only**: `cli/utils.py` imports only `argparse`, `json`, `math`, `sys`, `hephaestus._version_lookup`. No `_LAZY_EXPORTS` infrastructure needed; plain `from hephaestus.cli.utils import (…)` in `__init__.py` is correct.
+- **No COMPATIBILITY.md change**: `hephaestus.cli` appears only as a tier-level Stable entry at line 53; there is no per-symbol table. Nothing to update.
+- **Subset assertion, not strict equality**: `set(utils.__all__) - set(cli.__all__)` catches regressions (removed symbols) but tolerates parallel PRs that add new symbols. A strict-equality pin would break the moment any sibling PR lands a new symbol.
+- **Verify import-surface/boundary after any `__init__.py` widening**: `test_import_surface.py` and `test_automation_boundary.py` both passed after widening `cli/__init__.py` (no heavyweight or boundary-crossing imports were introduced).
+
+Additional planning steps (from a plan for ProjectHephaestus issue #1513 — unverified for COMPATIBILITY.md version-stamping):
+
+1. **Verify the COMPATIBILITY.md "Added" version against the ACTUAL next release — never guess it from the latest tag.** `git describe --tags --abbrev=0` returning `v0.9.7` does NOT mean the next release is `0.9.8`; the next version could be `0.9.8`, `0.10.0`, or `1.0.0` depending on cadence/roadmap. Stamping the wrong version silently mis-documents the stability contract. Either resolve the real target version, or flag it explicitly for the reviewer:
+   ```bash
+   git -C <repo> describe --tags --abbrev=0          # latest tag — NOT necessarily next version
+   sed -n '1,80p' docs/RELEASING.md                  # documented release cadence / next-version policy
+   gh api repos/:owner/:repo/milestones --jq '.[].title'  # an open milestone often names the target version
+   ```
+   If none of these resolve the next version unambiguously, write the plan with an explicit "**reviewer must confirm the target release version for the COMPATIBILITY.md 'Added' column**" callout rather than asserting a guessed number.
+
+2. **Grep the WHOLE test tree for an existing strict-equality surface pin BEFORE widening `__all__` — the breakage is non-local.** A strict-equality pin (`assert set(pkg.__all__) == {literal}`) for the target package may live in a *different* test file than the one you are editing. If it exists, adding three symbols to `__all__` breaks THAT test, and a plan that only touches the obvious test file misses it. Grep by package name AND `__all__` AND surface/pin/expected markers across all of `tests/`:
+   ```bash
+   grep -rn "logging" tests/ | grep -iE "__all__|surface|pin|expected"   # find ANY pin for this package
+   grep -rn "__all__" tests/ | grep -iE "==|expected|surface|pin"        # strict-equality pins anywhere
+   ```
+   A widening change has a non-local test blast radius — enumerate every pin that references the package, not just the test file you planned to edit.
+
+3. **Verify the audit's stability-tier premise on disk — an audit finding's premise is itself a claim to check.** The whole fix here rests on "`hephaestus.logging` is Stable (COMPATIBILITY.md:56)". Read the actual stability-tier source and confirm the tier before building the fix around it; audit findings are sometimes factually wrong (team KB has prior cases of 3/29 strict-audit findings being factually wrong). If the subpackage is NOT actually a Stable tier, the entire "promote to stable surface" framing is wrong.
+   ```bash
+   grep -n "logging" COMPATIBILITY.md | grep -iE "stable|tier|experimental|deprecated"  # confirm the tier
+   ```
+
+4. **Assert re-export IDENTITY and grep for existing submodule patch paths.** When re-exporting symbols that existing tests `monkeypatch`/`mock.patch` via the submodule path, the package-root re-export MUST be the SAME object so either patch path works. Add a test asserting identity (`pkg.set_correlation_id is utils.set_correlation_id`) and grep for any test that patches the submodule path to confirm none rely on a divergent binding:
+   ```bash
+   grep -rn 'patch("hephaestus.logging.utils' tests/    # any monkeypatch on the submodule path?
+   grep -rn "set_correlation_id\|get_current_correlation_id\|correlation_id_scope" tests/
+   ```
+
+5. **Include the import-surface/boundary tests in the verification set for ANY `__init__.py` widening — even a "pure re-export".** Adding eager re-exports to a package `__init__.py` can regress an enforced import-surface or boundary test (`test_import_surface.py`, `test_automation_boundary.py`) if the re-exported submodule pulls a heavyweight or boundary-crossing import. The plan reasoned `utils.py` only pulls stdlib + `hephaestus.constants` + formatters, which is safe — but that reasoning is a hypothesis until those tests run. Always run them after touching an `__init__.py`:
+   ```bash
+   pixi run pytest tests/unit/validation/test_import_surface.py tests/unit/validation/test_automation_boundary.py -q
+   ```
+
+Note on the pin choice: when ADDING the surface-pin test for the promoted symbols, prefer a subset assertion (`expected - set(__all__)`, see section B step 8) over a strict-equality pin, so this same widening pattern doesn't break future parallel branches.
+
+#### G′. Keeping a per-symbol COMPATIBILITY.md API table aligned when you widen `__all__` — and the FULL-SUITE-ONLY live-tree-scan hazard (verified-local)
+
+> **Verification:** `verified-local`. Executed end-to-end for ProjectHephaestus issue #1419 (added `configure_cli_logging` to `hephaestus/cli/utils.py:__all__` and re-exported it from `hephaestus/cli/__init__.py:__all__`). All affected tests pass locally: `tests/unit/cli/test_utils.py`, `tests/unit/automation/test_ensure_state_labels.py`, and `tests/unit/validation/test_api_table_docs.py` (3186 passed after the doc-row fix); ruff clean; `pixi run mypy` = "Success: no issues found in 446 source files"; `markdownlint-cli2` on `COMPATIBILITY.md` passed. Verified locally; CI confirmation pending on the originating PR. This section also UPGRADES the previously-`unverified` issue #1513 COMPATIBILITY.md version-stamping guidance to `verified-local`: the version column IS resolved from same-cycle siblings (confirmed on disk).
+
+When a repo enforces a *per-symbol* `COMPATIBILITY.md` API table with a **live-tree-scanning** validation test (e.g. ProjectHephaestus `tests/unit/validation/test_api_table_docs.py`), adding a name to a package `__all__` is NOT a no-op for docs — unlike section G's `hephaestus.cli` *tier-level* entry, the `### hephaestus.cli` section in this repo has a per-symbol table, and every name in `cli.__all__` MUST have a matching row.
+
+**The failure (verified):** adding `configure_cli_logging` to `hephaestus/cli/utils.py:__all__` and re-exporting it in `hephaestus/cli/__init__.py:__all__` produced:
+
+```text
+[missing-from-docs] hephaestus.cli.configure_cli_logging is in __all__ but has no row in COMPATIBILITY.md
+```
+
+raised by `TestLiveTreeAlignment::test_real_compatibility_md_is_aligned` (and the parallel `TestMain::test_main_returns_zero_on_real_repo`).
+
+1. **Add an ALPHABETICAL row to the matching `### <pkg>` section.** Rows are sorted by symbol name within each package section. `configure_cli_logging` belongs between `add_version_arg` and `configure_github_throttle_from_args`:
+   ```markdown
+   | `add_version_arg` | 0.1.0 | Add a `--version` flag to a parser |
+   | `configure_cli_logging` | 0.9.8 | Configure standard stderr-safe logging for a CLI |
+   | `configure_github_throttle_from_args` | 0.9.0 | Apply parsed throttle args to the GitHub client |
+   ```
+
+2. **Resolve the "since" version from SAME-CYCLE SIBLINGS, not the latest tag (verified — upgrades the issue #1513 caveat).** `git describe --tags --abbrev=0` returned `v0.9.7`. The correct "since" was `0.9.8`, but the reason is NOT "latest tag + 1" — it is that sibling helpers added in the same release cycle (`create_validation_parser`, `resolve_repo_root`) already carry `0.9.8` in the table. Read the version off the siblings, not the tag arithmetic:
+   ```bash
+   git describe --tags --abbrev=0                                   # v0.9.7 — latest tag, NOT the answer
+   grep -nE "create_validation_parser|resolve_repo_root" COMPATIBILITY.md  # siblings this cycle → 0.9.8
+   ```
+   (Issue #1513 flagged this as an unverified "never guess from the tag" caution; issue #1419 confirms the resolution rule: match the same-cycle siblings.)
+
+3. **THE FULL-SUITE-ONLY HAZARD — an isolated run is a FALSE NEGATIVE.** The live-tree test scans the actual on-disk `__all__` + `COMPATIBILITY.md` at scan time (not per-test fixtures). Empirically (issue #1419): running the two tests IN ISOLATION (`pytest …::test_real_compatibility_md_is_aligned` alone) PASSED even with the broken change present in some orderings, and passed on a stashed/clean tree. The failure reliably reproduced only when running the WHOLE `test_api_table_docs.py` module (or the broad `tests/unit/validation` suite) WITH the change applied. The authoritative check is the full module:
+   ```bash
+   pixi run python -m pytest tests/unit/validation/test_api_table_docs.py -q --no-cov
+   ```
+   General rule: **for any live-tree-scanning validation test, a clean isolated run is a false negative — run the full owning module before claiming green.** This applies after editing ANY package `__all__` or any `[project.scripts]`/public-export surface, not just this one symbol.
+
+4. **markdownlint the doc.** `markdownlint-cli2 COMPATIBILITY.md` (the table edit must stay lint-clean).
+
+5. **Secondary (cross-link to `dry-refactoring-workflow`, do NOT duplicate): a stale issue body / plan can instruct you to reverse already-merged code.** The issue #1419 body + approved plan predated sibling PR #1637, which had ALREADY merged most of the work with a WIDER `create_validation_parser` API. The plan said to give `create_validation_parser` a NARROW API (drop `include_repo_root`, `prog`, `usage`, `epilog`, `formatter_class`), but #1637 KEPT those knobs and many call sites now depend on them (`include_repo_root=False`, `prog=`, `epilog=`, `usage=`, `formatter_class=`). The correct move was NOT to reverse merged code; only the genuinely-unimplemented slice remained (the `configure_cli_logging` helper + an `ensure_state_labels.py` logging swap). This reinforces the existing `dry-refactoring-workflow` rule: **grep the CURRENT state of the code; issue bodies and approved plans go stale once a sibling PR merges.** See that skill for the full stale-plan-audit procedure — this is only a pointer.
+
+#### H. Adding the companion `__dir__()` to a PEP 562 lazy-loader package — UNVERIFIED planning-guidance
+
+> **Verification:** `unverified`. These steps were derived from an implementation *plan* for ProjectHephaestus issue #1512 — an `[S14 API Design]` audit finding that `hephaestus/__init__.py` implements PEP 562 `__getattr__` for lazy loading but omits the companion `__dir__()`, so `dir(hephaestus)` shows only ~4 eagerly-bound names and the entire lazily-loaded public API is invisible to introspection tools (IPython tab-completion, IDEs, doc generators). The plan adds a module-level `__dir__()` returning `sorted(set(_LAZY_IMPORTS) | set(__all__) | set(globals()))` and pins it with a `TestDirDiscoverability` class in the existing `tests/integration/test_package_import.py`. The plan has **not** been executed in CI; treat every step below as a checklist to confirm, not a verified outcome.
+
+PEP 562 pairs `__dir__` with `__getattr__` for discoverability. A package that defines a module-level `__getattr__` for lazy loading should also define a module-level `__dir__() -> list[str]`, or `dir(pkg)` shows only the eagerly-bound names and the entire lazy public API is invisible to tab-completion, IDEs, and doc generators. This is a POLA/discoverability defect, not a correctness bug — the symbols still *resolve* on access; they are just not *listed*. Work through these checks BEFORE writing the plan as fact:
+
+1. **A custom module `__dir__` REPLACES the default listing — it does NOT merge.** `dir(module)` uses ONLY the value your `__dir__` returns; it does not auto-union the module globals the way the default `dir()` does. So you MUST explicitly fold `globals()` into the return, or you will REMOVE names that are visible today (`__version__`, `__author__`, dunders, and any already-resolved-and-cached lazy names that PEP 562 wrote into `__dict__`) — a silent regression. This is the single most important and most easily-missed point. The correct return is the UNION of all three sources:
+   ```python
+   # hephaestus/__init__.py — add alongside __getattr__
+   def __dir__() -> list[str]:
+       """List lazily-loaded public symbols for tab-completion / introspection (PEP 562)."""
+       return sorted(set(_LAZY_IMPORTS) | set(__all__) | set(globals()))
+   ```
+   Returning only `sorted(set(_LAZY_IMPORTS) | set(__all__))` (forgetting `globals()`) is the classic bug — it drops `__version__`, `__author__`, dunders, and already-cached lazy names, so `dir()` SHRINKS versus today.
+
+2. **`__dir__` returns names (strings) only — it performs NO attribute access — so it triggers no lazy import and fires no access-time warning.** Critically, a deprecated lazy shim (e.g. `retry_with_jitter`, the section F symbol) can be SAFELY listed in `__dir__` output WITHOUT emitting its `DeprecationWarning`, because listing a name ≠ accessing it. The plan asserts this in a test: `dir()` emits no `DeprecationWarning` AND does not populate the symbol into `__dict__`. This connects directly to section F — the access-time warning fires only on attribute *access* through `__getattr__`, and `__dir__` never goes through `__getattr__`.
+   ```python
+   def test_dir_does_not_emit_deprecation_warning(self) -> None:
+       import hephaestus
+       hephaestus.__dict__.pop("retry_with_jitter", None)  # ensure not pre-cached
+       with warnings.catch_warnings(record=True) as caught:
+           warnings.simplefilter("always")
+           names = dir(hephaestus)
+       assert "retry_with_jitter" in names                 # listed
+       assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+       assert "retry_with_jitter" not in hephaestus.__dict__  # listing did not resolve it
+   ```
+
+3. **Pin the contract by SUBSET INVARIANT, not by count.** The audit snapshot said "35 symbols"; the live surface had already grown to 40 `_LAZY_IMPORTS` entries by fix-time. Assert the subset invariant (`set(_LAZY_IMPORTS) <= set(dir(pkg))` and `set(__all__) <= set(dir(pkg))`), never a hardcoded count — counts go stale exactly like the strict-equality `__all__` pins warned about in sections B / B′. Extend the existing surface test file (`tests/integration/test_package_import.py`); do NOT create a parallel one.
+   ```python
+   def test_dir_exposes_all_lazy_symbols(self) -> None:
+       import hephaestus
+       visible = set(dir(hephaestus))
+       assert set(hephaestus._LAZY_IMPORTS) <= visible   # subset invariant, not == count
+       assert set(hephaestus.__all__) <= visible
+   ```
+
+4. **Regression-test that `dir()` does not SHRINK the visible set** — assert previously-visible names like `__version__` / `__author__` remain. Because the replace-not-merge behavior in step 1 makes accidental shrinkage the primary failure mode, this guard is what catches a future refactor that drops `set(globals())` from the return:
+   ```python
+   def test_dir_does_not_shrink_visible_surface(self) -> None:
+       import hephaestus
+       visible = set(dir(hephaestus))
+       assert {"__version__", "__author__"} <= visible   # eagerly-bound names must stay listed
+   ```
+
+5. **Audit-snapshot counts drift between finding-time and fix-time — verify the live surface on disk before quoting any count.** The "35 symbols" in the audit finding was already stale (real = 40 `_LAZY_IMPORTS` entries). An audit finding's premise is itself a claim to check (consistent with section G step 3 and the team-KB lesson that strict-audit findings are sometimes factually wrong). Confirm the live count before relying on it, and never bake it into a test:
+   ```bash
+   python3 -c "import hephaestus; print(len(hephaestus._LAZY_IMPORTS), len(hephaestus.__all__))"
+   ```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+|---------|----------------|---------------|----------------|
+| Trust the issue's "in `__all__`" claim about the deprecated shim | Issue #1545 stated `retry_with_jitter` was exposed via `__all__`; planned the fix from that structural claim | The symbol is actually only in `_LAZY_IMPORTS`, not `__all__`. The fix seam (`__getattr__`) is the same either way, but the implementation differs slightly | Grep the named symbol against the source before trusting an issue's structural claim; don't assume `__all__` and `_LAZY_IMPORTS` always overlap. `verified-local` |
+| Assume the access-time warning duplicates the existing call-time warning | Considered "deduping" by relying on the function-body warning alone | Access-time (`hephaestus.X` binding) and call-time (`hephaestus.utils.X(...)`) are DIFFERENT access paths firing for different users; dropping either silently loses coverage | Keep both warnings — they are complementary layers, not duplicates. `verified-local` |
+| Write a one-shot warning-assertion test without resetting the cache | `with pytest.warns(DeprecationWarning): _ = hephaestus.retry_with_jitter` | PEP 562 caches the resolved name into module globals on first access; a prior test that touched the symbol means `__getattr__` never re-runs → false-negative / flaky | Call `module.__dict__.pop(name, None)` before asserting, to force a fresh `__getattr__` resolve. `verified-local` |
+| Treat the change as purely additive (new test only) | Planned to add a new warning-assertion test and leave existing tests alone | The existing test `test_retry_with_jitter_reachable_from_top_level_lazy_loader` explicitly documented and tolerated the silent lazy resolve; the new behavior contradicts that green test's documented contract | Grep for tests asserting the CURRENT (about-to-change) behavior; REWRITE the stale-tolerant one (don't just append a new test next to it). `verified-local` |
+| Change the behavior without touching the prose doc | Planned source + test edits only | `COMPATIBILITY.md` said the warning fires "when called"; a doc-cross-check test or reviewer catches the drift after access-time firing is added | Update the prose deprecation doc that describes the deprecation in the same PR. `verified-local` |
+| Assume `stacklevel=2` might be wrong for `__getattr__` indirection | Worried that attribute-lookup indirection might need a different stacklevel than the call-time warning | Not actually wrong — `stacklevel=2` IS correct. Call stack: user access line (frame 1) → `__getattr__` (frame 2) → `warnings.warn`. `stacklevel=2` skips `__getattr__` and correctly attributes the warning to the user's access line. Verified by `access_warnings[0].filename == __file__` assertion passing | `stacklevel=2` is correct for `__getattr__`. The attribute-lookup indirection has the same two-frame depth as a direct one-level helper call. `verified-local` |
+| Module-level child→parent import | `from hephaestus.logging.utils import get_current_correlation_id` at top of `helpers.py` | `CircularImportError`/`ImportError` at startup because `logging.utils` already imports `utils.helpers` | Any child-to-parent import at module level creates a cycle if the parent imports the child; use a function-local import |
+| Thread correlation ID as a parameter | `run_subprocess(cmd, cid=None)` plumbed through the call chain | Intermediate functions must accept a param they never use; refactor becomes painful | Reserve parameters for true call-level args; use ambient context (contextvars) for ambient state |
+| Move the helper function to dodge the edge | Relocate `get_current_correlation_id()` into `utils` | Creates a god-module, couples `utils.helpers` to logging concerns, violates SRP | Move the import, not the function — keep it where it semantically belongs |
+| Eager-load new phase modules in `__init__.py` | `from .address_reviewer import AddressReviewer` directly | Defeats lazy loading, increases import time, breaks the established pattern | Use `_LAZY_EXPORTS` + `__getattr__` and add the module to `_PHASE_ENTRYPOINTS` |
+| Create a parallel surface test file | New `test_package_surface.py` to pin `__all__` | DRY violation — existing `test_package_imports.py` already iterates `__all__` | Extend existing test coverage; don't duplicate iteration logic |
+| Pin the surface with strict equality | `assert set(automation.__all__) == {hardcoded literal}` authored on the feature branch | `AuditReviewer` landed on `main` via independent PR #1067 while the branch was open; CI failed on ALL Py legs with `Extra items in the left set: 'AuditReviewer'`. The source `__all__` was correct; the test literal went stale (branch-divergence / merge-skew) | A strict-equality pin breaks every open branch the instant a peer lands elsewhere. Prefer a subset assertion (`expected - set(__all__)`) that catches removals but tolerates parallel additions; if you keep equality, re-sync the literal on rebase |
+| "Fix" the stale pin by editing the source | Considered removing `AuditReviewer` from `__all__` to satisfy the failing equality assertion | Would have silently shrunk the public SDK surface — `AuditReviewer` is a legitimate peer export added by #1067 | Decide test-vs-source BEFORE editing: `git log -p -1 -- __init__.py` proved the symbol was a real, separately-landed export. Fix the stale TEST literal, never the correct source |
+| Trust the local suite over the CI log | Saw 3 local failures and assumed all 3 were caused by my change | 2 were live-session environment noise: `HEPH_*_MODEL` env vars set in the session, and live `gh` auth leaking real PR data past a mock. Only 1 (`test_public_surface_pins_expected_symbols`) was the genuine CI failure | When local shows MORE failures than CI, verify each against the CI log. `env -i HOME=$HOME PATH=$PATH pytest` isolates env-var leakage; `git stash` isolates pre-existing failures; `gh run view --log \| grep <test>` is the decisive tiebreaker (those 2 PASSED in CI) |
+| Re-run CI on a "CI failing" lazy-export PR with no failing test | Assumed a flaky/red check and triggered `gh run rerun` | The blocker was a merge conflict (`mergeStateStatus=DIRTY`), not a test; logs showed only runner setup | When a PR reads CI-failing but no test failed, check `gh pr view <N> --json mergeStateStatus` FIRST — `DIRTY` means rebase, not re-run |
+| Treat the duplicated `_LAZY_EXPORTS` entry as a real merge of two different lines | Tried to keep both sides of the add/add conflict | Both branches added the *identical* export (sibling PR #968 landed it first); keeping both yields a duplicate key | Keep ONE copy; verify with `git show origin/main:<__init__> \| grep <symbol>` |
+| Reorder `_LAZY_EXPORTS`/`__all__` keys to "match main" during the conflict | Fought over dict key ordering to make tests pass | Surface tests use `set()` equality / `<=` subset, so order never affected pass/fail — wasted effort | Order-insensitive surface tests mean you only need set-membership correct, not key order |
+| Commit the resolved rebase without re-running pre-commit | Assumed code clean on the old base stays clean post-rebase | `ruff-format` reflowed a multi-line f-string assertion onto one line on the new base → pre-commit failed | Always re-run `pre-commit run --all-files` after a rebase; ruff-format is base-sensitive |
+| `git push` the rebased branch normally | Plain push after a history-rewriting rebase | Non-fast-forward rejection (rebase rewrote history) | Push rebased branches with `--force-with-lease` |
+| Bare `import tomllib` assuming 3.11+ matrix | Used stdlib `tomllib` directly | Matrix also ran 3.10; collection failed with `ModuleNotFoundError: No module named 'tomllib'` | Always check the lowest Python in the matrix before using newer stdlib modules |
+| `try/except ImportError` instead of version guard | `try: import tomllib except ImportError: import tomli as tomllib` | Works at runtime but mypy cannot statically narrow the type; false positive on 3.11+ | Use `sys.version_info >= (3, 11)` — mypy treats it as a narrowing predicate |
+| Skip declaring the backport dependency | Did not add `tomli; python_version < '3.11'` | `tomli` absent in fresh CI env → `ModuleNotFoundError: No module named 'tomli'` | Declare backports as conditional deps in both `pyproject.toml` and `pixi.toml` |
+| Leave POSIX-only imports bare on Windows | `import curses`/`import fcntl` at top level, let CI surface it | `ModuleNotFoundError` broke the whole subpackage at import time, cascading into unrelated-looking entry-point/integrity checks | stdlib ≠ always available; POSIX-only stdlib needs the same guard as any optional dep |
+| Enable full OS matrix after only fixing imports | `[ubuntu, macos, windows]` after curses/fcntl/tzdata fixes | Windows still failed on file-mode bits, path encoding, POSIX-only signal/coredump tests | Runtime import guards don't fix tests that encode POSIX assumptions; full port is multi-session |
+| Inline per-test Windows skips | Ad-hoc `if sys.platform == "win32"` branches in each failing test | Death-by-a-thousand-cuts; sprawling diff, obscured scope | Track cross-OS port as a dedicated issue; revert matrix to ubuntu-only; keep the import guards |
+| Guessed the COMPATIBILITY.md "Added" version from the latest git tag | Stamped the stable-symbol table "Added" column `0.9.8` purely because `git describe --tags --abbrev=0` returned `v0.9.7` | The next release may be `0.9.8`, `0.10.0`, or `1.0.0` depending on cadence/roadmap; a guessed number silently mis-documents the stability contract | Resolve the target version from `docs/RELEASING.md` / open milestones / roadmap, or flag it explicitly for the reviewer to confirm — never infer it from the latest tag. `unverified` (plan for ProjectHephaestus #1513) |
+| Grepped only the obvious test file for `__all__` pins | Planned to add the surface-pin test to `tests/unit/logging/test_utils.py` and assumed no other pin existed | A strict-equality surface pin (`set(pkg.__all__) == literal`) can live in a DIFFERENT test file and breaks the moment you widen `__all__`; the plan would miss it | Grep the WHOLE test tree for package name + `__all__` + surface/pin/expected (`grep -rn "logging" tests/ \| grep -iE "__all__\|surface\|pin\|expected"`) before widening — a widening change has a non-local test blast radius. `unverified` (plan for ProjectHephaestus #1513) |
+| Took the audit finding's "Stable subpackage" premise as given | Built the whole "promote to stable surface" fix on "`hephaestus.logging` is Stable (COMPATIBILITY.md:56)" without re-reading the tier source | An audit finding's premise is itself a claim; if the tier were actually Experimental/Deprecated the entire framing would be wrong (team KB: 3/29 strict-audit findings were factually wrong) | Verify the stability-tier premise on disk before building the fix around it: `grep -n "logging" COMPATIBILITY.md \| grep -iE "stable\|tier"`. `unverified` (plan for ProjectHephaestus #1513) |
+| Assumed any re-export binding satisfies submodule patch paths | Re-exported the symbols from `__init__.py` without asserting they are the SAME object as the submodule's | Existing tests that `mock.patch("hephaestus.logging.utils.X")` rely on identity; a divergent package-root binding makes one patch path silently ineffective | Assert re-export identity (`pkg.X is utils.X`) and grep for existing `patch("hephaestus.logging.utils...")` usages to confirm none depend on a divergent binding. `unverified` (plan for ProjectHephaestus #1513) |
+| Treated an `__init__.py` re-export widening as boundary-risk-free | Reasoned the eager re-exports were safe because `utils.py` only pulls stdlib + `hephaestus.constants` + formatters, and skipped the surface/boundary tests | That reasoning is a hypothesis until the enforced tests run; any `__init__.py` import addition can regress `test_import_surface.py` / `test_automation_boundary.py` | Always include `test_import_surface.py` and `test_automation_boundary.py` in the verification set when touching a package `__init__.py`, even for a "pure re-export". `unverified` (plan for ProjectHephaestus #1513) |
+| Fixed only the 2 symbols named in the issue | Issue #1511 named `add_dry_run_arg` + `DRY_RUN_HELP_CAVEAT`; considered fixing just those two | `add_github_throttle_args` + `configure_github_throttle_from_args` had the identical defect — fixing only the named symbols would re-trigger the same `[S14 API Design]` audit finding for the skipped ones | When an audit finding names a subset of a defect class, fix the WHOLE defect class in one PR (check `set(submodule.__all__) - set(pkg.__all__)` to enumerate all missing symbols, not just the named ones). `verified-local` (ProjectHephaestus #1511) |
+| Considered using `_LAZY_EXPORTS` for a stdlib-only module | `cli/utils.py` pulls only `argparse`, `json`, `math`, `sys` + `hephaestus._version_lookup`; still reached for the lazy export pattern | Lazy export infrastructure is only justified when the submodule has heavyweight or boundary-crossing imports (e.g. `pydantic`, `curses`, `hephaestus.automation.*`). For a stdlib-only module, eager `from … import (…)` in `__init__.py` is simpler, faster, and avoids indirection | Use eager re-export when the source module is stdlib-only; reserve `_LAZY_EXPORTS`/`__getattr__` for modules that must stay unloaded at package import time. `verified-local` (ProjectHephaestus #1511) |
+| Used a strict-equality pin for the surface test | Considered `assert set(cli.__all__) == set(utils.__all__)` | A strict-equality pin breaks every open branch the moment any sibling PR adds a new symbol to either module | Use a subset assertion (`set(utils.__all__) - set(cli.__all__)`) — it catches regressions (symbols removed from `cli.__all__` that remain in `utils.__all__`) without blocking parallel additions. `verified-local` (ProjectHephaestus #1511) |
+| Ran the two failing tests in ISOLATION and called it green | `pytest tests/unit/validation/test_api_table_docs.py::TestLiveTreeAlignment::test_real_compatibility_md_is_aligned` (and the `TestMain` peer) alone, after adding `configure_cli_logging` to `__all__` without the doc row | The test scans the LIVE on-disk `__all__` + `COMPATIBILITY.md` at scan time; in isolation (and on a stashed/clean tree) it PASSED with the broken change present — a FALSE NEGATIVE. It only failed reliably when the WHOLE module / broad `tests/unit/validation` suite ran with the change applied | For live-tree-scanning validation tests, NEVER trust an isolated run. Run the full owning module (`pixi run python -m pytest tests/unit/validation/test_api_table_docs.py -q --no-cov`) after editing any `__all__` / `[project.scripts]` / public-export surface. `verified-local` (ProjectHephaestus #1419) |
+| Added `configure_cli_logging` to `__all__` without a COMPATIBILITY.md row | Added the symbol to `cli/utils.py:__all__` + re-export in `cli/__init__.py:__all__`; assumed (per section G's `cli` precedent) "no per-symbol table → no doc change" | Unlike the section-G tier-level entry, the `### hephaestus.cli` section in this repo DOES have a per-symbol API table; the live-tree test raised `[missing-from-docs] hephaestus.cli.configure_cli_logging is in __all__ but has no row in COMPATIBILITY.md` | Check whether the package section is a per-symbol TABLE vs a tier-level entry before assuming no doc change; if a per-symbol table exists, add an alphabetical row in the same PR. `verified-local` (ProjectHephaestus #1419) |
+| Stamped the COMPATIBILITY.md "since" column from the latest git tag | Considered `0.9.8` because `git describe --tags --abbrev=0` = `v0.9.7` (tag + 1) | Tag arithmetic is the wrong rule (the issue #1513 caution); the right answer is to read the version off SAME-CYCLE SIBLING helpers — `create_validation_parser`/`resolve_repo_root` already carried `0.9.8`, which is why `configure_cli_logging` = `0.9.8` (coincidentally tag+1, but for the right reason) | Resolve the "since" version from same-cycle siblings already in the table, not from `git describe`. `verified-local` (ProjectHephaestus #1419) — upgrades the issue #1513 `unverified` caution |
+| Followed the stale plan's "narrow `create_validation_parser` API" instruction | The approved plan (written before sibling PR #1637 merged) said to DROP `include_repo_root`/`prog`/`usage`/`epilog`/`formatter_class` from `create_validation_parser` | #1637 had ALREADY merged the WIDER API and many call sites now pass those exact kwargs; executing the plan literally would have REVERSED merged, depended-upon code | Grep the CURRENT state before implementing a plan; once a sibling PR merges, the issue body/plan goes stale — implement only the genuinely-unimplemented slice. Cross-link: `dry-refactoring-workflow`. `verified-local` (ProjectHephaestus #1419) |
+| Returned only `sorted(set(_LAZY_IMPORTS) \| set(__all__))` from `__dir__` | Built the companion `__dir__` from just the lazy map and `__all__`, omitting `globals()` | A custom module `__dir__` REPLACES the default listing — it does NOT auto-union module globals. The return dropped `__version__`, `__author__`, dunders, and already-cached lazy names, so `dir()` SHRANK versus today (a silent regression) | Always fold `set(globals())` into the return: `sorted(set(_LAZY_IMPORTS) \| set(__all__) \| set(globals()))`. `unverified` (plan for ProjectHephaestus #1512) |
+| Trusted the audit finding's "35 symbols" count | Planned to assert `dir()` exposes exactly 35 lazy symbols, taking the audit snapshot at face value | The live `_LAZY_IMPORTS` had already grown to 40 entries by fix-time; a hardcoded-count test would have been born stale (same failure mode as the strict-equality `__all__` pins in sections B/B′) | Pin by SUBSET invariant (`set(_LAZY_IMPORTS) <= set(dir(pkg))`) and verify the live count on disk; audit-snapshot counts drift between finding-time and fix-time. `unverified` (plan for ProjectHephaestus #1512) |
+| Worried that listing a deprecated shim in `__dir__` would fire its `DeprecationWarning` | Considered excluding `retry_with_jitter` from the `__dir__` output to avoid emitting the section-F access-time warning during tab-completion | It doesn't fire — `__dir__` returns names (strings) only and performs NO attribute access, so it never routes through `__getattr__` where the warning lives | Safe to list deprecated lazy symbols in `__dir__`; only ACCESS warns. Assert in a test that `dir()` emits no `DeprecationWarning` and does not populate the symbol into `__dict__`. `unverified` (plan for ProjectHephaestus #1512) |
+
+## Results & Parameters
+
+### Function-local import — before/after and cost
+
+```python
+# AFTER (acyclic): parent imports child at top-level (OK); child imports parent locally
+# hephaestus/utils/helpers.py
+def run_subprocess(cmd):
+    from hephaestus.logging.utils import get_current_correlation_id  # ✅ LOCAL
+    cid = get_current_correlation_id()
+    ...
+```
+
+| Strategy | Circular Dep Risk | Startup Time | Per-Call Cost | Best For |
+|----------|------------------|--------------|---------------|----------|
+| Module-level | High (creates cycle) | Slower | O(1) cache | Non-circular dependencies |
+| Function-local | None | Faster | O(1) cache (after first ~3–5µs) | Ambient state, one-off imports |
+| Parameter passing | None | Faster | O(1) | True call-level arguments |
+
+### Lazy exports — expected test output
+
+```text
+tests/unit/automation/test_package_imports.py::test_can_import_all_exports PASSED
+tests/unit/automation/test_package_imports.py::test_lazy_exports_dict_sorted PASSED
+tests/unit/automation/test_package_imports.py::test_all_in_lazy_exports PASSED
+tests/unit/automation/test_package_imports.py::test_no_circular_imports PASSED
+tests/unit/automation/test_package_imports.py::test_public_surface_pins_expected_symbols PASSED
+======================== 9 passed in 0.45s ========================
+```
+
+`__all__`, `_LAZY_EXPORTS` keys, and `TYPE_CHECKING` imports must all be alphabetically sorted (case-sensitive, uppercase first). `_PHASE_ENTRYPOINTS` order does not matter (membership check only).
+
+### Stale surface-pin — failure signature, diagnosis, and fix
+
+CI failure signature (every Python leg, exactly one failing test):
+
+```text
+FAILED tests/unit/automation/test_package_imports.py::test_public_surface_pins_expected_symbols
+    assert set(automation.__all__) == expected
+E   Extra items in the left set:
+E     'AuditReviewer'
+```
+
+Diagnose test-vs-source, then fix the test (not the source):
+
+```bash
+# 1. Confirm OPEN + which checks fail
+gh pr view 968 --json state,statusCheckRollup
+
+# 2. Find the single failing test among thousands
+gh run view --job <job-id> --log-failed | grep -iE "FAILED|AssertionError"
+
+# 3. Reproduce locally — the set-diff names the exact symbol
+pixi run python -m pytest tests/unit/automation/test_package_imports.py::test_public_surface_pins_expected_symbols -v
+
+# 4. PROVE the symbol is a legitimate, separately-landed export (decides test-vs-source)
+git log --oneline -- hephaestus/automation/__init__.py   # AuditReviewer entered via PR #1067 on main
+git log -p -1 -- hephaestus/automation/__init__.py        # "feat(automation): add audit reviewer..."
+```
+
+The fix is one line in the TEST, alphabetically placed, with zero source change:
+
+```python
+expected = {
+    "AddressReviewer",
+    "AuditReviewer",   # ← added: legitimate peer that landed on main via #1067
+    "CIDriver",
+    # ...
+}
+```
+
+Separating the real CI failure from live-session environment noise (3 local failures, only 1 genuine):
+
+```bash
+# env-var leak (HEPH_PLANNER_MODEL / HEPH_IMPLEMENTER_MODEL / HEPH_REVIEWER_MODEL set in the live session)
+env -i HOME="$HOME" PATH="$PATH" pixi run pytest \
+    tests/unit/automation/test_loop_runner.py::test_phase_env_model_vars_only_when_non_empty -q   # PASS ⇒ environmental
+
+# pre-existing vs your-change (live gh auth leaked 24/40 real PRs past the mock)
+git stash && pixi run pytest tests/unit/automation/test_ci_driver_prs_mode.py -q ; git stash pop  # same fail ⇒ not yours
+
+# decisive tiebreaker: all 3 noise tests PASSED in CI (no live gh auth, no HEPH_*_MODEL there)
+gh run view --job <job-id> --log | grep -E "test_phase_env_model_vars_only_when_non_empty|test_ci_driver_prs_mode"
+```
+
+### Version-gated guard — expected output & type-ignore
+
+```text
+$ pixi run pytest tests/unit -q --tb=no
+2590 passed, 2 skipped in 168.87s
+```
+
+Collection must succeed on both 3.10 and 3.11+ legs. On 3.11+ mypy knows the `else` is unreachable, so suppress with both codes:
+
+```python
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef, unused-ignore]
+```
+
+### POSIX-only guard — verified-passing pattern
+
+```python
+try:
+    import fcntl
+except ModuleNotFoundError:  # Windows: fcntl is POSIX-only
+    fcntl = None  # type: ignore[assignment]
+
+def _acquire_lock(fp) -> None:
+    if fcntl is not None:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+    # cross-process locking is best-effort no-op on Windows
+
+def _release_lock(fp) -> None:
+    if fcntl is not None:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+```
+
+```python
+# tests/integration/test_entry_points.py
+POSIX_ONLY_SUBPACKAGES = ("automation",)
+
+def test_entry_point_importable(module_path: str) -> None:
+    if sys.platform == "win32" and any(p in module_path for p in POSIX_ONLY_SUBPACKAGES):
+        pytest.skip("automation CLIs require POSIX stdlib (curses/fcntl)")
+    importlib.import_module(module_path)
+```
+
+### Access-time DeprecationWarning across the lazy-loader seam — verified pattern (verified-local)
+
+Executed end-to-end for ProjectHephaestus issue #1545. All tests listed below passed.
+
+```python
+# hephaestus/__init__.py — _DEPRECATED_LAZY dict + modified __getattr__
+# retry_with_jitter lives in _LAZY_IMPORTS (NOT __all__ — the issue misnamed this).
+
+_DEPRECATED_LAZY: dict[str, str] = {
+    "retry_with_jitter": (
+        "hephaestus.retry_with_jitter is deprecated; use "
+        "retry_with_backoff(jitter=True, max_delay=...) instead. "
+        "It will be removed no earlier than the next major version after 1.0."
+    ),
+}
+
+def __getattr__(name: str) -> Any:
+    """Lazy-load public symbols on first access (PEP 562)."""
+    if name in _LAZY_IMPORTS:
+        if name in _DEPRECATED_LAZY:
+            import warnings
+            warnings.warn(_DEPRECATED_LAZY[name], DeprecationWarning, stacklevel=2)
+        module_name, attr = _LAZY_IMPORTS[name]
+        import importlib
+        module = importlib.import_module(module_name)
+        value = getattr(module, attr)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module 'hephaestus' has no attribute {name!r}")
+```
+
+```python
+# Regression test — replaces stale-tolerant test_retry_with_jitter_reachable_from_top_level_lazy_loader
+def test_retry_with_jitter_access_emits_deprecation_warning(self) -> None:
+    import hephaestus
+
+    # Bust PEP 562 cache — force __getattr__ to re-run
+    hephaestus.__dict__.pop("retry_with_jitter", None)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        symbol = hephaestus.retry_with_jitter  # ACCESS only, do not call
+
+    assert callable(symbol)
+    access_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert access_warnings, "Accessing hephaestus.retry_with_jitter must emit DeprecationWarning"
+    assert "retry_with_jitter" in str(access_warnings[0].message)
+    # stacklevel=2 must attribute the warning to the caller's file
+    assert access_warnings[0].filename == __file__, (
+        f"DeprecationWarning should be attributed to the caller's file "
+        f"({__file__}); got {access_warnings[0].filename}. Check stacklevel."
+    )
+```
+
+Tests that passed:
+
+```text
+tests/unit/utils/test_deprecation_warnings.py — 3 passed
+tests/unit/utils/test_retry.py -k jitter — 7 passed
+tests/unit/validation/test_import_surface.py — passed
+tests/unit/validation/test_automation_boundary.py — passed
+ruff check hephaestus/__init__.py tests/unit/utils/test_deprecation_warnings.py — all checks passed
+ruff format --check — 2 files already formatted
+mypy — clean
+```
+
+Key confirmed values: `stacklevel=2` inside `__getattr__` correctly points at the user's access line
+(confirmed by `access_warnings[0].filename == __file__` assertion passing). `import warnings` deferred
+inside the `if name in _DEPRECATED_LAZY:` block does not breach `test_automation_boundary.py`.
+
+### Per-symbol COMPATIBILITY.md API-table alignment — failure signature & full-suite-only reproduction (verified-local)
+
+Executed end-to-end for ProjectHephaestus issue #1419. Failure signature when `configure_cli_logging` is in `__all__` but absent from the table:
+
+```text
+[missing-from-docs] hephaestus.cli.configure_cli_logging is in __all__ but has no row in COMPATIBILITY.md
+FAILED tests/unit/validation/test_api_table_docs.py::TestLiveTreeAlignment::test_real_compatibility_md_is_aligned
+FAILED tests/unit/validation/test_api_table_docs.py::TestMain::test_main_returns_zero_on_real_repo
+```
+
+The fix is one alphabetical row, version read from same-cycle siblings (zero source change to the test):
+
+```markdown
+| `add_version_arg` | 0.1.0 | Add a `--version` flag to a parser |
+| `configure_cli_logging` | 0.9.8 | Configure standard stderr-safe logging for a CLI |
+| `configure_github_throttle_from_args` | 0.9.0 | Apply parsed throttle args to the GitHub client |
+```
+
+Full-suite-only reproduction (the dangerous part — isolated runs are false negatives):
+
+```bash
+# FALSE NEGATIVE — passes in isolation even with the missing-row bug present:
+pixi run python -m pytest \
+    "tests/unit/validation/test_api_table_docs.py::TestLiveTreeAlignment::test_real_compatibility_md_is_aligned" -q --no-cov
+
+# AUTHORITATIVE — fails on the missing row; this is what you must run before claiming green:
+pixi run python -m pytest tests/unit/validation/test_api_table_docs.py -q --no-cov
+```
+
+Tests that passed after the doc-row fix: `tests/unit/cli/test_utils.py`, `tests/unit/automation/test_ensure_state_labels.py`,
+`tests/unit/validation/test_api_table_docs.py` (full `tests/unit/validation` + others: 3186 passed). `ruff` clean;
+`pixi run mypy` = "Success: no issues found in 446 source files"; `markdownlint-cli2 COMPATIBILITY.md` passed.
+Verified locally; CI confirmation pending on the originating PR.
+
+## Verified On
+
+| Project | Context | Details |
+|---------|---------|---------|
+| ProjectHephaestus | PR #633 — correlation_id propagation | Function-local import of `get_current_correlation_id` in `hephaestus/utils/helpers.py:170-172`; lint passes with no `noqa` |
+| ProjectHephaestus | Issue #799 / PR #988 — lazy-export add/add rebase conflict | Branch `799-auto-impl` widened `_LAZY_EXPORTS`/`__all__` in `hephaestus/automation/__init__.py`; main had already added the same `"PRReviewer"` entry via #968/#775 → PR read CI-failing but `mergeStateStatus=DIRTY` was the real blocker. Rebased onto origin/main (only `__init__.py` conflicted; `test_package_imports.py` rebased clean), kept ONE `"PRReviewer"` copy, set()-based surface tests ignored key order. Full suite 4136 passed / 19 skipped; pre-commit reflowed one f-string line; GPG-signed. **verified-local** |
+| ProjectHephaestus | Issue #775 / PR #968 — widen automation SDK surface | Exposed PlanReviewer, AddressReviewer, CIDriver (+Options) via `__all__`/`_LAZY_EXPORTS`/`_PHASE_ENTRYPOINTS`; surface-pinning test; 1081 automation tests pass |
+| ProjectHephaestus | Issue #775 / PR #968 vs #1067 — stale surface-pin repair | `test_public_surface_pins_expected_symbols` failed on every Py leg with `Extra items in the left set: 'AuditReviewer'`; `AuditReviewer` was a legitimate peer added on `main` by independent PR #1067. Fixed the stale test literal (one-line add, alphabetised), zero source change. `verified-local` — CI re-run confirmation pending. 2 sibling local failures (`HEPH_*_MODEL` env leak; live `gh` auth past a mock) proven environmental via `env -i` + `git stash` + grep-the-CI-log |
+| ProjectHephaestus | PR #657 — fix broken main CI | `sys.version_info` guard for `tomllib`/`tomli` in `tests/unit/ci/test_bandit_config.py`; conditional deps in `pyproject.toml`/`pixi.toml`; 2590 tests pass |
+| ProjectHephaestus | PRs #534, #536, #538 (issue #539 tracks full port) — Windows-importability | curses guard in `CursesUI`, fcntl guard in `planner.py`, `tzdata` for `hephaestus.github.rate_limit` |
+| ProjectHephaestus | Issue #1545 — access-time DeprecationWarning for `retry_with_jitter` | Executed end-to-end: added `_DEPRECATED_LAZY` dict + modified `__getattr__` in `hephaestus/__init__.py`; replaced stale-tolerant `test_retry_with_jitter_reachable_from_top_level_lazy_loader` with `test_retry_with_jitter_access_emits_deprecation_warning` (including `__dict__.pop` cache-bust and `stacklevel=2` filename assertion); updated `COMPATIBILITY.md` bullet. Symbol is in `_LAZY_IMPORTS`, not `__all__` (issue misnamed it). All tests passed: 3 in `test_deprecation_warnings.py`, 7 in `test_retry.py -k jitter`, `test_import_surface.py`, `test_automation_boundary.py`. Ruff + mypy clean. **verified-local** — CI pending after PR merges |
+| ProjectHephaestus | Issue #1511 — `[S14 API Design]` align `hephaestus/cli/__init__.py __all__` with `cli/utils.py __all__` | **verified-local** (section G). Added 4 missing symbols (`DRY_RUN_HELP_CAVEAT`, `add_dry_run_arg`, `add_github_throttle_args`, `configure_github_throttle_from_args`) to both the import block and `__all__` in `hephaestus/cli/__init__.py`. Eager re-export (`cli/utils.py` is stdlib-only). No COMPATIBILITY.md change (no per-symbol table for `hephaestus.cli`). Added `test_cli_all_covers_module_all` (subset assertion) + `test_dry_run_symbols_reexport_identity` (identity check) in `tests/unit/cli/test_utils.py`. All 79 tests in `tests/unit/cli/` passed; `test_import_surface.py` + `test_automation_boundary.py` passed; mypy clean (423 source files); ruff clean. CI pending after PR merges |
+| ProjectHephaestus | Issue #1419 — share validation CLI parser + centralize CLI logging; per-symbol COMPATIBILITY.md API-table alignment + full-suite-only live-tree-scan hazard | **verified-local** (section G′). Added `configure_cli_logging` to `hephaestus/cli/utils.py:__all__` and re-exported it in `hephaestus/cli/__init__.py:__all__`; the live-tree `test_api_table_docs.py` (`TestLiveTreeAlignment::test_real_compatibility_md_is_aligned` / `TestMain::test_main_returns_zero_on_real_repo`) failed with `[missing-from-docs] hephaestus.cli.configure_cli_logging is in __all__ but has no row in COMPATIBILITY.md`. Fix = one alphabetical row in `### hephaestus.cli` (`\| configure_cli_logging \| 0.9.8 \| …`), version read from same-cycle siblings (`create_validation_parser`/`resolve_repo_root` = 0.9.8; latest tag was `v0.9.7`). KEY HAZARD: the test PASSED in ISOLATION (and on a stashed/clean tree) with the bug present — a false negative — and failed only when the WHOLE module / broad `tests/unit/validation` suite ran. Authoritative check = `pixi run python -m pytest tests/unit/validation/test_api_table_docs.py -q --no-cov`. All affected tests pass: `tests/unit/cli/test_utils.py`, `tests/unit/automation/test_ensure_state_labels.py`, `test_api_table_docs.py` (3186 passed); ruff clean; mypy "Success: no issues found in 446 source files"; markdownlint clean. UPGRADES the issue #1513 COMPATIBILITY.md version-stamping guidance from `unverified` → `verified-local` (version resolved from same-cycle siblings, confirmed on disk). Secondary cross-link: the issue body/plan predated sibling PR #1637 (which merged a WIDER `create_validation_parser` API the plan said to narrow) → do NOT reverse merged code; implement only the genuinely-unimplemented slice (reinforces `dry-refactoring-workflow`). Verified locally; CI confirmation pending on the originating PR |
+| ProjectHephaestus | Issue #1513 — `[S14 API Design]` promote correlation-ID functions to the stable surface | **PLAN ONLY / unverified** (COMPATIBILITY.md version-stamping in section G). Plan re-exports `set_correlation_id` / `get_current_correlation_id` / `correlation_id_scope` from `hephaestus/logging/__init__.py`, adds them to `__all__`, documents them in the `COMPATIBILITY.md` stable-symbol table (stamped `0.9.8` purely because latest tag is `v0.9.7` — flagged as an UNVERIFIED guess that the reviewer must confirm against roadmap), and adds a subset-assertion surface-pin test. Five planning traps captured: version-stamp must be verified not guessed; grep the WHOLE test tree for a non-local strict-equality `__all__` pin before widening; verify the "Stable subpackage" premise on disk; assert re-export identity for `patch("hephaestus.logging.utils...")` paths; include `test_import_surface.py`/`test_automation_boundary.py` for the `__init__.py` widening. Not executed in CI. **Update (issue #1419):** the "version-stamp must be verified not guessed" trap is now RESOLVED `verified-local` — the resolution rule is to read the "since" version off SAME-CYCLE SIBLINGS already in the table (not tag arithmetic); see the issue #1419 row above and section G′ |
+| ProjectHephaestus | Issue #1512 — `[S14 API Design]` add companion `__dir__()` to the PEP 562 lazy-loader package | **PLAN ONLY / unverified** (section H). Plan adds a module-level `__dir__()` returning `sorted(set(_LAZY_IMPORTS) \| set(__all__) \| set(globals()))` to `hephaestus/__init__.py` (which already defines `__getattr__` for lazy loading but no `__dir__`, so `dir(hephaestus)` shows only ~4 eager names) and pins it with a `TestDirDiscoverability` class in the existing `tests/integration/test_package_import.py`. Durable lessons captured: a custom `__dir__` REPLACES (does not merge) the default listing, so `set(globals())` MUST be folded in or `dir()` SHRINKS; `__dir__` returns names only (no attribute access) so a deprecated lazy shim is listed without firing its `DeprecationWarning`; pin by SUBSET invariant not a hardcoded count (the audit's "35 symbols" was already stale at 40 `_LAZY_IMPORTS` on disk); regression-test that `dir()` does not shrink the visible set; extend the existing surface test file, not a parallel one. Not executed in CI |
+````
+
+---
+
 ## v1.8.0 (2026-06-29)
 
 **Changed by:** ProjectHephaestus issue #1419 (refactor: share validation CLI parser + centralize CLI logging; branch `1419-auto-impl`) — executed the addition of a single public symbol (`configure_cli_logging`) to `hephaestus/cli/utils.py:__all__` (re-exported in `hephaestus/cli/__init__.py:__all__`) in a repo whose `### hephaestus.cli` COMPATIBILITY.md section carries a PER-SYMBOL API table guarded by a LIVE-TREE-SCANNING validation test (`tests/unit/validation/test_api_table_docs.py` — `TestLiveTreeAlignment::test_real_compatibility_md_is_aligned` / `TestMain::test_main_returns_zero_on_real_repo`). Two tightly-coupled facets, SAME search surface ("I added a public symbol and an unrelated test broke"): (A) the missing-row failure and its alphabetical-row + same-cycle-sibling-version fix; (B) the live-tree test is a FALSE NEGATIVE in isolation and only fails in the full module.

--- a/skills/python-import-patterns-and-compatibility-guards.md
+++ b/skills/python-import-patterns-and-compatibility-guards.md
@@ -1,10 +1,22 @@
 ---
 name: python-import-patterns-and-compatibility-guards
-description: "Use when: (1) a child module would create circular dependencies by importing the parent at module level — use function-local imports to defer the lookup and keep the import graph acyclic; (2) extending a public SDK surface with peer classes using lazy-loading __init__.py infrastructure (lazy exports pattern via __getattr__) to prevent eager-load regressions when adding new peers to __all__; (3) code uses a stdlib module added in a later Python version (tomllib in 3.11+, ExceptionGroup in 3.11+) and the CI matrix includes older Python — add a version-gated try/except import guard so the module remains importable; (4) adding cross-OS CI matrix and Windows jobs fail with ModuleNotFoundError for POSIX-only stdlib modules (curses, fcntl, grp, tzdata) — add conditional import guards and ensure tzdata is listed as an optional Windows dependency; (5) a hardcoded surface-pinning test (set(__all__) == literal) fails on CI with 'Extra items in the left set' because a peer export landed on main via an independent PR while your branch was open — fix the stale test literal, not the (correct) source, and use env -i / git stash / grep-the-CI-log to separate real failures from live-session environment noise; (6) a branch widening a lazy SDK surface (_LAZY_EXPORTS/__all__/__getattr__ in __init__.py) goes DIRTY/CONFLICTING on rebase because a sibling PR already landed the identical export — resolve by keeping ONE copy of the shared entry, and FIRST check mergeStateStatus=DIRTY when a PR reads as CI-failing but no test actually failed; (7) adding a DeprecationWarning at ACCESS time (not just call time) for a deprecated lazy shim exposed via a PEP 562 package __getattr__ loader — grep the named symbol against the source first because the issue may misname the mechanism (in _LAZY_IMPORTS vs __all__), keep access-time and call-time warnings as complementary layers (both needed for different access paths), force a fresh resolve in the regression test via module.__dict__.pop(name) because PEP 562 caches into globals, rewrite any stale-tolerant test that documents the current silent behavior, use stacklevel=2 inside __getattr__ (verified: user line → __getattr__ → warn, so stacklevel=2 attributes to user's access line), and update the prose deprecation doc (COMPATIBILITY.md) in the same PR (verified-local, ProjectHephaestus issue #1545); (8) EXECUTING an audit-finding fix that PROMOTES existing public-looking symbols into a package's declared __all__ — scope creep is intentional: when the issue names a subset of affected symbols but the same defect class applies to sibling symbols in the same module, fix ALL of them in one PR (e.g. issue #1511 named add_dry_run_arg + DRY_RUN_HELP_CAVEAT but add_github_throttle_args + configure_github_throttle_from_args had the identical gap; fixing all four so set(utils.__all__) == set(cli.__all__) prevents re-triggering the same audit finding); choose EAGER re-export (plain 'from … import (…)' in __init__.py) when the source module pulls only stdlib — no need for _LAZY_EXPORTS infrastructure; NO COMPATIBILITY.md change is needed when the package has no per-symbol table (only a tier entry); pin the test with a SUBSET ASSERTION (set(submodule.__all__) - set(pkg.__all__) must be empty, not strict equality) so parallel PRs adding new symbols cannot break the pin; do NOT guess the COMPATIBILITY.md 'Added' version from the latest git tag (check RELEASING.md/milestones/roadmap or flag for reviewer), grep the WHOLE test tree (not just the obvious file) for a strict-equality surface pin before widening __all__ because the breakage is non-local, verify the audit's stability-tier premise on disk (audit findings can be factually wrong), assert re-export IDENTITY (pkg.sym is submodule.sym) and grep for existing patch(\"pkg.submodule...\") usages, and include test_import_surface.py/test_automation_boundary.py in the verification set for any __init__.py widening (verified-local, executed end-to-end for ProjectHephaestus issue #1511; planning-guidance for COMPATIBILITY.md version-stamping derived from plan for issue #1513 remains unverified); (9) PLANNING the companion module-level __dir__() for a PEP 562 lazy-loader package whose __getattr__ lazily resolves symbols but whose dir(pkg) shows only eagerly-bound names — define __dir__() returning sorted(set(_LAZY_IMPORTS) | set(__all__) | set(globals())) so the entire lazy public API is discoverable to IPython tab-completion / IDEs / doc generators; CRITICAL: a custom __dir__ REPLACES (does not merge with) the default listing, so you MUST fold set(globals()) in or you silently REMOVE today-visible names (__version__, __author__, dunders, already-cached lazy names); __dir__ returns names only and performs NO attribute access, so a deprecated lazy shim can be listed without firing its DeprecationWarning; pin the contract by SUBSET INVARIANT (set(_LAZY_IMPORTS) <= set(dir(pkg))) not a hardcoded count (the audit's '35 symbols' was already stale at 40); regression-test that dir() does not SHRINK the visible set; extend the existing surface test file, do not create a parallel one (unverified planning-guidance, derived from a plan for ProjectHephaestus issue #1512); (10) EXECUTING a fix that adds a single public symbol to a package __all__ in a repo that has a per-symbol COMPATIBILITY.md API table guarded by a live-tree-scanning validation test (e.g. hephaestus tests/unit/validation/test_api_table_docs.py — TestLiveTreeAlignment::test_real_compatibility_md_is_aligned / TestMain::test_main_returns_zero_on_real_repo) — adding the name to __all__ (and re-exporting it from the package __init__.py __all__) WITHOUT adding a matching COMPATIBILITY.md row fails with '[missing-from-docs] <pkg>.<name> is in __all__ but has no row in COMPATIBILITY.md'; the FIX is to add an ALPHABETICAL row to the right '### <pkg>' section with a 'since' version column resolved from sibling helpers added in the same release cycle (NOT blindly from `git describe --tags --abbrev=0` — verify against siblings, e.g. configure_cli_logging took 0.9.8 because create_validation_parser/resolve_repo_root in the same cycle used 0.9.8 even though the latest tag was v0.9.7). CRITICAL FULL-SUITE-ONLY HAZARD: this live-tree alignment test scans the actual on-disk __all__ + COMPATIBILITY.md at scan time, so it can PASS when run in ISOLATION (`pytest …::test_real_compatibility_md_is_aligned` alone) yet reliably FAIL only when you run the WHOLE module / the broad tests/unit/validation suite WITH the change applied — an isolated green run is a FALSE NEGATIVE. After editing ANY package __all__ or [project.scripts]/public-export surface, run the full module that owns the live-tree alignment check (here `pixi run python -m pytest tests/unit/validation/test_api_table_docs.py -q --no-cov`) before claiming green; never trust an isolated test run for live-tree-scanning validation tests (verified-local, ProjectHephaestus issue #1419). This UPGRADES the previously-unverified COMPATIBILITY.md per-symbol version-stamping guidance from issue #1513 to verified-local: issue #1419 executed the per-symbol-row addition end-to-end and confirmed the version column is resolved from same-cycle siblings, not the latest tag. SECONDARY (cross-link, not its own skill): the issue #1419 body + approved plan predated sibling PR #1637 which had ALREADY merged most of the work with a WIDER create_validation_parser API (kept include_repo_root/prog/usage/epilog/formatter_class that the plan said to drop) — do NOT reverse merged code to satisfy a stale plan; grep the CURRENT state and implement only the genuinely-unimplemented slice (reinforces dry-refactoring-workflow's 'issue bodies/plans go stale')."
+description: >-
+  Use when: (1) enforcing an acyclic Python runtime module graph with an AST
+  regression that counts module-level, function-local, resolvable
+  from-package child, and lazy-export-map dependencies; (2) extracting shared
+  low-level behavior into a dependency-neutral leaf while preserving public
+  import identity and signatures through explicit re-exports; (3) using a
+  function-local import to defer import-time lookup without falsely claiming
+  that it removes the structural dependency edge; (4) extending a PEP 562
+  lazy public surface, repairing stale surface pins, or preserving package
+  patch facades; (5) guarding imports across Python versions or operating
+  systems; (6) aligning public exports with compatibility documentation and
+  import-boundary checks.
 category: architecture
-date: 2026-06-29
-version: "1.8.0"
+date: 2026-08-08
+version: "2.0.0"
 user-invocable: false
+verification: unverified
 history: python-import-patterns-and-compatibility-guards.history
 tags:
   - import-strategy
@@ -55,6 +67,13 @@ tags:
   - false-negative-isolation
   - version-column
   - same-cycle-siblings
+  - runtime-import-graph
+  - ast
+  - tarjan
+  - strongly-connected-components
+  - dependency-neutral-leaf
+  - type-checking
+  - lazy-export-map
 ---
 
 # Python Import Patterns and Compatibility Guards
@@ -63,14 +82,15 @@ tags:
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-06-29 |
-| **Objective** | Manage the Python import graph and import compatibility across versions and platforms: avoid circular dependencies with function-local imports, extend public SDK surfaces via lazy exports without eager-load regressions, guard stdlib imports that vary by Python version or OS, keep hardcoded surface-pinning tests from going stale when peers land via parallel PRs, emit an access-time `DeprecationWarning` across the PEP 562 lazy-loader seam, and — when adding a public symbol to a package `__all__` in a repo with a per-symbol `COMPATIBILITY.md` API table guarded by a live-tree-scanning validation test — add the matching alphabetical table row (with a version column resolved from same-cycle siblings) AND run the full validation module, because the live-tree alignment check is a FALSE NEGATIVE when run in isolation |
-| **Outcome** | Acyclic import graphs, Windows-importable packages, CI matrices green on older Python and POSIX-only stdlib, lazy SDK surfaces that scale to new peer classes, a decision procedure for fixing stale pinned-`__all__` tests (test vs source) without chasing live-session environment noise, a verified workflow for emitting a deprecation warning at `__getattr__` access time, and a verified workflow for keeping a per-symbol `COMPATIBILITY.md` API table aligned with a widened `__all__` — confirming the `missing-from-docs` failure surfaces only in the FULL validation module (isolated runs are false negatives), that the row goes alphabetically into the right `### <pkg>` section, and that the "since" version is read off same-cycle sibling helpers (not `git describe --tags`) |
-| **Verification** | verified-ci (function-local / version-guard / Windows-guard / lazy-exports); verified-local (surface-pin-stale fix, access-time deprecation-warning implementation — section F executed end-to-end with all tests passing locally; section G — __all__ alignment / eager re-export / subset-assertion pin executed end-to-end for ProjectHephaestus issue #1511, all tests passing locally; section G′ — per-symbol COMPATIBILITY.md API-table row alignment + the full-suite-only live-tree-scan false-negative hazard executed end-to-end for ProjectHephaestus issue #1419, all affected tests passing locally including `tests/unit/validation/test_api_table_docs.py`, ruff/mypy/markdownlint clean; this also UPGRADES the COMPATIBILITY.md per-symbol version-stamping guidance — previously `unverified` from issue #1513 — to `verified-local` (the version column is resolved from same-cycle siblings, confirmed on disk: `configure_cli_logging` = 0.9.8, matching `create_validation_parser`/`resolve_repo_root`, even though the latest tag was `v0.9.7`); CI pending after the ProjectHephaestus PR merges); **unverified** planning-guidance (section H — adding the companion `__dir__()` to a PEP 562 lazy-loader package; derived from a plan for ProjectHephaestus issue #1512, not yet executed in CI) |
+| **Date** | 2026-08-08 |
+| **Objective** | Manage Python import compatibility and enforce an acyclic runtime module graph: distinguish import-time deferral from structural dependency removal, extract shared low-level behavior into neutral leaf modules, preserve package facades with explicit identity re-exports, and guard the complete graph with AST-based strongly connected component detection. |
+| **Outcome** | Existing version/OS, lazy-export, public-surface, and compatibility-table workflows remain available. The new runtime-graph workflow is a proposed, project-independent pattern that counts hidden runtime edges and preserves adapter behavior while cycles are removed. |
+| **Verification** | Existing sections retain their recorded `verified-ci` / `verified-local` levels. Section I (runtime graph, neutral leaf extraction, facade normalization, and Tarjan regression) is **unverified** planning guidance derived from a reviewed ProjectHephaestus implementation plan; implementation and CI evidence are pending. |
 
 ## When to Use
 
-- **Function-local imports (coupling avoidance)**: A child module needs ambient state from a parent module (e.g., `logging.utils` already imports `utils.helpers`), and a module-level child-to-parent import would create a circular dependency or import-graph bloat. The import is used in only one or two functions.
+- **Acyclic runtime module graph (unverified planning guidance)**: A package imports successfully but still contains structural cycles through function-local imports, package-attribute imports, lazy-export dictionaries, or a package facade. You need an executable graph invariant rather than import smoke tests alone.
+- **Function-local imports (import-time deferral only)**: A child module needs ambient state from a parent module and a module-level import would fail during partial initialization. A local import can defer lookup, but it remains a runtime dependency edge and must not be treated as proof that the graph is acyclic.
 - **Lazy exports (SDK surface)**: Extending a public package `__all__` with peer classes from submodules, adding `TYPE_CHECKING` imports, preventing eager-load regressions, or avoiding architectural restructuring when widening the public surface.
 - **Version-gated stdlib guard**: A CI matrix includes Python 3.10 and code does a bare import of a 3.11+ stdlib module (`tomllib`, `ExceptionGroup`); `pytest` collection fails with `ModuleNotFoundError` on the lowest Python in the matrix.
 - **Windows / POSIX-only stdlib guard**: Adding a cross-OS CI matrix where Windows jobs fail with `ModuleNotFoundError` for `curses`/`fcntl`/`termios`/`grp`/`pwd`, or `zoneinfo.ZoneInfo` raises `ZoneInfoNotFoundError` on Windows (needs `tzdata`).
@@ -86,8 +106,8 @@ tags:
 ### Quick Reference
 
 ```python
-# (1) FUNCTION-LOCAL IMPORT — break a circular dep child→parent
-# child module (utils/helpers.py); parent (logging/utils.py) already imports this child
+# (1) FUNCTION-LOCAL IMPORT — defer import-time lookup only
+# Static runtime-graph checks must still record child -> parent.
 def run_subprocess(cmd):
     from hephaestus.logging.utils import get_current_correlation_id  # local, not top-level
     cid = get_current_correlation_id()
@@ -177,20 +197,20 @@ markdownlint-cli2 COMPATIBILITY.md
 
 ### Detailed Steps
 
-#### A. Function-local imports to avoid coupling / circular deps
+#### A. Function-local imports to defer import-time cycles, not erase graph edges
 
-1. **Diagnose the cycle.** Confirm the parent already imports the child:
+1. **Diagnose both contracts.** Confirm the parent already imports the child, then decide whether the requirement is merely "imports without partial-initialization failure" or the stronger "runtime module graph is acyclic":
    ```bash
    grep -r "^from hephaestus.utils" hephaestus/logging/   # parent imports child?
    grep -r "^from hephaestus.logging" hephaestus/utils/   # child imports parent at top-level? → cycle
    ```
-2. **Move the import into the function** that needs the ambient state:
+2. **For import-time deferral only, move the import into the function** that needs the ambient state:
    ```python
    def run_subprocess(cmd: list[str]) -> str:
        """Run subprocess, injecting correlation ID into environment.
 
-       Note: import is inside the function to avoid a circular dependency
-       with hephaestus.logging (which imports from hephaestus.utils).
+       Note: import is inside the function to defer lookup until both modules
+       initialize; the runtime graph still contains this dependency edge.
        """
        from hephaestus.logging.utils import get_current_correlation_id
        env = os.environ.copy()
@@ -200,7 +220,10 @@ markdownlint-cli2 COMPATIBILITY.md
    ```
 3. **Keep the function where it semantically belongs** — move the *import*, not the function. Do not relocate `get_current_correlation_id()` into `utils` just to dodge the edge (that creates a god-module / SRP violation).
 4. **Accept the cost.** First call pays an import lookup (~1–5µs); subsequent calls hit `sys.modules` (negligible). For subprocess spawning the import is ~1,000,000x cheaper than the spawn itself.
-5. **Prefer function-local imports over threading a parameter** through intermediate functions that don't use it — that is what ambient context (contextvars/logging/config) is for. Reserve parameters for true call-level arguments.
+5. **Do not call the graph acyclic.** A function-local import changes *when* Python resolves the dependency, not *whether* the importing module depends on the target. Any runtime graph guard must visit imports at every AST depth.
+6. **When structural acyclicity is required, redesign the seam.** Extract shared low-level behavior into a dependency-neutral leaf, invert the collaborator dependency, or pass a true call-level argument. Keep ambient context local only when the architecture explicitly permits the runtime edge.
+
+The earlier version of this skill treated function-local imports as structural cycle removal. That is too broad: the technique can repair import-time initialization order while leaving a runtime dependency cycle intact. Section I defines the stronger graph invariant.
 
 #### B. Lazy exports to widen an SDK surface safely
 
@@ -559,17 +582,158 @@ PEP 562 pairs `__dir__` with `__getattr__` for discoverability. A package that d
    python3 -c "import hephaestus; print(len(hephaestus._LAZY_IMPORTS), len(hephaestus.__all__))"
    ```
 
+#### I. Proposed Workflow — enforce an acyclic runtime module graph
+
+> **Warning:** This workflow has not been validated end-to-end. Treat it as a
+> hypothesis until the production refactor, focused suites, and CI all pass.
+> Verification level: `unverified`.
+
+Use this stronger workflow when the contract is architectural acyclicity, not
+merely successful import order. Ship the graph guard and the refactor in the
+same atomic change: a guard without the repair leaves main red, while a repair
+without the guard lets the cycle return.
+
+1. **Define the runtime graph precisely before editing production code.**
+   Include every Python module under the target package, including
+   `__init__.py`. Visit the complete AST so imports inside functions, methods,
+   classes, exception handlers, and runtime branches remain edges.
+
+2. **Treat `TYPE_CHECKING` guards according to runtime execution.** Imports
+   under a positive `if TYPE_CHECKING:` branch are runtime-inert, but its
+   `else` branch is live. For `if not TYPE_CHECKING:`, visit the body and skip
+   the `else`. Handle qualified spellings such as `typing.TYPE_CHECKING` if the
+   package uses them; synthetic tests should pin both polarities.
+
+3. **Resolve ordinary imports without losing package semantics.**
+   - Derive `pkg.subpkg` for `pkg/subpkg/__init__.py`, not
+     `pkg.subpkg.__init__`.
+   - Resolve `ImportFrom.level` relative to the importing module's package.
+   - For `from package import child`, keep the edge to `package` and, when
+     `package.child` exists in the scanned tree, also keep the child edge.
+   - Retain modules with no outgoing edges so the graph is complete and error
+     output is deterministic.
+
+4. **Model lazy exports as runtime dependencies.** Parse string-valued targets
+   from both assigned and annotated lazy-export dictionaries (for example,
+   `_LAZY_EXPORTS = {...}` and `_LAZY_EXPORTS: dict[str, str] = {...}`). Do not
+   mutate the production lazy map merely to simplify the checker.
+
+5. **Normalize only an intentional patch-facade component.** A package whose
+   `__init__.py` deliberately imports implementation children so callers can
+   patch package-level collaborators may be represented as one component.
+   Normalize every endpoint first, discard only edges that become internal to
+   that component, and retain all incoming and outgoing edges. Do not broadly
+   allowlist the package or delete its external dependencies.
+
+6. **Detect strongly connected components with an in-test Tarjan pass.** Avoid
+   adding a graph dependency for a small validation test. Report deterministic,
+   sorted multi-node components and singleton components only when they carry
+   a self-loop.
+
+   ```python
+   def runtime_cycles(graph: dict[str, set[str]]) -> list[tuple[str, ...]]:
+       """Return deterministic multi-node SCCs and singleton self-loops."""
+       # Standard Tarjan indices/lowlinks/stack implementation.
+       # Sort nodes and adjacency during traversal for stable failures.
+       ...
+   ```
+
+7. **Break cycles at the lowest shared behavior.** If several higher-level
+   modules need the same subprocess, repository-identity, cache, or reference
+   helpers, move only those low-level pieces into a dependency-neutral leaf.
+   Keep branch, commit, push, worktree, API, and policy behavior in their
+   existing higher-level owners. Add an AST leaf test that rejects any import
+   back into the product package, including relative imports.
+
+8. **Preserve compatibility with explicit identity re-exports.** The former
+   owner should import each moved helper explicitly and bind the same public
+   name. Pin both object identity and `inspect.signature`; wrapper functions
+   are not equivalent when downstream callers patch or introspect the original
+   object.
+
+   ```python
+   from .runtime_leaf import (
+       clear_caches as clear_caches,
+       get_repo_info as get_repo_info,
+       run as run,
+   )
+
+   assert compatibility_module.run is runtime_leaf.run
+   assert inspect.signature(compatibility_module.run) == inspect.signature(
+       runtime_leaf.run
+   )
+   ```
+
+9. **Make package-attribute dependencies explicit.** Replace imports such as
+   `from package import collaborator` or `from . import collaborator` with an
+   exact module import (`import package.collaborator as collaborator`). This
+   records the real edge, avoids relying on package initialization order, and
+   makes monkeypatch targets predictable.
+
+10. **Remove legacy fallbacks only after adapter parity is pinned.** Route the
+    behavior through the collaborator that already owns transport, scoping,
+    payload parsing, and mutations. Cover scoped and unscoped paths, exact
+    argument vectors, absence/presence of a repository selector, dry-run zero
+    I/O, malformed JSON, transport failures, wrong or conflicting state, and
+    exclusive readback failures. Patch the symbol where the adapter resolves
+    it, not an obsolete facade module that is no longer called.
+
+11. **Pin historical import-order repairs in subprocesses.** Test both module
+    orderings in fresh interpreters. Import smoke tests and the AST graph guard
+    protect different contracts: the former catches partially initialized
+    modules; the latter catches structural runtime cycles even when all import
+    orders currently happen to succeed.
+
+12. **Make synthetic tests prove the checker cannot miss hidden cycles.** At a
+    minimum, generate tiny temporary packages for:
+    - a function-local cycle;
+    - a child-to-ancestor cycle;
+    - a `from package import submodule` cycle;
+    - an assigned lazy-export-map cycle; and
+    - an annotated lazy-export-map cycle.
+
+13. **Isolate process-global caches in tests.** Clear repository-keyed caches
+    before and after every runtime-leaf test. Clearing only before a test lets a
+    failing test leak state into the next test during teardown or reruns.
+
+14. **Verify the change atomically.** Run the real graph and synthetic graph
+    tests first, then compatibility identity/signature tests, import-order
+    subprocesses, all direct consumers, adapter parity, architecture-boundary
+    suites, lint, and typing. If compatibility identity or scoped/unscoped
+    parity fails, restore the original import targets and fallback paths before
+    redesigning the seam; do not weaken the graph guard or add a cycle
+    allowlist.
+
+Proposed generic verification sequence:
+
+```bash
+<package-manager> pytest \
+  <runtime-graph-test> <runtime-leaf-tests> <compatibility-tests> \
+  <adapter-tests> <import-order-tests> <boundary-tests> --no-cov -q
+<package-manager> ruff check <changed-python-files>
+<package-manager> mypy <changed-python-files>
+```
+
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
+| Treat a function-local import as structural cycle removal | Moved a child-to-parent import inside the calling function and declared the runtime graph acyclic | Python defers the lookup, so import order can succeed, but the child still depends on the parent whenever the function runs | Distinguish import-time initialization from runtime dependency structure; visit imports at every AST depth. `unverified` planning correction |
+| Scan only top-level imports | Built the graph from `tree.body` or a regex over module headers | Misses function-local, class-local, conditional, and exception-path edges, producing false acyclic results | Walk the complete AST, then suppress only branches proven runtime-inert. `unverified` |
+| Drop every `TYPE_CHECKING` conditional | Skipped the whole `if TYPE_CHECKING` node | Its `else` branch is live at runtime; negated guards invert which branch executes | Evaluate guard polarity and visit the runtime branch symmetrically. `unverified` |
+| Resolve `from package import child` only to the package | Added only the ancestor edge | Python may resolve a real child module, so a child cycle remains invisible | Keep the package edge and add the resolvable child edge. `unverified` |
+| Ignore lazy-export dictionaries | Modeled only `ast.Import` and `ast.ImportFrom` nodes | PEP 562 loaders turn string module targets into runtime dependencies; assigned and annotated maps can close a cycle | Parse both `Assign` and `AnnAssign` lazy-export maps without changing production maps. `unverified` |
+| Allowlist a facade package wholesale | Suppressed all edges touching an intentional package patch facade | This hides real incoming/outgoing cycles, not just intentional coupling among facade children | Normalize the facade and children to one component, then discard only normalized internal edges. `unverified` |
+| Move all Git behavior into the new leaf | Extracted branch, commit, push, worktree, and policy operations together with subprocess/identity helpers | The leaf stopped being dependency-neutral and accumulated higher-level reasons to change | Move only low-level execution, identity, caches, and formatting; leave orchestration with existing owners. `unverified` |
+| Preserve behavior with wrappers instead of re-exports | Reimplemented old public helpers as forwarding functions | Wrapper identity differs, signatures can drift, and existing patch targets may stop intercepting calls | Explicitly re-export the same objects and pin identity plus signature. `unverified` |
+| Patch the old fallback module in adapter tests | Monkeypatched the legacy facade after behavior moved into the transport owner | The adapter resolves a different symbol, so the test can pass without observing real calls or fail for the wrong reason | Patch at the lookup site and assert exact scoped/unscoped argument vectors. `unverified` |
 | Trust the issue's "in `__all__`" claim about the deprecated shim | Issue #1545 stated `retry_with_jitter` was exposed via `__all__`; planned the fix from that structural claim | The symbol is actually only in `_LAZY_IMPORTS`, not `__all__`. The fix seam (`__getattr__`) is the same either way, but the implementation differs slightly | Grep the named symbol against the source before trusting an issue's structural claim; don't assume `__all__` and `_LAZY_IMPORTS` always overlap. `verified-local` |
 | Assume the access-time warning duplicates the existing call-time warning | Considered "deduping" by relying on the function-body warning alone | Access-time (`hephaestus.X` binding) and call-time (`hephaestus.utils.X(...)`) are DIFFERENT access paths firing for different users; dropping either silently loses coverage | Keep both warnings — they are complementary layers, not duplicates. `verified-local` |
 | Write a one-shot warning-assertion test without resetting the cache | `with pytest.warns(DeprecationWarning): _ = hephaestus.retry_with_jitter` | PEP 562 caches the resolved name into module globals on first access; a prior test that touched the symbol means `__getattr__` never re-runs → false-negative / flaky | Call `module.__dict__.pop(name, None)` before asserting, to force a fresh `__getattr__` resolve. `verified-local` |
 | Treat the change as purely additive (new test only) | Planned to add a new warning-assertion test and leave existing tests alone | The existing test `test_retry_with_jitter_reachable_from_top_level_lazy_loader` explicitly documented and tolerated the silent lazy resolve; the new behavior contradicts that green test's documented contract | Grep for tests asserting the CURRENT (about-to-change) behavior; REWRITE the stale-tolerant one (don't just append a new test next to it). `verified-local` |
 | Change the behavior without touching the prose doc | Planned source + test edits only | `COMPATIBILITY.md` said the warning fires "when called"; a doc-cross-check test or reviewer catches the drift after access-time firing is added | Update the prose deprecation doc that describes the deprecation in the same PR. `verified-local` |
 | Assume `stacklevel=2` might be wrong for `__getattr__` indirection | Worried that attribute-lookup indirection might need a different stacklevel than the call-time warning | Not actually wrong — `stacklevel=2` IS correct. Call stack: user access line (frame 1) → `__getattr__` (frame 2) → `warnings.warn`. `stacklevel=2` skips `__getattr__` and correctly attributes the warning to the user's access line. Verified by `access_warnings[0].filename == __file__` assertion passing | `stacklevel=2` is correct for `__getattr__`. The attribute-lookup indirection has the same two-frame depth as a direct one-level helper call. `verified-local` |
-| Module-level child→parent import | `from hephaestus.logging.utils import get_current_correlation_id` at top of `helpers.py` | `CircularImportError`/`ImportError` at startup because `logging.utils` already imports `utils.helpers` | Any child-to-parent import at module level creates a cycle if the parent imports the child; use a function-local import |
+| Module-level child→parent import | `from hephaestus.logging.utils import get_current_correlation_id` at top of `helpers.py` | `CircularImportError`/`ImportError` at startup because `logging.utils` already imports `utils.helpers` | A function-local import can defer the import-time failure, but a structural acyclicity requirement needs a neutral leaf or inverted dependency. |
 | Thread correlation ID as a parameter | `run_subprocess(cmd, cid=None)` plumbed through the call chain | Intermediate functions must accept a param they never use; refactor becomes painful | Reserve parameters for true call-level args; use ambient context (contextvars) for ambient state |
 | Move the helper function to dodge the edge | Relocate `get_current_correlation_id()` into `utils` | Creates a god-module, couples `utils.helpers` to logging concerns, violates SRP | Move the import, not the function — keep it where it semantically belongs |
 | Eager-load new phase modules in `__init__.py` | `from .address_reviewer import AddressReviewer` directly | Defeats lazy loading, increases import time, breaks the established pattern | Use `_LAZY_EXPORTS` + `__getattr__` and add the module to `_PHASE_ENTRYPOINTS` |
@@ -606,10 +770,45 @@ PEP 562 pairs `__dir__` with `__getattr__` for discoverability. A package that d
 
 ## Results & Parameters
 
+### Runtime import-graph guard — proposed parameters
+
+| Parameter | Required behavior |
+|-----------|-------------------|
+| Module population | Every `**/*.py` under the target package, including `__init__.py` and modules with zero outgoing edges |
+| Runtime imports | `Import` and `ImportFrom` nodes at every AST depth |
+| Type-only branches | Skip positive `TYPE_CHECKING` bodies and negated-guard `else` branches; visit their runtime counterparts |
+| Imported children | Preserve the package edge and add the child edge when `package.child` resolves in the scanned population |
+| Lazy exports | Parse string module targets from assigned and annotated lazy-export dictionaries |
+| Facade normalization | Merge only named intentional facade components; preserve all external edges |
+| Cycle result | Sorted multi-node SCCs plus singleton self-loops |
+| Algorithm | In-test Tarjan implementation; no new runtime dependency |
+| Synthetic regressions | Function-local, child-to-ancestor, imported-submodule, assigned lazy export, annotated lazy export |
+| Compatibility pins | Re-export object identity and `inspect.signature` |
+| Import-order pins | Fresh subprocess for each historical ordering |
+| Cache isolation | Clear leaf-owned caches before and after each test |
+
+Expected failure shape before repair:
+
+```text
+runtime import graph contains cycles:
+- package.api -> package.manager -> package.runtime_helpers -> package.api
+```
+
+Expected state after repair:
+
+```text
+0 multi-node strongly connected components
+0 singleton self-loops
+```
+
+These values are proposed acceptance parameters, not observed results from the
+reviewed ProjectHephaestus plan.
+
 ### Function-local import — before/after and cost
 
 ```python
-# AFTER (acyclic): parent imports child at top-level (OK); child imports parent locally
+# AFTER (import-time deferred, but the runtime dependency remains):
+# parent imports child at top-level; child imports parent locally.
 # hephaestus/utils/helpers.py
 def run_subprocess(cmd):
     from hephaestus.logging.utils import get_current_correlation_id  # ✅ LOCAL
@@ -620,7 +819,7 @@ def run_subprocess(cmd):
 | Strategy | Circular Dep Risk | Startup Time | Per-Call Cost | Best For |
 |----------|------------------|--------------|---------------|----------|
 | Module-level | High (creates cycle) | Slower | O(1) cache | Non-circular dependencies |
-| Function-local | None | Faster | O(1) cache (after first ~3–5µs) | Ambient state, one-off imports |
+| Function-local | Structural edge remains; import-time failure may be avoided | Faster | O(1) cache (after first ~3–5µs) | Tactical import-time deferral when runtime cycles are permitted |
 | Parameter passing | None | Faster | O(1) | True call-level arguments |
 
 ### Lazy exports — expected test output
@@ -841,6 +1040,7 @@ Verified locally; CI confirmation pending on the originating PR.
 
 | Project | Context | Details |
 |---------|---------|---------|
+| ProjectHephaestus | Runtime module-graph acyclicity plan for `hephaestus.automation` | **PLAN ONLY / unverified** (section I). Reviewed design extracts shared Git execution/repository identity into a neutral leaf; retains explicit compatibility re-exports; removes adapter fallbacks only with scoped/unscoped parity and exclusive-readback tests; makes package-attribute imports explicit; and proposes an AST/Tarjan regression covering function-local, child-to-ancestor, imported-submodule, assigned lazy-export, and annotated lazy-export cycles. No implementation, local test, or CI evidence was produced in this `/learn` session. |
 | ProjectHephaestus | PR #633 — correlation_id propagation | Function-local import of `get_current_correlation_id` in `hephaestus/utils/helpers.py:170-172`; lint passes with no `noqa` |
 | ProjectHephaestus | Issue #799 / PR #988 — lazy-export add/add rebase conflict | Branch `799-auto-impl` widened `_LAZY_EXPORTS`/`__all__` in `hephaestus/automation/__init__.py`; main had already added the same `"PRReviewer"` entry via #968/#775 → PR read CI-failing but `mergeStateStatus=DIRTY` was the real blocker. Rebased onto origin/main (only `__init__.py` conflicted; `test_package_imports.py` rebased clean), kept ONE `"PRReviewer"` copy, set()-based surface tests ignored key order. Full suite 4136 passed / 19 skipped; pre-commit reflowed one f-string line; GPG-signed. **verified-local** |
 | ProjectHephaestus | Issue #775 / PR #968 — widen automation SDK surface | Exposed PlanReviewer, AddressReviewer, CIDriver (+Options) via `__all__`/`_LAZY_EXPORTS`/`_PHASE_ENTRYPOINTS`; surface-pinning test; 1081 automation tests pass |


### PR DESCRIPTION
## Summary

Amends `python-import-patterns-and-compatibility-guards` from v1.8.0 to v2.0.0.

The amendment corrects the prior claim that moving an import inside a function makes the runtime dependency graph acyclic. It adds an explicitly unverified proposed workflow for:

- complete AST runtime-import graph construction, including function-local imports, `TYPE_CHECKING` polarity, imported children, and lazy-export maps;
- dependency-neutral leaf extraction with public object-identity and signature-preserving re-exports;
- narrow facade-component normalization plus deterministic in-test Tarjan SCC detection;
- import-order, adapter-parity, synthetic-cycle, cache-isolation, and architecture-boundary regression coverage.

The exact v1.8.0 skill body is archived in the history file.

## Verification Level

**unverified** for the new runtime-graph workflow. The supplied ProjectHephaestus material was a reviewed implementation plan, not an executed patch, so the skill labels the workflow and project record accordingly.

Mnemosyne repository validation is complete:

- `just check`: 741/741 skills valid; 219 tests passed
- pre-commit on both changed files: passed
- pre-push locked test gate: 219 tests passed
- history snapshot compared byte-for-byte with v1.8.0 source

## Key Findings

**What Worked**:

- Consolidating into the existing canonical Python import skill rather than creating a duplicate search surface.
- Separating import-time initialization repair from structural runtime acyclicity.
- Preserving compatibility through explicit re-export identity/signature tests while moving only dependency-neutral behavior.

**What Failed**:

- Treating function-local imports as structural cycle removal hides a runtime edge.
- Scanning only top-level imports misses function-local and guarded dependencies.
- Broad facade allowlists erase real incoming and outgoing dependencies.

## Test Plan

- [x] Validate with `uv run python scripts/validate_plugins.py`
- [x] Run full Mnemosyne test suite with `just check`
- [x] Run pre-commit checks on changed files
- [ ] Verify skill discovery for `runtime import graph`, `Tarjan`, and `dependency-neutral leaf` after merge

Co-Authored-By: Codex <noreply@openai.com>
