### PR TITLE
docs(skill): replace append-only plan journal guidance

### DIFF
--- a/skills/automation-plan-review-journal-bounded-liveness.md
+++ b/skills/automation-plan-review-journal-bounded-liveness.md
@@ -1,15 +1,15 @@
 ---
 name: automation-plan-review-journal-bounded-liveness
-description: "Keep durable plan/review journals useful without making agent prompts unbounded or letting identical amendments exhaust review cycles. Use when: (1) a pipeline archives plan revisions and reviews in GitHub comments, (2) archived history is injected into planner or reviewer prompts, (3) a NOGO amendment can repeat the prior plan, or (4) a state machine promises to block on no progress."
+description: "Keep issue-based plan/review loops compact and live. Use when: (1) an issue has canonical plan and review comments, (2) review amendments risk growing the timeline, (3) repeated plans must stop without oscillation, or (4) migration must remove old actor-owned raw reviews and diffs safely."
 category: architecture
 date: 2026-07-21
-version: "1.0.0"
+version: "2.0.0"
 user-invocable: false
-verification: unverified
+verification: verified
 tags:
   - automation-loop
   - plan-review
-  - durable-journal
+  - canonical-comments
   - bounded-context
   - no-progress
   - liveness
@@ -17,96 +17,97 @@ tags:
   - prompt-budget
 ---
 
-# Automation Plan-Review Journal: Bounded Context and Liveness
+# Automation Plan-Review Journal: Canonical Comments and Liveness
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-07-21 |
-| **Objective** | Preserve a complete, auditable plan/review journal while giving agents a bounded actionable view and terminating repeated no-progress amendments as blocked. |
-| **Outcome** | A strict review of ProjectHephaestus PR #2357 found that every archived full plan, diff, and review was sent to later planner/reviewer prompts, while identical amendments continued through the full iteration budget. The proposed remediation was not implemented in this session. |
-| **Verification** | unverified — source-level review plus focused tests (437 passed) confirmed the current behavior, but the bounded-view/no-progress implementation and its CI evidence do not yet exist. |
+| **Date** | 2026-08-08 |
+| **Objective** | Keep the linked issue limited to the latest plan and latest plan review while preserving restart safety and terminating repeated no-progress amendments. |
+| **Outcome** | ProjectHephaestus replaced append-only public history with two actor-owned canonical comments, bounded hidden plan fingerprints, patch rejection, PR-scoped reply recovery, and a dry-run-first migration for legacy comments. |
+| **Verification** | Verified by the ProjectHephaestus #2719 implementation: 7,017 unit tests passed, the focused journal/prompt/migration suites passed, and a live dry-run against issue #2363 identified the expected canonical update and three obsolete actor-owned comments with zero failures. |
 
 ## When to Use
 
-- A workflow writes every plan revision and review to an issue or PR comment as a durable audit trail.
-- The same workflow feeds comment history back into an LLM planner, reviewer, or amendment prompt.
-- A plan review claims that "no improvement" should stop early, but the implementation only recognizes an explicit reviewer `BLOCKED` verdict.
-- An amend job can return text identical to an earlier plan, or a cycle can alternate between previously seen plans.
-- A long-lived issue risks context-window overflow, prompt-cost growth, or repeated stale guidance.
+- A workflow writes plans and reviews to a GitHub issue.
+- Repeated review rounds are making the issue or prompt context grow.
+- Only the current plan and current critique are actionable.
+- An amendment can repeat the immediately prior plan or oscillate back to an older one.
+- Legacy issues contain archived full plans, raw plan diffs, old reviews, skip-reason comments, or reply-recovery records.
 
-## Proposed Workflow
-
-> **Warning:** This workflow has not been validated end-to-end. Treat it as a design and test plan until the implementation passes CI.
+## Verified Workflow
 
 ### Quick Reference
 
 ```text
-GitHub comments are the complete durable journal.
-Agent prompts receive a deterministic, bounded projection.
+Linked GitHub issue:
+  original issue body and human comments
+  latest actor-owned canonical plan
+  latest actor-owned canonical plan review
 
 On amendment:
-  normalize candidate and prior plan content
-  if candidate is unchanged or repeats a known revision:
-      publish the reason
-      atomically set state:plan-blocked and remove sibling plan-state labels
-      stop; submit no further planner/reviewer job
-  otherwise:
-      archive the superseded full plan/review and continue
+  normalize candidate content
+  reject raw patches before publication
+  compare against current + bounded prior fingerprints
+  if unchanged or repeated: transition to the durable blocked path
+  otherwise: replace the two canonical comments in place
 
-For prompt context:
-  include current plan + latest review + bounded recent revision pairs
-  enforce a byte/token/revision limit with an explicit truncation marker
-  retain all older material only in the durable GitHub journal
+Detailed implementation evidence:
+  commits and PR-native review threads
+
+Legacy cleanup:
+  dry-run all open and closed issues
+  mutate only comments GitHub proves belong to the authenticated actor
+  fail one malformed issue without deleting its content
 ```
 
 ### Detailed Steps
 
