### PR TITLE
docs(skills): preserve PR-head benchmark evidence

### DIFF
--- a/skills/benchmark-artifact-triage-pr-splitting.history
+++ b/skills/benchmark-artifact-triage-pr-splitting.history
@@ -1,14 +1,34 @@
+# Benchmark Artifact Triage and PR Splitting — History
+
+## v1.3.0 (2026-08-19)
+
+**Changed by:** Privacy-cleared benchmark publication session.
+**Verification:** verified-local
+
+### What changed
+
+- Added a destination-head rule for integrating verified records into an existing PR without replacing a newer canonical snapshot.
+- Required stable-identity set proofs, recomputed counters, regeneration of direct and transitive consumers, and destination-head revalidation immediately before publication.
+- Added an added-line privacy scan and generator-boundary remediation for sensitive values exposed by rewritten aggregate rows.
+- Generalized prior verification evidence to remove session identifiers and operational measurements while preserving its decision value.
+
+### Why
+
+A locally valid result can still be unsafe to publish when it was rendered from an older evidence set than the destination PR. Stable-identity merging from the bound destination head prevents silent data loss, while regeneration and privacy scanning keep derived artifacts coherent and safe.
+
+### Previous version (v1.2.0) snapshot
+
+````markdown
 ---
 name: benchmark-artifact-triage-pr-splitting
 license: BSD-3-Clause
-description: "Triage and incrementally publish generated benchmark result artifacts. Use when: (1) benchmark/report runs leave many untracked files, (2) result PRs must include durable reports and exact current records without logs or scratch residue, (3) live sweeps need consistency-checked report snapshots with stable record identities, (4) a new result must be integrated into an existing PR without regressing its newer snapshot, (5) Pareto/report assets need validation before staging."
+description: "Triage and incrementally publish generated benchmark result artifacts. Use when: (1) benchmark/report runs leave many untracked files, (2) result PRs must include durable reports and exact current records without logs or scratch residue, (3) live sweeps need consistency-checked report snapshots with stable record identities, (4) Pareto/report assets need validation before staging, (5) large result sets need split into reviewable PRs."
 category: tooling
-date: 2026-08-19
-version: "1.3.0"
-history: benchmark-artifact-triage-pr-splitting.history
+date: 2026-07-30
+version: "1.2.0"
 user-invocable: false
 verification: verified-local
-tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reproducibility, concurrency, capacity, provenance, artifact-index, live-sweep, runner-compatibility, pr-head, redaction]
+tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reproducibility, concurrency, capacity, provenance, artifact-index, live-sweep, runner-compatibility]
 ---
 
 # Benchmark Artifact Triage and PR Splitting
@@ -17,10 +37,10 @@ tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reprodu
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-08-19 |
+| **Date** | 2026-07-30 |
 | **Objective** | Turn a messy or still-running benchmark campaign into reviewable, identity-stable result PRs that preserve useful data and exclude transient run residue. |
-| **Outcome** | Operational. The workflow preserves stable record identities, publishes consistency-checked incremental snapshots, and integrates a verified result into an existing PR without replacing the PR's newer canonical evidence set. |
-| **Verification** | verified-local. In addition to the prior artifact-triage and live-snapshot evidence, the PR-head integration rule was exercised when a local candidate contained one new record but an older snapshot. Replaying only that record onto the destination PR head preserved every destination identity, added the expected identity, regenerated direct and transitive consumers, passed deterministic render checks and targeted tests, and caught a latent private path in a rewritten aggregate row before publication. |
+| **Outcome** | Operational. The workflow produced separate result PRs for endpoint reports, model reports, and complete structured benchmark records while leaving logs, placeholders, progress traces, orphan metadata, and partial records untracked. It preserves concurrency as a measurement dimension, reuses only exact current results, and publishes consistency-checked incremental snapshots without changing existing opaque record identities. |
+| **Verification** | verified-local. The prior workflows were exercised through artifact triage, concurrency classification, exact-coordinate reuse, stable record identities, and a consistency-checked incremental snapshot. Repository tests passed for the rendered report and data commit; worker coordination and snapshot capture were verified separately. |
 
 ## When to Use
 
