### PR TITLE
refactor(validation): remove oversized-skill ratchet

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -209,11 +209,8 @@ jobs:
       - name: Build CI image (podman)
         run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
       - name: Run skill-file validation script (in container)
-        env:
-          MNEMOSYNE_SKILL_SIZE_BASE_REF: >-
-            ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: >
-          podman run --rm -e MNEMOSYNE_SKILL_SIZE_BASE_REF -v "$PWD:/workspace:Z"
+          podman run --rm -v "$PWD:/workspace:Z"
           --userns=keep-id:uid=1000,gid=1000
           mnemosyne-ci:local uv run python scripts/validate_plugins.py
       - name: Run test suite (in container)
@@ -239,11 +236,8 @@ jobs:
       - name: Build CI image (podman)
         run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
       - name: Validate every skill file across the corpus (in container)
-        env:
-          MNEMOSYNE_SKILL_SIZE_BASE_REF: >-
-            ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: >
-          podman run --rm -e MNEMOSYNE_SKILL_SIZE_BASE_REF -v "$PWD:/workspace:Z"
+          podman run --rm -v "$PWD:/workspace:Z"
           --userns=keep-id:uid=1000,gid=1000
           mnemosyne-ci:local uv run python scripts/validate_plugins.py
       - name: Assert the skills corpus is non-empty
@@ -444,11 +438,8 @@ jobs:
       - name: Build CI image (podman)
         run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
       - name: Assert every skill declares a valid semver version (in container)
-        env:
-          MNEMOSYNE_SKILL_SIZE_BASE_REF: >-
-            ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: >
-          podman run --rm -e MNEMOSYNE_SKILL_SIZE_BASE_REF -v "$PWD:/workspace:Z"
+          podman run --rm -v "$PWD:/workspace:Z"
           --userns=keep-id:uid=1000,gid=1000
           mnemosyne-ci:local uv run python scripts/validate_plugins.py
       - name: Cross-check pyproject version is valid semver (in container)

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -34,9 +34,6 @@ jobs:
         run: uv run ruff check scripts/ tests/
 
       - name: Validate flat-format skill files
-        env:
-          MNEMOSYNE_SKILL_SIZE_BASE_REF: >-
-            ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: uv run python scripts/validate_plugins.py
 
       - name: Type check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,9 +202,7 @@ The validator checks:
 - Failed Attempts table is included.
 - Description meets minimum length (20+ characters).
 - Category is one of the 9 approved values.
-- New or changed retrievable main skills do not exceed 30,000 bytes; unchanged oversized legacy
-  files are temporarily tolerated but cannot be amended without compaction. `.notes.md` companions
-  are excluded.
+- Every retrievable main skill is at most 30,000 bytes. `.notes.md` companions are excluded.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ All PRs are validated by CI:
 - Failed Attempts section is present with proper table format
 - Description is specific (20+ chars)
 - Category is valid