-1. Separate the durable store from the agent view. Keep every revision, review, and diff in GitHub comments if that is the audit contract. Do not equate "durably retained" with "must be passed to every agent." Construct a pure `agent_history_view` with an explicit maximum revision count and byte or token budget.
+1. Treat the issue body as the immutable task and mutually exclusive labels as the durable state authority. Comments are current audit/context pointers, not authorization.
 
-2. Make the bounded view deterministic and useful. Include the current complete plan, the latest complete review, and as many newest prior revision pairs as fit. Prefer an indexed summary or a clear omission marker for older revisions. Do not silently truncate the current plan or latest actionable review. Ensure the same journal produces the same prompt projection on retry.
+2. Keep exactly two automation-owned comments on the linked issue: the latest complete implementation plan and the latest complete plan review. Update those comments in place on every review cycle. Do not append superseded raw plans or reviews.
 
-3. Detect no progress before durable archive/upsert. Normalize content before comparison so generated comment markers and revision metadata cannot make identical plans appear different. Compare the candidate with the immediately prior plan and, where cycle repetition matters, with a stable content digest for prior revisions.
+3. Put a concise cumulative `Changes from Review` section in the current plan. Preserve useful prior bullets and fold new findings into high-level themes. Do not quote raw reviewer output, enumerate line-by-line findings, or include code patches.
 
-4. Turn no progress into a terminal blocked transition. Preserve or publish the reviewer reason, then atomically add `state:plan-blocked` and remove competing plan-state labels. Return the blocked outcome immediately. Do not archive a meaningless "no textual changes" revision, increment a revision number, or enqueue another planner/reviewer job.
+4. Reject unified patches before publication. Detect fenced `diff` blocks, `diff --git` headers, and unified hunk headers. A plan describes intended behavior and verification; Git commits remain the source of patch history.
 
-5. Keep explicit reviewer `BLOCKED` separate but equivalent in terminal effect. A reviewer can ask for external information directly; an unchanged/repeated amendment is an independent pipeline-observed signal that further automated work cannot improve the artifact. Both must be visible to an operator and leave the state machine in a durable, restart-safe blocked state.
+5. Preserve liveness with bounded fingerprints rather than full historical bodies. Normalize away generated markers and revision metadata, hash the plan, keep a fixed number of prior hashes in hidden canonical metadata, and block an identical or previously seen candidate before another revision/job is created.
 
-6. Add behavior-first tests before implementation:
-   - an oversized multi-revision journal retains the current plan/latest review, respects the exact bound, and emits the truncation marker;
-   - a retry of the same journal produces the identical bounded projection;
-   - an identical amendment produces `state:plan-blocked`, does not create a new archive/revision, and submits no further job;
-   - a repeated non-adjacent plan follows the same blocked path when repeat detection is enabled;
-   - a genuinely changed amendment still archives the prior pair and proceeds to review.
+6. Keep auxiliary artifacts off the linked issue. Log skip reasons while the `state:skip` label remains authoritative. Store transient implementation-reply recovery on the PR and leave human-facing replies attached to native review threads.
 
-## Verified Workflow
+7. Migrate old timelines with a dry-run-first, ownership-checked command. Scan open and closed issues but exclude PRs; preserve the issue body and every human/foreign comment; upsert canonical bodies; delete only strictly recognized actor-owned legacy artifacts; re-read after apply and require convergence. A malformed marker or conflicting legacy identity fails only that issue before deletion.
 