@@ -31,7 +51,6 @@ tags: [benchmark, artifacts, triage, results, pareto, pr-splitting, git, reprodu
 - A benchmark sweep is still running, but you need a reproducible incremental report snapshot without reading a moving index directly.
 - Opaque result identifiers are derived from paths and must remain stable across worktrees, resumes, and report refreshes.
 - A benchmark wrapper and runner may be at different revisions, so bulk submission must be gated on the exact interpreter and CLI contract.
-- A local result commit was built from an older snapshot than the open destination PR and must be integrated without removing records already present in that PR.
 - A large result set needs to be split by model family, backend, endpoint, or dataset so reviewers can inspect it without a huge all-in-one PR.
 - You need to preserve durable benchmark information without committing logs, scratch directories, progress files, overlays, or build/runtime residue.
 
@@ -101,16 +120,13 @@ git diff --cached --check
 7. **Freeze and verify an incremental snapshot.**
    Publish while workers continue only when the campaign provides a consistency boundary: a lock or immutable generation, or unchanged pre/post index digests plus validation that every indexed immutable result was captured. Otherwise, pause workers at a safe boundary before copying. Render the captured generation into a temporary snapshot directory rather than directly into the clean PR worktree. Compare the previous and candidate identity sets: existing IDs should remain unless a documented supersession rule applies, and unexpected removals or broad ID churn must stop publication. Reconcile complete, comparable, and non-comparable counts before copying only the validated generated artifacts into the clean PR worktree.
 
-8. **Integrate an addition into an existing PR from the PR's current head.**
-   Fetch and bind the destination head before editing, then compare stable identity sets. If the destination contains identities absent from the local candidate, the candidate is stale and must not replace the snapshot. Start from the destination head, insert only the verified new records by stable identity, recompute counters from the merged set, and require that every destination identity remains plus exactly the expected additions. Regenerate every direct and transitive consumer, including reports, figures, indexes, manifests, and source locks. Re-fetch the destination head immediately before publishing and stop if it moved.
-
-9. **Keep campaign execution separate from publication.**
+8. **Keep campaign execution separate from publication.**
    Leave raw results and live worker residue in the campaign worktree. Promote only the frozen aggregate, detailed reports, data bundles, and intentional generator changes into a clean result-PR worktree. This prevents runtime logs and a partially refreshed report tree from entering the publication diff.
 
-10. **Create explicit candidate lists in `/tmp`.**
+9. **Create explicit candidate lists in `/tmp`.**
    Write one file list per intended PR, such as `/tmp/endpoint-reports.txt`, `/tmp/model-baseline.txt`, or `/tmp/inference-json-complete.txt`. Avoid `git add -A` and broad directory adds; generated benchmark directories often contain valuable reports next to useless runtime files.
 
-11. **Classify artifacts by information value.**
+10. **Classify artifacts by information value.**
    Keep durable information:
 - generated reports such as `PARETO.md`, backend reports, and README files that summarize results;
 - `summary.csv` and `summary.md` files with non-empty result rows;
@@ -126,28 +142,28 @@ git diff --cached --check
 - empty failure logs;
 - partial or zero-completion JSON benchmark records unless the PR is explicitly a failure-analysis archive.
 
-12. **Validate CSV report artifacts before staging.**
+11. **Validate CSV report artifacts before staging.**
    For each summary, check row count, status values, profile/scenario coverage, and backend/model labels. A useful report PR should say exactly what it includes, such as "69 rows across short, medium, and long" or "TRT rows only, SGLang absent." If rows are marked interrupted but still plotted, put that caveat in the PR body.
 
-13. **Validate report asset references.**
+12. **Validate report asset references.**
    Search markdown reports for referenced images and confirm each image exists. If a referenced image is untracked, include it with the report. A report without its referenced Pareto images is broken rendered documentation, not a clean text-only result.
 
-14. **Validate structured JSON benchmark records by completion.**
+13. **Validate structured JSON benchmark records by completion.**
    Parse JSON rather than relying on filenames. Require `completed == prompt_count` or `completed == num_prompts` and zero failed requests for result PRs that claim comparable records. Validate freshness separately from the canonical benchmark index; raw result JSON may not carry `freshness_status`. Leave zero-completion and partial records untracked unless the PR title and body are explicitly about failure evidence.
 
-15. **Preserve concurrency coverage and scope capacity claims.**
+14. **Preserve concurrency coverage and scope capacity claims.**
    Treat concurrency as a first-class result dimension. Record the requested and observed concurrency for every retained result, and state the observed set in the report or PR body. A concurrency-one result is a latency baseline; it cannot establish saturation, largest supported concurrency, or maximum throughput. Make those claims only after an explicit sweep over higher concurrency values, and only select a capacity or maximum-performance point from a run with complete prompt accounting, zero failed requests, and finite non-negative throughput. Retain failed or partial sweep records only when they are deliberately included as failure evidence, and never use them as peak-performance candidates.
 
-16. **Stage from the reviewed file lists.**
+15. **Stage from the reviewed file lists.**
    Use `git add --pathspec-from-file=/tmp/<list>.txt` so the staged set exactly matches the reviewed set. After staging, compare `git diff --cached --name-only` to the list and investigate any mismatch.
 
-17. **Run a pre-commit staged audit for every PR.**
-   Before each commit, run staged stats, staged file count, a transient-pattern scan, `git diff --cached --check`, data-specific validation, and an added-line privacy scan. Rewriting an aggregate JSONL or table row can expose an old sensitive value even when the newly integrated record is clean. Fix that value at the generator or import boundary, add a regression check, regenerate the affected consumers, and rescan; do not hand-edit generated output.
+16. **Run a pre-commit staged audit for every PR.**
+   Before each commit, run staged stats, staged file count, a transient-pattern scan, `git diff --cached --check`, and data-specific validation. The transient scan is allowed to have false positives, but every match should be intentionally explained or removed from staging.
 
-18. **Split PRs by dataset and review size.**
+17. **Split PRs by dataset and review size.**
    Prefer one PR per endpoint/model family/report surface. For large structured JSON sets, split by model family or experiment group so each PR remains reviewable. State exact included counts and excluded categories in every PR body.
 
-19. **Return to trunk and inspect leftovers.**
+18. **Return to trunk and inspect leftovers.**
    After opening PRs, switch back to trunk and run `git status --short --untracked-files=all`. The remaining untracked files should all be intentionally excluded categories, not forgotten report assets.
 
 ## Failed Attempts
@@ -164,7 +180,6 @@ git diff --cached --check
 | Change the indexed-results root during a refresh | Render once from the canonical result subtree and later from a higher repository ancestor | Path-relative opaque IDs changed for all existing records although their metrics were identical | Reuse one canonical indexed-results root and compare identity sets before publication. |
 | Render directly into the PR worktree during a live sweep | Let the report generator consume mutating indexes while replacing published assets | The result can mix generations and leave reports, counts, and referenced data out of sync | Establish a lock, immutable generation, or stable pre/post index digests with referenced-result validation; render to a temporary snapshot, validate it, then promote it. |
 | Run overlapping workers against one endpoint | Treat benchmark worker parallelism as equivalent to request concurrency | Workers contend for one capacity surface and can race on the same index, obscuring both performance and provenance | Use one writer per independently isolated endpoint; express load through the coordinate's request concurrency. |
-| Replace an existing PR snapshot with a stale local candidate | Push a locally valid snapshot containing one new record over a destination that already has additional valid identities | Direct replacement silently removes destination-only evidence and can also leave derived reports or source locks inconsistent | Bind the destination head, merge by stable identity with zero unexpected removals, regenerate every consumer, and verify the head again before publishing. |
 
 ## Results & Parameters
 
@@ -181,7 +196,6 @@ git diff --cached --check
 | Non-comparable attempt evidence | Keep only when deliberate | Label explicitly, exclude from coverage and Pareto lines, and separate it from successful performance records. |
 | Stable canonical indexed-results root | Keep invariant | Do not change the path ancestor used to derive opaque record identities between snapshots. |
 | Incremental live-sweep snapshot | Keep after consistency audit | Use a lock, immutable generation, or stable pre/post index digests with referenced-result validation; preserve prior IDs unless explicitly superseded and render outside the PR worktree first. |
-| Existing-PR snapshot addition | Merge from the bound destination head | Require all destination identities plus exactly the expected additions, recompute counts, regenerate direct and transitive consumers, scan added lines for sensitive values, and stop if the destination head moves. |
 | Benchmark workers | One per isolated endpoint | Parallelize across distinct endpoints; use request concurrency inside a coordinate to measure capacity. |
 | Concurrency-one records | Keep as latency baselines | Label as `concurrency=1`; do not use for saturation or capacity claims. |
 | Higher-concurrency sweep records | Keep when complete | Record the requested and observed set; use only complete, zero-failure records for capacity or peak-throughput selection. |
@@ -252,9 +266,6 @@ PY
 - Exact runner revision and interpreter used for new coordinates.
 - Canonical indexed-results root and snapshot cutoff or generation.
 - Prior, added, removed, comparable, and non-comparable record counts.
-- Destination PR head bound before integration and verified again immediately before publication.
-- Stable-identity proof that no destination records were removed and only the expected additions appeared.
-- Direct and transitive render checks plus an added-line privacy scan.
 
 ## Verified On
 
@@ -262,4 +273,5 @@ PY
 |---------|---------|---------|
 | Public benchmark harness | Post-run artifact triage | Durable endpoint reports, baseline datasets, complete structured records, and interrupted-run caveats were separated into reviewable result changes. |
 | Public benchmark harness | Incremental endpoint-matrix refresh while workers continued | A consistency-checked snapshot preserved all prior opaque record identities, added only expected identities with no removals, reconciled complete and comparable counts, and passed its test suite. |
-| Public benchmark harness | Existing-PR snapshot integration | A verified addition was replayed onto the bound destination head by stable identity; all destination identities were retained, consumers were regenerated, targeted tests passed, and an added-line scan caught a private path before publication. |
+
+````

--- a/skills/benchmark-artifact-triage-pr-splitting.notes.md
+++ b/skills/benchmark-artifact-triage-pr-splitting.notes.md
@@ -1,0 +1,15 @@
+# Benchmark Artifact Triage and PR Splitting — Notes
+
+## Verification evidence for v1.3.0
+
+- A local publication candidate contained one new valid record but had been built from a strict subset of the destination PR's current snapshot.
+- Replacing the destination with that candidate would have removed destination-only stable identities even though the candidate itself passed local checks.
+- The safe integration started from the bound destination head, inserted exactly the verified new identity, recomputed aggregate counts from the merged set, and regenerated every direct and transitive consumer.
+- Stable-identity comparison proved that all destination records remained and only the expected addition appeared. Deterministic render checks and targeted tests passed.
+- An added-line privacy scan found a private absolute path in a rewritten aggregate row. The value was corrected at the generation boundary, covered by a regression check, regenerated, and rescanned successfully.
+
+## Evidence boundaries
+
+- Raw profiler captures, operational logs, endpoints, internal paths, model or customer identifiers, repository names, issue numbers, and exact campaign measurements are intentionally excluded.
+- The evidence supports snapshot integration, provenance, regeneration, and privacy-audit rules. It does not establish profiler-capture completeness or kernel-level performance conclusions.
+- Existing-PR publication remains conditional on rebinding the destination identity and head immediately before push; a moved head requires stopping and repeating the merge proof.


### PR DESCRIPTION
## Summary

- amend the canonical benchmark-artifact triage skill with a destination-head integration rule
- require stable-identity proofs, zero unexpected removals, complete consumer regeneration, and a final head recheck
- add added-line privacy scanning with generator-boundary remediation
- archive the privacy-cleared v1.2.0 skill and retain generalized verification notes outside normal retrieval

## Disposition

`amend` — the existing canonical entry already covered stable identities and incremental snapshots; this change adds the verified stale-local-candidate versus newer-PR-head failure mode. No duplicate skill is created or retired.

## Validation

- `just check` — 776/776 retrievable skills valid; 227 tests passed
- `uv run python scripts/check_pii.py` — repository scan reported no direct PII patterns
- `git diff --cached --check`
- main skill size: 23,390 bytes (30,000-byte limit)
- signed commit verified; DCO sign-off present

## Artifact partition

- current generalized workflow: `skills/benchmark-artifact-triage-pr-splitting.md`
- archived prior version and provenance: `skills/benchmark-artifact-triage-pr-splitting.history`
- privacy-cleared supporting evidence and boundaries: `skills/benchmark-artifact-triage-pr-splitting.notes.md`