-- New or changed retrievable main skill files are no larger than 30,000 bytes; unchanged oversized
-  legacy files are ratcheted and must be compacted when next amended
+- Every retrievable main skill file is no larger than 30,000 bytes
 
 Run validation locally:
 

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -3,7 +3,7 @@
 Validate flat-format skill files (skills/*.md).
 
 Checks:
-- Maximum new/changed retrievable skill size (30,000 bytes; unchanged legacy files ratcheted)
+- Maximum retrievable skill size (30,000 bytes)
 - Required YAML frontmatter fields (name, description, category, date, version)
 - Section presence (Overview, When to Use, Verified Workflow, Failed Attempts, Results & Parameters)
 - Failed Attempts table structure
@@ -13,9 +13,7 @@ Checks:
 """
 
 import argparse
-import os
 import re
-import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -47,21 +45,6 @@ RESET = "\033[0m"
 def find_plugins() -> List[Path]:
     """Find all flat skill files (skills/*.md, exclude *.notes*.md and *.history)."""
     return find_skill_files(SKILLS_DIR)
-
-
-def matches_oversized_base_file(file_path: Path) -> bool:
-    """Return whether an oversized legacy skill is byte-identical to the base revision."""
-    base_ref = os.environ.get("MNEMOSYNE_SKILL_SIZE_BASE_REF")
-    if not base_ref:
-        github_base_ref = os.environ.get("GITHUB_BASE_REF")
-        base_ref = f"origin/{github_base_ref}" if github_base_ref else "origin/main"
-
-    result = subprocess.run(
-        ["git", "show", f"{base_ref}:skills/{file_path.name}"],
-        check=False,
-        capture_output=True,
-    )
-    return result.returncode == 0 and result.stdout == file_path.read_bytes()
 
 
 def validate_frontmatter(frontmatter: Dict, filename: str) -> List[str]:
@@ -210,7 +193,7 @@ def validate_plugin(filename: str) -> List[str]:
         return [f"Cannot read file: {e}"]
 
     size_bytes = file_path.stat().st_size
-    if size_bytes > MAX_SKILL_FILE_SIZE_BYTES and not matches_oversized_base_file(file_path):
+    if size_bytes > MAX_SKILL_FILE_SIZE_BYTES:
         errors.append(
             f"Skill file {file_path} is {size_bytes:,} bytes; allowed maximum is {MAX_SKILL_FILE_SIZE_BYTES:,} bytes"
         )

--- a/tests/test_validate_plugins.py
+++ b/tests/test_validate_plugins.py
@@ -12,7 +12,6 @@ Covers:
 - validate_plugin: integration tests with valid and invalid skill files
 """
 
-import os
 import subprocess
 from typing import Any
 from unittest.mock import patch
@@ -350,11 +349,37 @@ class TestValidatePlugin:
         assert len(errors) == 1
         assert "Cannot read file" in errors[0]
 
-    def test_oversized_retrievable_skill_reports_path_measured_and_allowed_bytes(self, tmp_path):
+    def test_oversized_retrievable_skill_always_reports_path_measured_and_allowed_bytes(self, tmp_path, monkeypatch):
         skills = tmp_path / "skills"
         skills.mkdir()
         skill_path = skills / "oversized.md"
-        skill_path.write_bytes(b"x" * 30_001)
+        oversized_content = b"x" * 30_001
+        skill_path.write_bytes(oversized_content)
+
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "add", skill_path], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@localhost",
+                "commit",
+                "-m",
+                "base",
+            ],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        monkeypatch.chdir(tmp_path)
 
         with patch("validate_plugins.SKILLS_DIR", skills):
             errors = validate_plugin(skill_path.name)
@@ -369,121 +394,10 @@ class TestValidatePlugin:
         content = CLEAN_SKILL_MD.encode()
         skill_path.write_bytes(content + (b" " * (30_000 - len(content))))
 
-        with (
-            patch("validate_plugins.SKILLS_DIR", skills),
-            patch("subprocess.run") as git_show,
-        ):
+        with patch("validate_plugins.SKILLS_DIR", skills):
             errors = validate_plugin(skill_path.name)
 
         assert not any("allowed maximum" in error for error in errors)
-        git_show.assert_not_called()
-
-    def test_unchanged_oversized_legacy_skill_is_grandfathered(self, tmp_path):
-        skills = tmp_path / "skills"
-        skills.mkdir()
-        skill_path = skills / "legacy.md"
-        legacy_content = b"x" * 30_001
-        skill_path.write_bytes(legacy_content)
-        base_result = subprocess.CompletedProcess(
-            args=["git", "show"],
-            returncode=0,
-            stdout=legacy_content,
-            stderr=b"",
-        )
-
-        with (
-            patch("validate_plugins.SKILLS_DIR", skills),
-            patch("subprocess.run", return_value=base_result),
-        ):
-            errors = validate_plugin(skill_path.name)
-
-        assert not any("allowed maximum" in error for error in errors)
-
-    def test_oversized_ratchet_selects_the_expected_base_and_skill_path(self, tmp_path):
-        skills = tmp_path / "skills"
-        skills.mkdir()
-        skill_path = skills / "legacy.md"
-        legacy_content = b"x" * 30_001
-        skill_path.write_bytes(legacy_content)
-        base_result = subprocess.CompletedProcess(
-            args=["git", "show"],
-            returncode=0,
-            stdout=legacy_content,
-            stderr=b"",
-        )
-        cases: tuple[tuple[dict[str, str], str], ...] = (
-            (
-                {"MNEMOSYNE_SKILL_SIZE_BASE_REF": "base-sha"},
-                "base-sha:skills/legacy.md",
-            ),
-            ({"GITHUB_BASE_REF": "release"}, "origin/release:skills/legacy.md"),
-            ({}, "origin/main:skills/legacy.md"),
-        )
-
-        for environment, expected_object in cases:
-            with (
-                patch.dict(os.environ, environment, clear=True),
-                patch("validate_plugins.SKILLS_DIR", skills),
-                patch("subprocess.run", return_value=base_result) as git_show,
-            ):
-                errors = validate_plugin(skill_path.name)
-
-            assert not any("allowed maximum" in error for error in errors)
-            git_show.assert_called_once_with(
-                ["git", "show", expected_object],
-                check=False,
-                capture_output=True,
-            )
-
-    def test_unresolved_base_cannot_grandfather_an_oversized_skill(self, tmp_path):
-        skills = tmp_path / "skills"
-        skills.mkdir()
-        skill_path = skills / "legacy.md"
-        skill_path.write_bytes(b"x" * 30_001)
-        missing_base = subprocess.CompletedProcess(
-            args=["git", "show"],
-            returncode=128,
-            stdout=b"",
-            stderr=b"unknown revision",
-        )
-
-        with (
-            patch.dict(
-                os.environ,
-                {"MNEMOSYNE_SKILL_SIZE_BASE_REF": "missing-base"},
-                clear=True,
-            ),
-            patch("validate_plugins.SKILLS_DIR", skills),
-            patch("subprocess.run", return_value=missing_base) as git_show,
-        ):
-            errors = validate_plugin(skill_path.name)
-
-        assert any("allowed maximum" in error for error in errors)
-        git_show.assert_called_once_with(
-            ["git", "show", "missing-base:skills/legacy.md"],
-            check=False,
-            capture_output=True,
-        )
-
-    def test_changed_oversized_legacy_skill_is_rejected(self, tmp_path):
-        skills = tmp_path / "skills"
-        skills.mkdir()
-        skill_path = skills / "legacy.md"
-        skill_path.write_bytes(b"x" * 30_001)
-        base_result = subprocess.CompletedProcess(
-            args=["git", "show"],
-            returncode=0,
-            stdout=b"y" * 30_001,
-            stderr=b"",
-        )
-
-        with (
-            patch("validate_plugins.SKILLS_DIR", skills),
-            patch("subprocess.run", return_value=base_result),
-        ):
-            errors = validate_plugin(skill_path.name)
-
-        assert any("allowed maximum" in error for error in errors)
 
     def test_oversized_notes_file_is_excluded_from_retrieval_and_size_validation(self, tmp_path):
         skills = tmp_path / "skills"


### PR DESCRIPTION
## Summary

- enforce the 30,000-byte retrievable-skill limit unconditionally now that all 63 issue-listed skills are compacted
- remove byte-identity base lookup, its obsolete tests/imports, and the CI base-ref environment interface
- retain boundary coverage for 30,001-byte rejection, exactly 30,000-byte acceptance, and oversized notes exclusion
- update README and CONTRIBUTING validation text to describe the universal limit

## TDD evidence

The retained regression creates a real temporary Git repository, commits a 30,001-byte retrievable
skill, and points `refs/remotes/origin/main` at the identical commit.

- RED against the base validator: 1 selected test failed because the byte-identical file was
  grandfathered and the expected size error was absent
- GREEN with unconditional enforcement: the 30,001-byte, exactly-30,000-byte, and oversized-notes
  boundary tests all pass (3/3)

## Acceptance evidence

- zero retrievable main skills over 30,000 bytes
- validator discovery and validation: 776/776
- issue #3335 inventory: 63/63 mains at or below 30,000 bytes, with BSD license, history reference/file,
  and notes companion
- all original retrievable skill names and categories preserved
- zero remaining `MNEMOSYNE_SKILL_SIZE_BASE_REF`, `GITHUB_BASE_REF` fallback,
  `matches_oversized_base_file`, or ratchet/grandfather documentation matches in validator, tests,
  workflows, README, and CONTRIBUTING
- exactly three `_required.yml` validator environment-forwarding sites and the standalone validator
  environment block removed; checkout depth, discovery, and unrelated CI behavior are unchanged

## Validation

- focused size-boundary tests: 3 passed
- `just check`: 776/776 skills valid; 223 tests passed
- pre-push locked test suite: 223 tests passed
- ruff and ruff format: pass
- mypy: no issues in 18 source files
- PII and credential scans: zero findings
- yamllint: pass with one pre-existing non-fatal line-length warning
- GitHub workflow schema validation: pass
- repository-wide Markdown lint: 983 files, zero issues
- release contract and project-version semver checks: pass
- scoped pre-commit and repository staged-file hook: pass
- signed commit and DCO sign-off: verified

### Local container CI condition

`just ci-build` could not connect to the external container runtimes: the Podman socket at
`127.0.0.1:52275` refused the connection, and the Docker daemon at `/var/run/docker.sock` was not
running. The subsequent `just ci-all` therefore stopped at preflight because
`mnemosyne-ci:local` was absent; no container-suite pass is claimed and no check was bypassed.

The GitHub current-head full PR suite and the merge-group full suite are mandatory substitutes and
must pass before merge.

Closes #3335