-> **Warning:** This workflow has not been validated end-to-end. `Verified Workflow` is retained only for marketplace schema compatibility; follow the proposed workflow above and require new CI evidence before treating it as established practice.
+8. Test observable behavior: canonical comment count remains two across amendments, raw patches never publish, repeated plans block, foreign marker comments remain inert, dry-run performs no writes, apply is idempotent, and restart repairs a stale canonical review without appending history.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 |---------|----------------|---------------|----------------|
-| Pass every durable comment to every later agent | Rendered all archived full plans, diffs, reviews, and current artifacts into each planner/reviewer prompt. | The journal grows on each revision, so prompt size, token cost, and eventual context-limit failure grow with issue age even though only recent context is actionable. | Preserve the full durable journal, but project a bounded deterministic view for agents. |
-| Treat only reviewer-emitted `BLOCKED` as no progress | NOGO/AMBIGUOUS always entered amendment until the fixed budget was exhausted. | An amend job can return the same plan; the system then archived a no-textual-change diff, re-reviewed it, and eventually produced no-go/exhaustion instead of the documented blocked outcome. | Detect unchanged or repeated candidate plans at the state-machine boundary and block before archive/upsert or another job. |
-| Compare raw stored comment bodies | Used durable comment text directly as the equality basis. | Revision markers or generated wrappers can make semantically identical plans compare unequal, causing a false impression of progress. | Normalize content or compare a stable semantic digest that excludes generated metadata. |
-| Test only explicit reviewer blocking | Covered a reviewer returning `BLOCKED`, but not a planner returning an unchanged amendment. | The test suite could pass while the promised no-improvement behavior remained absent. | Test the observable no-progress transition, labels, absence of new jobs, and absence of a new durable revision. |
+| Retain every plan/review/diff on the GitHub issue | Appended complete old plans, unified diffs, reviews, skip explanations, and recovery records as new comments. | Issue timelines and API/model context grew without bound; stale critique competed with the current decision and source patches duplicated Git history. | Keep only the latest canonical plan and review. Put detailed evidence in commits and PR-native review threads. |
+| Bound prompts but preserve complete public history | Excluded older comments from agent prompts while leaving them on the issue. | This reduced prompt projection but did not solve noisy, oversized GitHub issues or costly comment ingestion. | Compact the durable public surface itself; bounded prompt projection alone is insufficient. |
+| Delete every marker-bearing comment | Considered marker prefixes sufficient proof of automation ownership. | A human or another actor can quote the same marker, making prefix-only deletion destructive. | Require GitHub-authenticated ownership plus an exact recognized format before mutation. |
+| Treat only reviewer-emitted `BLOCKED` as no progress | NOGO amendments continued until the fixed iteration budget even when the planner returned the same plan. | The loop re-reviewed identical work and could oscillate between old plans. | Compare normalized current and bounded prior fingerprints before publication and enter the durable blocked path immediately. |
+| Compare raw stored comment bodies | Compared generated comment text directly. | Revision markers and wrappers made equivalent plans look different. | Normalize to plan payload before hashing or equality checks. |
 
 ## Results & Parameters
 
 | Item | Required contract |
 |------|-------------------|
-| Durable retention | Keep the complete historical plan/review journal in GitHub comments. |
-| Agent context | Current plan + latest review + newest prior pairs within an explicit revision and byte/token bound. |
-| Truncation | Deterministic, visible marker or index; never silent loss of the latest actionable artifacts. |
-| Equality basis | Normalized plan content or stable digest excluding generated revision/comment metadata. |
-| No-progress result | Preserve the reason, atomically transition to `state:plan-blocked`, stop without another agent job. |
-| Required regression evidence | Bound/ordering test, deterministic retry test, identical/repeated amendment test, and changed-amendment control test. |
-| Observed source evidence | ProjectHephaestus PR #2357: `_plan_history()` returned the complete archive to prompts and amendment persistence did not compare `plan_text` to `old_plan`; focused affected tests passed 437 locally. |
+| Linked issue automation comments | At most one actor-owned canonical plan and one actor-owned canonical plan review. |
+| Review-cycle summary | Cumulative high-level bullets in the latest plan only. |
+| Patch content | Reject fenced diffs, `diff --git`, and unified hunk headers before publication. |
+| Historical liveness state | Fixed-size prior normalized-plan fingerprints, not full bodies. |
+| No-progress result | Durable blocked state; no new revision and no further planner/reviewer job. |
+| Skip explanations | Structured run log; `state:skip` remains durable authority. |
+| Implementation discussion | Commits and PR-native review threads. |
+| Migration default | Dry-run, open + closed issues, PRs excluded. |
+| Mutation authority | Exact recognized format plus authenticated actor ownership. |
+| Apply verification | Re-read every changed issue and require idempotent two-comment convergence. |
 
 ## Verified On
 
 | Project | Context | Details |
 |---------|---------|---------|
-| ProjectHephaestus | PR #2357 strict review | Source review found the unbounded history and no-progress paths; two MAJOR inline review comments were posted. Focused affected tests passed locally, but no remediation exists yet, so this skill remains unverified. |
+| ProjectHephaestus | Issue #2719 implementation | Canonical replacement, bounded fingerprints, patch guard, PR-scoped handoff journal, strict migration planner/CLI, docs/ADR, and full unit suite (7,017 passed). |
+| ProjectHephaestus | Live dry-run on issue #2363 | Proposed one canonical metadata update and deletion of three obsolete actor-owned artifacts; zero failures and no writes. |


### PR DESCRIPTION
## Summary

- replace the unverified append-only journal recommendation with the verified canonical two-comment workflow
- preserve bounded fingerprint and no-progress guidance
- document raw public history and marker-only deletion as failed approaches
- record Hephaestus #2719 verification evidence

## Verification

- `just validate` (741/741 skills valid)
- pre-push suite (219 passed)

Closes #3312