### PR TITLE
refactor(skills): compact oversized batch 13

### DIFF
--- a/skills/bash-script-and-jq-failure-modes.history
+++ b/skills/bash-script-and-jq-failure-modes.history
@@ -1,3 +1,630 @@
+## v2.0.0 (2026-08-20) — Compact oversized retrievable skill
+
+**Issue:** [#3335](https://github.com/HomericIntelligence/Mnemosyne/issues/3335)
+
+**Immutable batch base:** `10e28497993009cc221cb991e1ee183e6117eda8`
+
+**Version:** v1.2.0 -> v2.0.0
+
+**Retrievable bytes:** 30,074 -> 10,443
+
+**Superseded snapshot SHA-256:** `27c5a2d2f8b7a3068a9c623794064736164ab4e275fc5b29fbea52f5e2e2a1bc`
+
+### Compaction and verification
+
+The retrievable main was compacted to its decision-changing triggers, commands, parameters, failed approaches, and evidence boundaries. Project-specific cases and detailed verification moved to the linked notes companion. The base main below was archived byte-for-byte and SHA-256 checked; the complete pre-existing history follows this entry unchanged. Repository validation, Markdown lint, scoped hooks, and the semantic audit are recorded in the batch PR.
+
+### Full snapshot of superseded v1.2.0 retrievable content
+
+````markdown
+---
+name: bash-script-and-jq-failure-modes
+description: "Diagnose and fix silent failures in bash scripting and jq under strict error-checking modes. Use when: (1) a bash script with set -euo pipefail exits unexpectedly mid-loop or mid-function, (2) grep finds no matches and kills the script via pipefail, (3) bash arrays crash with 'unbound variable' despite being declared, (4) exit 127 appears and all binaries are installed, (5) jq // operator silently drops boolean false values, (6) jq fails with syntax errors on array concatenation with conditionals, (7) Claude Code Bash cwd drifts from Read/Edit absolute paths in multi-worktree sessions, (8) a bash function with set -m + set +e silently aborts mid-execution after a single-command (...) subshell finishes with no error log and no continuation past the subshell, (9) gh api output captured with 2>&1 corrupts jq input via non-JSON stderr lines (deprecation banners, rate-limit notices, GH_DEBUG traces)."
+category: debugging
+date: 2026-06-13
+version: "1.2.0"
+verification: verified-ci
+user-invocable: false
+history: bash-script-and-jq-failure-modes.history
+tags:
+  - bash
+  - pipefail
+  - set-euo
+  - grep
+  - array
+  - exit-127
+  - shell-function
+  - jq
+  - boolean
+  - falsy
+  - cwd
+  - worktree
+  - tool-divergence
+  - json
+  - set-m
+  - job-control
+  - subshell
+  - exec-optimization
+  - silent-abort
+  - orchestrator-rewrite
+  - stderr
+  - 2>&1
+  - command-substitution
+  - gh-cli
+  - mock-gh
+  - integration-test
+  - ruff
+  - D401
+---
+
+# Bash Script and jq Failure Modes Under Strict Error-Checking
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-05-19 |
+| **Objective** | Consolidate known failure modes in bash scripting and jq processing under set -euo pipefail and related strict modes |
+| **Outcome** | Synthesised from 6 verified skills; all patterns confirmed in CI or local runs |
+| **Theme** | Shell/jq behavior under error-checking modes silently produces wrong behavior, requiring the same class of defensive fixes |
+
+## When to Use
+
+- A bash script with `set -euo pipefail` exits silently mid-loop — especially around `grep \| while read` pipelines
+- Bash exits with code 127 and all binaries (`yq`, `jq`, `curl`) are installed — function-not-found, not binary-not-found
+- A sourced shell library was recently refactored and old function names were removed or renamed in a merge
+- An array is declared (`local -a ARRAY`) but crashes with "unbound variable" when first accessed
+- A jq expression using `//` returns empty when the JSON field holds `false`
+- jq fails with `syntax error, unexpected '+', expecting '}'` on array concatenation with conditionals
+- `Read` shows content that `grep` in Bash cannot find — or a commit lands on the wrong branch — in a multi-worktree session
+- A bash function with `set -m` + `set +e` silently aborts mid-execution after a single-command `(...)` subshell finishes, with no error log and no continuation past the subshell — bash trace shows execution jumping to the parent loop. The defang-with-`set +e` pattern is NOT sufficient against this trigger.
+- `gh api` output is captured with `2>&1` into a variable, then piped to `jq`, and `jq` returns empty or the script exits with "allows no merge methods" / "no valid value" — even though the API endpoint is valid.
+- A Python subprocess integration test needs to stub `gh` without creating a fake binary on `PATH`.
+- A docstring on a private helper function (`_foo`) fails ruff D401 despite starting with a capital letter.
+
+Do NOT use when:
+
+- The 127 originates from a bats test (different diagnostic path — bats wraps function calls differently)
+- The jq error is unrelated to array concatenation (e.g., malformed JSON input)
+- Only one git worktree is checked out (cwd divergence cannot occur)
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# --- EXIT 127: trace the missing function ---
+bash -x tests/foo.sh 2>&1 | head -80
+git log --all --oneline --grep='<function-name-stem>'
+git show <sha>:scripts/lib/api.sh | grep -A 50 '^old_function_name()'
+
+# --- GREP KILLING SCRIPT: guard before piping ---
+# WRONG:
+grep "pattern" "$file" | while read -r line; do process "$line"; done
+# CORRECT (preferred):
+if grep -q "pattern" "$file"; then
+  while read -r line; do process "$line"; done < <(grep "pattern" "$file")
+fi
+
+# --- UNBOUND ARRAY: always initialize ---
+# WRONG:
+local -a FAILED=
+# CORRECT:
+local -a FAILED=()
+
+# --- ARITHMETIC COUNTER: guard set -e ---
+(( count++ )) || true
+# or:
+count=$(( count + 1 ))
+
+# --- JQ BOOLEAN: never use // on booleans ---
+# WRONG:
+value=$(echo "$json" | jq -r '.converged // empty')
+# CORRECT:
+value=$(echo "$json" | jq -r '.converged | if . == null then "" else tostring end')
+
+# --- JQ ARRAY CONCAT COMPATIBILITY: build array in bash ---
+files_json="[\"${DIR}/file1.sh\"]"
+if [[ "$condition" == "true" ]]; then files_json+=", \"${DIR}/extra.sh\""; fi
+files_json+="]"
+jq -n --argjson files "$files_json" '{ files: $files }'
+
+# --- CWD DIVERGENCE: anchor at session start ---
+cd /abs/path/to/main/worktree && pwd
+git rev-parse --show-toplevel
+git worktree list
+
+# --- GH API 2>&1 CORRUPTION: capture stdout only ---
+# WRONG — merges stderr into $raw; any non-JSON line breaks jq:
+raw=$(gh api "repos/${repo}" 2>&1)
+flag=$(printf '%s' "$raw" | jq -r '...')
+# CORRECT — capture stdout only; gh writes its error to stderr on failure:
+if ! raw=$(gh api "repos/${repo}"); then
+    echo "gh api repos/${repo} failed" >&2
+    return 1
+fi
+flag=$(printf '%s' "$raw" | jq -r '...')
+```
+
+### Failure Mode 1: Exit 127 — Orphaned Shell Function
+
+Exit 127 in a bash test has two distinct causes: missing binary vs. missing function. The `-x` trace distinguishes them — a missing binary shows `command not found`; a missing function just stops.
+
+1. Trace where the 127 fires: `bash -x tests/foo.sh 2>&1 | head -100`
+2. Ignore misleading stdout (e.g., tool help text emitted in an unexpected context).
+3. Search git history for the function:
+   ```bash
+   git log --all --oneline --grep='<function-name-stem>'
+   git show <sha>:scripts/lib/api.sh | grep -A 50 '^old_function()'
+   ```
+4. Restore the function body and add a delegate shim so both old and new callers work.
+5. Fix any co-located `jq select` fallback bugs (see Failure Mode 4).
+
+### Failure Mode 2: grep No-Match Killing Script Under set -euo pipefail
+
+`grep` exits 1 when it finds no matches. Under `set -e` + `pipefail`, this exit code is indistinguishable from a real error and aborts the script — the loop body is never entered, but the script also does not continue.
+
+**Preferred fix — process substitution with guard:**
+
+```bash
+if grep -q "pattern" "$file"; then
+  while read -r line; do
+    process "$line"
+  done < <(grep "pattern" "$file")
+fi
+```
+
+**Alternative — temporarily disable pipefail:**
+
+```bash
+set +o pipefail
+grep "pattern" "$file" | while read -r line; do process "$line"; done
+set -o pipefail
+```
+
+Avoid `|| true` at the end of the whole pipeline — it silently swallows all errors inside the loop body, not just grep's exit 1.
+
+### Failure Mode 3: Unbound Array Under set -u
+
+`local -a ARRAY` and `declare -a ARRAY` *declare* the variable as an array type but leave it in an unset state. Under `set -u` (nounset), reading `${#ARRAY[@]}` or `${ARRAY[0]}` on an unset array triggers "unbound variable" and `set -e` exits immediately.
+
+**Fix — one character:**
+
+```bash
+# WRONG:
+local -a FAILED_AGENT_NAMES
+# CORRECT:
+local -a FAILED_AGENT_NAMES=()
+```
+
+**Pattern for tracking failures:**
+
+```bash
+my_function() {
+  local -a FAILED=()
+  local -i failure_count=0
+  for item in "${ITEMS[@]}"; do
+    if ! run_item "$item"; then
+      FAILED+=("$item")
+      (( failure_count++ )) || true  # arithmetic exit code guard
+    fi
+  done
+  echo "Failures: ${#FAILED[@]}"
+}
+```
+
+### Failure Mode 4: jq // Operator Dropping Boolean false
+
+jq's `//` operator returns the right side when the left is `false` OR `null`. This traces to Perl's `||` semantics — unlike most JSON tools, jq treats `false` and `null` as equivalent "alternatives."
+
+**jq manual (1.6+):** "The operator `//` produces its left-hand side if it is not `false` or `null`, and otherwise produces its right-hand side."
+
+**Correct patterns by use case:**
+
+```jq
+# Serialize boolean to string (null-safe):
+.converged | if . == null then "" else tostring end
+
+# Default only for null/missing (not false):
+(.converged // false) | tostring
+
+# In object construction:
+{convergence: (.converged | if . == null then null else tostring end)}
+```
+
+Also applies to `select` + fallback:
+
+```bash
+# WRONG — select filters out the row; // never fires on empty:
+result=$(jq -r '.[] | select(.name == $name) | .status // "unknown"' ...)
+# CORRECT — first() so fallback applies when no match:
+result=$(jq -r 'first(.[] | select(.name == $name) | .status) // "unknown"' ...)
+result="${result:-unknown}"   # shell-level fallback
+```
+
+### Failure Mode 5: jq Array Concatenation Syntax Error (Older jq)
+
+`] + (if $var then [...] else [] end)` works on jq 1.6+ but fails on older versions with `syntax error, unexpected '+', expecting '}'`.
+
+**Fix — build the array in bash:**
+
+```bash
+local files_json
+files_json="[\"${INSTALL_DIR}/file1.sh\", \"${HELPERS_DIR}/file2.sh\""
+if [[ "$condition" == "true" ]]; then
+  files_json+=", \"${DIR}/optional.sh\""
+fi
+files_json+="]"
+
+jq -n \
+  --argjson files "$files_json" \
+  '{ files: $files }'
+```
+
+### Failure Mode 6: Bash CWD Drifting from Edit/Read Absolute Paths
+
+Claude Code's Bash tool persists cwd across invocations. Read/Edit/Write/Grep/Glob always use absolute paths verbatim. When a `cd <other-worktree>` appears in any Bash call, Bash commands silently operate on the sibling worktree while Edit/Read operate on the main worktree.
+
+**Tool cwd behavior:**
+
+| Tool | CWD-dependent? | Notes |
+| ---- | -------------- | ----- |
+| Bash | YES — persists across calls | Every `cd` leaks into the next Bash turn |
+| Read | NO | Requires absolute path |
+| Edit | NO | Requires absolute path |
+| Write | NO | Requires absolute path |
+| Grep | NO | Uses absolute or workspace-relative path arg |
+| Glob | NO | Uses absolute or workspace-relative path arg |
+
+**Prevention — anchor cwd at session start:**
+
+```bash
+cd /abs/path/to/main/worktree && pwd
+git worktree list
+git rev-parse --show-toplevel
+```
+
+**Prefer cwd-free patterns:**
+
+```bash
+git -C /abs/path/to/other/worktree status       # no cd needed
+(cd /abs/path/to/other/worktree && cmd)          # subshell — does not leak
+```
+
+**Detection when results disagree:**
+
+```bash
+pwd
+git rev-parse --show-toplevel
+realpath <file>
+git log -1 --oneline -- <file>
+```
+
+**Recovery from stray commit in wrong worktree:**
+
+```bash
+cd /wrong/worktree && git log --oneline -5
+cd /correct/worktree && git cherry-pick <stray-sha>
+cd /wrong/worktree && git reset --hard HEAD~1
+```
+
+### Failure Mode 7: `set -m` + Single-Command `(...)` Subshell Exec-Optimization Silent Abort
+
+When a bash function combines `set -m` (job control, putting the function's subshell in its own process group) with a single-command `(...)` subshell whose last/only command is an external binary, bash applies exec-optimization: the subshell process `exec`-replaces itself into the external command. When that command exits, the subshell PID dies with its rc — but the parent function's continuation context can be lost. Subsequent commands in the function body (including `rc=$?`, `phase_done` logging, `wait`, and follow-up phases) never execute. Bash `-x` trace shows execution jumping directly to the outer parent loop.
+
+The classic "defang errexit" pattern (`set +e` + `trap 'set -e' RETURN`) does NOT help here, because nothing after the subshell runs to be defanged. Adding more `set +e` is the wrong direction.
+
+**Diagnostic recipe: silent abort after single-command subshell**
+
+```bash
+# Add this near the top of the suspect function:
+set -E
+trap 'echo "[DIAG] ERR at line $LINENO rc=$? cmd=$BASH_COMMAND" >&2' ERR
+trap 'echo "[DIAG] EXIT rc=$? last_line=$LINENO" >&2' EXIT
+# Re-run with: bash -x script.sh ... 2> trace.log
+# If START banner appears but no DONE/ERR fires after the subshell,
+# the bash subshell exec-replaced into the external command and never returned.
+```
+
+Concrete symptom signature (from ProjectHephaestus `scripts/run_automation_loop.sh`):
+- `phase 1/6 plan START` logged on every invocation (75/75).
+- Planner Python process logs "Planning complete" (rc=0).
+- No `phase_done`, no `Warning:`, no `phase 2` banner ever logged.
+- Outer `wait()` always reports non-zero.
+- `bash -x` trace shows the next command after the planner subshell is the OUTER loop's echo — process_repo's trace simply does not resume.
+
+**Fixes (in order of preference):**
+
+1. **Restructure to avoid the single-command subshell.** Extract the work into a real function or pipe through another stage so the subshell does not have a single trailing external command:
+   ```bash
+   # Instead of:
+   ( cd "$dir" || exit 1; "$PLAN_BIN" --foo "$bar" )
+   # Use:
+   run_plan() { cd "$1" || return 1; "$PLAN_BIN" --foo "$2"; echo done; }
+   run_plan "$dir" "$bar"
+   ```
+   The trailing `echo done` (or any builtin) blocks exec-optimization.
+
+2. **Rewrite the orchestrator in Python.** When 3+ interacting safety mechanisms (`set -euo pipefail` + `set -m` + `set +e` defang + ERR/EXIT traps + RETURN traps + single-command subshells) accumulate, the rewrite-to-Python option becomes lower-risk than another patch. The Python equivalent uses `subprocess.run` inside a plain `for phase in ALL_PHASES` loop — phase isolation is then **structural**, not behavioral, and no shell-option landmine can silently skip iterations. See ProjectHephaestus `hephaestus/automation/loop_runner.py` for the verified replacement pattern.
+
+### Failure Mode 8: `2>&1` in Command Substitution Corrupts jq Input
+
+When `gh api` (or any CLI that emits non-JSON to stderr) is captured with `2>&1` inside `$()`, deprecation banners, update notices, and `GH_DEBUG=1` traces are merged into the captured variable. Any non-JSON line appearing before the JSON body causes `jq` to fail or return empty — silently under `-r`, producing downstream "no valid value" / "allows no merge methods" false errors even when the API response is correct.
+
+**Trigger conditions:**
+- `gh` CLI writes to stderr: deprecation notices, "A new release of gh is available", rate-limit hints, or `GH_DEBUG` traces.
+- The variable is later piped to `jq`.
+- `jq` receives a mixed blob (e.g., `"warning: new gh version available\n{...json...}"`) and either errors or returns empty.
+- Downstream code interprets empty as "no valid value" and falls through to a failure path.
+
+**Bug pattern:**
+
+```bash
+# WRONG — merges gh stderr into $raw; any non-JSON line breaks jq
+if ! raw=$(gh api "repos/${repo}/merge-methods" 2>&1); then
+    echo "failed: ${raw}" >&2
+    return 1
+fi
+flag=$(printf '%s' "$raw" | jq -r '.allow_squash_merge // false')
+```
+
+The `2>&1` was added to capture gh's error message into `$raw` for the error path — but it also captures all advisory stderr on the success path.
+
+**Correct pattern — capture stdout only:**
+
+```bash
+# CORRECT — capture stdout only; gh writes its own error to stderr on failure
+if ! raw=$(gh api "repos/${repo}/merge-methods"); then
+    echo "gh api repos/${repo}/merge-methods failed" >&2
+    echo "  (check: gh auth status; token needs 'repo' scope; repo exists)" >&2
+    return 1
+fi
+flag=$(printf '%s' "$raw" | jq -r '.allow_squash_merge // false')
+```
+
+On failure, `$raw` is empty (gh already wrote its error message to stderr). The error path message should not reference `$raw`.
+
+**Diagnostic: verify corruption is the cause:**
+
+```bash
+# Run with GH_DEBUG=1 and capture both separately:
+raw_out=$(gh api "repos/owner/repo" 2>/tmp/gh_stderr.txt)
+cat /tmp/gh_stderr.txt   # should contain only diagnostic lines, not JSON
+echo "$raw_out" | jq .   # should parse cleanly
+```
+
+### Failure Mode 9: Stubbing `gh` in Python Subprocess Integration Tests
+
+When integration-testing shell scripts that call `gh`, creating a fake `gh` binary on PATH is fragile (requires temp dir, PATH manipulation, cleanup). The simpler pattern uses an inline bash function with `export -f`:
+
+```python
+import subprocess
+from pathlib import Path
+
+SNIPPET = Path(__file__).resolve().parents[2] / "scripts" / "choose_merge_flag.sh"
+
+def _run_choose(json_body: str, *, stderr_noise: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
+    if stderr_noise:
+        gh_impl = (
+            f"gh() {{\n"
+            f"    case \"$1\" in\n"
+            f"        api)\n"
+            f"            echo \"warning: new gh version available\" >&2\n"
+            f"            printf '%s\\n' '{json_body}'\n"
+            f"            ;;\n"
+            f"    esac\n"
+            f"}}"
+        )
+    else:
+        gh_impl = f"gh() {{ case \"$1\" in api) printf '%s\\n' '{json_body}';; esac; }}"
+
+    script = f"""
+{gh_impl}
+export -f gh
+. {SNIPPET}
+choose_merge_flag owner/repo
+"""
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+```
+
+Key points:
+- `export -f gh` makes the bash function visible to the sourced script — no fake binary needed.
+- `stderr_noise: bool` flag lets tests verify the fix holds even when gh emits non-JSON to stderr.
+- The sourced script (`. SNIPPET`) runs in the same shell process, so the exported function is inherited.
+- Docstring must use imperative mood ("Run …") — not "Helper to run …" — to satisfy ruff D401.
+
+### Failure Mode 10: ruff D401 Applies to Private Helper Docstrings
+
+ruff enforces D401 ("First line of docstring should be in imperative mood") on **all** public and private functions, including those named `_foo`. The rule checks whether the first word of the docstring is an imperative verb.
+
+**Fails D401:**
+```python
+def _run_choose(json_body: str) -> subprocess.CompletedProcess[str]:
+    """Helper to run choose_merge_flag with a mocked gh."""  # "Helper" is not imperative
+```
+
+**Passes D401:**
+```python
+def _run_choose(json_body: str) -> subprocess.CompletedProcess[str]:
+    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
+```
+
+Common failing openers: "Helper to", "Wrapper for", "Utility that", "Used to". Use "Run", "Execute", "Return", "Build", "Validate" instead.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Reading stderr/stdout from test runner | Examined "Available tasks:" output in stdout to diagnose 127 | Output was pixi help text from `yq` called in unexpected context — a red herring | Trust `bash -x` trace over raw stdout when diagnosing exit 127 |
+| Assuming 127 = missing binary | Checked whether `yq`\|`jq`\|`curl` were installed | All binaries present; 127 came from a missing bash function in a sourced library | Exit 127 has two distinct causes: missing binary vs. missing function; `-x` trace distinguishes them |
+| `grep "pattern" file \| while read line; do` | Direct pipe from grep into while-read | When grep exits 1 (no matches), pipefail propagates non-zero exit and set -e aborts script | Never pipe grep into while-read under set -euo pipefail without a guard |
+| `\|\| true` on the whole while-read pipeline | Appended `\|\| true` after `done` | Works but silently swallows ALL errors inside loop body, masking real failures | Use process substitution (Option A); reserve `\|\| true` only for truly ignorable errors |
+| Logic inversion: else sets rc=1 for non-matching files | Expected that `else rc=1` would fire on non-matching files | The abort-on-grep-miss masked the real logic flow; else branch was never reached | Pipefail trap can invert apparent logic: what looks like a missing-string check exits instead |
+| `local -a FAILED_AGENT_NAMES` (no `=()`) | Declared array without initializing | Under `set -u`, bash treats unassigned array as unbound on first access | Always use `=()` when declaring arrays; declaration alone is not initialization |
+| Guarding with `[[ -v ARRAY ]]` check | Used `[[ -v FAILED_AGENT_NAMES ]]` before each access | Verbose and easy to miss in new code paths; doesn't fix root cause | Initialize at declaration instead of guarding every access site |
+| `.converged // empty` | Used jq alternative operator to skip null | `false` is falsy in jq — `//` triggers on `false` too, returning empty | Never use `//` with boolean fields; use `if . == null` instead |
+| `.converged // "false"` | Tried to default to string "false" | `//` replaces `false` with the alternative regardless — output is always `"false"` even when `.converged` is `true` | The alternative operator is wrong for booleans; use `tostring` with a null guard |
+| `.converged \| tostring` | Direct tostring without null check | Works for booleans but crashes if field is missing (null input to tostring) | Add `// null` guard before `tostring` or use `if . == null then "" else tostring end` |
+| jq inline array concatenation `] + (if $cond then [...] else [] end)` | Used jq's `+` operator for conditional array building | Fails on jq 1.5 and some distro-patched builds with `syntax error, unexpected '+'` | Build conditional arrays in bash; pass via `--argjson` for version compatibility |
+| Trust Edit succeeded (multi-worktree) | Assumed Edit on an absolute path edited the file Bash subsequently grep'd | Edit operated on main worktree path; Bash grep ran in sibling worktree via stale cwd | Edit and Bash can target different copies of the same logical file when multiple worktrees exist |
+| Re-Read to verify after Edit | Re-read file via Read (absolute path) to confirm the edit landed | Read showed correct content (main worktree) — but Bash kept grepping wrong copy via relative path | A successful Read does not prove subsequent Bash commands see the same file |
+| Python heredoc rewrite | Switched to `python3 <<EOF` rewrite when Edit refused | Python interpreter inherits Bash cwd; opened relative path resolving into wrong worktree | Heredoc/subprocess tools inherit Bash cwd — same root cause, different surface |
+| Grep with relative path | Used `grep PATTERN .github/workflows/file.yml` to confirm change | Relative path resolved against stale cwd; returned no match | Always use absolute paths in Bash when cross-checking Edit results |
+| Blame the Edit tool | Suspected Edit was silently no-oping or operating on a cached buffer | Edit had worked correctly — divergence was in the verifier, not the editor | When two tools disagree, suspect cwd before suspecting tool bugs |
+| `set -m` + single-command `(...)` subshell exec-optimization | Defang errexit inside the function via `set +e` + `trap 'set -e' RETURN`; expected `rc=$?` to capture exit and `phase_done` to fire | bash trace shows no commands execute after the subshell completes — control returns directly to the outer parent loop. `set -m` puts the subshell in its own process group, and bash optimises single-command subshells via exec-replace, so the subshell PID dies with the command's rc and the parent's continuation context is lost. `set +e` does not help because nothing runs after the subshell to be defanged. | Diagnose with `bash -x` + ERR/EXIT traps inside the function: if `phase_start` banners appear but `phase_done` banners NEVER appear (even with stderr captured), the function body is not running past the subshell. Don't add more `set +e` — restructure to avoid the single-command subshell (e.g., extract into a real function), or replace the bash orchestrator entirely. |
+| `gh api … 2>&1` in command substitution | Added `2>&1` to capture gh's error message into `$raw` for the error path in `choose_merge_flag.sh` | gh also writes deprecation banners, update notices, and GH_DEBUG traces to stderr on SUCCESS paths; merging these into `$raw` before piping to jq produced non-JSON input, causing jq to return empty; downstream "allows no merge methods" false error on valid repos | Never redirect `2>&1` in a `$(…)` capturing API output for jq; capture stdout only; on failure `$raw` is empty and gh already printed the error to stderr |
+| Using "Helper to" opener for private function docstring | Wrote `"""Helper to run choose_merge_flag with a mocked gh."""` on `_run_choose` | ruff D401 rejected it: "Helper" is not imperative mood | ruff D401 applies to private functions too; use imperative verb openers ("Run", "Execute", "Build", "Return") regardless of whether the function name starts with `_` |
+
+## Results & Parameters
+
+### grep exit code semantics
+
+```
+grep exit codes: 0 = matches found, 1 = no matches, 2 = error
+Under set -e + pipefail, exit code 1 (no matches) is indistinguishable from a real error.
+```
+
+### Arithmetic counter guard pattern
+
+```bash
+(( count++ )) || true       # safe: || true prevents set -e seeing 0 result
+count=$(( count + 1 ))      # also safe: arithmetic expansion never triggers set -e
+```
+
+### Restored function with delegate shim pattern
+
+```bash
+# Restored original with retry logic:
+_agamemnon_curl_retry() {
+  local max_attempts="${AGAMEMNON_MAX_RETRIES:-3}"
+  local attempt=1
+  local response
+  while [ "$attempt" -le "$max_attempts" ]; do
+    response=$(curl -sf "$@") && { printf '%s' "$response"; return 0; }
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+  return 1
+}
+
+# Renamed public function delegates so both old and new callers work:
+_agamemnon_curl() {
+  _agamemnon_curl_retry "$@"
+}
+```
+
+### jq select + fallback pattern
+
+```bash
+result=$(echo "$json" | jq -r --arg name "$name" \
+  'first(.[] | select(.name == $name) | .status) // "unknown"')
+result="${result:-unknown}"   # shell fallback in case jq returns empty
+```
+
+### Pre-commit hook template (grep no-match safe)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+rc=0
+for workflow_file in .github/workflows/*.yml; do
+  if grep -q "gitleaks detect" "$workflow_file"; then
+    while read -r line; do
+      echo "Found in $workflow_file: $line"
+    done < <(grep "gitleaks detect" "$workflow_file")
+  else
+    echo "WARN: $workflow_file does not call gitleaks detect" >&2
+    rc=1
+  fi
+done
+exit "$rc"
+```
+
+### Session-start checklist for multi-worktree sessions
+
+```bash
+cd /abs/path/to/main/worktree
+pwd
+git worktree list
+git rev-parse --show-toplevel
+```
+
+### gh api stdout-only capture pattern
+
+```bash
+# Capture stdout only — do NOT use 2>&1 when the output is piped to jq
+if ! raw=$(gh api "repos/${owner}/${repo}"); then
+    echo "gh api failed" >&2
+    return 1
+fi
+result=$(printf '%s' "$raw" | jq -r '.some_field // empty')
+```
+
+On failure, `$raw` is empty; gh has already written its error message to stderr. Do not reference `$raw` in the error message.
+
+### mock-gh bash function pattern for Python integration tests
+
+```python
+import subprocess
+from pathlib import Path
+
+SNIPPET = Path(__file__).resolve().parents[2] / "scripts" / "choose_merge_flag.sh"
+
+def _run_choose(json_body: str, *, stderr_noise: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
+    if stderr_noise:
+        gh_impl = (
+            f"gh() {{\n"
+            f"    case \"$1\" in\n"
+            f"        api)\n"
+            f"            echo \"warning: new gh version available\" >&2\n"
+            f"            printf '%s\\n' '{json_body}'\n"
+            f"            ;;\n"
+            f"    esac\n"
+            f"}}"
+        )
+    else:
+        gh_impl = f"gh() {{ case \"$1\" in api) printf '%s\\n' '{json_body}';; esac; }}"
+
+    script = f"""
+{gh_impl}
+export -f gh
+. {SNIPPET}
+choose_merge_flag owner/repo
+"""
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+```
+
+Key: `export -f gh` exports the bash function into the environment so the sourced script inherits it. No fake binary on PATH needed. The `stderr_noise=True` variant verifies the fix holds under realistic gh advisory output.
+
+### ruff D401 imperative-mood docstring openers
+
+| Fails D401 | Passes D401 |
+| ---------- | ----------- |
+| "Helper to run X" | "Run X with …" |
+| "Wrapper for X" | "Wrap X and return …" |
+| "Utility that does X" | "Execute X and …" |
+| "Used to build X" | "Build X from …" |
+| "This function validates X" | "Validate X against …" |
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| HomericIntelligence/Myrmidons | PR #564 — check-gitleaks-coe.sh pre-commit hook exited on grep no-match before reaching else rc=1 | grep \| while-read abort under pipefail |
+| HomericIntelligence/Myrmidons | PR #623 — apply.sh failed-agent tracking crashed at `${#FAILED_AGENT_NAMES[@]}` | Unbound array under set -u |
+| HomericIntelligence/Myrmidons | PR #623 — convergence serialization bats test 318 failing on false value | jq // operator falsy boolean trap |
+| HomericIntelligence/Myrmidons | CI debug session — test-api-retry.sh exit 127 after `_agamemnon_curl_retry` renamed | Exit-127 function recovery |
+| ai-maestro (23blocks-OS) | Issue #272 — install-agent-cli.sh jq syntax error on older jq | jq array concatenation compatibility |
+| HomericIntelligence/ProjectOdyssey | Multi-worktree session — stray commit cf710fb4 on ci-pipe-handler-cores-gate branch | Bash cwd drift from Edit/Read absolute paths |
+| HomericIntelligence/ProjectHephaestus | Session 2026-05-26 — `scripts/run_automation_loop.sh` `process_repo` silently aborting after planner subshell (phases 2-6 skipped 75/75 invocations); replaced with `hephaestus/automation/loop_runner.py` | `set -m` + single-command subshell exec-optimization silent abort |
+| HomericIntelligence/ProjectHephaestus | Issue #1122, PR #1273 — `scripts/choose_merge_flag.sh` `2>&1` on `gh api` merged deprecation banners into `$raw`, causing jq to return empty; spurious "allows no merge methods" exit-1 on valid repos | `2>&1` in command substitution corrupts jq input; mock-gh bash function integration test pattern; ruff D401 on private helper docstrings |
+````
+
+---
+
 ## Version History
 
 ### v1.2.0 (2026-06-13)

--- a/skills/bash-script-and-jq-failure-modes.md
+++ b/skills/bash-script-and-jq-failure-modes.md
@@ -1,604 +1,226 @@
 ---
 name: bash-script-and-jq-failure-modes
-description: "Diagnose and fix silent failures in bash scripting and jq under strict error-checking modes. Use when: (1) a bash script with set -euo pipefail exits unexpectedly mid-loop or mid-function, (2) grep finds no matches and kills the script via pipefail, (3) bash arrays crash with 'unbound variable' despite being declared, (4) exit 127 appears and all binaries are installed, (5) jq // operator silently drops boolean false values, (6) jq fails with syntax errors on array concatenation with conditionals, (7) Claude Code Bash cwd drifts from Read/Edit absolute paths in multi-worktree sessions, (8) a bash function with set -m + set +e silently aborts mid-execution after a single-command (...) subshell finishes with no error log and no continuation past the subshell, (9) gh api output captured with 2>&1 corrupts jq input via non-JSON stderr lines (deprecation banners, rate-limit notices, GH_DEBUG traces)."
+description: "Diagnose and fix silent failures in bash scripting and jq under strict error-checking modes. Use when: (1) a bash script with set -euo pipefail exits unexpectedly mid-loop or mid-function, (2) grep finds no matches and kills the script via pipefail, (3) bash arrays crash with 'unbound variable' despite being declared, (4) exit 127 appears and all binaries are installed, (5) jq // operator silently drops boolean false values, (6) jq fails with syntax errors on array concatenation with conditionals, (7) Bash cwd drifts from absolute-path editing in multi-worktree sessions, (8) set -m plus a single-command subshell silently loses continuation, (9) gh API stderr corrupts JSON captured for jq."
 category: debugging
 date: 2026-06-13
-version: "1.2.0"
+version: "2.0.0"
+license: BSD-3-Clause
 verification: verified-ci
 user-invocable: false
 history: bash-script-and-jq-failure-modes.history
-tags:
-  - bash
-  - pipefail
-  - set-euo
-  - grep
-  - array
-  - exit-127
-  - shell-function
-  - jq
-  - boolean
-  - falsy
-  - cwd
-  - worktree
-  - tool-divergence
-  - json
-  - set-m
-  - job-control
-  - subshell
-  - exec-optimization
-  - silent-abort
-  - orchestrator-rewrite
-  - stderr
-  - 2>&1
-  - command-substitution
-  - gh-cli
-  - mock-gh
-  - integration-test
-  - ruff
-  - D401
+tags: [bash, pipefail, set-euo, grep, array, exit-127, shell-function, jq, boolean, cwd, worktree, set-m, job-control, subshell, stderr, command-substitution, gh-cli, integration-test, ruff, D401]
 ---
 
-# Bash Script and jq Failure Modes Under Strict Error-Checking
+# Bash Script and jq Failure Modes Under Strict Error Checking
 
 ## Overview
 
-| Field | Value |
-| ------- | ------- |
-| **Date** | 2026-05-19 |
-| **Objective** | Consolidate known failure modes in bash scripting and jq processing under set -euo pipefail and related strict modes |
-| **Outcome** | Synthesised from 6 verified skills; all patterns confirmed in CI or local runs |
-| **Theme** | Shell/jq behavior under error-checking modes silently produces wrong behavior, requiring the same class of defensive fixes |
+Use trace evidence and shell/jq semantics to diagnose scripts that exit, skip work, or produce
+empty data under `set -euo pipefail`. The canonical rules are `verified-ci`; project-specific
+reproductions and their verification are indexed in
+[the notes](bash-script-and-jq-failure-modes.notes.md).
 
 ## When to Use
 
-- A bash script with `set -euo pipefail` exits silently mid-loop — especially around `grep \| while read` pipelines
-- Bash exits with code 127 and all binaries (`yq`, `jq`, `curl`) are installed — function-not-found, not binary-not-found
-- A sourced shell library was recently refactored and old function names were removed or renamed in a merge
-- An array is declared (`local -a ARRAY`) but crashes with "unbound variable" when first accessed
-- A jq expression using `//` returns empty when the JSON field holds `false`
-- jq fails with `syntax error, unexpected '+', expecting '}'` on array concatenation with conditionals
-- `Read` shows content that `grep` in Bash cannot find — or a commit lands on the wrong branch — in a multi-worktree session
-- A bash function with `set -m` + `set +e` silently aborts mid-execution after a single-command `(...)` subshell finishes, with no error log and no continuation past the subshell — bash trace shows execution jumping to the parent loop. The defang-with-`set +e` pattern is NOT sufficient against this trigger.
-- `gh api` output is captured with `2>&1` into a variable, then piped to `jq`, and `jq` returns empty or the script exits with "allows no merge methods" / "no valid value" — even though the API endpoint is valid.
-- A Python subprocess integration test needs to stub `gh` without creating a fake binary on `PATH`.
-- A docstring on a private helper function (`_foo`) fails ruff D401 despite starting with a capital letter.
+- A strict Bash script stops after `grep`, an arithmetic increment, array access, function call,
+  command substitution, or a single-command subshell.
+- Exit 127 occurs although expected binaries are installed or a sourced function was renamed.
+- jq drops a JSON `false`, fallback after `select` never fires, or conditional array concatenation
+  fails on the repository's jq version.
+- An API command captured with `2>&1` feeds warnings or debug traces into jq.
+- File reads and Bash verification disagree across multiple worktrees.
+- A subprocess test needs a controllable `gh` stub, or ruff D401 rejects a private helper.
 
-Do NOT use when:
-
-- The 127 originates from a bats test (different diagnostic path — bats wraps function calls differently)
-- The jq error is unrelated to array concatenation (e.g., malformed JSON input)
-- Only one git worktree is checked out (cwd divergence cannot occur)
+First reproduce with the same shell, options, jq version, environment, and working directory as
+the failing consumer. Do not use these patterns for malformed JSON or a genuinely missing binary
+without confirming the distinct cause.
 
 ## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# --- EXIT 127: trace the missing function ---
-bash -x tests/foo.sh 2>&1 | head -80
+# Trace the first missing continuation or failing command.
+bash -x <script> <args> 2>trace.log
+
+# Make grep no-match nonfatal without hiding loop failures.
+if grep -q '<pattern>' "$file"; then
+  while IFS= read -r line; do process "$line"; done < <(grep '<pattern>' "$file")
+fi
+
+# Initialize nounset-safe arrays and counters.
+local -a failures=()
+count=$((count + 1))
+
+# Preserve boolean false; default only null/missing.
+jq -r '.converged | if . == null then "" else tostring end'
+
+# Capture machine-readable stdout separately from diagnostics.
+if ! raw=$(gh api "repos/${owner}/${repo}"); then
+  echo 'gh api failed' >&2
+  return 1
+fi
+printf '%s' "$raw" | jq .
+```
+
+### 1. Diagnose exit 127 by trace, not surrounding noise
+
+Exit 127 can mean a missing external command or an orphaned shell function. Run `bash -x` and find
+the last traced command. An explicit `command not found` identifies the missing executable; an
+abrupt stop at a bare function call after a library refactor suggests a removed function.
+
+```bash
 git log --all --oneline --grep='<function-name-stem>'
-git show <sha>:scripts/lib/api.sh | grep -A 50 '^old_function_name()'
-
-# --- GREP KILLING SCRIPT: guard before piping ---
-# WRONG:
-grep "pattern" "$file" | while read -r line; do process "$line"; done
-# CORRECT (preferred):
-if grep -q "pattern" "$file"; then
-  while read -r line; do process "$line"; done < <(grep "pattern" "$file")
-fi
-
-# --- UNBOUND ARRAY: always initialize ---
-# WRONG:
-local -a FAILED=
-# CORRECT:
-local -a FAILED=()
-
-# --- ARITHMETIC COUNTER: guard set -e ---
-(( count++ )) || true
-# or:
-count=$(( count + 1 ))
-
-# --- JQ BOOLEAN: never use // on booleans ---
-# WRONG:
-value=$(echo "$json" | jq -r '.converged // empty')
-# CORRECT:
-value=$(echo "$json" | jq -r '.converged | if . == null then "" else tostring end')
-
-# --- JQ ARRAY CONCAT COMPATIBILITY: build array in bash ---
-files_json="[\"${DIR}/file1.sh\"]"
-if [[ "$condition" == "true" ]]; then files_json+=", \"${DIR}/extra.sh\""; fi
-files_json+="]"
-jq -n --argjson files "$files_json" '{ files: $files }'
-
-# --- CWD DIVERGENCE: anchor at session start ---
-cd /abs/path/to/main/worktree && pwd
-git rev-parse --show-toplevel
-git worktree list
-
-# --- GH API 2>&1 CORRUPTION: capture stdout only ---
-# WRONG — merges stderr into $raw; any non-JSON line breaks jq:
-raw=$(gh api "repos/${repo}" 2>&1)
-flag=$(printf '%s' "$raw" | jq -r '...')
-# CORRECT — capture stdout only; gh writes its error to stderr on failure:
-if ! raw=$(gh api "repos/${repo}"); then
-    echo "gh api repos/${repo} failed" >&2
-    return 1
-fi
-flag=$(printf '%s' "$raw" | jq -r '...')
+git show <commit>:<library> | rg -n -A 40 '^<old_function>\(\)'
 ```
 
-### Failure Mode 1: Exit 127 — Orphaned Shell Function
+Restore the required implementation when callers still depend on it. If a new public function
+supersedes the old name, keep the old implementation and make the new name delegate until all
+callers migrate. Do not diagnose from unrelated help text on stdout.
 
-Exit 127 in a bash test has two distinct causes: missing binary vs. missing function. The `-x` trace distinguishes them — a missing binary shows `command not found`; a missing function just stops.
+### 2. Distinguish benign non-match from pipeline failure
 
-1. Trace where the 127 fires: `bash -x tests/foo.sh 2>&1 | head -100`
-2. Ignore misleading stdout (e.g., tool help text emitted in an unexpected context).
-3. Search git history for the function:
-   ```bash
-   git log --all --oneline --grep='<function-name-stem>'
-   git show <sha>:scripts/lib/api.sh | grep -A 50 '^old_function()'
-   ```
-4. Restore the function body and add a delegate shim so both old and new callers work.
-5. Fix any co-located `jq select` fallback bugs (see Failure Mode 4).
+`grep` returns 0 for matches, 1 for no matches, and 2 for an error. With `errexit` and `pipefail`,
+1 aborts a pipeline before the script can apply its intended “not found” logic. Guard with
+`grep -q`, then use process substitution as shown above. Avoid `... | while ...; done || true`:
+that swallows failures from the loop body as well as the benign grep result.
 
-### Failure Mode 2: grep No-Match Killing Script Under set -euo pipefail
+Arithmetic commands also expose status: `((count++))` returns 1 when the expression evaluates to
+zero. Prefer `count=$((count + 1))`, or narrowly use `((count++)) || true` when the status is
+deliberately irrelevant.
 
-`grep` exits 1 when it finds no matches. Under `set -e` + `pipefail`, this exit code is indistinguishable from a real error and aborts the script — the loop body is never entered, but the script also does not continue.
+### 3. Initialize arrays under nounset
 
-**Preferred fix — process substitution with guard:**
+`local -a items` declares a type but can remain unset. `${#items[@]}` and `${items[0]}` then fail
+under `set -u`. Initialize at declaration:
 
 ```bash
-if grep -q "pattern" "$file"; then
-  while read -r line; do
-    process "$line"
-  done < <(grep "pattern" "$file")
-fi
+local -a failed_items=()
+local -i failure_count=0
 ```
 
-**Alternative — temporarily disable pipefail:**
+Fix the invariant once instead of scattering `[[ -v ARRAY ]]` guards across consumers.
 
-```bash
-set +o pipefail
-grep "pattern" "$file" | while read -r line; do process "$line"; done
-set -o pipefail
-```
+### 4. Preserve jq booleans and empty-stream fallbacks
 
-Avoid `|| true` at the end of the whole pipeline — it silently swallows all errors inside the loop body, not just grep's exit 1.
-
-### Failure Mode 3: Unbound Array Under set -u
-
-`local -a ARRAY` and `declare -a ARRAY` *declare* the variable as an array type but leave it in an unset state. Under `set -u` (nounset), reading `${#ARRAY[@]}` or `${ARRAY[0]}` on an unset array triggers "unbound variable" and `set -e` exits immediately.
-
-**Fix — one character:**
-
-```bash
-# WRONG:
-local -a FAILED_AGENT_NAMES
-# CORRECT:
-local -a FAILED_AGENT_NAMES=()
-```
-
-**Pattern for tracking failures:**
-
-```bash
-my_function() {
-  local -a FAILED=()
-  local -i failure_count=0
-  for item in "${ITEMS[@]}"; do
-    if ! run_item "$item"; then
-      FAILED+=("$item")
-      (( failure_count++ )) || true  # arithmetic exit code guard
-    fi
-  done
-  echo "Failures: ${#FAILED[@]}"
-}
-```
-
-### Failure Mode 4: jq // Operator Dropping Boolean false
-
-jq's `//` operator returns the right side when the left is `false` OR `null`. This traces to Perl's `||` semantics — unlike most JSON tools, jq treats `false` and `null` as equivalent "alternatives."
-
-**jq manual (1.6+):** "The operator `//` produces its left-hand side if it is not `false` or `null`, and otherwise produces its right-hand side."
-
-**Correct patterns by use case:**
+jq's `//` selects its right side when the left is either `null` or `false`. Therefore
+`.converged // empty` drops a valid false. Use an explicit null test when false is data:
 
 ```jq
-# Serialize boolean to string (null-safe):
 .converged | if . == null then "" else tostring end
-
-# Default only for null/missing (not false):
-(.converged // false) | tostring
-
-# In object construction:
-{convergence: (.converged | if . == null then null else tostring end)}
 ```
 
-Also applies to `select` + fallback:
+For a selection, `select` can emit no value at all, so a downstream `//` never executes. Collapse
+the stream before applying the fallback:
+
+```jq
+first(.[] | select(.name == $name) | .status) // "unknown"
+```
+
+Keep a shell fallback such as `result="${result:-unknown}"` only when an empty string is also
+invalid by contract.
+
+### 5. Support the repository's jq version
+
+Some older or patched jq builds reject inline array concatenation around conditional expressions.
+When compatibility is required, construct JSON in Bash and pass it through `--argjson`:
 
 ```bash
-# WRONG — select filters out the row; // never fires on empty:
-result=$(jq -r '.[] | select(.name == $name) | .status // "unknown"' ...)
-# CORRECT — first() so fallback applies when no match:
-result=$(jq -r 'first(.[] | select(.name == $name) | .status) // "unknown"' ...)
-result="${result:-unknown}"   # shell-level fallback
+files_json='["path/to/required.sh"'
+if [[ "$condition" == true ]]; then files_json+=', "path/to/optional.sh"'; fi
+files_json+=']'
+jq -n --argjson files "$files_json" '{files: $files}'
 ```
 
-### Failure Mode 5: jq Array Concatenation Syntax Error (Older jq)
+Validate the generated JSON before using it; do not interpolate untrusted strings into this
+pattern. For arbitrary values, build JSON with jq arguments rather than manual quoting.
 
-`] + (if $var then [...] else [] end)` works on jq 1.6+ but fails on older versions with `syntax error, unexpected '+', expecting '}'`.
+### 6. Anchor multi-worktree commands
 
-**Fix — build the array in bash:**
-
-```bash
-local files_json
-files_json="[\"${INSTALL_DIR}/file1.sh\", \"${HELPERS_DIR}/file2.sh\""
-if [[ "$condition" == "true" ]]; then
-  files_json+=", \"${DIR}/optional.sh\""
-fi
-files_json+="]"
-
-jq -n \
-  --argjson files "$files_json" \
-  '{ files: $files }'
-```
-
-### Failure Mode 6: Bash CWD Drifting from Edit/Read Absolute Paths
-
-Claude Code's Bash tool persists cwd across invocations. Read/Edit/Write/Grep/Glob always use absolute paths verbatim. When a `cd <other-worktree>` appears in any Bash call, Bash commands silently operate on the sibling worktree while Edit/Read operate on the main worktree.
-
-**Tool cwd behavior:**
-
-| Tool | CWD-dependent? | Notes |
-| ---- | -------------- | ----- |
-| Bash | YES — persists across calls | Every `cd` leaks into the next Bash turn |
-| Read | NO | Requires absolute path |
-| Edit | NO | Requires absolute path |
-| Write | NO | Requires absolute path |
-| Grep | NO | Uses absolute or workspace-relative path arg |
-| Glob | NO | Uses absolute or workspace-relative path arg |
-
-**Prevention — anchor cwd at session start:**
-
-```bash
-cd /abs/path/to/main/worktree && pwd
-git worktree list
-git rev-parse --show-toplevel
-```
-
-**Prefer cwd-free patterns:**
-
-```bash
-git -C /abs/path/to/other/worktree status       # no cd needed
-(cd /abs/path/to/other/worktree && cmd)          # subshell — does not leak
-```
-
-**Detection when results disagree:**
+When file inspection and Bash disagree, print the active roots before editing or verifying:
 
 ```bash
 pwd
 git rev-parse --show-toplevel
+git worktree list
 realpath <file>
 git log -1 --oneline -- <file>
 ```
 
-**Recovery from stray commit in wrong worktree:**
+Prefer `git -C /absolute/worktree ...` or `(cd /absolute/worktree && command)` so a directory change
+cannot leak. Absolute-path reads do not prove a later relative Bash command sees the same copy.
+Move a stray commit with a reviewed `git cherry-pick`; do not discard the original branch during
+diagnosis.
+
+### 7. Detect lost continuation after a subshell
+
+With job control (`set -m`) and a single-command `(...)` subshell ending in an external command,
+Bash may exec-replace the subshell. If the trace shows the phase start and child completion but no
+command after the subshell, additional `set +e` cannot help because continuation never runs.
 
 ```bash
-cd /wrong/worktree && git log --oneline -5
-cd /correct/worktree && git cherry-pick <stray-sha>
-cd /wrong/worktree && git reset --hard HEAD~1
-```
-
-### Failure Mode 7: `set -m` + Single-Command `(...)` Subshell Exec-Optimization Silent Abort
-
-When a bash function combines `set -m` (job control, putting the function's subshell in its own process group) with a single-command `(...)` subshell whose last/only command is an external binary, bash applies exec-optimization: the subshell process `exec`-replaces itself into the external command. When that command exits, the subshell PID dies with its rc — but the parent function's continuation context can be lost. Subsequent commands in the function body (including `rc=$?`, `phase_done` logging, `wait`, and follow-up phases) never execute. Bash `-x` trace shows execution jumping directly to the outer parent loop.
-
-The classic "defang errexit" pattern (`set +e` + `trap 'set -e' RETURN`) does NOT help here, because nothing after the subshell runs to be defanged. Adding more `set +e` is the wrong direction.
-
-**Diagnostic recipe: silent abort after single-command subshell**
-
-```bash
-# Add this near the top of the suspect function:
 set -E
-trap 'echo "[DIAG] ERR at line $LINENO rc=$? cmd=$BASH_COMMAND" >&2' ERR
-trap 'echo "[DIAG] EXIT rc=$? last_line=$LINENO" >&2' EXIT
-# Re-run with: bash -x script.sh ... 2> trace.log
-# If START banner appears but no DONE/ERR fires after the subshell,
-# the bash subshell exec-replaced into the external command and never returned.
+trap 'echo "ERR line=$LINENO rc=$? cmd=$BASH_COMMAND" >&2' ERR
+trap 'echo "EXIT line=$LINENO rc=$?" >&2' EXIT
 ```
 
-Concrete symptom signature (from ProjectHephaestus `scripts/run_automation_loop.sh`):
-- `phase 1/6 plan START` logged on every invocation (75/75).
-- Planner Python process logs "Planning complete" (rc=0).
-- No `phase_done`, no `Warning:`, no `phase 2` banner ever logged.
-- Outer `wait()` always reports non-zero.
-- `bash -x` trace shows the next command after the planner subshell is the OUTER loop's echo — process_repo's trace simply does not resume.
+Restructure into a real function and ensure the child command is not the lone trailing command. If
+three or more interacting mechanisms (`errexit`, job control, RETURN/ERR traps, nested subshells,
+manual defanging) are required, replace the orchestrator with a structured subprocess loop in a
+language with explicit control flow.
 
-**Fixes (in order of preference):**
+### 8. Keep stderr out of JSON
 
-1. **Restructure to avoid the single-command subshell.** Extract the work into a real function or pipe through another stage so the subshell does not have a single trailing external command:
-   ```bash
-   # Instead of:
-   ( cd "$dir" || exit 1; "$PLAN_BIN" --foo "$bar" )
-   # Use:
-   run_plan() { cd "$1" || return 1; "$PLAN_BIN" --foo "$2"; echo done; }
-   run_plan "$dir" "$bar"
-   ```
-   The trailing `echo done` (or any builtin) blocks exec-optimization.
+Never use `2>&1` inside a command substitution whose value is parsed as JSON. `gh` may emit update,
+deprecation, rate-limit, or `GH_DEBUG` lines to stderr on a successful request. Capture stdout only;
+on failure, let the command's stderr remain visible and emit a contextual error that does not quote
+the empty capture.
 
-2. **Rewrite the orchestrator in Python.** When 3+ interacting safety mechanisms (`set -euo pipefail` + `set -m` + `set +e` defang + ERR/EXIT traps + RETURN traps + single-command subshells) accumulate, the rewrite-to-Python option becomes lower-risk than another patch. The Python equivalent uses `subprocess.run` inside a plain `for phase in ALL_PHASES` loop — phase isolation is then **structural**, not behavioral, and no shell-option landmine can silently skip iterations. See ProjectHephaestus `hephaestus/automation/loop_runner.py` for the verified replacement pattern.
-
-### Failure Mode 8: `2>&1` in Command Substitution Corrupts jq Input
-
-When `gh api` (or any CLI that emits non-JSON to stderr) is captured with `2>&1` inside `$()`, deprecation banners, update notices, and `GH_DEBUG=1` traces are merged into the captured variable. Any non-JSON line appearing before the JSON body causes `jq` to fail or return empty — silently under `-r`, producing downstream "no valid value" / "allows no merge methods" false errors even when the API response is correct.
-
-**Trigger conditions:**
-- `gh` CLI writes to stderr: deprecation notices, "A new release of gh is available", rate-limit hints, or `GH_DEBUG` traces.
-- The variable is later piped to `jq`.
-- `jq` receives a mixed blob (e.g., `"warning: new gh version available\n{...json...}"`) and either errors or returns empty.
-- Downstream code interprets empty as "no valid value" and falls through to a failure path.
-
-**Bug pattern:**
+To prove contamination, separate the streams:
 
 ```bash
-# WRONG — merges gh stderr into $raw; any non-JSON line breaks jq
-if ! raw=$(gh api "repos/${repo}/merge-methods" 2>&1); then
-    echo "failed: ${raw}" >&2
-    return 1
-fi
-flag=$(printf '%s' "$raw" | jq -r '.allow_squash_merge // false')
+raw=$(GH_DEBUG=1 gh api "repos/${owner}/${repo}" 2>/tmp/gh.stderr)
+jq . <<<"$raw"
+sed -n '1,20p' /tmp/gh.stderr
 ```
 
-The `2>&1` was added to capture gh's error message into `$raw` for the error path — but it also captures all advisory stderr on the success path.
+### 9. Test shell integrations at the process boundary
 
-**Correct pattern — capture stdout only:**
-
-```bash
-# CORRECT — capture stdout only; gh writes its own error to stderr on failure
-if ! raw=$(gh api "repos/${repo}/merge-methods"); then
-    echo "gh api repos/${repo}/merge-methods failed" >&2
-    echo "  (check: gh auth status; token needs 'repo' scope; repo exists)" >&2
-    return 1
-fi
-flag=$(printf '%s' "$raw" | jq -r '.allow_squash_merge // false')
-```
-
-On failure, `$raw` is empty (gh already wrote its error message to stderr). The error path message should not reference `$raw`.
-
-**Diagnostic: verify corruption is the cause:**
-
-```bash
-# Run with GH_DEBUG=1 and capture both separately:
-raw_out=$(gh api "repos/owner/repo" 2>/tmp/gh_stderr.txt)
-cat /tmp/gh_stderr.txt   # should contain only diagnostic lines, not JSON
-echo "$raw_out" | jq .   # should parse cleanly
-```
-
-### Failure Mode 9: Stubbing `gh` in Python Subprocess Integration Tests
-
-When integration-testing shell scripts that call `gh`, creating a fake `gh` binary on PATH is fragile (requires temp dir, PATH manipulation, cleanup). The simpler pattern uses an inline bash function with `export -f`:
-
-```python
-import subprocess
-from pathlib import Path
-
-SNIPPET = Path(__file__).resolve().parents[2] / "scripts" / "choose_merge_flag.sh"
-
-def _run_choose(json_body: str, *, stderr_noise: bool = False) -> subprocess.CompletedProcess[str]:
-    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
-    if stderr_noise:
-        gh_impl = (
-            f"gh() {{\n"
-            f"    case \"$1\" in\n"
-            f"        api)\n"
-            f"            echo \"warning: new gh version available\" >&2\n"
-            f"            printf '%s\\n' '{json_body}'\n"
-            f"            ;;\n"
-            f"    esac\n"
-            f"}}"
-        )
-    else:
-        gh_impl = f"gh() {{ case \"$1\" in api) printf '%s\\n' '{json_body}';; esac; }}"
-
-    script = f"""
-{gh_impl}
-export -f gh
-. {SNIPPET}
-choose_merge_flag owner/repo
-"""
-    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
-```
-
-Key points:
-- `export -f gh` makes the bash function visible to the sourced script — no fake binary needed.
-- `stderr_noise: bool` flag lets tests verify the fix holds even when gh emits non-JSON to stderr.
-- The sourced script (`. SNIPPET`) runs in the same shell process, so the exported function is inherited.
-- Docstring must use imperative mood ("Run …") — not "Helper to run …" — to satisfy ruff D401.
-
-### Failure Mode 10: ruff D401 Applies to Private Helper Docstrings
-
-ruff enforces D401 ("First line of docstring should be in imperative mood") on **all** public and private functions, including those named `_foo`. The rule checks whether the first word of the docstring is an imperative verb.
-
-**Fails D401:**
-```python
-def _run_choose(json_body: str) -> subprocess.CompletedProcess[str]:
-    """Helper to run choose_merge_flag with a mocked gh."""  # "Helper" is not imperative
-```
-
-**Passes D401:**
-```python
-def _run_choose(json_body: str) -> subprocess.CompletedProcess[str]:
-    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
-```
-
-Common failing openers: "Helper to", "Wrapper for", "Utility that", "Used to". Use "Run", "Execute", "Return", "Build", "Validate" instead.
+For a Python integration test that sources a Bash snippet, define and export a Bash function named
+`gh` in the same shell. Make it write JSON to stdout and optional advisory noise to stderr, then
+source the script and call the target. `export -f gh` avoids a fake binary and verifies stdout/
+stderr separation. The Python helper docstring must begin with an imperative verb even when its
+name begins with an underscore.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
-| Reading stderr/stdout from test runner | Examined "Available tasks:" output in stdout to diagnose 127 | Output was pixi help text from `yq` called in unexpected context — a red herring | Trust `bash -x` trace over raw stdout when diagnosing exit 127 |
-| Assuming 127 = missing binary | Checked whether `yq`\|`jq`\|`curl` were installed | All binaries present; 127 came from a missing bash function in a sourced library | Exit 127 has two distinct causes: missing binary vs. missing function; `-x` trace distinguishes them |
-| `grep "pattern" file \| while read line; do` | Direct pipe from grep into while-read | When grep exits 1 (no matches), pipefail propagates non-zero exit and set -e aborts script | Never pipe grep into while-read under set -euo pipefail without a guard |
-| `\|\| true` on the whole while-read pipeline | Appended `\|\| true` after `done` | Works but silently swallows ALL errors inside loop body, masking real failures | Use process substitution (Option A); reserve `\|\| true` only for truly ignorable errors |
-| Logic inversion: else sets rc=1 for non-matching files | Expected that `else rc=1` would fire on non-matching files | The abort-on-grep-miss masked the real logic flow; else branch was never reached | Pipefail trap can invert apparent logic: what looks like a missing-string check exits instead |
-| `local -a FAILED_AGENT_NAMES` (no `=()`) | Declared array without initializing | Under `set -u`, bash treats unassigned array as unbound on first access | Always use `=()` when declaring arrays; declaration alone is not initialization |
-| Guarding with `[[ -v ARRAY ]]` check | Used `[[ -v FAILED_AGENT_NAMES ]]` before each access | Verbose and easy to miss in new code paths; doesn't fix root cause | Initialize at declaration instead of guarding every access site |
-| `.converged // empty` | Used jq alternative operator to skip null | `false` is falsy in jq — `//` triggers on `false` too, returning empty | Never use `//` with boolean fields; use `if . == null` instead |
-| `.converged // "false"` | Tried to default to string "false" | `//` replaces `false` with the alternative regardless — output is always `"false"` even when `.converged` is `true` | The alternative operator is wrong for booleans; use `tostring` with a null guard |
-| `.converged \| tostring` | Direct tostring without null check | Works for booleans but crashes if field is missing (null input to tostring) | Add `// null` guard before `tostring` or use `if . == null then "" else tostring end` |
-| jq inline array concatenation `] + (if $cond then [...] else [] end)` | Used jq's `+` operator for conditional array building | Fails on jq 1.5 and some distro-patched builds with `syntax error, unexpected '+'` | Build conditional arrays in bash; pass via `--argjson` for version compatibility |
-| Trust Edit succeeded (multi-worktree) | Assumed Edit on an absolute path edited the file Bash subsequently grep'd | Edit operated on main worktree path; Bash grep ran in sibling worktree via stale cwd | Edit and Bash can target different copies of the same logical file when multiple worktrees exist |
-| Re-Read to verify after Edit | Re-read file via Read (absolute path) to confirm the edit landed | Read showed correct content (main worktree) — but Bash kept grepping wrong copy via relative path | A successful Read does not prove subsequent Bash commands see the same file |
-| Python heredoc rewrite | Switched to `python3 <<EOF` rewrite when Edit refused | Python interpreter inherits Bash cwd; opened relative path resolving into wrong worktree | Heredoc/subprocess tools inherit Bash cwd — same root cause, different surface |
-| Grep with relative path | Used `grep PATTERN .github/workflows/file.yml` to confirm change | Relative path resolved against stale cwd; returned no match | Always use absolute paths in Bash when cross-checking Edit results |
-| Blame the Edit tool | Suspected Edit was silently no-oping or operating on a cached buffer | Edit had worked correctly — divergence was in the verifier, not the editor | When two tools disagree, suspect cwd before suspecting tool bugs |
-| `set -m` + single-command `(...)` subshell exec-optimization | Defang errexit inside the function via `set +e` + `trap 'set -e' RETURN`; expected `rc=$?` to capture exit and `phase_done` to fire | bash trace shows no commands execute after the subshell completes — control returns directly to the outer parent loop. `set -m` puts the subshell in its own process group, and bash optimises single-command subshells via exec-replace, so the subshell PID dies with the command's rc and the parent's continuation context is lost. `set +e` does not help because nothing runs after the subshell to be defanged. | Diagnose with `bash -x` + ERR/EXIT traps inside the function: if `phase_start` banners appear but `phase_done` banners NEVER appear (even with stderr captured), the function body is not running past the subshell. Don't add more `set +e` — restructure to avoid the single-command subshell (e.g., extract into a real function), or replace the bash orchestrator entirely. |
-| `gh api … 2>&1` in command substitution | Added `2>&1` to capture gh's error message into `$raw` for the error path in `choose_merge_flag.sh` | gh also writes deprecation banners, update notices, and GH_DEBUG traces to stderr on SUCCESS paths; merging these into `$raw` before piping to jq produced non-JSON input, causing jq to return empty; downstream "allows no merge methods" false error on valid repos | Never redirect `2>&1` in a `$(…)` capturing API output for jq; capture stdout only; on failure `$raw` is empty and gh already printed the error to stderr |
-| Using "Helper to" opener for private function docstring | Wrote `"""Helper to run choose_merge_flag with a mocked gh."""` on `_run_choose` | ruff D401 rejected it: "Helper" is not imperative mood | ruff D401 applies to private functions too; use imperative verb openers ("Run", "Execute", "Build", "Return") regardless of whether the function name starts with `_` |
+| --- | --- | --- | --- |
+| Pipeline-wide `|| true` | Suppressed a grep/while pipeline | It also hid real loop-body failures | Guard grep and use process substitution |
+| Declared-only array | Used `local -a ARRAY` under nounset | The array remained unset | Initialize with `=()` |
+| Boolean `//` fallback | Used `.field // empty` for a boolean | jq treats false like null for this operator | Test null explicitly |
+| Inline conditional array | Used jq `] + (if ...` syntax | The deployed jq rejected it | Use a compatible `--argjson` construction |
+| More `set +e` | Defanged errexit after a lone subshell | No continuation ran after exec replacement | Restructure control flow |
+| Captured `2>&1` | Mixed `gh` diagnostics with API JSON | jq received a non-JSON prefix | Capture stdout only |
+| Relative verification path | Grepped from a stale worktree cwd | It inspected a different file than the editor | Anchor the worktree and path |
+| “Helper to” docstring | Described a private Python test helper | ruff D401 still applied | Use an imperative opener |
 
 ## Results & Parameters
 
-### grep exit code semantics
+| Failure signature | Required rule |
+| --- | --- |
+| Exit 127 | Trace to distinguish missing binary from missing function |
+| grep no-match | Treat status 1 as benign only at the grep boundary |
+| Nounset array | Initialize with `=()` before every read |
+| Counter under errexit | Assignment form or narrowly guarded arithmetic command |
+| JSON boolean | Explicit null test; preserve false |
+| Empty selection | `first(stream) // fallback` |
+| Machine output | stdout only; diagnostics on stderr |
+| Worktree commands | Explicit absolute root or `git -C` |
+| Silent subshell return | Trace ERR/EXIT, then restructure rather than defang |
+| Private docstring | Imperative first line for D401 |
 
-```
-grep exit codes: 0 = matches found, 1 = no matches, 2 = error
-Under set -e + pipefail, exit code 1 (no matches) is indistinguishable from a real error.
-```
+## Companions
 
-### Arithmetic counter guard pattern
-
-```bash
-(( count++ )) || true       # safe: || true prevents set -e seeing 0 result
-count=$(( count + 1 ))      # also safe: arithmetic expansion never triggers set -e
-```
-
-### Restored function with delegate shim pattern
-
-```bash
-# Restored original with retry logic:
-_agamemnon_curl_retry() {
-  local max_attempts="${AGAMEMNON_MAX_RETRIES:-3}"
-  local attempt=1
-  local response
-  while [ "$attempt" -le "$max_attempts" ]; do
-    response=$(curl -sf "$@") && { printf '%s' "$response"; return 0; }
-    attempt=$((attempt + 1))
-    sleep 1
-  done
-  return 1
-}
-
-# Renamed public function delegates so both old and new callers work:
-_agamemnon_curl() {
-  _agamemnon_curl_retry "$@"
-}
-```
-
-### jq select + fallback pattern
-
-```bash
-result=$(echo "$json" | jq -r --arg name "$name" \
-  'first(.[] | select(.name == $name) | .status) // "unknown"')
-result="${result:-unknown}"   # shell fallback in case jq returns empty
-```
-
-### Pre-commit hook template (grep no-match safe)
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-rc=0
-for workflow_file in .github/workflows/*.yml; do
-  if grep -q "gitleaks detect" "$workflow_file"; then
-    while read -r line; do
-      echo "Found in $workflow_file: $line"
-    done < <(grep "gitleaks detect" "$workflow_file")
-  else
-    echo "WARN: $workflow_file does not call gitleaks detect" >&2
-    rc=1
-  fi
-done
-exit "$rc"
-```
-
-### Session-start checklist for multi-worktree sessions
-
-```bash
-cd /abs/path/to/main/worktree
-pwd
-git worktree list
-git rev-parse --show-toplevel
-```
-
-### gh api stdout-only capture pattern
-
-```bash
-# Capture stdout only — do NOT use 2>&1 when the output is piped to jq
-if ! raw=$(gh api "repos/${owner}/${repo}"); then
-    echo "gh api failed" >&2
-    return 1
-fi
-result=$(printf '%s' "$raw" | jq -r '.some_field // empty')
-```
-
-On failure, `$raw` is empty; gh has already written its error message to stderr. Do not reference `$raw` in the error message.
-
-### mock-gh bash function pattern for Python integration tests
-
-```python
-import subprocess
-from pathlib import Path
-
-SNIPPET = Path(__file__).resolve().parents[2] / "scripts" / "choose_merge_flag.sh"
-
-def _run_choose(json_body: str, *, stderr_noise: bool = False) -> subprocess.CompletedProcess[str]:
-    """Run choose_merge_flag with a mocked gh that returns json_body on stdout."""
-    if stderr_noise:
-        gh_impl = (
-            f"gh() {{\n"
-            f"    case \"$1\" in\n"
-            f"        api)\n"
-            f"            echo \"warning: new gh version available\" >&2\n"
-            f"            printf '%s\\n' '{json_body}'\n"
-            f"            ;;\n"
-            f"    esac\n"
-            f"}}"
-        )
-    else:
-        gh_impl = f"gh() {{ case \"$1\" in api) printf '%s\\n' '{json_body}';; esac; }}"
-
-    script = f"""
-{gh_impl}
-export -f gh
-. {SNIPPET}
-choose_merge_flag owner/repo
-"""
-    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
-```
-
-Key: `export -f gh` exports the bash function into the environment so the sourced script inherits it. No fake binary on PATH needed. The `stderr_noise=True` variant verifies the fix holds under realistic gh advisory output.
-
-### ruff D401 imperative-mood docstring openers
-
-| Fails D401 | Passes D401 |
-| ---------- | ----------- |
-| "Helper to run X" | "Run X with …" |
-| "Wrapper for X" | "Wrap X and return …" |
-| "Utility that does X" | "Execute X and …" |
-| "Used to build X" | "Build X from …" |
-| "This function validates X" | "Validate X against …" |
-
-## Verified On
-
-| Project | Context | Details |
-| --------- | --------- | --------- |
-| HomericIntelligence/Myrmidons | PR #564 — check-gitleaks-coe.sh pre-commit hook exited on grep no-match before reaching else rc=1 | grep \| while-read abort under pipefail |
-| HomericIntelligence/Myrmidons | PR #623 — apply.sh failed-agent tracking crashed at `${#FAILED_AGENT_NAMES[@]}` | Unbound array under set -u |
-| HomericIntelligence/Myrmidons | PR #623 — convergence serialization bats test 318 failing on false value | jq // operator falsy boolean trap |
-| HomericIntelligence/Myrmidons | CI debug session — test-api-retry.sh exit 127 after `_agamemnon_curl_retry` renamed | Exit-127 function recovery |
-| ai-maestro (23blocks-OS) | Issue #272 — install-agent-cli.sh jq syntax error on older jq | jq array concatenation compatibility |
-| HomericIntelligence/ProjectOdyssey | Multi-worktree session — stray commit cf710fb4 on ci-pipe-handler-cores-gate branch | Bash cwd drift from Edit/Read absolute paths |
-| HomericIntelligence/ProjectHephaestus | Session 2026-05-26 — `scripts/run_automation_loop.sh` `process_repo` silently aborting after planner subshell (phases 2-6 skipped 75/75 invocations); replaced with `hephaestus/automation/loop_runner.py` | `set -m` + single-command subshell exec-optimization silent abort |
-| HomericIntelligence/ProjectHephaestus | Issue #1122, PR #1273 — `scripts/choose_merge_flag.sh` `2>&1` on `gh api` merged deprecation banners into `$raw`, causing jq to return empty; spurious "allows no merge methods" exit-1 on valid repos | `2>&1` in command substitution corrupts jq input; mock-gh bash function integration test pattern; ruff D401 on private helper docstrings |
+- [Case index and detailed verification](bash-script-and-jq-failure-modes.notes.md)
+- [Version history and superseded content](bash-script-and-jq-failure-modes.history)

--- a/skills/bash-script-and-jq-failure-modes.notes.md
+++ b/skills/bash-script-and-jq-failure-modes.notes.md
@@ -1,0 +1,55 @@
+# Bash Script and jq Failure Modes — Notes
+
+Supporting case evidence for
+[`bash-script-and-jq-failure-modes`](bash-script-and-jq-failure-modes.md). The exact 30,074-byte
+v1.2.0 main is archived once in
+[`bash-script-and-jq-failure-modes.history`](bash-script-and-jq-failure-modes.history), with
+SHA-256 `27c5a2d2f8b7a3068a9c623794064736164ab4e275fc5b29fbea52f5e2e2a1bc`.
+
+## Case Index
+
+| Case | Source | Verification status | Reusable result |
+| --- | --- | --- | --- |
+| grep no-match under `pipefail` | [Myrmidons PR #564](https://github.com/HomericIntelligence/Myrmidons/pull/564) | verified-ci | Guard grep and use process substitution |
+| Nounset arrays and jq false serialization | [Myrmidons PR #623](https://github.com/HomericIntelligence/Myrmidons/pull/623) | verified-ci | Initialize arrays with `=()` and test null explicitly |
+| Exit-127 function recovery | [Immutable v1.2.0 source](https://github.com/HomericIntelligence/Mnemosyne/blob/10e28497993009cc221cb991e1ee183e6117eda8/skills/bash-script-and-jq-failure-modes.md) | verified-local; later consolidated status remains `verified-ci` | Use `bash -x` to distinguish missing functions from binaries |
+| Older-jq conditional array syntax | [ai-maestro issue #272](https://github.com/23blocks-OS/ai-maestro/issues/272) | verified in reported environment | Build compatible JSON and pass through `--argjson` |
+| Multi-worktree cwd divergence | [Immutable v1.2.0 source](https://github.com/HomericIntelligence/Mnemosyne/blob/10e28497993009cc221cb991e1ee183e6117eda8/skills/bash-script-and-jq-failure-modes.md) | verified-local | Anchor every shell command to the intended worktree |
+| Job-control/subshell continuation loss | [Immutable v1.2.0 source](https://github.com/HomericIntelligence/Mnemosyne/blob/10e28497993009cc221cb991e1ee183e6117eda8/skills/bash-script-and-jq-failure-modes.md) | verified-local replacement | Trace ERR/EXIT, restructure, or replace a brittle orchestrator |
+| `gh api` stderr corrupting jq input | [ProjectHephaestus issue #1122](https://github.com/HomericIntelligence/ProjectHephaestus/issues/1122) and [PR #1273](https://github.com/HomericIntelligence/ProjectHephaestus/pull/1273) | verified-ci | Keep diagnostic stderr out of captured JSON |
+| Exported-function `gh` test stub and D401 | [ProjectHephaestus PR #1273](https://github.com/HomericIntelligence/ProjectHephaestus/pull/1273) | verified-ci | Test both streams without a fake binary; use imperative docstrings |
+
+## Detailed Case Notes
+
+### Myrmidons strict-mode failures
+
+The grep hook stopped before its intended else branch because no-match status 1 propagated through
+`pipefail`. A pipeline-wide `|| true` appeared attractive but would also mask failures in the loop.
+In a separate case, a declared-but-uninitialized failure array crashed at its first length read,
+and jq's alternative operator replaced a valid false. These cases validate three distinct language
+semantics rather than one generic “strict mode” fix.
+
+### ProjectHephaestus JSON boundary
+
+The merge-method probe captured `gh api ... 2>&1`; advisory stderr prefixed otherwise valid JSON,
+so jq produced an empty result and the caller reported that a valid repository allowed no merge
+method. PR #1273 preserved stdout as the data channel and tested realistic stderr noise through an
+exported Bash `gh` function. Its private Python test helper also established that D401 applies to
+underscore-prefixed functions.
+
+### Shell complexity escape hatch
+
+The job-control case combined `set -euo pipefail`, `set -m`, RETURN/ERR/EXIT traps, manual errexit
+defanging, and a trailing external command inside a subshell. Once control-flow correctness depends
+on several interacting shell options, a structured subprocess loop can be a smaller and more
+testable fix than another local shell patch. This is a decision threshold, not a rule that every
+shell script should be rewritten.
+
+## Verification Checklist
+
+- Reproduce with the failing Bash/jq versions and the same option set.
+- Save `bash -x` around the first missing continuation, not only user-facing stdout.
+- Test grep match, no-match, and actual error separately.
+- Test JSON `true`, `false`, `null`, missing field, empty selection, and stderr noise.
+- Verify the absolute worktree root before and after every cross-worktree command.
+- For shell-to-Python rewrites, retain exit codes, signals, stream routing, and phase ordering.

--- a/skills/ci-failure-triage-and-diagnosis.history
+++ b/skills/ci-failure-triage-and-diagnosis.history
@@ -1,3 +1,503 @@
+## v2.0.0 (2026-08-20) — Compact oversized retrievable skill
+
+**Issue:** [#3335](https://github.com/HomericIntelligence/Mnemosyne/issues/3335)
+
+**Immutable batch base:** `10e28497993009cc221cb991e1ee183e6117eda8`
+
+**Version:** v1.1.0 -> v2.0.0
+
+**Retrievable bytes:** 30,593 -> 9,974
+
+**Superseded snapshot SHA-256:** `dbfeed396bb4cb23d547fc0d9077a6e5756b9f71b820cda2b4e2ee6acd83e592`
+
+### Compaction and verification
+
+The retrievable main was compacted to its decision-changing triggers, commands, parameters, failed approaches, and evidence boundaries. Project-specific cases and detailed verification moved to the linked notes companion. The base main below was archived byte-for-byte and SHA-256 checked; the complete pre-existing history follows this entry unchanged. Repository validation, Markdown lint, scoped hooks, and the semantic audit are recorded in the batch PR.
+
+### Full snapshot of superseded v1.1.0 retrievable content
+
+````markdown
+---
+name: ci-failure-triage-and-diagnosis
+description: "Canonical workflow for triaging CI failures: log analysis, core dump capture, subprocess hang diagnosis, container forensics, libKGEN/JIT crash retrieval, GHA-only vs cross-environment failures, PR-specific vs systemic failure separation. Use when: (1) a CI run failed and you need to identify the root cause, (2) deciding whether a failure is PR-induced or pre-existing, (3) capturing core dumps from container environments, (4) reproducing a GHA-only crash locally, (5) GraphQL/REST rate-limited CI monitoring."
+category: ci-cd
+date: 2026-06-20
+version: "1.1.0"
+user-invocable: false
+verification: verified-local
+history: ci-failure-triage-and-diagnosis.history
+tags: [merged, ci-failure, triage, log-analysis, core-dump, forensics, coredump, gdb, podman, mojo, libkgen, github-actions, rate-limit, subprocess, signal, avx-512, cpu-survey, workflow-dispatch]
+---
+
+# CI Failure Triage and Diagnosis
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-05-18 |
+| **Objective** | Consolidated canonical skill for triaging any CI failure: from identifying whether a failure is PR-induced or systemic, to capturing core dumps from containerized JIT crashes, diagnosing subprocess hangs, and reproducing GHA-only crashes across CPU fleets. |
+| **Outcome** | Operational — merged from 14 narrower skills covering the full CI-triage lifecycle. |
+
+## When to Use
+
+- A CI run failed and you need to identify the root cause before deciding to revert, fix, or rerun
+- `mergeStateStatus: BLOCKED` with zero failing checks (required context never posted)
+- Multiple unrelated PRs failing on the same job at the same file/line — treat as broken-main, not per-PR
+- Core dumps are empty despite a known JIT crash inside a container (mount-namespace or signal-handler pitfall)
+- GHA-only crash suspected to be CPU-feature-sensitive (AVX-512, CPUID masking under Hyper-V)
+- E2E runner hangs at "Starting N tiers in parallel" and ignores Ctrl+C
+- GitHub API 403 rate-limit errors during batch CI diagnostic loops
+- Debug CI instrumentation (gdb, coredump capture) is slowing every PR run and you need an opt-in gate
+- pixi.lock stale across multiple PR branches
+- You are writing an implementation plan / fix for a reported CI failure and have NOT yet fetched the actual failing-step log — STOP and fetch it first (`gh run view --job=<id> --log-failed`) before forming any root-cause hypothesis
+- An issue reports a CI failure with a run ID/URL and says "no detailed error output available via API" — the per-step log IS still retrievable; the issue author simply did not fetch it
+- Before proposing any CI fix, you have not yet checked whether the reported failure was already resolved by a later commit/PR on main
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+# ── PHASE 0: BEFORE writing any plan/fix — read the ACTUAL failing log ──
+#    (verified-local against ProjectOdyssey run 25217481782, issue #252)
+# 0a. List jobs/steps; the failing step shows an X
+gh run view <RUN_ID> --repo <org>/<repo>
+# 0b. Pull the ACTUAL failing-step log — works even when the issue claims "no output via API"
+gh run view --job=<JOB_ID> --repo <org>/<repo> --log-failed \
+  | grep -iE "command not found|exit code|error|traceback" | head
+# 0c. Note action VERSIONS in the failing log (e.g. setup-pixi@v0.8.1). A stale version
+#     proves the workflow changed since the run — the fix may already exist on main.
+# 0d. Check whether the fix already landed on main BEFORE proposing anything:
+git log -S "<the fix string, e.g. Install just>" --oneline -- .github/workflows/<file>
+gh run list --repo <org>/<repo> --workflow=<file> --branch main --limit 3 \
+  --json conclusion --jq '.[].conclusion'   # all "success" => already fixed; document, don't re-fix
+# exit 127 / "command not found" => the recipe NEVER RAN (missing tool/interpreter on PATH),
+# the failure is BEFORE the recipe body — not inside it.
+
+# ── PHASE 1: Is main broken? Check BEFORE rebasing any downstream PR ──
+gh run list --branch main --limit 5 --json conclusion,status,name,createdAt
+# If "Build and Test" or "Static Analysis" show conclusion=failure → fix main FIRST
+
+# ── PHASE 2: Transient vs reproducible ──
+gh run rerun <run_id> --failed --repo HomericIntelligence/<repo>
+gh run watch <new_run_id> --repo HomericIntelligence/<repo>
+# Passes → transient, no action. Fails again → reproducible, file issue + PR.
+
+# ── PHASE 3: Identify root cause from log ──
+gh run view <run_id> --repo <org>/<repo> --log-failed 2>&1 | \
+  grep -E "::error|Error:|FAILED|Killed|out of memory|libKGEN" | head -20
+
+# ── PHASE 4: Classify OOM vs JIT crash (modular#6433 vs #6413) ──
+JOB_IDS=$(gh pr view <PR> --json statusCheckRollup | python3 -c "
+import sys, json
+for c in (json.load(sys.stdin).get('statusCheckRollup') or []):
+    if c.get('conclusion') == 'FAILURE':
+        print(c.get('detailsUrl','?').rsplit('/job/',1)[-1])")
+for id in $JOB_IDS; do
+  HITS=$(gh run view --job=$id --log 2>&1 \
+    | grep -iE "Killed|OOM-killer|out of memory|virtual address|mmap.*failed" \
+    | grep -vE "TCMalloc|echo|# " | head -3)
+  [ -n "$HITS" ] && echo "OOM (#6433 not fixed)" || \
+    gh run view --job=$id --log 2>&1 | grep -E "libKGENCompilerRTShared.so\+0x" | head -1
+done
+
+# ── PHASE 5: Same job failing on N unrelated PRs → broken-main lint ──
+git log --oneline -5 -- skills/<offending-file>.md   # when file landed on main
+gh pr diff <num> -- skills/<offending-file>.md        # empty → PR didn't touch it
+# YES → fix at root with one PR against main, rebase downstream after merge
+
+# ── PHASE 6: Required context never posted (BLOCKED, 0 FAILUREs) ──
+gh api "repos/<ORG>/<REPO>/branches/main/protection/required_status_checks" \
+  --jq '.contexts' > /tmp/required.json
+gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[].name]|unique' \
+  > /tmp/present.json
+comm -23 <(jq -r '.[]' /tmp/required.json | sort) \
+         <(jq -r '.[]' /tmp/present.json  | sort)
+# Output = required contexts that never posted = the blockers
+
+# ── PHASE 7: GitHub API rate limit budget ──
+gh api rate_limit --jq '.resources.core | "used:\(.used)/\(.limit) resets:\(.reset|todate)"'
+RESET=$(gh api rate_limit --jq '.resources.core.reset')
+DELAY=$(( RESET - $(date +%s) + 60 ))
+echo "Sleep ${DELAY}s until reset"
+
+# ── PHASE 8: Fix stale pixi.lock ──
+git checkout <branch>
+pixi install   # regenerates pixi.lock
+git add pixi.lock && git commit -m "chore: regenerate pixi.lock" && git push
+# Re-trigger if SHA mismatch (empty commits don't reliably trigger CI):
+gh run list --branch <branch> --json databaseId,conclusion \
+  --jq '.[]|select(.conclusion=="failure").databaseId' \
+  | xargs -I{} gh run rerun {} --repo <org>/<repo> --failed
+```
+
+### Detailed Steps
+
+#### Step 0 — Triage discipline: read the failing log before forming a hypothesis (verified-local)
+
+When planning a fix for a *reported* CI failure (an issue links a run ID/URL), the FIRST action is to fetch the actual failing-step log — never hypothesize a root cause from the recipe's internals.
+
+1. `gh run view <RUN_ID> --repo <org>/<repo>` to find the failing job ID (failing step shows an X).
+2. `gh run view --job=<JOB_ID> --repo <org>/<repo> --log-failed` to pull the exact error line. This works even when the issue says "no detailed error output available via API" — that narration is not authoritative; the author simply did not fetch it.
+3. Read the error literally:
+   - `command not found` / exit code **127** → the recipe/tool **never ran**; the runner lacked the interpreter or tool on PATH (e.g. `just: command not found` because the job had no "Install just" step). This is a whole class of "fails in CI, passes locally" failures that have nothing to do with the recipe body. "Passes locally + recipe exits 0 locally" is a strong signal the failure happened **before** the recipe body executed.
+4. Reconcile the failing run's workflow snapshot against current main. The failing log captures the action **versions** in effect at run time (e.g. `setup-pixi@v0.8.1`); if current main pins a newer version (`v0.9.6`), the workflow changed since the run and the fix may already exist.
+5. Check whether the failure was already resolved on main BEFORE proposing a fix:
+   - `git log -S "<fix string>" --oneline -- .github/workflows/<file>` to find the landing commit/PR.
+   - `gh run list --workflow=<file> --branch main --limit 3 --json conclusion --jq '.[].conclusion'` — all `success` ⇒ already fixed.
+   - An "investigate" issue can be legitimately resolved by DOCUMENTING that the failure is already fixed plus a minimal residual hardening — not by inventing a large fix.
+6. Any tool you cite in a `verification:` block must actually exist in the repo's env. Grep the dependency manifest first (`pixi.toml`, `pyproject.toml`) and mirror how the repo's own jobs invoke it — e.g. do not write `pixi run check-jsonschema` if `check-jsonschema` is installed via pip in the schema-validation job rather than declared in `pixi.toml`.
+
+> Verification note: the triage commands in this step (`gh run view --log-failed`, `git log -S`, `gh run list --branch main`) are **verified-local** — run live against ProjectOdyssey run 25217481782 (issue #252) this session. The downstream Odysseus hardening they informed (sourcing yamllint from pixi) is a **proposal**, not yet applied or CI-verified.
+
+#### Step 1 — Pre-flight: Is main broken?
+
+Before rebasing any downstream PR, verify main is green:
+
+```bash
+gh run list --branch main --limit 5 \
+  --json conclusion,status,name,createdAt \
+  --jq '.[] | "\(.name): \(.conclusion // .status)"'
+```
+
+If "Build and Test", "Static Analysis", or "Code Coverage" show `failure`:
+1. Create `fix-ci-<symptom>-<date>` branch from `origin/main`
+2. Apply minimal fix
+3. Open PR with `gh pr merge <N> --auto --squash`
+4. After fix merges, rebase all downstream PRs and re-arm auto-merge (force-push clears it)
+
+#### Step 2 — Identical failure across unrelated PRs
+
+When N unrelated PRs all fail on the same job pointing to the same file/line:
+
+1. Same job failing on multiple unrelated PRs?
+2. `gh run view --job <id> --log-failed` points to the same file and line on every PR?
+3. Is that file on `main` and untouched by each PR's diff?
+
+If all YES → fix at root. Do NOT add per-PR suppression comments — this is technical debt across N branches.
+
+#### Step 3 — Required context never posts (BLOCKED, 0 FAILUREs)
+
+Two mechanisms that block PRs with no failing checks:
+
+| Cause | Tell-tale | Fix |
+| ----- | --------- | --- |
+| Workflow `paths:` filter excludes PR | `gh run list --branch <branch> --workflow=<file>` shows no runs | Broaden `paths:` filter |
+| Whole-job `if:` skip on event type | Job shows `conclusion: skipped` in run view | Aggregator/summary gate |
+
+Key invariant: a whole-job `if:` skip shows as **missing** to branch protection, not success. A step-level skip inside a running job still posts success.
+
+#### Step 4 — Coredump capture in containerized CI
+
+When a JIT crash inside a Podman/Docker container produces an empty `cores/` directory:
+
+**Mount-namespace fix**: `core_pattern` is resolved in the crashing process's mount namespace, NOT the host's. Set it to the container-side path:
+
+```bash
+# WRONG — host CWD path, invisible inside container
+echo "$(pwd)/crash-bundle/cores/core.%p.%e.%t" | sudo tee /proc/sys/kernel/core_pattern
+
+# CORRECT — container-side bind-mount path
+echo "/workspace/crash-bundle/cores/core.%p.%e.%t" | sudo tee /proc/sys/kernel/core_pattern
+```
+
+**libKGEN signal-handler defeat**: When `ulimit -c unlimited` + `core_pattern` still produce no cores (libKGEN installs its own in-process SIGABRT/SIGILL handler that beats the kernel), run `mojo` under gdb:
+
+```bash
+# scripts/mojo-under-gdb.sh <cores-dir> <mojo args...>
+#!/usr/bin/env bash
+set -euo pipefail
+CORES_DIR="${1:?}"; shift
+mkdir -p "$CORES_DIR"
+MOJO_BIN="$(pixi run -- bash -c 'command -v mojo')"
+EXIT_FILE="$(mktemp)"; trap 'rm -f "$EXIT_FILE"' EXIT
+GDB_PY=$(cat <<'PYEOF'
+import gdb, os
+signaled = False
+NAME_TO_NUM = {"SIGHUP":1,"SIGINT":2,"SIGILL":4,"SIGABRT":6,"SIGBUS":7,
+               "SIGFPE":8,"SIGKILL":9,"SIGSEGV":11,"SIGTERM":15}
+def on_stop(ev):
+    global signaled
+    if isinstance(ev, gdb.SignalEvent):
+        signo = NAME_TO_NUM.get(ev.stop_signal, 6)
+        gdb.execute(f"generate-core-file {os.environ['CORES_DIR']}/core.{gdb.selected_inferior().pid}")
+        with open(os.environ["EXIT_FILE"], "w") as f: f.write(str(128 + signo))
+        signaled = True
+def on_exit(ev):
+    if not signaled:
+        code = ev.exit_code if ev.exit_code is not None else 0
+        with open(os.environ["EXIT_FILE"], "w") as f: f.write(str(code))
+gdb.events.stop.connect(on_stop)
+gdb.events.exited.connect(on_exit)
+PYEOF
+)
+export CORES_DIR EXIT_FILE
+set +e
+pixi run -- gdb -batch -nx \
+  -ex "python\n$GDB_PY" \
+  -ex "set pagination off" \
+  -ex "handle SIGILL SIGSEGV SIGABRT SIGBUS SIGFPE stop nopass" \
+  -ex "run $*" "$MOJO_BIN"
+set -e
+cat "$EXIT_FILE" 2>/dev/null | { read -r rc; exit "${rc:-1}"; }
+```
+
+**Key rules**:
+- Always run gdb **through** `pixi run -- gdb` (inherits `MODULAR_HOME` and stdlib paths)
+- Use Python `gdb.events.stop` filtered to `SignalEvent`, NOT `hook-stop` (fires on exit-stop in gdb 15.1)
+- Write exit code to a file; `--return-child-result` is unreliable in `-batch` mode
+- Handle SIGILL in addition to SIGABRT/SIGSEGV — Mojo `os.abort()` lowers to `llvm.trap` → SIGILL
+
+**Symbolication must run inside the container**:
+
+```yaml
+- name: Symbolicate cores (disasm + registers around $pc)
+  if: inputs.phase == 'collect' && always()
+  shell: bash
+  run: |
+    mkdir -p crash-bundle/symbolicated
+    shopt -s nullglob
+    CORES=( crash-bundle/cores/core.* crash-bundle/cores/core.gdb.* )
+    shopt -u nullglob
+    [ ${#CORES[@]} -eq 0 ] && exit 0
+    for core in "${CORES[@]}"; do
+      base=$(basename "$core")
+      c_core="/workspace/crash-bundle/cores/$base"
+      out="crash-bundle/symbolicated/${base}.symbolicated.log"
+      podman compose exec -T <service> bash <<HEREDOC > "$out" 2>&1 || true
+    MOJO_BIN=\$(pixi run which mojo 2>/dev/null | tail -1)
+    pixi run gdb -batch -ex "set pagination off" \
+      -ex "thread apply 1 bt 25" \
+      -ex "info all-registers" \
+      -ex "disassemble \\\$pc - 64, \\\$pc + 64" \
+      "\$MOJO_BIN" "${c_core}" 2>&1 | head -400
+HEREDOC
+    done
+```
+
+#### Step 5 — GHA-only crash: cross-CPU survey
+
+When a crash reproduces only on GHA runners (suspected CPU-feature mismatch):
+
+```bash
+TARGETS="host1 host2 host3 host4 host5"
+JUMPHOST=host2
+rsync -avz --partial container-image-*/dev.tar "${JUMPHOST}:~/dev.tar"
+for host in $TARGETS; do
+  [ "$host" = "$JUMPHOST" ] && continue
+  ssh "$JUMPHOST" "scp ~/dev.tar ${host}:~/dev.tar" &
+done; wait
+for host in $TARGETS; do
+  ssh "$JUMPHOST" "ssh $host '
+    grep -m1 \"model name\" /proc/cpuinfo
+    grep -o -E \"avx2|avx512[a-z]*\" /proc/cpuinfo | sort -u | tr \"\n\" \" \"; echo
+    podman load -i ~/dev.tar >/dev/null
+    for i in \$(seq 1 50); do
+      podman run --rm --userns=keep-id -v \"\$(pwd):/workspace:Z\" -w /workspace \
+        <image>:dev bash -c \"pixi run mojo run repro/REPRO.mojo >/dev/null 2>&1; echo exit=\$?\"
+    done | sort | uniq -c
+  '"
+done | tee survey-results.log
+```
+
+Note: On GHA Azure runners, silicon is AMD EPYC Zen 4 (native AVX-512) but Hyper-V **masks** AVX-512 CPUID bits. LLVM may emit AVX-512 based on CPU-name fingerprinting, not CPUID probing, causing SIGILL on hardware that reports no AVX-512 capability.
+
+#### Step 6 — Gate debug instrumentation behind workflow_dispatch
+
+When always-on debug instrumentation (gdb wrapper, coredump capture) slows every PR run:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      enable_gdb_cores:
+        description: 'Capture gdb core dumps for libKGEN JIT crashes'
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    env:
+      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
+    steps:
+      - run: just test-mojo  # reads MOJO_TEST_UNDER_GDB internally
+```
+
+```bash
+# Manually trigger with gdb capture enabled
+gh workflow run comprehensive-tests.yml -f enable_gdb_cores=true --ref <branch>
+```
+
+Rules: always `default: false` (opt-in); always combine `github.event_name == 'workflow_dispatch'` with `inputs.X`; place at job-level `env:`, not step-level.
+
+#### Step 7 — Subprocess hang and signal fixes
+
+When a Python test runner hangs at "Starting N tiers in parallel" or ignores Ctrl+C:
+
+```python
+# Replace blocking as_completed() + future.result() with poll loop
+from concurrent.futures import FIRST_COMPLETED, wait
+
+pending = set(futures.keys())
+while pending:
+    if is_shutdown_requested():
+        for f in pending: f.cancel()
+        raise ShutdownInterruptedError("Shutdown during parallel execution")
+    done, pending = wait(pending, timeout=2.0, return_when=FIRST_COMPLETED)
+    for future in done:
+        result = future.result(timeout=0)  # already done, no block
+
+# Replace proc.communicate(timeout=3600) with polling helper
+def _communicate_with_shutdown_check(proc, timeout, ctx):
+    poll_interval = 2.0
+    remaining = float(timeout)
+    while True:
+        try:
+            return proc.communicate(timeout=poll_interval)
+        except subprocess.TimeoutExpired:
+            remaining -= poll_interval
+            if remaining <= 0: raise
+            if is_shutdown_requested():
+                _kill_process_group(proc)
+                raise ShutdownInterruptedError() from None
+```
+
+```python
+# Prevent terminal corruption from subprocess inheriting stdin
+result = subprocess.run(cmd, stdout=log_file, stderr=subprocess.STDOUT,
+                        stdin=subprocess.DEVNULL, text=True, check=False)
+
+# Restore terminal on exit
+def _restore_terminal():
+    if sys.stdin.isatty():
+        try: subprocess.run(["stty", "sane"], stdin=sys.stdin, check=False)
+        except Exception: pass
+```
+
+Key invariants:
+- `as_completed()` + `future.result()` blocks indefinitely — always use `wait(timeout=N)`
+- `communicate(timeout=N)` does NOT consume partial output on `TimeoutExpired` — safe to loop
+- `threading.Event.wait()` without timeout blocks forever — always add a timeout
+- SIGTSTP is job-control — don't register it alongside graceful shutdown handlers
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| `core_pattern` set to host runner CWD | `echo "$(pwd)/crash-bundle/cores/core.%p.%e.%t" \| sudo tee /proc/sys/kernel/core_pattern` | Crashing PID runs inside `podman compose exec` where host path doesn't exist; kernel silently writes nothing | `core_pattern` paths resolve in the crashing PID's mount namespace — use the container-side bind-mount path |
+| Bare `ulimit -c unlimited` + `core_pattern` for Mojo crashes | Standard recipe applied to Mojo JIT crashes | `libKGENCompilerRTShared.so` installs an in-process SIGABRT/SIGILL handler; user-space handler beats the kernel, calls `_exit()`, kernel never dumps | Run `mojo` under `gdb` (ptrace intercepts signals before delivery to user-space handlers) |
+| `gdb $(which mojo)` outside `pixi run` | Bare gdb invocation to avoid pixi overhead | Mojo errors with `unable to locate module 'std'` before it can crash — `MODULAR_HOME` and stdlib paths unset | Always launch gdb through `pixi run -- gdb` so inferior inherits the activated pixi env |
+| `hook-stop` + `generate-core-file` in gdb | Standard gdb idiom for "dump on signal stop" | In gdb 15.1, `hook-stop` fires on the synthetic "Inferior exited normally" stop; `generate-core-file` errors `You can't do that without a process to debug` on every clean-exit test | Use Python `gdb.events.stop` filtered to `isinstance(event, gdb.SignalEvent)` — exit-stop is an `ExitedEvent` and is harmlessly ignored |
+| `--return-child-result` in gdb batch mode | Documented gdb flag for exit-code propagation | In gdb 15.1 `-batch`, returns `0` even when inferior died on a handled signal | Write exit code to a temp file from Python event handlers; read it after gdb exits |
+| Handle only SIGABRT and SIGSEGV in gdb wrapper | Assumed those were the only fatal signals | Mojo `os.abort()` lowers to `llvm.trap` → SIGILL on Linux, not SIGABRT | Always include SIGILL (+ SIGBUS, SIGFPE) in the handled-signal set for any Mojo wrapper |
+| Host-side gdb for symbolication | Resolved mojo path via `podman compose exec which mojo`, then ran gdb on host | Container-side path unresolvable on host → "Could not resolve mojo binary — skipping" | Symbolication must run inside the container alongside the binary and the bind-mounted cores |
+| `apt-get install gdb` on runner to unblock host-side symbolication | Pre-install gdb on host image | Mojo binary path still container-side; solving tool availability doesn't fix namespace mismatch | The bottleneck is mount-namespace alignment, not gdb availability |
+| Treating all JIT failures as `modular#6433` (OOM) | Assumed 7 red jobs on a fix-verification PR meant #6433 unfixed | Failures were `modular#6413` (separate pre-existing bug); reverting would have lost a valid cleanup | Read log signatures literally: OOM keywords = #6433; `libKGENCompilerRTShared.so+0x` = #6413 |
+| Using exit code 137 to classify OOM vs JIT crash | Assumed `137` == SIGKILL == OOM-killer | libKGEN crashes also exit 137 via in-process signal handler | Combine exit code with log signature — the log signature beats the exit code |
+| Trusting CPUID flags as ground truth for GHA-only crash | Hypothesis: "any non-AVX-512 CPU triggers it" | All 6 surveyed non-AVX-512 Intel CPUs ran clean; GHA Azure runner crashes 80% | Hyper-V on AMD Zen 4 masks AVX-512 CPUID bits while LLVM may still emit AVX-512 based on CPU-name fingerprinting |
+| Per-PR `gh pr view` loop for batch investigation | Called `gh pr view <N>` for each of 13 PRs sequentially | 13 API calls instead of 1 | Use `gh pr list --json` to get all PR statuses at once; check rate limit (`gh api rate_limit`) before batch ops |
+| Empty commits to re-trigger CI | `git commit --allow-empty -m "ci: re-trigger"` | Workflows with `concurrency: cancel-in-progress: true` deduplicate same SHA | Use `gh run rerun --failed` instead |
+| Filing issues without first re-running CI | Filed issues immediately after observing a red run | Some failures were transient (network, timing); issue was unnecessary | Always re-run the failing job first; only file if the new run also fails |
+| Admin-merge to bypass missing required context | Skipped required check via admin for one PR | Leaves every future PR that touches the same files permanently BLOCKED | Fix the workflow misconfig in a separate PR; admin-merge is for one-off pre-existing rot, not systemic gaps |
+| `as_completed()` + `future.result()` for parallel subprocess wait | Standard concurrent.futures pattern | Blocks indefinitely when no future completes; main thread never checks shutdown flag | Use `wait(timeout=2.0, return_when=FIRST_COMPLETED)` to poll with interruptibility windows |
+| Gate debug CI instrumentation at step level with `if:` | Added `if: github.event_name == 'workflow_dispatch' && inputs.X` to each gdb step | Duplicates logic per job; cannot toggle env-var-driven behavior inside a step that always runs | Gate at job-level `env:` — the env var propagates to all steps including container exec |
+| Default debug gate to `true` for safety during libKGEN investigation | Kept default `true` so cores still captured during investigation | Every PR pays the gdb cost; defeats the opt-in purpose | Debug gates must be `default: false`; dispatch manually when cores needed |
+| Hypothesized root cause from the recipe internals without reading the failing log | Wrote a full plan blaming unpinned yamllint + a silent-no-op `yamllint configs/` | The recipe never ran — real error was `just: command not found` / exit 127, visible only in the per-step log; plan got NOGO grade D | ALWAYS `gh run view --job=<id> --log-failed` BEFORE forming a root-cause hypothesis |
+| Trusted the issue's claim that "no detailed error output is available via API" | Skipped log retrieval because the issue said the log was unavailable | `--log-failed` returned the exact error line; the issue author simply hadn't fetched it | Issue narration about missing logs is not authoritative — try `gh run view --log-failed` yourself |
+| Proposed a fix without checking if the failure was already resolved on main | Planned recipe changes for an already-green build job | PR #254 had already added the missing `Install just` step; latest main runs were all green | Before any CI fix: `git log -S` for the fix + `gh run list --branch main` to confirm current status |
+| Cited a verification tool not in the repo env | `pixi run check-jsonschema` in the verification block | `check-jsonschema` absent from `pixi.toml`; the schema-validation job installs it via pip, so the command would itself fail | Grep the dependency manifest before putting a tool in a verification command; mirror how the repo's own jobs invoke it |
+
+## Results & Parameters
+
+### OOM vs JIT Crash Classification
+
+| Signal | Bug | Action |
+| ------ | --- | ------ |
+| OOM keywords (`Killed`, `out of memory`, `virtual address`), no libKGEN trace | `modular#6433` not fixed | Revert the workaround removal |
+| `libKGENCompilerRTShared.so+0x<offset>` trace, no OOM | `modular#6413` (separate open bug) | Keep the change; file separate upstream bug |
+| All jobs green | Both workarounds unnecessary | Ship it |
+| Mixed OOM + libKGEN | `modular#6433` only partially fixed | Investigate before reverting |
+| Unknown signature | Neither pattern matches | Escalate; do not auto-revert or auto-ship |
+
+### Rate Limit Budget
+
+| Operation | Cost |
+| --------- | ---- |
+| `gh api rate_limit` | 1 call |
+| `gh pr list --json ...` (50 PRs) | 1 call (bulk — always prefer) |
+| `gh pr view <N> --json statusCheckRollup` | 1 call |
+| `gh run view <RUN_ID> --log-failed` | 2-5 calls |
+| `gh api /repos/.../actions/jobs/<ID>/logs` | 1+ calls (expensive; avoid in bulk) |
+
+Stop log fetching when `remaining < 500`; stop all non-essential calls when `remaining < 100`.
+
+### Subprocess Signal Fix Parameters
+
+```yaml
+poll_interval: 2.0            # seconds between shutdown checks
+wait_return_when: FIRST_COMPLETED
+future_result_timeout: 0      # done futures only, never blocks
+resume_event_timeout: 2.0     # worker pause poll interval
+```
+
+### GHA Coredump Capture — Required Config
+
+```yaml
+core_pattern: '/workspace/crash-bundle/cores/core.%p.%e.%t'  # container-side path
+suid_dumpable: 2
+ulimit_c: unlimited (set inside the same exec that runs the crashing process)
+upload-artifact.if-no-files-found: warn  # NOT ignore — missing artifact must be visible
+upload-artifact.retention-days: 14
+systemd-coredump: stopped      # must stop both systemd-coredump.socket and apport.service
+```
+
+Always emit metadata + symbols even when no cores exist (signals that capture ran vs capture broken).
+
+### Most Uncertain Assumptions (reviewer focus for the Odysseus #252 hardening proposal)
+
+These are unverified at plan time — flagged so a reviewer reuses the TRIAGE discipline (verified-local) without inheriting the unverified downstream fix as fact:
+
+- `yamllint >=1.35,<2` resolving on conda-forge `linux-64` is NOT yet run (gated behind `pixi install` with a `yamllint = "*"` fallback; resolution unconfirmed).
+- Removing the `pip install yamllint` CI step is safe ONLY if `pixi.lock` is correctly regenerated and committed; if the lock is not updated, `pixi run yamllint` hard-breaks the currently-green build job — a self-inflicted regression risk.
+- The local verification of `pixi run yamllint` used an ambient yamllint 1.38.0 from an unrelated active env (Hephaestus), NOT the Odysseus pixi env, so the "verified" tool behavior is partly ambient.
+
+### CPU Survey Table Format
+
+```text
+| Host     | CPU                           | Year | AVX2 | AVX-512 | Hypervisor | Result      |
+| -------- | ----------------------------- | ---- | ---- | ------- | ---------- | ----------- |
+| aeolus   | Intel i7-3820 Sandy Bridge-E  | 2012 | no   | no      | bare       | clean 50/50 |
+| titan    | Intel i5-4440 Haswell         | 2013 | yes  | no      | bare       | clean 50/50 |
+| GHA Azure| AMD EPYC 9V74 Zen 4           | -    | yes  | masked  | Hyper-V    | crash ~80%  |
+```
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| ProjectOdyssey | PRs #5363, #5364, #5378, #5380, #5382, #5399, #5406, #5407, #5411; modular/modular#6413 JIT crash investigation | Coredump capture, symbolication, cross-CPU survey, workflow_dispatch gate, required-context triage; verified-ci on multiple CI runs |
+| ProjectScylla | PR #1515 — E2E runner hang and signal handling | 6 signal/hang bugs fixed, 4924 tests pass, 77.74% coverage; verified-ci |
+| AchaeanFleet | Batch investigation of 13 open PRs, 2026-04-24 | Rate limit exhaustion observed; bulk endpoint patterns verified |
+| HomericIntelligence ecosystem | All 14 repos triaged, 2026-05-01; Mnemosyne 5 unrelated PRs with identical lint failure, 2026-05-18 | Broken-main pattern, transient-vs-reproducible triage, fix-at-root vs per-PR suppression |
+| Odysseus | Issue #252 ("validate-configs fails in CI, passes locally"), run 25217481782, 2026-06-20 | Step 0 triage discipline (verified-local): `--log-failed` surfaced `just: command not found`/exit 127; `git log -S "Install just"` + `gh run list --branch main` confirmed PR #254 had already fixed it. Downstream pixi-yamllint hardening is a proposal, not yet CI-verified. |
+
+## References
+
+- [ci-cd-triage-pr-vs-systemic-failures](ci-cd-triage-pr-vs-systemic-failures.md) — PR vs systemic failure separation (keep as example)
+- [pr-preexisting-failure-triage](pr-preexisting-failure-triage.md) — pre-existing failure triage (keep as example)
+- [extract-gha-container-image-cache-locally](extract-gha-container-image-cache-locally.md) — extract GHA cached container image for local reproduction
+- [ci-cd-summary-aggregator-job-skip-required-context](ci-cd-summary-aggregator-job-skip-required-context.md) — aggregator gate for whole-job skip required context
+- [mojo-jit-crash-retry](mojo-jit-crash-retry.md) — dynsym/objdump procedure for analysing captured cores
+````
+
+---
+
 # ci-failure-triage-and-diagnosis — History
 
 ## v1.1.0 (2026-06-20) — Add "read the failing log first" triage discipline

--- a/skills/ci-failure-triage-and-diagnosis.md
+++ b/skills/ci-failure-triage-and-diagnosis.md
@@ -3,475 +3,189 @@ name: ci-failure-triage-and-diagnosis
 description: "Canonical workflow for triaging CI failures: log analysis, core dump capture, subprocess hang diagnosis, container forensics, libKGEN/JIT crash retrieval, GHA-only vs cross-environment failures, PR-specific vs systemic failure separation. Use when: (1) a CI run failed and you need to identify the root cause, (2) deciding whether a failure is PR-induced or pre-existing, (3) capturing core dumps from container environments, (4) reproducing a GHA-only crash locally, (5) GraphQL/REST rate-limited CI monitoring."
 category: ci-cd
 date: 2026-06-20
-version: "1.1.0"
+version: "2.0.0"
+license: BSD-3-Clause
 user-invocable: false
 verification: verified-local
 history: ci-failure-triage-and-diagnosis.history
-tags: [merged, ci-failure, triage, log-analysis, core-dump, forensics, coredump, gdb, podman, mojo, libkgen, github-actions, rate-limit, subprocess, signal, avx-512, cpu-survey, workflow-dispatch]
+tags: [ci-failure, triage, log-analysis, core-dump, forensics, gdb, podman, mojo, libkgen, github-actions, rate-limit, subprocess, signal, cpu-survey, workflow-dispatch]
 ---
 
 # CI Failure Triage and Diagnosis
 
 ## Overview
 
-| Field | Value |
-| ------- | ------- |
-| **Date** | 2026-05-18 |
-| **Objective** | Consolidated canonical skill for triaging any CI failure: from identifying whether a failure is PR-induced or systemic, to capturing core dumps from containerized JIT crashes, diagnosing subprocess hangs, and reproducing GHA-only crashes across CPU fleets. |
-| **Outcome** | Operational — merged from 14 narrower skills covering the full CI-triage lifecycle. |
+Use evidence from the failing run to separate a PR regression, broken main, transient failure,
+missing required context, environment-specific crash, and hung subprocess. The workflow is
+`verified-local`; individual CI-confirmed cases and the unverified downstream hardening proposal
+are indexed in [the notes](ci-failure-triage-and-diagnosis.notes.md).
 
 ## When to Use
 
-- A CI run failed and you need to identify the root cause before deciding to revert, fix, or rerun
-- `mergeStateStatus: BLOCKED` with zero failing checks (required context never posted)
-- Multiple unrelated PRs failing on the same job at the same file/line — treat as broken-main, not per-PR
-- Core dumps are empty despite a known JIT crash inside a container (mount-namespace or signal-handler pitfall)
-- GHA-only crash suspected to be CPU-feature-sensitive (AVX-512, CPUID masking under Hyper-V)
-- E2E runner hangs at "Starting N tiers in parallel" and ignores Ctrl+C
-- GitHub API 403 rate-limit errors during batch CI diagnostic loops
-- Debug CI instrumentation (gdb, coredump capture) is slowing every PR run and you need an opt-in gate
-- pixi.lock stale across multiple PR branches
-- You are writing an implementation plan / fix for a reported CI failure and have NOT yet fetched the actual failing-step log — STOP and fetch it first (`gh run view --job=<id> --log-failed`) before forming any root-cause hypothesis
-- An issue reports a CI failure with a run ID/URL and says "no detailed error output available via API" — the per-step log IS still retrievable; the issue author simply did not fetch it
-- Before proposing any CI fix, you have not yet checked whether the reported failure was already resolved by a later commit/PR on main
+- A CI run failed, a report links a run but claims detailed logs are unavailable, or a proposed
+  fix was formed without reading `--log-failed`.
+- Several unrelated PRs fail in the same job/file, or main may already be broken.
+- A PR is `BLOCKED` with no failed check because a required context never posted.
+- A containerized JIT crash leaves no core, or a crash appears only on GitHub-hosted CPUs.
+- A parallel runner hangs, ignores shutdown, or corrupts the caller's terminal.
+- Diagnostic API loops approach rate limits, debug instrumentation should be opt-in, or a stale
+  lockfile failure needs a current-SHA rerun.
+
+Do not use a stale issue narrative as the source of truth. Reconcile the run's workflow snapshot,
+action versions, current main, and repository dependency declarations before proposing a fix.
 
 ## Verified Workflow
 
 ### Quick Reference
 
 ```bash
-# ── PHASE 0: BEFORE writing any plan/fix — read the ACTUAL failing log ──
-#    (verified-local against ProjectOdyssey run 25217481782, issue #252)
-# 0a. List jobs/steps; the failing step shows an X
+# Read the real failure before hypothesizing.
 gh run view <RUN_ID> --repo <org>/<repo>
-# 0b. Pull the ACTUAL failing-step log — works even when the issue claims "no output via API"
-gh run view --job=<JOB_ID> --repo <org>/<repo> --log-failed \
-  | grep -iE "command not found|exit code|error|traceback" | head
-# 0c. Note action VERSIONS in the failing log (e.g. setup-pixi@v0.8.1). A stale version
-#     proves the workflow changed since the run — the fix may already exist on main.
-# 0d. Check whether the fix already landed on main BEFORE proposing anything:
-git log -S "<the fix string, e.g. Install just>" --oneline -- .github/workflows/<file>
-gh run list --repo <org>/<repo> --workflow=<file> --branch main --limit 3 \
-  --json conclusion --jq '.[].conclusion'   # all "success" => already fixed; document, don't re-fix
-# exit 127 / "command not found" => the recipe NEVER RAN (missing tool/interpreter on PATH),
-# the failure is BEFORE the recipe body — not inside it.
+gh run view --job=<JOB_ID> --repo <org>/<repo> --log-failed
 
-# ── PHASE 1: Is main broken? Check BEFORE rebasing any downstream PR ──
-gh run list --branch main --limit 5 --json conclusion,status,name,createdAt
-# If "Build and Test" or "Static Analysis" show conclusion=failure → fix main FIRST
+# Check current main and whether the fix already landed.
+git log -S '<fix string>' --oneline -- .github/workflows/<workflow>
+gh run list --repo <org>/<repo> --workflow=<workflow> --branch main --limit 5 \
+  --json conclusion,status,name,createdAt
 
-# ── PHASE 2: Transient vs reproducible ──
-gh run rerun <run_id> --failed --repo HomericIntelligence/<repo>
-gh run watch <new_run_id> --repo HomericIntelligence/<repo>
-# Passes → transient, no action. Fails again → reproducible, file issue + PR.
+# Distinguish transient from reproducible failure.
+gh run rerun <RUN_ID> --failed --repo <org>/<repo>
+gh run watch <RUN_ID> --repo <org>/<repo>
 
-# ── PHASE 3: Identify root cause from log ──
-gh run view <run_id> --repo <org>/<repo> --log-failed 2>&1 | \
-  grep -E "::error|Error:|FAILED|Killed|out of memory|libKGEN" | head -20
-
-# ── PHASE 4: Classify OOM vs JIT crash (modular#6433 vs #6413) ──
-JOB_IDS=$(gh pr view <PR> --json statusCheckRollup | python3 -c "
-import sys, json
-for c in (json.load(sys.stdin).get('statusCheckRollup') or []):
-    if c.get('conclusion') == 'FAILURE':
-        print(c.get('detailsUrl','?').rsplit('/job/',1)[-1])")
-for id in $JOB_IDS; do
-  HITS=$(gh run view --job=$id --log 2>&1 \
-    | grep -iE "Killed|OOM-killer|out of memory|virtual address|mmap.*failed" \
-    | grep -vE "TCMalloc|echo|# " | head -3)
-  [ -n "$HITS" ] && echo "OOM (#6433 not fixed)" || \
-    gh run view --job=$id --log 2>&1 | grep -E "libKGENCompilerRTShared.so\+0x" | head -1
-done
-
-# ── PHASE 5: Same job failing on N unrelated PRs → broken-main lint ──
-git log --oneline -5 -- skills/<offending-file>.md   # when file landed on main
-gh pr diff <num> -- skills/<offending-file>.md        # empty → PR didn't touch it
-# YES → fix at root with one PR against main, rebase downstream after merge
-
-# ── PHASE 6: Required context never posted (BLOCKED, 0 FAILUREs) ──
-gh api "repos/<ORG>/<REPO>/branches/main/protection/required_status_checks" \
-  --jq '.contexts' > /tmp/required.json
-gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[].name]|unique' \
-  > /tmp/present.json
-comm -23 <(jq -r '.[]' /tmp/required.json | sort) \
-         <(jq -r '.[]' /tmp/present.json  | sort)
-# Output = required contexts that never posted = the blockers
-
-# ── PHASE 7: GitHub API rate limit budget ──
+# Budget batch diagnostics.
 gh api rate_limit --jq '.resources.core | "used:\(.used)/\(.limit) resets:\(.reset|todate)"'
-RESET=$(gh api rate_limit --jq '.resources.core.reset')
-DELAY=$(( RESET - $(date +%s) + 60 ))
-echo "Sleep ${DELAY}s until reset"
-
-# ── PHASE 8: Fix stale pixi.lock ──
-git checkout <branch>
-pixi install   # regenerates pixi.lock
-git add pixi.lock && git commit -m "chore: regenerate pixi.lock" && git push
-# Re-trigger if SHA mismatch (empty commits don't reliably trigger CI):
-gh run list --branch <branch> --json databaseId,conclusion \
-  --jq '.[]|select(.conclusion=="failure").databaseId' \
-  | xargs -I{} gh run rerun {} --repo <org>/<repo> --failed
 ```
 
-### Detailed Steps
+### 1. Establish the failing evidence
 
-#### Step 0 — Triage discipline: read the failing log before forming a hypothesis (verified-local)
+1. List the run, identify the failing job and step, then fetch that job's `--log-failed` output.
+2. Read the error literally. Exit 127 or `command not found` means the recipe may never have run;
+   first identify the missing interpreter, tool, or shell function.
+3. Record action versions from the run log. A different version on current main proves the run's
+   workflow snapshot is stale.
+4. Search current history for the suspected fix and inspect the latest main runs. If recent main
+   runs are green, document the already-landed fix instead of inventing another.
+5. Confirm every proposed verification command exists in the dependency manifest or is installed
+   by the same workflow step. Do not cite an unavailable `pixi run <tool>` command.
 
-When planning a fix for a *reported* CI failure (an issue links a run ID/URL), the FIRST action is to fetch the actual failing-step log — never hypothesize a root cause from the recipe's internals.
+The log retrieval and current-main checks were exercised locally. Any implementation inferred
+from them remains unverified until its own tests or CI run succeed.
 
-1. `gh run view <RUN_ID> --repo <org>/<repo>` to find the failing job ID (failing step shows an X).
-2. `gh run view --job=<JOB_ID> --repo <org>/<repo> --log-failed` to pull the exact error line. This works even when the issue says "no detailed error output available via API" — that narration is not authoritative; the author simply did not fetch it.
-3. Read the error literally:
-   - `command not found` / exit code **127** → the recipe/tool **never ran**; the runner lacked the interpreter or tool on PATH (e.g. `just: command not found` because the job had no "Install just" step). This is a whole class of "fails in CI, passes locally" failures that have nothing to do with the recipe body. "Passes locally + recipe exits 0 locally" is a strong signal the failure happened **before** the recipe body executed.
-4. Reconcile the failing run's workflow snapshot against current main. The failing log captures the action **versions** in effect at run time (e.g. `setup-pixi@v0.8.1`); if current main pins a newer version (`v0.9.6`), the workflow changed since the run and the fix may already exist.
-5. Check whether the failure was already resolved on main BEFORE proposing a fix:
-   - `git log -S "<fix string>" --oneline -- .github/workflows/<file>` to find the landing commit/PR.
-   - `gh run list --workflow=<file> --branch main --limit 3 --json conclusion --jq '.[].conclusion'` — all `success` ⇒ already fixed.
-   - An "investigate" issue can be legitimately resolved by DOCUMENTING that the failure is already fixed plus a minimal residual hardening — not by inventing a large fix.
-6. Any tool you cite in a `verification:` block must actually exist in the repo's env. Grep the dependency manifest first (`pixi.toml`, `pyproject.toml`) and mirror how the repo's own jobs invoke it — e.g. do not write `pixi run check-jsonschema` if `check-jsonschema` is installed via pip in the schema-validation job rather than declared in `pixi.toml`.
+### 2. Classify ownership and recurrence
 
-> Verification note: the triage commands in this step (`gh run view --log-failed`, `git log -S`, `gh run list --branch main`) are **verified-local** — run live against ProjectOdyssey run 25217481782 (issue #252) this session. The downstream Odysseus hardening they informed (sourcing yamllint from pixi) is a **proposal**, not yet applied or CI-verified.
+Check main before rebasing downstream branches. When unrelated PRs fail at the same job/file/line,
+confirm the file is on main and absent from each PR diff; fix main once, then rebase downstream.
+Do not scatter suppressions across the affected PRs. After force-updating a downstream branch,
+re-arm its auto-merge request because the force update clears it.
 
-#### Step 1 — Pre-flight: Is main broken?
+For a red run, rerun only failed jobs. A pass is evidence of a transient failure; a repeated,
+same-signature failure is reproducible. Empty commits are unreliable with concurrency
+deduplication; use `gh run rerun --failed`.
 
-Before rebasing any downstream PR, verify main is green:
+For `BLOCKED` with no failure, compare required and posted contexts:
 
 ```bash
-gh run list --branch main --limit 5 \
-  --json conclusion,status,name,createdAt \
-  --jq '.[] | "\(.name): \(.conclusion // .status)"'
+gh api repos/<org>/<repo>/branches/main/protection/required_status_checks \
+  --jq '.contexts[]' | sort > /tmp/required.txt
+gh pr view <PR> --repo <org>/<repo> --json statusCheckRollup \
+  --jq '.statusCheckRollup[].name' | sort -u > /tmp/present.txt
+comm -23 /tmp/required.txt /tmp/present.txt
 ```
 
-If "Build and Test", "Static Analysis", or "Code Coverage" show `failure`:
-1. Create `fix-ci-<symptom>-<date>` branch from `origin/main`
-2. Apply minimal fix
-3. Open PR with `gh pr merge <N> --auto --squash`
-4. After fix merges, rebase all downstream PRs and re-arm auto-merge (force-push clears it)
+A whole-job `if:` or excluding `paths:` filter can prevent a required context from posting. Keep
+the required job running and skip work at step level, or provide an aggregator that always posts.
 
-#### Step 2 — Identical failure across unrelated PRs
+### 3. Classify OOM and JIT crashes
 
-When N unrelated PRs all fail on the same job pointing to the same file/line:
+Exit code 137 is not decisive: both OOM and an in-process signal handler can produce it. Prefer
+log signatures:
 
-1. Same job failing on multiple unrelated PRs?
-2. `gh run view --job <id> --log-failed` points to the same file and line on every PR?
-3. Is that file on `main` and untouched by each PR's diff?
+| Signal | Disposition |
+| --- | --- |
+| `Killed`, OOM-killer, address-space or `mmap` failure without libKGEN | Treat as OOM |
+| `libKGENCompilerRTShared.so+0x...` without OOM evidence | Treat as a separate JIT crash |
+| Mixed or unknown signature | Escalate; neither auto-revert nor auto-ship |
 
-If all YES → fix at root. Do NOT add per-PR suppression comments — this is technical debt across N branches.
-
-#### Step 3 — Required context never posts (BLOCKED, 0 FAILUREs)
-
-Two mechanisms that block PRs with no failing checks:
-
-| Cause | Tell-tale | Fix |
-| ----- | --------- | --- |
-| Workflow `paths:` filter excludes PR | `gh run list --branch <branch> --workflow=<file>` shows no runs | Broaden `paths:` filter |
-| Whole-job `if:` skip on event type | Job shows `conclusion: skipped` in run view | Aggregator/summary gate |
-
-Key invariant: a whole-job `if:` skip shows as **missing** to branch protection, not success. A step-level skip inside a running job still posts success.
-
-#### Step 4 — Coredump capture in containerized CI
-
-When a JIT crash inside a Podman/Docker container produces an empty `cores/` directory:
-
-**Mount-namespace fix**: `core_pattern` is resolved in the crashing process's mount namespace, NOT the host's. Set it to the container-side path:
+If a container crash leaves an empty core directory, set `/proc/sys/kernel/core_pattern` to a path
+visible in the crashing process's mount namespace, such as the container-side bind mount:
 
 ```bash
-# WRONG — host CWD path, invisible inside container
-echo "$(pwd)/crash-bundle/cores/core.%p.%e.%t" | sudo tee /proc/sys/kernel/core_pattern
-
-# CORRECT — container-side bind-mount path
-echo "/workspace/crash-bundle/cores/core.%p.%e.%t" | sudo tee /proc/sys/kernel/core_pattern
+echo '/workspace/crash-bundle/cores/core.%p.%e.%t' \
+  | sudo tee /proc/sys/kernel/core_pattern
 ```
 
-**libKGEN signal-handler defeat**: When `ulimit -c unlimited` + `core_pattern` still produce no cores (libKGEN installs its own in-process SIGABRT/SIGILL handler that beats the kernel), run `mojo` under gdb:
+When a user-space libKGEN handler consumes SIGILL/SIGABRT before the kernel dumps, run the inferior
+through `pixi run -- gdb`, register `gdb.events.stop`, and accept only `gdb.SignalEvent`. Handle
+SIGILL, SIGABRT, SIGSEGV, SIGBUS, and SIGFPE; write `128 + signal` to a temporary exit file because
+`--return-child-result` is unreliable in batch mode. Symbolicate inside the container where both
+the binary and bind-mounted core paths resolve.
 
-```bash
-# scripts/mojo-under-gdb.sh <cores-dir> <mojo args...>
-#!/usr/bin/env bash
-set -euo pipefail
-CORES_DIR="${1:?}"; shift
-mkdir -p "$CORES_DIR"
-MOJO_BIN="$(pixi run -- bash -c 'command -v mojo')"
-EXIT_FILE="$(mktemp)"; trap 'rm -f "$EXIT_FILE"' EXIT
-GDB_PY=$(cat <<'PYEOF'
-import gdb, os
-signaled = False
-NAME_TO_NUM = {"SIGHUP":1,"SIGINT":2,"SIGILL":4,"SIGABRT":6,"SIGBUS":7,
-               "SIGFPE":8,"SIGKILL":9,"SIGSEGV":11,"SIGTERM":15}
-def on_stop(ev):
-    global signaled
-    if isinstance(ev, gdb.SignalEvent):
-        signo = NAME_TO_NUM.get(ev.stop_signal, 6)
-        gdb.execute(f"generate-core-file {os.environ['CORES_DIR']}/core.{gdb.selected_inferior().pid}")
-        with open(os.environ["EXIT_FILE"], "w") as f: f.write(str(128 + signo))
-        signaled = True
-def on_exit(ev):
-    if not signaled:
-        code = ev.exit_code if ev.exit_code is not None else 0
-        with open(os.environ["EXIT_FILE"], "w") as f: f.write(str(code))
-gdb.events.stop.connect(on_stop)
-gdb.events.exited.connect(on_exit)
-PYEOF
-)
-export CORES_DIR EXIT_FILE
-set +e
-pixi run -- gdb -batch -nx \
-  -ex "python\n$GDB_PY" \
-  -ex "set pagination off" \
-  -ex "handle SIGILL SIGSEGV SIGABRT SIGBUS SIGFPE stop nopass" \
-  -ex "run $*" "$MOJO_BIN"
-set -e
-cat "$EXIT_FILE" 2>/dev/null | { read -r rc; exit "${rc:-1}"; }
-```
+For a GitHub-hosted-only SIGILL, compare repeated runs across CPU families and record model name,
+CPUID flags, image digest, iteration count, and exit-code histogram. Do not conclude that missing
+AVX-512 flags alone are causal: virtualization may mask CPUID while code generation uses another
+CPU identity signal.
 
-**Key rules**:
-- Always run gdb **through** `pixi run -- gdb` (inherits `MODULAR_HOME` and stdlib paths)
-- Use Python `gdb.events.stop` filtered to `SignalEvent`, NOT `hook-stop` (fires on exit-stop in gdb 15.1)
-- Write exit code to a file; `--return-child-result` is unreliable in `-batch` mode
-- Handle SIGILL in addition to SIGABRT/SIGSEGV — Mojo `os.abort()` lowers to `llvm.trap` → SIGILL
+### 4. Make expensive diagnostics opt-in
 
-**Symbolication must run inside the container**:
+Gate gdb/core capture behind a boolean `workflow_dispatch` input with `default: false`. Set the
+derived switch at job-level so every relevant step sees it, and guard against inputs on other
+events:
 
 ```yaml
-- name: Symbolicate cores (disasm + registers around $pc)
-  if: inputs.phase == 'collect' && always()
-  shell: bash
-  run: |
-    mkdir -p crash-bundle/symbolicated
-    shopt -s nullglob
-    CORES=( crash-bundle/cores/core.* crash-bundle/cores/core.gdb.* )
-    shopt -u nullglob
-    [ ${#CORES[@]} -eq 0 ] && exit 0
-    for core in "${CORES[@]}"; do
-      base=$(basename "$core")
-      c_core="/workspace/crash-bundle/cores/$base"
-      out="crash-bundle/symbolicated/${base}.symbolicated.log"
-      podman compose exec -T <service> bash <<HEREDOC > "$out" 2>&1 || true
-    MOJO_BIN=\$(pixi run which mojo 2>/dev/null | tail -1)
-    pixi run gdb -batch -ex "set pagination off" \
-      -ex "thread apply 1 bt 25" \
-      -ex "info all-registers" \
-      -ex "disassemble \\\$pc - 64, \\\$pc + 64" \
-      "\$MOJO_BIN" "${c_core}" 2>&1 | head -400
-HEREDOC
-    done
+env:
+  MOJO_TEST_UNDER_GDB: >-
+    ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
 ```
 
-#### Step 5 — GHA-only crash: cross-CPU survey
-
-When a crash reproduces only on GHA runners (suspected CPU-feature mismatch):
+Trigger it explicitly with:
 
 ```bash
-TARGETS="host1 host2 host3 host4 host5"
-JUMPHOST=host2
-rsync -avz --partial container-image-*/dev.tar "${JUMPHOST}:~/dev.tar"
-for host in $TARGETS; do
-  [ "$host" = "$JUMPHOST" ] && continue
-  ssh "$JUMPHOST" "scp ~/dev.tar ${host}:~/dev.tar" &
-done; wait
-for host in $TARGETS; do
-  ssh "$JUMPHOST" "ssh $host '
-    grep -m1 \"model name\" /proc/cpuinfo
-    grep -o -E \"avx2|avx512[a-z]*\" /proc/cpuinfo | sort -u | tr \"\n\" \" \"; echo
-    podman load -i ~/dev.tar >/dev/null
-    for i in \$(seq 1 50); do
-      podman run --rm --userns=keep-id -v \"\$(pwd):/workspace:Z\" -w /workspace \
-        <image>:dev bash -c \"pixi run mojo run repro/REPRO.mojo >/dev/null 2>&1; echo exit=\$?\"
-    done | sort | uniq -c
-  '"
-done | tee survey-results.log
+gh workflow run <workflow>.yml -f enable_gdb_cores=true --ref <branch>
 ```
 
-Note: On GHA Azure runners, silicon is AMD EPYC Zen 4 (native AVX-512) but Hyper-V **masks** AVX-512 CPUID bits. LLVM may emit AVX-512 based on CPU-name fingerprinting, not CPUID probing, causing SIGILL on hardware that reports no AVX-512 capability.
+### 5. Keep subprocess orchestration interruptible
 
-#### Step 6 — Gate debug instrumentation behind workflow_dispatch
+Replace indefinite completion waits with `wait(pending, timeout=2.0,
+return_when=FIRST_COMPLETED)`, checking the shutdown event after every timeout. A completed future
+may use `future.result(timeout=0)`. Poll `proc.communicate(timeout=2.0)` and subtract from the total
+timeout; on shutdown, kill the process group and raise the shutdown exception.
 
-When always-on debug instrumentation (gdb wrapper, coredump capture) slows every PR run:
+Use `stdin=subprocess.DEVNULL` for noninteractive children. Restore the terminal only when stdin is
+a TTY. Never register SIGTSTP as an ordinary graceful-shutdown signal, and never call
+`threading.Event.wait()` without a timeout in the coordinator.
 
-```yaml
-on:
-  workflow_dispatch:
-    inputs:
-      enable_gdb_cores:
-        description: 'Capture gdb core dumps for libKGEN JIT crashes'
-        required: false
-        default: false
-        type: boolean
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+### 6. Preserve API and rerun budgets
 
-jobs:
-  test:
-    env:
-      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
-    steps:
-      - run: just test-mojo  # reads MOJO_TEST_UNDER_GDB internally
-```
-
-```bash
-# Manually trigger with gdb capture enabled
-gh workflow run comprehensive-tests.yml -f enable_gdb_cores=true --ref <branch>
-```
-
-Rules: always `default: false` (opt-in); always combine `github.event_name == 'workflow_dispatch'` with `inputs.X`; place at job-level `env:`, not step-level.
-
-#### Step 7 — Subprocess hang and signal fixes
-
-When a Python test runner hangs at "Starting N tiers in parallel" or ignores Ctrl+C:
-
-```python
-# Replace blocking as_completed() + future.result() with poll loop
-from concurrent.futures import FIRST_COMPLETED, wait
-
-pending = set(futures.keys())
-while pending:
-    if is_shutdown_requested():
-        for f in pending: f.cancel()
-        raise ShutdownInterruptedError("Shutdown during parallel execution")
-    done, pending = wait(pending, timeout=2.0, return_when=FIRST_COMPLETED)
-    for future in done:
-        result = future.result(timeout=0)  # already done, no block
-
-# Replace proc.communicate(timeout=3600) with polling helper
-def _communicate_with_shutdown_check(proc, timeout, ctx):
-    poll_interval = 2.0
-    remaining = float(timeout)
-    while True:
-        try:
-            return proc.communicate(timeout=poll_interval)
-        except subprocess.TimeoutExpired:
-            remaining -= poll_interval
-            if remaining <= 0: raise
-            if is_shutdown_requested():
-                _kill_process_group(proc)
-                raise ShutdownInterruptedError() from None
-```
-
-```python
-# Prevent terminal corruption from subprocess inheriting stdin
-result = subprocess.run(cmd, stdout=log_file, stderr=subprocess.STDOUT,
-                        stdin=subprocess.DEVNULL, text=True, check=False)
-
-# Restore terminal on exit
-def _restore_terminal():
-    if sys.stdin.isatty():
-        try: subprocess.run(["stty", "sane"], stdin=sys.stdin, check=False)
-        except Exception: pass
-```
-
-Key invariants:
-- `as_completed()` + `future.result()` blocks indefinitely — always use `wait(timeout=N)`
-- `communicate(timeout=N)` does NOT consume partial output on `TimeoutExpired` — safe to loop
-- `threading.Event.wait()` without timeout blocks forever — always add a timeout
-- SIGTSTP is job-control — don't register it alongside graceful shutdown handlers
+Prefer one `gh pr list --json ...` over a per-PR `gh pr view` loop. Stop bulk log retrieval below
+500 remaining core calls and stop nonessential API use below 100. For a stale lockfile, regenerate
+with the repository package manager, commit the lockfile, push, then rerun the failed run tied to
+the current head SHA.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
-| `core_pattern` set to host runner CWD | `echo "$(pwd)/crash-bundle/cores/core.%p.%e.%t" \| sudo tee /proc/sys/kernel/core_pattern` | Crashing PID runs inside `podman compose exec` where host path doesn't exist; kernel silently writes nothing | `core_pattern` paths resolve in the crashing PID's mount namespace — use the container-side bind-mount path |
-| Bare `ulimit -c unlimited` + `core_pattern` for Mojo crashes | Standard recipe applied to Mojo JIT crashes | `libKGENCompilerRTShared.so` installs an in-process SIGABRT/SIGILL handler; user-space handler beats the kernel, calls `_exit()`, kernel never dumps | Run `mojo` under `gdb` (ptrace intercepts signals before delivery to user-space handlers) |
-| `gdb $(which mojo)` outside `pixi run` | Bare gdb invocation to avoid pixi overhead | Mojo errors with `unable to locate module 'std'` before it can crash — `MODULAR_HOME` and stdlib paths unset | Always launch gdb through `pixi run -- gdb` so inferior inherits the activated pixi env |
-| `hook-stop` + `generate-core-file` in gdb | Standard gdb idiom for "dump on signal stop" | In gdb 15.1, `hook-stop` fires on the synthetic "Inferior exited normally" stop; `generate-core-file` errors `You can't do that without a process to debug` on every clean-exit test | Use Python `gdb.events.stop` filtered to `isinstance(event, gdb.SignalEvent)` — exit-stop is an `ExitedEvent` and is harmlessly ignored |
-| `--return-child-result` in gdb batch mode | Documented gdb flag for exit-code propagation | In gdb 15.1 `-batch`, returns `0` even when inferior died on a handled signal | Write exit code to a temp file from Python event handlers; read it after gdb exits |
-| Handle only SIGABRT and SIGSEGV in gdb wrapper | Assumed those were the only fatal signals | Mojo `os.abort()` lowers to `llvm.trap` → SIGILL on Linux, not SIGABRT | Always include SIGILL (+ SIGBUS, SIGFPE) in the handled-signal set for any Mojo wrapper |
-| Host-side gdb for symbolication | Resolved mojo path via `podman compose exec which mojo`, then ran gdb on host | Container-side path unresolvable on host → "Could not resolve mojo binary — skipping" | Symbolication must run inside the container alongside the binary and the bind-mounted cores |
-| `apt-get install gdb` on runner to unblock host-side symbolication | Pre-install gdb on host image | Mojo binary path still container-side; solving tool availability doesn't fix namespace mismatch | The bottleneck is mount-namespace alignment, not gdb availability |
-| Treating all JIT failures as `modular#6433` (OOM) | Assumed 7 red jobs on a fix-verification PR meant #6433 unfixed | Failures were `modular#6413` (separate pre-existing bug); reverting would have lost a valid cleanup | Read log signatures literally: OOM keywords = #6433; `libKGENCompilerRTShared.so+0x` = #6413 |
-| Using exit code 137 to classify OOM vs JIT crash | Assumed `137` == SIGKILL == OOM-killer | libKGEN crashes also exit 137 via in-process signal handler | Combine exit code with log signature — the log signature beats the exit code |
-| Trusting CPUID flags as ground truth for GHA-only crash | Hypothesis: "any non-AVX-512 CPU triggers it" | All 6 surveyed non-AVX-512 Intel CPUs ran clean; GHA Azure runner crashes 80% | Hyper-V on AMD Zen 4 masks AVX-512 CPUID bits while LLVM may still emit AVX-512 based on CPU-name fingerprinting |
-| Per-PR `gh pr view` loop for batch investigation | Called `gh pr view <N>` for each of 13 PRs sequentially | 13 API calls instead of 1 | Use `gh pr list --json` to get all PR statuses at once; check rate limit (`gh api rate_limit`) before batch ops |
-| Empty commits to re-trigger CI | `git commit --allow-empty -m "ci: re-trigger"` | Workflows with `concurrency: cancel-in-progress: true` deduplicate same SHA | Use `gh run rerun --failed` instead |
-| Filing issues without first re-running CI | Filed issues immediately after observing a red run | Some failures were transient (network, timing); issue was unnecessary | Always re-run the failing job first; only file if the new run also fails |
-| Admin-merge to bypass missing required context | Skipped required check via admin for one PR | Leaves every future PR that touches the same files permanently BLOCKED | Fix the workflow misconfig in a separate PR; admin-merge is for one-off pre-existing rot, not systemic gaps |
-| `as_completed()` + `future.result()` for parallel subprocess wait | Standard concurrent.futures pattern | Blocks indefinitely when no future completes; main thread never checks shutdown flag | Use `wait(timeout=2.0, return_when=FIRST_COMPLETED)` to poll with interruptibility windows |
-| Gate debug CI instrumentation at step level with `if:` | Added `if: github.event_name == 'workflow_dispatch' && inputs.X` to each gdb step | Duplicates logic per job; cannot toggle env-var-driven behavior inside a step that always runs | Gate at job-level `env:` — the env var propagates to all steps including container exec |
-| Default debug gate to `true` for safety during libKGEN investigation | Kept default `true` so cores still captured during investigation | Every PR pays the gdb cost; defeats the opt-in purpose | Debug gates must be `default: false`; dispatch manually when cores needed |
-| Hypothesized root cause from the recipe internals without reading the failing log | Wrote a full plan blaming unpinned yamllint + a silent-no-op `yamllint configs/` | The recipe never ran — real error was `just: command not found` / exit 127, visible only in the per-step log; plan got NOGO grade D | ALWAYS `gh run view --job=<id> --log-failed` BEFORE forming a root-cause hypothesis |
-| Trusted the issue's claim that "no detailed error output is available via API" | Skipped log retrieval because the issue said the log was unavailable | `--log-failed` returned the exact error line; the issue author simply hadn't fetched it | Issue narration about missing logs is not authoritative — try `gh run view --log-failed` yourself |
-| Proposed a fix without checking if the failure was already resolved on main | Planned recipe changes for an already-green build job | PR #254 had already added the missing `Install just` step; latest main runs were all green | Before any CI fix: `git log -S` for the fix + `gh run list --branch main` to confirm current status |
-| Cited a verification tool not in the repo env | `pixi run check-jsonschema` in the verification block | `check-jsonschema` absent from `pixi.toml`; the schema-validation job installs it via pip, so the command would itself fail | Grep the dependency manifest before putting a tool in a verification command; mirror how the repo's own jobs invoke it |
+| --- | --- | --- | --- |
+| Hypothesis before log retrieval | Diagnosed workflow internals from an issue narrative | The failing recipe never ran; `--log-failed` showed exit 127 | Fetch the failing job log first |
+| Host-path core capture | Put the runner CWD in `core_pattern` | The path did not exist in the crashing container namespace | Use the container-visible bind path |
+| Bare gdb and `hook-stop` | Ran host gdb and dumped on every stop | Environment paths were absent and exit-stop is not a live signal stop | Use `pixi run -- gdb` plus `SignalEvent` |
+| Exit 137 as OOM proof | Classified every 137 as OOM | A JIT signal handler produced the same code | Combine exit code with log signatures |
+| Per-PR suppression | Patched identical failures on each branch | The defective file came from main | Fix main once, then rebase |
+| Blocking futures | Used `as_completed()` and unbounded waits | Shutdown could not be observed while nothing completed | Poll at two-second intervals |
+| Always-on debug capture | Defaulted gdb collection to true | Every PR paid the diagnostic cost | Use an opt-in dispatch input |
 
 ## Results & Parameters
 
-### OOM vs JIT Crash Classification
+| Parameter | Recommended value or rule |
+| --- | --- |
+| Failing evidence | `gh run view --job=<JOB_ID> --log-failed` before diagnosis |
+| Recurrence | One failed-job rerun; repeated same signature is reproducible |
+| Shutdown poll interval | `2.0` seconds |
+| gdb signals | SIGILL, SIGABRT, SIGSEGV, SIGBUS, SIGFPE |
+| Debug input | Boolean, `default: false`, dispatch-only |
+| API reserve | Stop bulk logs below 500; nonessential calls below 100 |
+| CPU survey | Same image/reproducer, repeated runs, model/flags/exit histogram |
 
-| Signal | Bug | Action |
-| ------ | --- | ------ |
-| OOM keywords (`Killed`, `out of memory`, `virtual address`), no libKGEN trace | `modular#6433` not fixed | Revert the workaround removal |
-| `libKGENCompilerRTShared.so+0x<offset>` trace, no OOM | `modular#6413` (separate open bug) | Keep the change; file separate upstream bug |
-| All jobs green | Both workarounds unnecessary | Ship it |
-| Mixed OOM + libKGEN | `modular#6433` only partially fixed | Investigate before reverting |
-| Unknown signature | Neither pattern matches | Escalate; do not auto-revert or auto-ship |
+## Companions
 
-### Rate Limit Budget
-
-| Operation | Cost |
-| --------- | ---- |
-| `gh api rate_limit` | 1 call |
-| `gh pr list --json ...` (50 PRs) | 1 call (bulk — always prefer) |
-| `gh pr view <N> --json statusCheckRollup` | 1 call |
-| `gh run view <RUN_ID> --log-failed` | 2-5 calls |
-| `gh api /repos/.../actions/jobs/<ID>/logs` | 1+ calls (expensive; avoid in bulk) |
-
-Stop log fetching when `remaining < 500`; stop all non-essential calls when `remaining < 100`.
-
-### Subprocess Signal Fix Parameters
-
-```yaml
-poll_interval: 2.0            # seconds between shutdown checks
-wait_return_when: FIRST_COMPLETED
-future_result_timeout: 0      # done futures only, never blocks
-resume_event_timeout: 2.0     # worker pause poll interval
-```
-
-### GHA Coredump Capture — Required Config
-
-```yaml
-core_pattern: '/workspace/crash-bundle/cores/core.%p.%e.%t'  # container-side path
-suid_dumpable: 2
-ulimit_c: unlimited (set inside the same exec that runs the crashing process)
-upload-artifact.if-no-files-found: warn  # NOT ignore — missing artifact must be visible
-upload-artifact.retention-days: 14
-systemd-coredump: stopped      # must stop both systemd-coredump.socket and apport.service
-```
-
-Always emit metadata + symbols even when no cores exist (signals that capture ran vs capture broken).
-
-### Most Uncertain Assumptions (reviewer focus for the Odysseus #252 hardening proposal)
-
-These are unverified at plan time — flagged so a reviewer reuses the TRIAGE discipline (verified-local) without inheriting the unverified downstream fix as fact:
-
-- `yamllint >=1.35,<2` resolving on conda-forge `linux-64` is NOT yet run (gated behind `pixi install` with a `yamllint = "*"` fallback; resolution unconfirmed).
-- Removing the `pip install yamllint` CI step is safe ONLY if `pixi.lock` is correctly regenerated and committed; if the lock is not updated, `pixi run yamllint` hard-breaks the currently-green build job — a self-inflicted regression risk.
-- The local verification of `pixi run yamllint` used an ambient yamllint 1.38.0 from an unrelated active env (Hephaestus), NOT the Odysseus pixi env, so the "verified" tool behavior is partly ambient.
-
-### CPU Survey Table Format
-
-```text
-| Host     | CPU                           | Year | AVX2 | AVX-512 | Hypervisor | Result      |
-| -------- | ----------------------------- | ---- | ---- | ------- | ---------- | ----------- |
-| aeolus   | Intel i7-3820 Sandy Bridge-E  | 2012 | no   | no      | bare       | clean 50/50 |
-| titan    | Intel i5-4440 Haswell         | 2013 | yes  | no      | bare       | clean 50/50 |
-| GHA Azure| AMD EPYC 9V74 Zen 4           | -    | yes  | masked  | Hyper-V    | crash ~80%  |
-```
-
-## Verified On
-
-| Project | Context | Details |
-| --------- | --------- | --------- |
-| ProjectOdyssey | PRs #5363, #5364, #5378, #5380, #5382, #5399, #5406, #5407, #5411; modular/modular#6413 JIT crash investigation | Coredump capture, symbolication, cross-CPU survey, workflow_dispatch gate, required-context triage; verified-ci on multiple CI runs |
-| ProjectScylla | PR #1515 — E2E runner hang and signal handling | 6 signal/hang bugs fixed, 4924 tests pass, 77.74% coverage; verified-ci |
-| AchaeanFleet | Batch investigation of 13 open PRs, 2026-04-24 | Rate limit exhaustion observed; bulk endpoint patterns verified |
-| HomericIntelligence ecosystem | All 14 repos triaged, 2026-05-01; Mnemosyne 5 unrelated PRs with identical lint failure, 2026-05-18 | Broken-main pattern, transient-vs-reproducible triage, fix-at-root vs per-PR suppression |
-| Odysseus | Issue #252 ("validate-configs fails in CI, passes locally"), run 25217481782, 2026-06-20 | Step 0 triage discipline (verified-local): `--log-failed` surfaced `just: command not found`/exit 127; `git log -S "Install just"` + `gh run list --branch main` confirmed PR #254 had already fixed it. Downstream pixi-yamllint hardening is a proposal, not yet CI-verified. |
-
-## References
-
-- [ci-cd-triage-pr-vs-systemic-failures](ci-cd-triage-pr-vs-systemic-failures.md) — PR vs systemic failure separation (keep as example)
-- [pr-preexisting-failure-triage](pr-preexisting-failure-triage.md) — pre-existing failure triage (keep as example)
-- [extract-gha-container-image-cache-locally](extract-gha-container-image-cache-locally.md) — extract GHA cached container image for local reproduction
-- [ci-cd-summary-aggregator-job-skip-required-context](ci-cd-summary-aggregator-job-skip-required-context.md) — aggregator gate for whole-job skip required context
-- [mojo-jit-crash-retry](mojo-jit-crash-retry.md) — dynsym/objdump procedure for analysing captured cores
+- [Case evidence and detailed verification](ci-failure-triage-and-diagnosis.notes.md)
+- [Version history and superseded content](ci-failure-triage-and-diagnosis.history)

--- a/skills/ci-failure-triage-and-diagnosis.notes.md
+++ b/skills/ci-failure-triage-and-diagnosis.notes.md
@@ -1,0 +1,57 @@
+# CI Failure Triage and Diagnosis — Notes
+
+Supporting case evidence for the canonical
+[`ci-failure-triage-and-diagnosis`](ci-failure-triage-and-diagnosis.md) skill. The exact
+30,593-byte v1.1.0 main is archived once in
+[`ci-failure-triage-and-diagnosis.history`](ci-failure-triage-and-diagnosis.history), with
+SHA-256 `dbfeed396bb4cb23d547fc0d9077a6e5756b9f71b820cda2b4e2ee6acd83e592`.
+
+## Case Index
+
+| Case | Source | Verification status | Reusable result |
+| --- | --- | --- | --- |
+| Read the actual failing log before planning | [ProjectOdyssey issue #252](https://github.com/HomericIntelligence/ProjectOdyssey/issues/252) | verified-local | `--log-failed` exposed exit 127 before the recipe body |
+| Confirm an already-landed workflow fix | [ProjectOdyssey PR #254](https://github.com/HomericIntelligence/ProjectOdyssey/pull/254) | verified-local against later main runs | Search the fix string and inspect current-main runs before replanning |
+| Container/JIT core capture and symbolication | [ProjectOdyssey PR #5380](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5380) | verified-ci | Use a container-visible core path and symbolicate beside the binary |
+| Separate OOM from the libKGEN crash | [modular issue #6413](https://github.com/modular/modular/issues/6413) and [ProjectOdyssey PR #5381](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5381) | verified-ci | Log signature outranks exit code 137 |
+| Opt-in gdb capture and required-context triage | [ProjectOdyssey PR #5411](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5411) | verified-ci | Dispatch-only diagnostics avoid taxing every PR while keeping the gate visible |
+| Interruptible E2E subprocess runner | [ProjectScylla PR #1515](https://github.com/HomericIntelligence/ProjectScylla/pull/1515) | verified-ci | Poll futures/processes every two seconds and isolate stdin/process groups |
+| Cross-CPU survey | [Immutable v1.1.0 source](https://github.com/HomericIntelligence/Mnemosyne/blob/10e28497993009cc221cb991e1ee183e6117eda8/skills/ci-failure-triage-and-diagnosis.md) | verified-local survey; causal interpretation not proved | Hold image/reproducer constant and record CPU model, flags, iterations, and exits |
+| Proposed pixi/yamllint hardening | [ProjectOdyssey issue #252](https://github.com/HomericIntelligence/ProjectOdyssey/issues/252) | unverified proposal | Do not upgrade a planning suggestion to verified behavior |
+
+## Detailed Case Notes
+
+### ProjectOdyssey issue #252
+
+The issue described configuration validation as failing in CI while passing locally and suggested
+that detailed output was unavailable. Direct job-log retrieval showed `just: command not found`, so
+the recipe never ran. The workflow version in the old run and a `git log -S "Install just"` search
+then identified PR #254; subsequent main runs were green. The general lesson is evidence ordering,
+not the project-specific command name.
+
+### Containerized libKGEN failures
+
+The investigation separated three boundaries that can otherwise be conflated:
+
+- the host controls `core_pattern`, but its path is resolved in the crashing process namespace;
+- an in-process signal handler can suppress kernel dumping, requiring ptrace interception;
+- the executable and core must be symbolicated in a namespace where both paths exist.
+
+The CI cases validated SIGILL handling, an exit-code side channel from gdb event callbacks, and
+container-side symbolication. Exact scripts and workflow fragments remain available in the archived
+v1.1.0 snapshot.
+
+### CPU survey boundary
+
+Six surveyed non-AVX-512 Intel hosts ran clean while the hosted environment remained flaky. That
+observation rejected the simple “no AVX-512 always crashes” hypothesis; it did not prove the
+virtualization/CPU-name mechanism. Treat the latter as a focused hypothesis requiring additional
+compiler/runtime evidence.
+
+## Verification Checklist
+
+- Preserve the run ID, job ID, failing step, exact signature, action versions, and head SHA.
+- Mark reruns as transient or reproducible only after comparing the same signature.
+- For cores, record host/container paths, signal, debugger version, inferior exit, and artifact.
+- For CPU surveys, pin image digest and reproducer and report all iterations, including successes.
+- Keep proposals labeled unverified until their own implementation and CI evidence exist.

--- a/skills/docstring-api-doc-generation-and-comment-hygiene.history
+++ b/skills/docstring-api-doc-generation-and-comment-hygiene.history
@@ -1,3 +1,588 @@
+## v2.0.0 (2026-08-20) — Compact oversized retrievable skill
+
+**Issue:** [#3335](https://github.com/HomericIntelligence/Mnemosyne/issues/3335)
+
+**Immutable batch base:** `10e28497993009cc221cb991e1ee183e6117eda8`
+
+**Version:** v1.2.0 -> v2.0.0
+
+**Retrievable bytes:** 30,530 -> 10,391
+
+**Superseded snapshot SHA-256:** `b61f3ef3127af173828449a3513260b8efed6c30ab964e7974b8d03488776379`
+
+### Compaction and verification
+
+The retrievable main was compacted to its decision-changing triggers, commands, parameters, failed approaches, and evidence boundaries. Project-specific cases and detailed verification moved to the linked notes companion. The base main below was archived byte-for-byte and SHA-256 checked; the complete pre-existing history follows this entry unchanged. Repository validation, Markdown lint, scoped hooks, and the semantic audit are recorded in the batch PR.
+
+### Full snapshot of superseded v1.2.0 retrievable content
+
+````markdown
+---
+name: docstring-api-doc-generation-and-comment-hygiene
+description: "Use when: (1) updating, fixing, or extending docstrings and API documentation in source files to match current implementation semantics — changed signatures, memory semantics, orphaned fragments, undocumented methods; (2) creating API reference documentation from docstrings for a public module interface; (3) generating docstrings for undocumented functions and classes; (4) auditing and cleaning up inline NOTE/TODO/FIXME/placeholder comments — normalization, removal of shipped-feature placeholders, magic-number extraction; (5) using a package's public __version__ attribute in demo/example scripts rather than hardcoded strings, so version references stay in sync with releases."
+category: documentation
+date: 2026-06-07
+version: "1.2.0"
+user-invocable: false
+history: docstring-api-doc-generation-and-comment-hygiene.history
+tags:
+  - docstring
+  - api-docs
+  - docstring-generation
+  - comment-hygiene
+  - note-cleanup
+  - comment-normalization
+  - placeholder
+  - todo
+  - copy-vs-view
+  - module-docstring
+  - error-handling-contract
+  - POLA
+  - version-management
+  - demo-scripts
+  - mojo
+  - python
+---
+
+## Overview
+
+| Attribute | Value |
+| ----------- | ------- |
+| **Skill Name** | docstring-api-doc-generation-and-comment-hygiene |
+| **Category** | documentation |
+| **Languages** | Mojo, Python, Markdown |
+| **PR Type** | docs-only (no functional change) |
+| **Risk** | Very low — docstring/comment prose only |
+| **Verification** | verified-ci |
+
+This skill consolidates the full lifecycle of source-level documentation hygiene:
+authoring and updating docstrings, generating API reference docs from those docstrings,
+cleaning up inline NOTE/TODO/FIXME/placeholder comments, and keeping version references in
+demo scripts dynamic. All changes are docs-only and carry near-zero functional risk.
+
+## When to Use
+
+1. A function signature changed and the module docstring example still shows the old call
+   (omits a required argument, references a removed helper, etc.)
+2. Memory semantics (copy vs view, `_is_view` flag) are mislabeled in docstrings or
+   inconsistent across sibling methods (`slice()`, `__getitem__(Slice)`, `__getitem__(*slices)`)
+3. Inline `# NOTE` or `# Note:` comments in `__init__` files need to be promoted to proper
+   module docstring `Note:` sections
+4. A utility function (subprocess wrapper, file I/O helper) has an undocumented error-handling
+   contract — it silently swallows exceptions and returns a special value (e.g., `(False, "")`)
+   instead of raising, violating the Principle of Least Astonishment (POLA)
+5. Module docstrings have orphaned lowercase continuation fragments, or a new trait-implementing
+   dunder method (`__hash__`, `__eq__`) is undocumented
+6. You need to create API reference documentation (HTML/Markdown) from docstrings for a public
+   module interface
+7. Undocumented functions and classes need docstrings written in a standard format (Google,
+   NumPy, reStructuredText)
+8. A cleanup issue targets `# NOTE:`/`# TODO:`/`# FIXME:`/placeholder markers for normalization,
+   removal, magic-number extraction, or issue-reference tracing
+9. Runtime `print("NOTE: ...")` statements confuse users into thinking something is broken
+10. A demo/example script contains a hardcoded version string that should be the package's
+    public `__version__` so example code stays in sync with releases
+11. A behavior-change PR fixed a function's docstring but the module-level summary block
+    (e.g., a `FAILS LOUDLY` / `FAILS WITH` / `RAISES` / `CONTRACT` block at the top of the
+    module) was not updated — they diverged and now give contradictory information to readers
+    who only read the module header
+
+## Verified Workflow
+
+### Quick Reference
+
+| Step | Action | Tool |
+| ------ | -------- | ------ |
+| 1 | Read the issue and locate target files | `gh issue view`, `Glob`, `Grep` |
+| 2 | Read ALL sibling methods / related files before writing | `Read`, `Grep -C 10` |
+| 3 | Classify the change type (docstring update / API gen / comment cleanup / version) | — |
+| 4 | Apply targeted `Edit` with unique `old_string` anchors | `Edit` |
+| 5 | Verify (`py_compile`, script smoke-run, or grep audit) | `Bash` |
+| 6 | Run pre-commit; stage only modified files | `Bash` |
+| 7 | Commit with `docs(scope):` / `cleanup(scope):` prefix, push, open PR, auto-merge | `Bash`, `gh` |
+
+| Cleanup Scenario | Detection Pattern | Action |
+| -------- | ----------------- | ------ |
+| Runtime NOTE print | `print.*NOTE\|print.*Note:` in examples/ | Reword to plain factual text; remove prefix |
+| Mixed casing | `# Note:` in shared/ files | Normalize to `# NOTE:` |
+| Unlinked workaround NOTE | `# NOTE:` without `#[0-9]{4,}` | Add `(#NNNN)` to marker |
+| Inverted canonical order | `# NOTE (Mojo vX.Y, #NNNN):` | Swap to `# NOTE(#NNNN, Mojo vX.Y):` |
+| TODO-style NOTE | future-tense prose ("could be added") | Convert to `# TODO:` |
+| Magic-number NOTE | `# NOTE: epsilon=` | Extract to named module-level constant |
+| Shipped-feature placeholder | `aliases to.*until.*supports` | Verify shipped, then remove stale comment |
+| No-op placeholder test | `pass  # Placeholder`, zero assertions | Remove function and its `main()` call |
+| Generator TODO in template string | `# TODO:` inside Python string literal | Replace with `# TEMPLATE:` |
+| New catalog MODULE section | `## SUMMARY TABLE:` in catalog.md | Insert before it; update all 4 header stats atomically |
+| Test-file Float16 NOTE | `# NOTE: Float16` in `tests/**/*.mojo` | Classify expected-vs-bug; `=`-underline header for expected |
+
+### Detailed Steps
+
+#### A. Generating docstrings for undocumented code
+
+1. **Analyze the function**: understand purpose, parameters, and return value before writing.
+2. **Choose a format** (Google recommended; NumPy or reStructuredText also acceptable). Be
+   consistent across the module.
+3. Write a one-line summary, then `Args:`, `Returns:`, `Raises:`, and an `Example:` block.
+
+```python
+# Google-style docstring format
+def matrix_multiply(a: ExTensor, b: ExTensor) -> ExTensor:
+    """Multiply two matrices using optimized Mojo kernels.
+
+    Args:
+        a: First matrix (shape: m x n)
+        b: Second matrix (shape: n x k)
+
+    Returns:
+        Product matrix (shape: m x k)
+
+    Raises:
+        ValueError: If matrix dimensions don't align for multiplication
+
+    Example:
+        ```mojo
+        >>> a = ExTensor([[1, 2], [3, 4]], DType.float32)
+        >>> b = ExTensor([[1, 0], [0, 1]], DType.float32)
+        >>> c = matrix_multiply(a, b)
+        ```
+    """
+    ...
+```
+
+#### B. Generating API reference documentation from docstrings
+
+1. **Ensure docstrings**: verify all public functions/classes have docstrings.
+2. **Validate format**: confirm a consistent docstring style (Google, NumPy, or reST).
+3. **Extract metadata**: parse signatures, parameter types, return types.
+4. **Generate**: produce HTML or Markdown API reference.
+5. **Validate output**: verify links work and examples are correct.
+
+```bash
+# Python with pdoc
+pdoc --html module_name -o docs/
+
+# Python with Sphinx
+sphinx-quickstart docs/
+make -C docs html
+
+# Quick docstring extraction
+python3 -c "import module; help(module.function)"
+```
+
+API doc output should include: module overview, signatures with type hints, parameter docs
+(type/description/default), return docs, raises/exceptions, code examples, and cross-references.
+
+#### C. Updating docstrings to match current implementation
+
+**Stale example after signature change:** grep the current signature
+(`grep "fn function_name" path -C 5`), verify every required parameter (no default) is passed,
+then edit the docstring example to show all required imports and arguments.
+
+**Copy vs view semantics:** run `grep -n "fn slice\|fn __getitem__\|_is_view" <file>`, read ALL
+sibling methods together, classify each (true view / copy-with-view-flag / independent copy),
+and update only the docstring. Use precise language ("zero-copy view", "pointer offset",
+"independent copy"). For struct-level docs, insert a Memory Semantics ASCII table between
+`Attributes:` and `Examples:` (Mojo-parser safe). Scalar overloads need an explicit N/A note.
+
+**Promoting inline NOTE to docstring Note:** grep `# NOTE` in `__init__` files, read each fully
+to check whether a `Note:` section already exists, then add/expand. Preferred section order:
+`Modules:` → `Note:` → `Example:` (place `Note:` BEFORE `Example:`).
+
+**Silent error-handling contracts (POLA):** when a utility function swallows exceptions and
+returns a special value, add an explicit `Note:` section **immediately after the summary,
+before `Args:`** documenting both the success shape and every failure shape.
+
+```python
+def run_command(cmd: str, timeout: int = 60) -> tuple[bool, str]:
+    """Run a command and return stdout if successful.
+
+    Note:
+        This function has a silent error-handling contract:
+        - On success (exit code 0): returns `(True, <stdout>)`
+        - On non-zero exit / timeout / OSError: returns `(False, "")` — empty
+          string, NOT stderr; no exception raised.
+        All exceptions (TimeoutError, CalledProcessError, OSError) are swallowed.
+        Use :func:`get_command_path` to verify availability first if early
+        failure is preferred over a silent `(False, "")`.
+
+    Args:
+        cmd: Shell command to execute (must exist in PATH)
+        timeout: Execution timeout in seconds (default 60)
+
+    Returns:
+        Tuple `(success, output)`:
+        - `(True, stdout)` when exit code == 0
+        - `(False, "")` when exit code != 0, timeout, or OSError
+    """
+```
+
+After editing, confirm existing tests exercise the documented contract (e.g.,
+`test_run_command_timeout()` asserts the `(False, "")` shape).
+
+**Module docstring line-wrap audit:** an orphaned fragment is a line inside a module-level
+docstring that starts with a lowercase coordinating conjunction and does not grammatically
+continue the prior line. Delete those; keep legitimate sentence wraps.
+
+```bash
+grep -rn '^[a-z]' <package>/**/__init__.py <package>/**/runner.py
+```
+
+**Placeholder docstrings:** verify test/implementation exists, then replace
+"Placeholder…require implementation" with "implemented and passing".
+
+**Dunder / trait method docs:** grep with `-C 10`, update the method docstring (trait name,
+algorithm note, expanded `Example:`), and update the package listing entry (append
+`(ExTensor, implements Hashable via __hash__)`). Do NOT add dunders to the import list — they
+are trait implementations, not importable symbols.
+
+#### D. Backward-pass catalog / dev-guide edits
+
+A backward-pass catalog (`backward-pass-catalog.md`) or dev guide (`testing-strategy.md`) often
+needs a new module section, formula block, or "Known Test Gotchas" subsection. These are
+structured docs — placement and atomic stat updates matter.
+
+1. Read the full target file first (use `Grep -C` / `offset`+`limit` if it exceeds the read
+   token limit).
+2. For a new MODULE section, insert it **before** `## SUMMARY TABLE:` — not at end of file —
+   so the catalog stays organized by module ahead of the summary.
+3. Update **all 4 header stat lines atomically** in one `Edit` call (total backward-function
+   count, broadcasting fraction, stability fraction, module count). Updating the total without
+   the fractions leaves the denominators wrong.
+4. For a "Known Test Gotchas" entry, insert between `## Gradient Checking` and
+   `## Layer Deduplication`; include Symptom, Root cause, Mathematical Proof sub-section, Safe
+   Alternatives, Rule, and Discovery context with PR/issue reference.
+5. Use ` ```text ` (not ` ```mojo `) for mathematical formulas and pseudocode.
+
+**Float16 accumulation in dev guides:** insert a `### Float16 Convolution Limitations`
+subsection between `### Parameters` and `### Example` under Gradient Checking. The accumulation
+error scales as `n × ε_machine`:
+
+```text
+Accumulation error ≈ n × ε_machine
+  where n = kernel_area × input_channels, ε_machine ≈ 9.77e-4 (Float16)
+```
+
+Float16 safe accumulations (tolerance `1e-1`): `n < ~100` (precisely ~102). Production
+convolutional layers exceed this for most kernels — supply per-layer `n` values (LeNet-5
+Conv2: `n=150`; AlexNet Conv1: `n=363`). See the Float16 Accumulation Reference table in
+Results & Parameters for the full per-layer breakdown.
+
+#### E. Test-file docstring documentation (Float16 NOTE review)
+
+Distinct from dev-guide subsection insertion (section D): this targets **test file docstring
+headers** when an issue asks to review and document Float16 precision NOTEs scattered across
+test files.
+
+1. **Assess each NOTE first** — classify every `# NOTE: Float16 ...` comment:
+   - **Expected limitation** (large-kernel accumulations, insufficient mantissa bits for
+     epsilon perturbations) → document in the test file header docstring.
+   - **Bug candidate** (unexpected NaN/Inf in small kernels, run-to-run inconsistency) → open
+     a separate tracking issue; do NOT silently document it as if expected.
+2. Explain the mixed-precision context: real training computes convolutions in **FP32 for
+   numerical stability** while storing activations/weights in **FP16 for memory efficiency**.
+   Tests that "use FP32 compute" faithfully model this — they are not working around Float16
+   failures. Float16's ~3.3 decimal digit precision (~11-bit mantissa) is insufficient for
+   large-kernel accumulations (K² × C_in > ~100–200) and finite-difference gradient checking.
+3. Write the section with the `=` underline heading style (not `###`) so it renders in IDE doc
+   viewers and Mojo parsers:
+
+```text
+Float16 Precision Limitations
+==============================
+<Layer/operation> accumulates <N> multiplications per output element.
+Float16's ~3.3 decimal digit precision (~11-bit mantissa) is insufficient
+for <large kernel accumulations / finite-difference epsilon / etc.>.
+
+This is an expected, fundamental limitation of Float16 arithmetic (not a bug).
+In practice, mixed-precision training computes in FP32 while storing in FP16
+for memory efficiency — tests using "FP32 compute" faithfully model this.
+See issue #<tracking-issue> for detailed analysis.
+```
+
+4. Commit with the `docs(tests):` prefix and a per-file list in the body:
+
+```text
+docs(tests): document Float16 precision limitations in test headers
+
+Add Float16 Precision Limitations sections to test file docstrings for:
+- tests/models/test_X.mojo: <brief explanation>
+- tests/shared/core/test_Y.mojo: <brief explanation>
+
+All limitations reference issue #NNNN for detailed analysis.
+
+Closes #<issue>
+```
+
+#### F. Inline comment / NOTE cleanup
+
+1. **Discovery** — always grep before editing (issue plans go stale):
+
+```bash
+grep -rn "# NOTE" <scope>/ --include="*.mojo"
+grep -rn 'print.*NOTE\|print.*TODO\|print.*FIXME\|print.*Note:' examples/ --include="*.mojo" -i
+grep -rn "# NOTE:" --include="*.mojo" . | grep -v "#[0-9]\{4,\}"   # untracked workarounds
+grep -rn "aliases to.*until\|Will use.*when available" . --include="*.mojo"  # shipped-feature
+grep -rn "# TODO:" scripts/generators/ --include="*.py"            # generator template TODOs
+```
+
+2. **Categorize** each marker in context (decision tree): runtime print → plain status text;
+   magic-number used 2+ places → named module constant; docstring NOTE → strip prefix to prose;
+   shipped-feature placeholder → confirm landed then remove; no-op placeholder test → remove;
+   generator TODO in template string → `# TEMPLATE:`; bare workaround NOTE → add `(#NNNN)`;
+   non-canonical format → normalize to `# NOTE(#NNNN, Mojo vX.Y):`.
+
+   **Always keep**: FP16/SIMD compiler-limitation notes, epsilon/tolerance justifications with
+   issue refs, active Track/Phase blocker notes, Mojo language-limitation notes (`no __all__`).
+
+3. **Apply edits** with `Edit` (`replace_all: false` for unique strings). Examples:
+
+```mojo
+# Normalize casing
+old: # Note: This comment explains the workaround.
+new: # NOTE: This comment explains the workaround.
+
+# Convert runtime NOTE print to plain status
+old: print("Note: Training requires batch_norm2d_backward implementation.")
+new: print("Training requires batch_norm2d_backward (see GAP_ANALYSIS.md).")
+
+# Extract magic-number NOTE to module-level constant
+old: # NOTE: epsilon=3e-4 for float32 prevents precision loss in matmul (see #2704)
+     var epsilon = 3e-4 if dtype == DType.float32 else 1e-3
+new: alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4  # see #2704
+     var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else 1e-3
+```
+
+4. **Verify** — re-run the discovery greps and confirm zero remaining hits for the targeted
+   categories.
+
+#### G. Dynamic version from package attribute in demo scripts
+
+Demo/example scripts should consume the version the same way users should — by importing the
+package's public `__version__`, not hardcoding a string or calling `importlib.metadata` directly.
+
+```python
+#!/usr/bin/env python3
+"""Demo script showing how to use the package."""
+
+from mypackage import __version__   # replaces: VERSION = "0.7.1"
+
+print(f"Using mypackage version {__version__}")
+```
+
+Steps: (1) find demo scripts (`find scripts/ -name "*example*" -o -name "*demo*"`); (2) confirm
+the package `__init__.py` exports `__version__` (typically
+`__version__ = importlib.metadata.version("<dist>")`); (3) replace the hardcoded string with the
+import; (4) smoke-run `python3 scripts/example_usage.py` to verify the real version prints. For a
+one-line literal swap with no test suite, smoke-run verification is sufficient — no unit test
+needed.
+
+### Commit and PR Conventions
+
+```bash
+# docstring/doc updates
+git commit -m "docs(scope): <what was documented>
+
+<One sentence: why — what implicit behaviour is now explicit.>
+
+Closes #<issue>"
+
+# comment cleanup
+git commit -m "cleanup(scope): normalize inline NOTE/TODO/placeholder comments
+
+<markers linked, casing normalized, stale removed, etc.>
+
+Closes #<issue>"
+
+gh pr create --title "docs(scope): ..." --body "Closes #<issue>"
+gh pr merge --auto --rebase <pr-number>
+```
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Guessing signatures from memory | Wrote a function signature/docstring example without reading source | Line numbers and parameter names were wrong | Always read the actual source — grep for the signature, then Read the docstring |
+| Copying old docstring example verbatim | Kept stale example after a signature change | Did not demonstrate the new required argument | Grep the actual signature; check every parameter with no default value |
+| Treating all slice methods as identical | Assumed `__getitem__(Slice)` was a view like `slice()` | The 1D `__getitem__(Slice)` always copies | Read ALL sibling implementations before writing docstrings |
+| Fixing implementation instead of docstring | Considered changing `__getitem__(*slices)` to a pointer offset | Multi-dim slices are non-contiguous; needs stride metadata | Decide whether the bug is in the docs or the code first |
+| Adding `Note:` after `Example:` | Placed `Note:` section after the `Example:` block | Wrong order for module docstrings | Place `Note:` before `Example:` |
+| Expanding `Note:` without reading first | Started editing an `__init__` that already had a `Note:` | Would have created a duplicate | Read the full file before adding/expanding a section |
+| Documenting only the success return | Wrote `Returns: (bool, str)` without the failure shape | Callers unsure what `(False, "")` means | Document BOTH success `(True, stdout)` AND every failure `(False, "")` shape |
+| Placing the error contract in a trailing Note: | Put the swallow-exception contract at the end of the docstring | Callers read `Returns:` first and miss it; POLA still violated | Place `Note:` immediately after the summary, before `Args:` |
+| Trying to add `__hash__` to the import list | Considered re-exporting a dunder as a symbol | Dunders are trait implementations, not importable | Document dunders via docstrings/comments, not import lists |
+| Trusting issue-plan line numbers | Edited at the plan's line numbers directly | Files were partially fixed; numbers had shifted | Always grep to discover the actual state — plans go stale |
+| Case-sensitive grep only | Used `print.*NOTE` without `-i` | Missed mixed-case `Note:` variants | Use case-insensitive grep or include all case variants |
+| Linking all NOTEs | Added issue refs to informational NOTEs too | Created unnecessary issue noise | Only link NOTEs describing temporary workarounds or blocked features |
+| Creating new issues without searching | Opened a tracking issue per group immediately | Would have duplicated existing cleanup issues | `gh issue list --search` before creating |
+| Editing main-repo file from a worktree session | Edited `/repo/...` instead of the worktree copy | File is tracked by `main`, not the feature branch | Always edit the worktree path |
+| Use `importlib.metadata.version()` directly in demo | `print(version("MyPackage"))` in the demo | Teaches users to bypass the package's public interface | Demo code should import the package and use `__version__` |
+| Keep hardcoded version, bump manually | `VERSION = "0.7.1"` updated each release PR | Doesn't scale; demo lags real version; teaches hardcoding | Never hardcode versions in demos; use `__version__` |
+| Replace version with literal `"__version__"` placeholder | `VERSION = "__version__"` | Output shows the literal string, not a number | Replace with the actual imported `__version__` attribute |
+| Using `just pre-commit-all` | Ran `just` for pre-commit | `just` not on PATH | Use `pixi run pre-commit run --all-files` |
+| Running markdownlint via `pixi run npx` | `pixi run npx markdownlint-cli2 ...` | `npx: command not found` | Rely on pre-commit hooks instead |
+| Staging with `git add -A` | Added all untracked files | Picked up `__pycache__/` | Stage specific files for docs-only changes |
+| API doc / docstring gen treated as a one-shot | Assumed the direct approach always works | For greenfield docstrings the direct approach IS straightforward; the risk is skipping the read-first step | The pattern is simple, but still read existing code/docstrings before generating |
+| Re-adding an issue ref to an already-linked NOTE | Appended `(#NNNN)` to a multi-line NOTE block | The `#NNNN` already appeared elsewhere in the same NOTE block — it was already linked | If `#NNNN` appears anywhere in a multi-line NOTE block, it is already linked — don't re-add |
+| Skipping the issue-plan comment | Started editing straight from the issue title | The issue-plan comment had a pre-computed disposition table for each marker | Read the issue-plan comment first — it often has a ready disposition table |
+| Reading a full source file with `Read` | Attempted `Read` on a large file (e.g., `extensor.mojo`) | File exceeds the 25K token limit; the read fails | Use `Grep -C` for targeted context or `offset`+`limit` for specific line ranges |
+| Renaming a test fn without updating call sites | Renamed `test_slice_is_view` but left the `main()` call | Would cause a compile error — the old name is still referenced | Grep ALL call sites incl `main()` when renaming a test function |
+| Updating the header total without the fractions | Bumped the total backward-function count only | Broadcasting and stability fractions kept the old (wrong) denominator | Update all 4 header stat lines atomically in one Edit |
+| Inserting a MODULE section after the summary table | Appended the new module at end of catalog | Breaks reading flow — catalog is organized by module before the summary | Always insert a new MODULE section before `## SUMMARY TABLE:` |
+| Silently documenting a bug-candidate NOTE | Wrote an "expected limitation" header for a suspicious NaN NOTE | Buried a real bug as if it were by-design | Classify each NOTE expected-vs-bug; open a tracking issue for bug candidates |
+| Trusting issue body's variable name | Issue body cited `STATIC_FALLBACK_LICENSES`; nearly edited code searching for that symbol | Real symbol on disk was `FALLBACK_LICENSES`; issue body had a stale name from an earlier draft | Always grep for the actual symbol name before editing — issue descriptions can reference pre-refactor names |
+
+## Results & Parameters
+
+### Key Docstring Patterns
+
+**Copy-returning vs view-returning slice methods:**
+
+```mojo
+fn __getitem__(self, slice: Slice) raises -> Self:
+    """Get slice of 1D tensor [start:end].
+
+    Returns:
+        New tensor containing a **copy** of the sliced data (`_is_view = False`).
+    Notes:
+        Always copies regardless of step. For zero-copy extraction use `slice()`.
+    """
+
+fn slice(self, start: Int, end: Int, axis: Int = 0) raises -> ExTensor:
+    """Extract a slice along the specified axis.
+
+    Returns:
+        A new tensor **view** sharing memory with the original (`_is_view = True`).
+    Notes:
+        Data pointer is offset into the original buffer; refcount incremented.
+    """
+```
+
+**Memory Semantics table (ASCII, Mojo-safe):**
+
+```text
+Memory Semantics:
+    +----------------------------+----------+---------------------+---------------------------+
+    | Method                     | Returns  | _is_view            | Memory                    |
+    +----------------------------+----------+---------------------+---------------------------+
+    | slice(start, end, axis)    | ExTensor | True  (view)        | Shared — zero-copy        |
+    | __getitem__(Slice)         | ExTensor | False (copy)        | Independent — data copied |
+    | __getitem__(*slices)       | ExTensor | False (copy)        | Independent — data copied |
+    | __getitem__(Int)           | Float32  | N/A (scalar result) | Scalar value, not tensor  |
+    +----------------------------+----------+---------------------+---------------------------+
+```
+
+**`__init__.mojo` re-export Note: template:**
+
+```mojo
+Note:
+    Mojo v0.26.1+ automatically exports all imported symbols to package consumers.
+    No ``__all__`` equivalent is needed. Callers may import directly from the parent:
+
+    ```mojo
+    from <package> import <Symbol1>, <Symbol2>
+    ```
+```
+
+**Placeholder update pattern:**
+
+```text
+# BEFORE: Placeholder import tests in tests/.../test_imports.mojo require implementation.
+# AFTER:  Import tests in tests/.../test_imports.mojo are implemented and passing.
+```
+
+### Canonical NOTE Format Reference (Mojo)
+
+```mojo
+# Plain limitation (no issue ref):
+# NOTE (Mojo v0.26.1): <description>
+
+# Limitation with issue reference (issue number FIRST):
+# NOTE(#NNNN, Mojo v0.26.1): <description>
+# Track resolution via #<parent>. Implement when <condition>.
+
+# Wrong (fix by swapping):  # NOTE (Mojo v0.26.1, #3076): ...
+# Wrong (append version):   # NOTE(#3076): ...
+# Wrong (TODO disguised):   # NOTE: X could be added  →  # TODO: Add X if needed
+```
+
+### Gradient-Check / Tolerance Constants (cleanup reference)
+
+| Constant | Value | Use Case |
+| -------- | ----- | -------- |
+| `GRADIENT_CHECK_EPSILON_FLOAT32` | `3e-4` | float32 matmul-heavy layers (conv2d, linear) |
+| `GRADIENT_CHECK_EPSILON_OTHER` | `1e-3` | Non-float32 dtypes (BF16, FP16) |
+
+| Layer | Tolerance | Rationale |
+| ----- | --------- | --------- |
+| Conv2d / BatchNorm backward | `1e-1` (10%) | Accumulated matmul / normalization errors |
+| Linear backward | `0.10` wide + `0.01` abs | Matrix-op accumulated errors (#2704) |
+| Activation backward | `1e-2` float32, `1e-1` other | Elementwise, less accumulation |
+
+### Float16 Accumulation Reference Table
+
+Accumulation error ≈ `n × ε_machine`, where `n = kernel_area × input_channels` and Float16
+machine epsilon ≈ `9.77e-4`. Safe accumulations (tol=`1e-1`): `n < ~102`.
+
+| Layer | Formula | n | Float16 error | Exceeds tol 1e-1? |
+| ------- | --------- | --- | -------------- | ------------------- |
+| LeNet-5 Conv1 | 5² × 1 | 25 | ~2.4e-2 | Borderline |
+| LeNet-5 Conv2 | 5² × 6 | 150 | ~1.5e-1 | Yes |
+| AlexNet Conv1 | 11² × 3 | 363 | ~3.5e-1 | Yes |
+| AlexNet Conv2 | 5² × 64 | 1,600 | ~1.6 | Yes |
+| AlexNet Conv3 | 3² × 192 | 1,728 | ~1.7 | Yes |
+
+### Dynamic Version Pattern
+
+| Aspect | Details |
+| ------ | ------- |
+| Import | `from <package> import __version__` at top of demo script |
+| Definition | `__init__.py` sets `__version__ = importlib.metadata.version("<dist>")` |
+| Synchronization | Automatic — reflects each released git tag |
+| Verification | Smoke-run the script; expect the actual installed version printed |
+
+### Module-Level vs Function-Level Docstring Drift
+
+When a behavior-change PR fixes a function's docstring, the module-level summary block
+(common patterns: `FAILS LOUDLY`, `FAILS WITH`, `RAISES`, `CONTRACT`, `NOTE:`) is NOT
+automatically updated. These blocks are maintained independently and can diverge after a PR.
+
+**Detection grep:**
+
+```bash
+grep -n "FAILS LOUDLY\|FAILS WITH\|CONTRACT\|RAISES\|NOTE:" <file> | head -10
+```
+
+If the function docstring describes a path that does not appear in the module summary block,
+add the missing bullet. The module summary is what readers see first and must stay in sync
+with the function-level contract.
+
+**Scope of change:** module summary block only — no functional code change, docs-only PR.
+
+### Validation Commands
+
+```bash
+python3 -m py_compile scripts/<script>.py            # Python syntax
+python3 scripts/example_usage.py                     # demo smoke-run
+SKIP=mojo-format pixi run pre-commit run --files <f> # Mojo (skip mojo-format if GLIBC < 2.34)
+pixi run pre-commit run --all-files                  # full pre-commit
+grep -rn '^[a-z]' <package>/**/__init__.py           # orphaned-fragment audit
+```
+
+`mojo-format` may be skipped locally on hosts with GLIBC < 2.34; it passes in CI Docker. All
+other hooks (ruff, markdownlint, trailing-whitespace, end-of-file-fixer, check-yaml) must pass.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| ProjectOdyssey | Copy/view, catalog, fp16, re-export docstring updates | see history |
+| ProjectScylla | Issue #1364, PR #1397 (module docstring line-wrap audit) | see history |
+| ProjectHephaestus | Issue #797 (run_command POLA contract); Issue #787 (demo `__version__`); Issue #1306 (module-level FAILS LOUDLY block drift after #1303 added fallback path) | see history |
+| Multiple repos | NOTE/TODO/FIXME inline-comment cleanup passes | see history |
+````
+
+---
+
 <!-- markdownlint-disable MD024 -->
 
 # History: docstring-api-doc-generation-and-comment-hygiene

--- a/skills/docstring-api-doc-generation-and-comment-hygiene.md
+++ b/skills/docstring-api-doc-generation-and-comment-hygiene.md
@@ -3,560 +3,188 @@ name: docstring-api-doc-generation-and-comment-hygiene
 description: "Use when: (1) updating, fixing, or extending docstrings and API documentation in source files to match current implementation semantics — changed signatures, memory semantics, orphaned fragments, undocumented methods; (2) creating API reference documentation from docstrings for a public module interface; (3) generating docstrings for undocumented functions and classes; (4) auditing and cleaning up inline NOTE/TODO/FIXME/placeholder comments — normalization, removal of shipped-feature placeholders, magic-number extraction; (5) using a package's public __version__ attribute in demo/example scripts rather than hardcoded strings, so version references stay in sync with releases."
 category: documentation
 date: 2026-06-07
-version: "1.2.0"
+version: "2.0.0"
+license: BSD-3-Clause
 user-invocable: false
+verification: mixed
 history: docstring-api-doc-generation-and-comment-hygiene.history
-tags:
-  - docstring
-  - api-docs
-  - docstring-generation
-  - comment-hygiene
-  - note-cleanup
-  - comment-normalization
-  - placeholder
-  - todo
-  - copy-vs-view
-  - module-docstring
-  - error-handling-contract
-  - POLA
-  - version-management
-  - demo-scripts
-  - mojo
-  - python
+tags: [docstring, api-docs, comment-hygiene, note-cleanup, placeholder, copy-vs-view, module-docstring, error-handling-contract, version-management, mojo, python]
 ---
+
+# Docstring, API Documentation, and Comment Hygiene
 
 ## Overview
 
-| Attribute | Value |
-| ----------- | ------- |
-| **Skill Name** | docstring-api-doc-generation-and-comment-hygiene |
-| **Category** | documentation |
-| **Languages** | Mojo, Python, Markdown |
-| **PR Type** | docs-only (no functional change) |
-| **Risk** | Very low — docstring/comment prose only |
-| **Verification** | verified-ci |
-
-This skill consolidates the full lifecycle of source-level documentation hygiene:
-authoring and updating docstrings, generating API reference docs from those docstrings,
-cleaning up inline NOTE/TODO/FIXME/placeholder comments, and keeping version references in
-demo scripts dynamic. All changes are docs-only and carry near-zero functional risk.
+Keep public documentation synchronized with executable behavior. This includes authoring missing
+docstrings, generating API references from the public surface, correcting copy/view and error
+contracts, maintaining catalogs, and removing misleading inline comments. Evidence is mixed: the
+case index in [the notes](docstring-api-doc-generation-and-comment-hygiene.notes.md) distinguishes
+CI-verified, locally verified, and historical-only material.
 
 ## When to Use
 
-1. A function signature changed and the module docstring example still shows the old call
-   (omits a required argument, references a removed helper, etc.)
-2. Memory semantics (copy vs view, `_is_view` flag) are mislabeled in docstrings or
-   inconsistent across sibling methods (`slice()`, `__getitem__(Slice)`, `__getitem__(*slices)`)
-3. Inline `# NOTE` or `# Note:` comments in `__init__` files need to be promoted to proper
-   module docstring `Note:` sections
-4. A utility function (subprocess wrapper, file I/O helper) has an undocumented error-handling
-   contract — it silently swallows exceptions and returns a special value (e.g., `(False, "")`)
-   instead of raising, violating the Principle of Least Astonishment (POLA)
-5. Module docstrings have orphaned lowercase continuation fragments, or a new trait-implementing
-   dunder method (`__hash__`, `__eq__`) is undocumented
-6. You need to create API reference documentation (HTML/Markdown) from docstrings for a public
-   module interface
-7. Undocumented functions and classes need docstrings written in a standard format (Google,
-   NumPy, reStructuredText)
-8. A cleanup issue targets `# NOTE:`/`# TODO:`/`# FIXME:`/placeholder markers for normalization,
-   removal, magic-number extraction, or issue-reference tracing
-9. Runtime `print("NOTE: ...")` statements confuse users into thinking something is broken
-10. A demo/example script contains a hardcoded version string that should be the package's
-    public `__version__` so example code stays in sync with releases
-11. A behavior-change PR fixed a function's docstring but the module-level summary block
-    (e.g., a `FAILS LOUDLY` / `FAILS WITH` / `RAISES` / `CONTRACT` block at the top of the
-    module) was not updated — they diverged and now give contradictory information to readers
-    who only read the module header
+- Public or private functions/classes lack docstrings, a signature changed, or an example still
+  names a removed parameter or helper.
+- A module needs generated API reference pages based on its exported interface.
+- Copy versus view behavior, ownership/refcount behavior, mutation, exceptions, or special failure
+  return shapes are missing or contradicted across sibling methods.
+- A module summary and function docstring disagree, or an `__init__` docstring has orphaned text,
+  stale re-export guidance, or an undocumented trait/dunder method.
+- A developer guide/catalog needs a module section, formula, limitations, or synchronized counts.
+- `NOTE`, `TODO`, `FIXME`, placeholder, or magic-number comments may be obsolete or malformed.
+- A demo prints a hard-coded package version instead of importing the public `__version__`.
+
+Do not use this workflow to change runtime behavior while calling the change documentation-only.
+If the implementation is wrong or the comment exposes a likely bug, open or link the defect and
+keep the documentation honest about the current behavior.
 
 ## Verified Workflow
 
 ### Quick Reference
 
-| Step | Action | Tool |
-| ------ | -------- | ------ |
-| 1 | Read the issue and locate target files | `gh issue view`, `Glob`, `Grep` |
-| 2 | Read ALL sibling methods / related files before writing | `Read`, `Grep -C 10` |
-| 3 | Classify the change type (docstring update / API gen / comment cleanup / version) | — |
-| 4 | Apply targeted `Edit` with unique `old_string` anchors | `Edit` |
-| 5 | Verify (`py_compile`, script smoke-run, or grep audit) | `Bash` |
-| 6 | Run pre-commit; stage only modified files | `Bash` |
-| 7 | Commit with `docs(scope):` / `cleanup(scope):` prefix, push, open PR, auto-merge | `Bash`, `gh` |
-
-| Cleanup Scenario | Detection Pattern | Action |
-| -------- | ----------------- | ------ |
-| Runtime NOTE print | `print.*NOTE\|print.*Note:` in examples/ | Reword to plain factual text; remove prefix |
-| Mixed casing | `# Note:` in shared/ files | Normalize to `# NOTE:` |
-| Unlinked workaround NOTE | `# NOTE:` without `#[0-9]{4,}` | Add `(#NNNN)` to marker |
-| Inverted canonical order | `# NOTE (Mojo vX.Y, #NNNN):` | Swap to `# NOTE(#NNNN, Mojo vX.Y):` |
-| TODO-style NOTE | future-tense prose ("could be added") | Convert to `# TODO:` |
-| Magic-number NOTE | `# NOTE: epsilon=` | Extract to named module-level constant |
-| Shipped-feature placeholder | `aliases to.*until.*supports` | Verify shipped, then remove stale comment |
-| No-op placeholder test | `pass  # Placeholder`, zero assertions | Remove function and its `main()` call |
-| Generator TODO in template string | `# TODO:` inside Python string literal | Replace with `# TEMPLATE:` |
-| New catalog MODULE section | `## SUMMARY TABLE:` in catalog.md | Insert before it; update all 4 header stats atomically |
-| Test-file Float16 NOTE | `# NOTE: Float16` in `tests/**/*.mojo` | Classify expected-vs-bug; `=`-underline header for expected |
-
-### Detailed Steps
-
-#### A. Generating docstrings for undocumented code
-
-1. **Analyze the function**: understand purpose, parameters, and return value before writing.
-2. **Choose a format** (Google recommended; NumPy or reStructuredText also acceptable). Be
-   consistent across the module.
-3. Write a one-line summary, then `Args:`, `Returns:`, `Raises:`, and an `Example:` block.
-
-```python
-# Google-style docstring format
-def matrix_multiply(a: ExTensor, b: ExTensor) -> ExTensor:
-    """Multiply two matrices using optimized Mojo kernels.
-
-    Args:
-        a: First matrix (shape: m x n)
-        b: Second matrix (shape: n x k)
-
-    Returns:
-        Product matrix (shape: m x k)
-
-    Raises:
-        ValueError: If matrix dimensions don't align for multiplication
-
-    Example:
-        ```mojo
-        >>> a = ExTensor([[1, 2], [3, 4]], DType.float32)
-        >>> b = ExTensor([[1, 0], [0, 1]], DType.float32)
-        >>> c = matrix_multiply(a, b)
-        ```
-    """
-    ...
-```
-
-#### B. Generating API reference documentation from docstrings
-
-1. **Ensure docstrings**: verify all public functions/classes have docstrings.
-2. **Validate format**: confirm a consistent docstring style (Google, NumPy, or reST).
-3. **Extract metadata**: parse signatures, parameter types, return types.
-4. **Generate**: produce HTML or Markdown API reference.
-5. **Validate output**: verify links work and examples are correct.
-
 ```bash
-# Python with pdoc
-pdoc --html module_name -o docs/
+# Find public surface and undocumented definitions.
+rg -n '^(class|def|fn|struct|trait) ' <package>
+rg -n '^(from .* import|__all__|pub )' <package>/__init__* <package>
 
-# Python with Sphinx
-sphinx-quickstart docs/
-make -C docs html
+# Find drift and comment debt.
+rg -n 'FAILS LOUDLY|FAILS WITH|CONTRACT|RAISES|NOTE:|TODO|FIXME|placeholder' <paths>
+rg -n '^[[:space:]]*[a-z].*' <package>/**/__init__.*
 
-# Quick docstring extraction
-python3 -c "import module; help(module.function)"
+# Generate or inspect references using tools already declared by the repository.
+pdoc <package> --output-directory <docs/api>
+sphinx-apidoc -o <docs/api> <package>
+
+# Validate the changed surfaces.
+python3 -m py_compile <changed-python-files>
+python3 <demo-script>
+pre-commit run --files <all-changed-files>
 ```
 
-API doc output should include: module overview, signatures with type hints, parameter docs
-(type/description/default), return docs, raises/exceptions, code examples, and cross-references.
+### 1. Bind documentation to the current implementation
 
-#### C. Updating docstrings to match current implementation
+Read the implementation, callers, tests, exports, and existing documentation before editing.
+Record the exact signature, return type, mutation/ownership semantics, exceptions, failure return
+shape, and supported version. Search for the actual symbol rather than trusting an issue's
+pre-refactor name.
 
-**Stale example after signature change:** grep the current signature
-(`grep "fn function_name" path -C 5`), verify every required parameter (no default) is passed,
-then edit the docstring example to show all required imports and arguments.
+For each documented callable:
 
-**Copy vs view semantics:** run `grep -n "fn slice\|fn __getitem__\|_is_view" <file>`, read ALL
-sibling methods together, classify each (true view / copy-with-view-flag / independent copy),
-and update only the docstring. Use precise language ("zero-copy view", "pointer offset",
-"independent copy"). For struct-level docs, insert a Memory Semantics ASCII table between
-`Attributes:` and `Examples:` (Mojo-parser safe). Scalar overloads need an explicit N/A note.
+- begin with one imperative summary line;
+- document every parameter and return value using the repository's existing style;
+- describe exceptions or explicitly state a non-raising failure shape such as `(False, "")`;
+- state copy/view behavior and aliasing/refcount consequences when they change caller choices;
+- include a runnable snippet only when prose cannot make the contract clear.
 
-**Promoting inline NOTE to docstring Note:** grep `# NOTE` in `__init__` files, read each fully
-to check whether a `Note:` section already exists, then add/expand. Preferred section order:
-`Modules:` → `Note:` → `Example:` (place `Note:` BEFORE `Example:`).
+Private Python helpers are not exempt from ruff D401. Prefer “Run”, “Return”, “Build”, or
+“Validate” over “Helper to” or “Utility that”.
 
-**Silent error-handling contracts (POLA):** when a utility function swallows exceptions and
-returns a special value, add an explicit `Note:` section **immediately after the summary,
-before `Args:`** documenting both the success shape and every failure shape.
+### 2. Audit cross-level consistency
 
-```python
-def run_command(cmd: str, timeout: int = 60) -> tuple[bool, str]:
-    """Run a command and return stdout if successful.
+After changing a function docstring, search the containing module's summary blocks (`CONTRACT`,
+`RAISES`, `FAILS LOUDLY`, `NOTE`) and sibling methods. Update all levels atomically when they
+describe the same behavior. A copy-returning slice and a view-returning `slice()` must say so in
+both their individual docs and any memory-semantics table.
 
-    Note:
-        This function has a silent error-handling contract:
-        - On success (exit code 0): returns `(True, <stdout>)`
-        - On non-zero exit / timeout / OSError: returns `(False, "")` — empty
-          string, NOT stderr; no exception raised.
-        All exceptions (TimeoutError, CalledProcessError, OSError) are swallowed.
-        Use :func:`get_command_path` to verify availability first if early
-        failure is preferred over a silent `(False, "")`.
+For package initializers, turn an inline re-export comment into a module-docstring `Note:` only
+after verifying actual export behavior. Remove orphaned lowercase continuation fragments. Document
+new trait or dunder methods in the owning type and public package surface.
 
-    Args:
-        cmd: Shell command to execute (must exist in PATH)
-        timeout: Execution timeout in seconds (default 60)
+### 3. Generate API reference from the public surface
 
-    Returns:
-        Tuple `(success, output)`:
-        - `(True, stdout)` when exit code == 0
-        - `(False, "")` when exit code != 0, timeout, or OSError
-    """
-```
+1. Enumerate exports and exclude private/internal helpers unless the project deliberately exposes
+   them.
+2. Fill missing source docstrings first; generated pages reproduce source defects.
+3. Use the repository's configured generator (`pdoc`, Sphinx, or equivalent), not an undeclared
+   substitute.
+4. Inspect navigation, links, signatures, code formatting, and omitted exports in rendered output.
+5. Re-run generation from a clean tree when generated files are product artifacts. Do not commit
+   generated pages when the repository builds them only in CI.
 
-After editing, confirm existing tests exercise the documented contract (e.g.,
-`test_run_command_timeout()` asserts the `(False, "")` shape).
+### 4. Maintain guides and test documentation atomically
 
-**Module docstring line-wrap audit:** an orphaned fragment is a line inside a module-level
-docstring that starts with a lowercase coordinating conjunction and does not grammatically
-continue the prior line. Delete those; keep legitimate sentence wraps.
+Insert a new catalog module section before the established summary table, not after it. When a
+catalog header contains module, implementation, documented, and missing counts, recompute and
+update all related values together. Preserve formulas and thresholds that change test selection;
+move case-specific arithmetic and inventories to notes.
 
-```bash
-grep -rn '^[a-z]' <package>/**/__init__.py <package>/**/runner.py
-```
+For each test-file `NOTE`, classify it before rewriting:
 
-**Placeholder docstrings:** verify test/implementation exists, then replace
-"Placeholder…require implementation" with "implemented and passing".
+- expected limitation: document precisely and include the relevant version;
+- tracked limitation: retain the issue link and resolution condition;
+- likely defect: open/link a defect rather than normalizing it into accepted behavior;
+- obsolete placeholder: remove or replace it only after confirming implementation/tests exist.
 
-**Dunder / trait method docs:** grep with `-C 10`, update the method docstring (trait name,
-algorithm note, expanded `Example:`), and update the package listing entry (append
-`(ExTensor, implements Hashable via __hash__)`). Do NOT add dunders to the import list — they
-are trait implementations, not importable symbols.
+Renaming a test or documented helper requires a repository-wide caller search, including manual
+`main()` entry points and catalog references.
 
-#### D. Backward-pass catalog / dev-guide edits
+### 5. Normalize comments without erasing intent
 
-A backward-pass catalog (`backward-pass-catalog.md`) or dev guide (`testing-strategy.md`) often
-needs a new module section, formula block, or "Known Test Gotchas" subsection. These are
-structured docs — placement and atomic stat updates matter.
-
-1. Read the full target file first (use `Grep -C` / `offset`+`limit` if it exceeds the read
-   token limit).
-2. For a new MODULE section, insert it **before** `## SUMMARY TABLE:` — not at end of file —
-   so the catalog stays organized by module ahead of the summary.
-3. Update **all 4 header stat lines atomically** in one `Edit` call (total backward-function
-   count, broadcasting fraction, stability fraction, module count). Updating the total without
-   the fractions leaves the denominators wrong.
-4. For a "Known Test Gotchas" entry, insert between `## Gradient Checking` and
-   `## Layer Deduplication`; include Symptom, Root cause, Mathematical Proof sub-section, Safe
-   Alternatives, Rule, and Discovery context with PR/issue reference.
-5. Use ` ```text ` (not ` ```mojo `) for mathematical formulas and pseudocode.
-
-**Float16 accumulation in dev guides:** insert a `### Float16 Convolution Limitations`
-subsection between `### Parameters` and `### Example` under Gradient Checking. The accumulation
-error scales as `n × ε_machine`:
-
-```text
-Accumulation error ≈ n × ε_machine
-  where n = kernel_area × input_channels, ε_machine ≈ 9.77e-4 (Float16)
-```
-
-Float16 safe accumulations (tolerance `1e-1`): `n < ~100` (precisely ~102). Production
-convolutional layers exceed this for most kernels — supply per-layer `n` values (LeNet-5
-Conv2: `n=150`; AlexNet Conv1: `n=363`). See the Float16 Accumulation Reference table in
-Results & Parameters for the full per-layer breakdown.
-
-#### E. Test-file docstring documentation (Float16 NOTE review)
-
-Distinct from dev-guide subsection insertion (section D): this targets **test file docstring
-headers** when an issue asks to review and document Float16 precision NOTEs scattered across
-test files.
-
-1. **Assess each NOTE first** — classify every `# NOTE: Float16 ...` comment:
-   - **Expected limitation** (large-kernel accumulations, insufficient mantissa bits for
-     epsilon perturbations) → document in the test file header docstring.
-   - **Bug candidate** (unexpected NaN/Inf in small kernels, run-to-run inconsistency) → open
-     a separate tracking issue; do NOT silently document it as if expected.
-2. Explain the mixed-precision context: real training computes convolutions in **FP32 for
-   numerical stability** while storing activations/weights in **FP16 for memory efficiency**.
-   Tests that "use FP32 compute" faithfully model this — they are not working around Float16
-   failures. Float16's ~3.3 decimal digit precision (~11-bit mantissa) is insufficient for
-   large-kernel accumulations (K² × C_in > ~100–200) and finite-difference gradient checking.
-3. Write the section with the `=` underline heading style (not `###`) so it renders in IDE doc
-   viewers and Mojo parsers:
-
-```text
-Float16 Precision Limitations
-==============================
-<Layer/operation> accumulates <N> multiplications per output element.
-Float16's ~3.3 decimal digit precision (~11-bit mantissa) is insufficient
-for <large kernel accumulations / finite-difference epsilon / etc.>.
-
-This is an expected, fundamental limitation of Float16 arithmetic (not a bug).
-In practice, mixed-precision training computes in FP32 while storing in FP16
-for memory efficiency — tests using "FP32 compute" faithfully model this.
-See issue #<tracking-issue> for detailed analysis.
-```
-
-4. Commit with the `docs(tests):` prefix and a per-file list in the body:
-
-```text
-docs(tests): document Float16 precision limitations in test headers
-
-Add Float16 Precision Limitations sections to test file docstrings for:
-- tests/models/test_X.mojo: <brief explanation>
-- tests/shared/core/test_Y.mojo: <brief explanation>
-
-All limitations reference issue #NNNN for detailed analysis.
-
-Closes #<issue>
-```
-
-#### F. Inline comment / NOTE cleanup
-
-1. **Discovery** — always grep before editing (issue plans go stale):
-
-```bash
-grep -rn "# NOTE" <scope>/ --include="*.mojo"
-grep -rn 'print.*NOTE\|print.*TODO\|print.*FIXME\|print.*Note:' examples/ --include="*.mojo" -i
-grep -rn "# NOTE:" --include="*.mojo" . | grep -v "#[0-9]\{4,\}"   # untracked workarounds
-grep -rn "aliases to.*until\|Will use.*when available" . --include="*.mojo"  # shipped-feature
-grep -rn "# TODO:" scripts/generators/ --include="*.py"            # generator template TODOs
-```
-
-2. **Categorize** each marker in context (decision tree): runtime print → plain status text;
-   magic-number used 2+ places → named module constant; docstring NOTE → strip prefix to prose;
-   shipped-feature placeholder → confirm landed then remove; no-op placeholder test → remove;
-   generator TODO in template string → `# TEMPLATE:`; bare workaround NOTE → add `(#NNNN)`;
-   non-canonical format → normalize to `# NOTE(#NNNN, Mojo vX.Y):`.
-
-   **Always keep**: FP16/SIMD compiler-limitation notes, epsilon/tolerance justifications with
-   issue refs, active Track/Phase blocker notes, Mojo language-limitation notes (`no __all__`).
-
-3. **Apply edits** with `Edit` (`replace_all: false` for unique strings). Examples:
+Use the repository's canonical marker syntax. For Mojo limitations:
 
 ```mojo
-# Normalize casing
-old: # Note: This comment explains the workaround.
-new: # NOTE: This comment explains the workaround.
-
-# Convert runtime NOTE print to plain status
-old: print("Note: Training requires batch_norm2d_backward implementation.")
-new: print("Training requires batch_norm2d_backward (see GAP_ANALYSIS.md).")
-
-# Extract magic-number NOTE to module-level constant
-old: # NOTE: epsilon=3e-4 for float32 prevents precision loss in matmul (see #2704)
-     var epsilon = 3e-4 if dtype == DType.float32 else 1e-3
-new: alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4  # see #2704
-     var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else 1e-3
+# NOTE (Mojo v<version>): <current limitation>
+# NOTE(#<issue>, Mojo v<version>): <limitation>. Implement when <condition>.
 ```
 
-4. **Verify** — re-run the discovery greps and confirm zero remaining hits for the targeted
-   categories.
+Keep an already-linked multi-line note linked once; do not append duplicate issue references.
+Convert future work phrased as a note into a `TODO`, remove shipped-feature placeholders only after
+verification, and extract repeated magic numbers into named constants. Plain runtime status output
+is not a `NOTE` merely because it uses that word.
 
-#### G. Dynamic version from package attribute in demo scripts
+### 6. Keep demo versions dynamic
 
-Demo/example scripts should consume the version the same way users should — by importing the
-package's public `__version__`, not hardcoding a string or calling `importlib.metadata` directly.
+Import the package's public version attribute rather than copying a release string:
 
 ```python
-#!/usr/bin/env python3
-"""Demo script showing how to use the package."""
+from <package> import __version__
 
-from mypackage import __version__   # replaces: VERSION = "0.7.1"
-
-print(f"Using mypackage version {__version__}")
+print(f"<package> {__version__}")
 ```
 
-Steps: (1) find demo scripts (`find scripts/ -name "*example*" -o -name "*demo*"`); (2) confirm
-the package `__init__.py` exports `__version__` (typically
-`__version__ = importlib.metadata.version("<dist>")`); (3) replace the hardcoded string with the
-import; (4) smoke-run `python3 scripts/example_usage.py` to verify the real version prints. For a
-one-line literal swap with no test suite, smoke-run verification is sufficient — no unit test
-needed.
+Confirm that `__version__` is backed by the project's canonical metadata (for example,
+`importlib.metadata.version("<distribution>")`) and smoke-run the installed demo. Do not infer the
+distribution name from the import package when they differ.
 
-### Commit and PR Conventions
+### 7. Validate at the right boundary
+
+Run syntax/format/lint checks for every changed source and documentation file, then the narrow tests
+that exercise documented behavior. For a docs-only change, verify no executable line changed.
+Render generated docs when that is the consumer. On a host with GLIBC below 2.34, the Mojo
+formatter may be unavailable; run the remaining hooks explicitly and report the skip:
 
 ```bash
-# docstring/doc updates
-git commit -m "docs(scope): <what was documented>
-
-<One sentence: why — what implicit behaviour is now explicit.>
-
-Closes #<issue>"
-
-# comment cleanup
-git commit -m "cleanup(scope): normalize inline NOTE/TODO/placeholder comments
-
-<markers linked, casing normalized, stale removed, etc.>
-
-Closes #<issue>"
-
-gh pr create --title "docs(scope): ..." --body "Closes #<issue>"
-gh pr merge --auto --rebase <pr-number>
+SKIP=mojo-format pixi run pre-commit run --files <changed-mojo-and-doc-files>
 ```
+
+Rely on the repository's container/CI gate for that formatter and never claim it passed locally.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
-| Guessing signatures from memory | Wrote a function signature/docstring example without reading source | Line numbers and parameter names were wrong | Always read the actual source — grep for the signature, then Read the docstring |
-| Copying old docstring example verbatim | Kept stale example after a signature change | Did not demonstrate the new required argument | Grep the actual signature; check every parameter with no default value |
-| Treating all slice methods as identical | Assumed `__getitem__(Slice)` was a view like `slice()` | The 1D `__getitem__(Slice)` always copies | Read ALL sibling implementations before writing docstrings |
-| Fixing implementation instead of docstring | Considered changing `__getitem__(*slices)` to a pointer offset | Multi-dim slices are non-contiguous; needs stride metadata | Decide whether the bug is in the docs or the code first |
-| Adding `Note:` after `Example:` | Placed `Note:` section after the `Example:` block | Wrong order for module docstrings | Place `Note:` before `Example:` |
-| Expanding `Note:` without reading first | Started editing an `__init__` that already had a `Note:` | Would have created a duplicate | Read the full file before adding/expanding a section |
-| Documenting only the success return | Wrote `Returns: (bool, str)` without the failure shape | Callers unsure what `(False, "")` means | Document BOTH success `(True, stdout)` AND every failure `(False, "")` shape |
-| Placing the error contract in a trailing Note: | Put the swallow-exception contract at the end of the docstring | Callers read `Returns:` first and miss it; POLA still violated | Place `Note:` immediately after the summary, before `Args:` |
-| Trying to add `__hash__` to the import list | Considered re-exporting a dunder as a symbol | Dunders are trait implementations, not importable | Document dunders via docstrings/comments, not import lists |
-| Trusting issue-plan line numbers | Edited at the plan's line numbers directly | Files were partially fixed; numbers had shifted | Always grep to discover the actual state — plans go stale |
-| Case-sensitive grep only | Used `print.*NOTE` without `-i` | Missed mixed-case `Note:` variants | Use case-insensitive grep or include all case variants |
-| Linking all NOTEs | Added issue refs to informational NOTEs too | Created unnecessary issue noise | Only link NOTEs describing temporary workarounds or blocked features |
-| Creating new issues without searching | Opened a tracking issue per group immediately | Would have duplicated existing cleanup issues | `gh issue list --search` before creating |
-| Editing main-repo file from a worktree session | Edited `/repo/...` instead of the worktree copy | File is tracked by `main`, not the feature branch | Always edit the worktree path |
-| Use `importlib.metadata.version()` directly in demo | `print(version("MyPackage"))` in the demo | Teaches users to bypass the package's public interface | Demo code should import the package and use `__version__` |
-| Keep hardcoded version, bump manually | `VERSION = "0.7.1"` updated each release PR | Doesn't scale; demo lags real version; teaches hardcoding | Never hardcode versions in demos; use `__version__` |
-| Replace version with literal `"__version__"` placeholder | `VERSION = "__version__"` | Output shows the literal string, not a number | Replace with the actual imported `__version__` attribute |
-| Using `just pre-commit-all` | Ran `just` for pre-commit | `just` not on PATH | Use `pixi run pre-commit run --all-files` |
-| Running markdownlint via `pixi run npx` | `pixi run npx markdownlint-cli2 ...` | `npx: command not found` | Rely on pre-commit hooks instead |
-| Staging with `git add -A` | Added all untracked files | Picked up `__pycache__/` | Stage specific files for docs-only changes |
-| API doc / docstring gen treated as a one-shot | Assumed the direct approach always works | For greenfield docstrings the direct approach IS straightforward; the risk is skipping the read-first step | The pattern is simple, but still read existing code/docstrings before generating |
-| Re-adding an issue ref to an already-linked NOTE | Appended `(#NNNN)` to a multi-line NOTE block | The `#NNNN` already appeared elsewhere in the same NOTE block — it was already linked | If `#NNNN` appears anywhere in a multi-line NOTE block, it is already linked — don't re-add |
-| Skipping the issue-plan comment | Started editing straight from the issue title | The issue-plan comment had a pre-computed disposition table for each marker | Read the issue-plan comment first — it often has a ready disposition table |
-| Reading a full source file with `Read` | Attempted `Read` on a large file (e.g., `extensor.mojo`) | File exceeds the 25K token limit; the read fails | Use `Grep -C` for targeted context or `offset`+`limit` for specific line ranges |
-| Renaming a test fn without updating call sites | Renamed `test_slice_is_view` but left the `main()` call | Would cause a compile error — the old name is still referenced | Grep ALL call sites incl `main()` when renaming a test function |
-| Updating the header total without the fractions | Bumped the total backward-function count only | Broadcasting and stability fractions kept the old (wrong) denominator | Update all 4 header stat lines atomically in one Edit |
-| Inserting a MODULE section after the summary table | Appended the new module at end of catalog | Breaks reading flow — catalog is organized by module before the summary | Always insert a new MODULE section before `## SUMMARY TABLE:` |
-| Silently documenting a bug-candidate NOTE | Wrote an "expected limitation" header for a suspicious NaN NOTE | Buried a real bug as if it were by-design | Classify each NOTE expected-vs-bug; open a tracking issue for bug candidates |
-| Trusting issue body's variable name | Issue body cited `STATIC_FALLBACK_LICENSES`; nearly edited code searching for that symbol | Real symbol on disk was `FALLBACK_LICENSES`; issue body had a stale name from an earlier draft | Always grep for the actual symbol name before editing — issue descriptions can reference pre-refactor names |
+| --- | --- | --- | --- |
+| Trusting the issue symbol | Edited a name quoted by the ticket | The implementation had already been refactored | Search the current symbol and callers first |
+| Function-only update | Fixed a callable docstring but not the module contract | Readers saw contradictory behavior at the top of the file | Audit module, function, sibling, and export docs together |
+| “Helper to” opener | Used a descriptive noun phrase on a private helper | ruff D401 requires imperative mood there too | Start with an imperative verb |
+| Normalizing a bug note | Reworded suspicious behavior as an expected limitation | Documentation hid an unresolved defect | Classify and link defects before cleanup |
+| Partial catalog counts | Updated one summary statistic | The catalog became internally inconsistent | Recompute every dependent count atomically |
+| Hard-coded demo version | Copied the current release string | The demo drifted at the next release | Import the public version attribute |
+| Blind generation | Ran an API generator before auditing exports/docstrings | Generated pages amplified missing and stale contracts | Repair the source surface first |
 
 ## Results & Parameters
 
-### Key Docstring Patterns
+| Contract | Required disposition |
+| --- | --- |
+| Signature | Exact current parameters, defaults, and return type |
+| Memory | Explicit copy/view, aliasing, mutation, and ownership behavior |
+| Errors | Raised exceptions or precise non-raising failure shape |
+| Public surface | Export inventory matched to generated reference |
+| Comments | Current limitation, linked future work, tracked defect, or removal |
+| Catalog updates | Placement, formula, and all dependent counts synchronized |
+| Demo version | Public `__version__` backed by canonical package metadata |
+| Verification | Syntax/lint plus behavior or rendered-doc consumer; gaps stated |
 
-**Copy-returning vs view-returning slice methods:**
+## Companions
 
-```mojo
-fn __getitem__(self, slice: Slice) raises -> Self:
-    """Get slice of 1D tensor [start:end].
-
-    Returns:
-        New tensor containing a **copy** of the sliced data (`_is_view = False`).
-    Notes:
-        Always copies regardless of step. For zero-copy extraction use `slice()`.
-    """
-
-fn slice(self, start: Int, end: Int, axis: Int = 0) raises -> ExTensor:
-    """Extract a slice along the specified axis.
-
-    Returns:
-        A new tensor **view** sharing memory with the original (`_is_view = True`).
-    Notes:
-        Data pointer is offset into the original buffer; refcount incremented.
-    """
-```
-
-**Memory Semantics table (ASCII, Mojo-safe):**
-
-```text
-Memory Semantics:
-    +----------------------------+----------+---------------------+---------------------------+
-    | Method                     | Returns  | _is_view            | Memory                    |
-    +----------------------------+----------+---------------------+---------------------------+
-    | slice(start, end, axis)    | ExTensor | True  (view)        | Shared — zero-copy        |
-    | __getitem__(Slice)         | ExTensor | False (copy)        | Independent — data copied |
-    | __getitem__(*slices)       | ExTensor | False (copy)        | Independent — data copied |
-    | __getitem__(Int)           | Float32  | N/A (scalar result) | Scalar value, not tensor  |
-    +----------------------------+----------+---------------------+---------------------------+
-```
-
-**`__init__.mojo` re-export Note: template:**
-
-```mojo
-Note:
-    Mojo v0.26.1+ automatically exports all imported symbols to package consumers.
-    No ``__all__`` equivalent is needed. Callers may import directly from the parent:
-
-    ```mojo
-    from <package> import <Symbol1>, <Symbol2>
-    ```
-```
-
-**Placeholder update pattern:**
-
-```text
-# BEFORE: Placeholder import tests in tests/.../test_imports.mojo require implementation.
-# AFTER:  Import tests in tests/.../test_imports.mojo are implemented and passing.
-```
-
-### Canonical NOTE Format Reference (Mojo)
-
-```mojo
-# Plain limitation (no issue ref):
-# NOTE (Mojo v0.26.1): <description>
-
-# Limitation with issue reference (issue number FIRST):
-# NOTE(#NNNN, Mojo v0.26.1): <description>
-# Track resolution via #<parent>. Implement when <condition>.
-
-# Wrong (fix by swapping):  # NOTE (Mojo v0.26.1, #3076): ...
-# Wrong (append version):   # NOTE(#3076): ...
-# Wrong (TODO disguised):   # NOTE: X could be added  →  # TODO: Add X if needed
-```
-
-### Gradient-Check / Tolerance Constants (cleanup reference)
-
-| Constant | Value | Use Case |
-| -------- | ----- | -------- |
-| `GRADIENT_CHECK_EPSILON_FLOAT32` | `3e-4` | float32 matmul-heavy layers (conv2d, linear) |
-| `GRADIENT_CHECK_EPSILON_OTHER` | `1e-3` | Non-float32 dtypes (BF16, FP16) |
-
-| Layer | Tolerance | Rationale |
-| ----- | --------- | --------- |
-| Conv2d / BatchNorm backward | `1e-1` (10%) | Accumulated matmul / normalization errors |
-| Linear backward | `0.10` wide + `0.01` abs | Matrix-op accumulated errors (#2704) |
-| Activation backward | `1e-2` float32, `1e-1` other | Elementwise, less accumulation |
-
-### Float16 Accumulation Reference Table
-
-Accumulation error ≈ `n × ε_machine`, where `n = kernel_area × input_channels` and Float16
-machine epsilon ≈ `9.77e-4`. Safe accumulations (tol=`1e-1`): `n < ~102`.
-
-| Layer | Formula | n | Float16 error | Exceeds tol 1e-1? |
-| ------- | --------- | --- | -------------- | ------------------- |
-| LeNet-5 Conv1 | 5² × 1 | 25 | ~2.4e-2 | Borderline |
-| LeNet-5 Conv2 | 5² × 6 | 150 | ~1.5e-1 | Yes |
-| AlexNet Conv1 | 11² × 3 | 363 | ~3.5e-1 | Yes |
-| AlexNet Conv2 | 5² × 64 | 1,600 | ~1.6 | Yes |
-| AlexNet Conv3 | 3² × 192 | 1,728 | ~1.7 | Yes |
-
-### Dynamic Version Pattern
-
-| Aspect | Details |
-| ------ | ------- |
-| Import | `from <package> import __version__` at top of demo script |
-| Definition | `__init__.py` sets `__version__ = importlib.metadata.version("<dist>")` |
-| Synchronization | Automatic — reflects each released git tag |
-| Verification | Smoke-run the script; expect the actual installed version printed |
-
-### Module-Level vs Function-Level Docstring Drift
-
-When a behavior-change PR fixes a function's docstring, the module-level summary block
-(common patterns: `FAILS LOUDLY`, `FAILS WITH`, `RAISES`, `CONTRACT`, `NOTE:`) is NOT
-automatically updated. These blocks are maintained independently and can diverge after a PR.
-
-**Detection grep:**
-
-```bash
-grep -n "FAILS LOUDLY\|FAILS WITH\|CONTRACT\|RAISES\|NOTE:" <file> | head -10
-```
-
-If the function docstring describes a path that does not appear in the module summary block,
-add the missing bullet. The module summary is what readers see first and must stay in sync
-with the function-level contract.
-
-**Scope of change:** module summary block only — no functional code change, docs-only PR.
-
-### Validation Commands
-
-```bash
-python3 -m py_compile scripts/<script>.py            # Python syntax
-python3 scripts/example_usage.py                     # demo smoke-run
-SKIP=mojo-format pixi run pre-commit run --files <f> # Mojo (skip mojo-format if GLIBC < 2.34)
-pixi run pre-commit run --all-files                  # full pre-commit
-grep -rn '^[a-z]' <package>/**/__init__.py           # orphaned-fragment audit
-```
-
-`mojo-format` may be skipped locally on hosts with GLIBC < 2.34; it passes in CI Docker. All
-other hooks (ruff, markdownlint, trailing-whitespace, end-of-file-fixer, check-yaml) must pass.
-
-## Verified On
-
-| Project | Context | Details |
-| --------- | --------- | --------- |
-| ProjectOdyssey | Copy/view, catalog, fp16, re-export docstring updates | see history |
-| ProjectScylla | Issue #1364, PR #1397 (module docstring line-wrap audit) | see history |
-| ProjectHephaestus | Issue #797 (run_command POLA contract); Issue #787 (demo `__version__`); Issue #1306 (module-level FAILS LOUDLY block drift after #1303 added fallback path) | see history |
-| Multiple repos | NOTE/TODO/FIXME inline-comment cleanup passes | see history |
+- [Case index and detailed verification](docstring-api-doc-generation-and-comment-hygiene.notes.md)
+- [Version history and superseded content](docstring-api-doc-generation-and-comment-hygiene.history)

--- a/skills/docstring-api-doc-generation-and-comment-hygiene.notes.md
+++ b/skills/docstring-api-doc-generation-and-comment-hygiene.notes.md
@@ -1,0 +1,61 @@
+# Docstring, API Documentation, and Comment Hygiene — Notes
+
+Supporting case evidence for
+[`docstring-api-doc-generation-and-comment-hygiene`](docstring-api-doc-generation-and-comment-hygiene.md).
+The exact 30,530-byte v1.2.0 main is archived once in
+[`docstring-api-doc-generation-and-comment-hygiene.history`](docstring-api-doc-generation-and-comment-hygiene.history),
+with SHA-256 `b61f3ef3127af173828449a3513260b8efed6c30ab964e7974b8d03488776379`.
+
+## Case Index
+
+| Case | Source | Verification status | Reusable result |
+| --- | --- | --- | --- |
+| Copy/view and package re-export contracts | [Immutable v1.2.0 source](https://github.com/HomericIntelligence/Mnemosyne/blob/10e28497993009cc221cb991e1ee183e6117eda8/skills/docstring-api-doc-generation-and-comment-hygiene.md) | historical verified project cases; exact downstream receipts retained in history | Audit sibling methods and package summaries together |
+| Backward-pass catalog and Float16 notes | [Immutable v1.2.0 source](https://github.com/HomericIntelligence/Mnemosyne/blob/10e28497993009cc221cb991e1ee183e6117eda8/skills/docstring-api-doc-generation-and-comment-hygiene.md) | mixed historical verification | Preserve formulas/thresholds that change test choices; move case arithmetic out of main |
+| Module-docstring line-wrap audit | [ProjectScylla issue #1364](https://github.com/HomericIntelligence/ProjectScylla/issues/1364) and [PR #1397](https://github.com/HomericIntelligence/ProjectScylla/pull/1397) | verified-ci | Search orphaned fragments and validate the full edited module |
+| Subprocess helper POLA contract | [ProjectHephaestus issue #797](https://github.com/HomericIntelligence/ProjectHephaestus/issues/797) | historical case; implementation receipt not asserted here | Document swallowed exceptions and exact success/failure return shapes |
+| Dynamic demo version | [ProjectHephaestus issue #787](https://github.com/HomericIntelligence/ProjectHephaestus/issues/787) | historical case; smoke evidence retained in history | Import public `__version__` backed by canonical metadata |
+| Module/function contract drift | [ProjectHephaestus issue #1306](https://github.com/HomericIntelligence/ProjectHephaestus/issues/1306) and [PR #1303](https://github.com/HomericIntelligence/ProjectHephaestus/pull/1303) | locally audited; follow-up status retained in history | A function-doc fix does not automatically update the module summary |
+| NOTE/TODO/FIXME cleanup passes | [Immutable v1.2.0 source](https://github.com/HomericIntelligence/Mnemosyne/blob/10e28497993009cc221cb991e1ee183e6117eda8/skills/docstring-api-doc-generation-and-comment-hygiene.md) | mixed across repositories | Classify limitation, future work, defect, or obsolete text before editing |
+
+## Detailed Case Notes
+
+### Copy, view, and ownership language
+
+The original project cases distinguished a slice operation that allocates an independent tensor
+from a `slice(start, end, axis)` operation that aliases storage and increments ownership state.
+Those differences affect caller behavior, so they remain in the retrievable decision rule. The
+project-specific memory table and worked tensor cases remain in the exact archived snapshot.
+
+### Catalog and Float16 evidence
+
+Catalog updates depended on four synchronized header counts and an established placement before a
+summary table. Float16 accumulation used the rough bound `n × epsilon`, where `n` depends on kernel
+area and input channels. The project used machine epsilon near `9.77e-4`; at tolerance `1e-1`,
+roughly `n < 102` was the safe accumulation region. Its reusable gradient-check parameters were
+`3e-4` for float32 matmul-heavy layers and `1e-3` for other dtypes. Case-specific decisions included
+`1e-1` for convolution/BatchNorm backward, a `0.10` wide plus `0.01` absolute check for linear
+backward, and `1e-2` float32/`1e-1` other for activation backward. These are historical project
+parameters, not universal thresholds; recalculate them for another kernel and dtype.
+
+### Comment classification
+
+A cleanup pass should assign every marker one disposition:
+
+1. current limitation with version context;
+2. linked limitation with a concrete resolution condition;
+3. future work expressed as `TODO`;
+4. likely defect linked to an issue;
+5. obsolete/shipped placeholder removed after verification.
+
+Do not add a second issue reference to an already-linked multi-line note, and do not treat a
+runtime status string containing “NOTE” as documentation debt.
+
+## Verification Checklist
+
+- Diff implementation and docs separately; a docs-only claim requires no executable change.
+- Verify signatures, callers, exports, return/error contracts, and sibling/module summaries.
+- Render the configured API generator when rendered output is the product consumer.
+- Recompute all catalog counts and confirm section placement/formulas.
+- Smoke-run versioned demos against an installed package.
+- Report platform-skipped formatters as skipped, not passed.


### PR DESCRIPTION
## Summary

- compact the final three oversized retrievable skills from issue #3335 below the 30,000-byte limit
- archive each immutable-base main exactly once in its history companion while preserving the complete prior history byte-for-byte
- add notes companions with clickable case sources and explicit case-level verification status
- retain retrieval identity, decision-changing triggers, commands, parameters, error modes, named failures, and evidence boundaries

## Per-skill migration

| Skill | Version | Main bytes | Snapshot SHA-256 | Semantic-audit disposition |
| --- | --- | ---: | --- | --- |
| `ci-failure-triage-and-diagnosis` | 1.1.0 -> 2.0.0 | 30,593 -> 9,974 | `dbfeed396bb4cb23d547fc0d9077a6e5756b9f71b820cda2b4e2ee6acd83e592` | Retained log-first/current-main discipline, transient/broken-main ownership, required-context diagnosis, downstream auto-merge re-arming after force updates, OOM/JIT signatures, namespace-correct gdb capture, CPU surveys, opt-in instrumentation, interruptible subprocesses, API budgets, and stale-lock reruns. Evidence remains `verified-local`; CI-confirmed cases and the unverified hardening proposal are distinguished in notes. |
| `docstring-api-doc-generation-and-comment-hygiene` | 1.2.0 -> 2.0.0 | 30,530 -> 10,391 | `b61f3ef3127af173828449a3513260b8efed6c30ab964e7974b8d03488776379` | Retained implementation-bound docstrings, public-surface generation, cross-level contract audits, catalog/test-note atomicity, NOTE/TODO/defect classification, dynamic versions, exact GLIBC/Mojo formatter exception, and validation boundaries. Mixed historical evidence is now explicit, not upgraded. |
| `bash-script-and-jq-failure-modes` | 1.2.0 -> 2.0.0 | 30,074 -> 10,443 | `27c5a2d2f8b7a3068a9c623794064736164ab4e275fc5b29fbea52f5e2e2a1bc` | Retained exit-127 tracing, grep/pipefail and nounset-array fixes, arithmetic status, jq boolean/empty-stream/version traps, worktree anchoring, job-control continuation loss, stdout/stderr separation, exported-function integration testing, and private-helper D401. Evidence remains `verified-ci`. |

The immutable batch base is `10e28497993009cc221cb991e1ee183e6117eda8`.

## Verification

- independent pre-publication semantic/acceptance audit passed on staged digest `3277ec6e57b4479d971eb4e5ba330af6af372061fe2ce720cf4e6901b7257671`
- exact base snapshots occur once and complete prior-history suffixes remain byte-for-byte identical for all three skills
- original snapshots pre-scanned with the credential-hook regex; no conflicts or snapshot normalization
- digest/base identifiers checked for PII/Luhn false positives; no split presentation required
- staged PII scan and global credential hook passed without bypass
- repository-wide `markdownlint-cli2` v0.20.0 passed (983 files, 0 issues)
- scoped `pre-commit` passed for all nine artifacts
- `git diff --check` passed
- `just validate` passed (776/776)
- `just check` passed (227 tests)
- push-time locked test gate passed (227 tests)
- commit is signed and DCO-attested

Refs #3335
