### PR TITLE
chore(deps): add cooldown window for newly released packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: '/'
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -31,6 +33,8 @@ updates:
     directory: '/'
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

Add a `cooldown` block (`default-days: 7`) to every Dependabot `package-ecosystem` entry so newly published packages are not proposed until 7 days after release. This addresses the Semgrep `dependabot-missing-cooldown` code-scanning rule (see https://semgrep.dev/r/package_managers.dependabot.dependabot-missing-cooldown).

## Notes

- The cooldown applies per ecosystem entry, per the Dependabot configuration reference.
- Commit is GPG-verified with a DCO Signed-off-by trailer.

Closes #3328