### PR TITLE
feat: amend testing-source-line-number-assertions-are-churn-engines to v1.1.0

### DIFF
--- a/skills/testing-source-line-number-assertions-are-churn-engines.md
+++ b/skills/testing-source-line-number-assertions-are-churn-engines.md
@@ -1,12 +1,13 @@
 ---
 name: testing-source-line-number-assertions-are-churn-engines
 license: BSD-3-Clause
-description: "A test that asserts an exact SOURCE LINE NUMBER (`inspect.getsourcelines(fn)[1] == <literal>`, `fn.__code__.co_firstlineno == N`, or a doc `path:LINE function` reference pinned against the current source line) is a churn engine — REMOVE it and assert symbol presence/resolution instead. Any edit above the function shifts its line number and fails the test with zero behavior change; under concurrent merging the correct line is only knowable at the merge instant, so no PR author (human or agent) can pin it ahead of time. Use when: (1) a doc/regression test fails only because a line number drifted, (2) a PR keeps re-conflicting on a doc that hardcodes `file.py:NNN`, (3) you see `getsourcelines(...)[1]` or `co_firstlineno` compared to a constant in tests, (4) an automation loop keeps force-pushing a wrong-line-number CI fix."
+description: "A test that asserts an exact SOURCE LINE NUMBER (`inspect.getsourcelines(fn)[1] == <literal>`, `fn.__code__.co_firstlineno == N`, or a doc `path:LINE function` reference pinned against the current source line) is a churn engine — REMOVE it and assert symbol presence/resolution instead. Any edit above the function shifts its line number and fails the test with zero behavior change; under concurrent merging the correct line is only knowable at the merge instant, so no PR author (human or agent) can pin it ahead of time. Use when: (1) a doc/regression test fails only because a line number drifted, (2) a PR keeps re-conflicting on a doc that hardcodes `file.py:NNN`, (3) you see `getsourcelines(...)[1]` or `co_firstlineno` compared to a constant in tests, (4) an automation loop keeps force-pushing a wrong-line-number CI fix, (5) you are designing the systemic guard that bans the anti-pattern. v1.1.0 adds the guard design: a blanket AST ban on any `getsourcelines/findsource(...)[1]` subscript or `.co_firstlineno` access in tests (compare-only checks miss variable indirection), a fence-aware `\\.py:\\d+` regex guard over living docs excluding point-in-time records (ADRs, release notes), and a pre-push CI-fix test gate that MUST treat pytest exit code 5 (no tests ran) as pass — otherwise deleting the churn-engine test deadlocks the gate against its own fix."
 category: testing
-date: 2026-07-12
-version: "1.0.0"
+date: 2026-07-16
+version: "1.1.0"
 user-invocable: false
 verification: verified-ci
+history: testing-source-line-number-assertions-are-churn-engines.history
 tags:
   - line-number-assertion
   - getsourcelines
@@ -18,10 +19,14 @@ tags:
   - concurrency
   - symbol-presence
   - lint-guard
+  - ast-guard
+  - pre-push-test-gate
   - hephaestus
 ---
 
 # Testing: Source-Line-Number Assertions Are Churn Engines
+
+**History:** [changelog](./testing-source-line-number-assertions-are-churn-engines.history)
 
 ## Overview
 
@@ -32,6 +37,13 @@ tags:
 | **Outcome** | Successful — removed the test, stripped the volatile `:LINE` from the doc's function references (kept `path function` for navigation), removed the now-unused imports/list, and filed a systemic lint-guard follow-up. Merged into Hephaestus PR #2056 (commit `79f9ebb3`) which then had 0 real CI failures |
 | **Verification** | verified-ci |
 
+> **v1.1.0 (2026-07-16) — planning-stage additions.** The removal workflow above is
+> `verified-ci` (Hephaestus PR #2056). The **Systemic Guard Design** section below is the
+> reviewed implementation plan for the follow-up guard (Hephaestus #2122) and is
+> **`unverified`** — the guards were designed against the live codebase (all cited
+> file/line anchors grep-verified) but had not yet merged and run in CI when captured.
+> Treat its design decisions as strong hypotheses until #2122's PR merges green.
+
 ## When to Use
 
 - A doc or regression test fails **only** because a line number drifted — the referenced code has zero behavior change.
@@ -39,6 +51,7 @@ tags:
 - You see `inspect.getsourcelines(x)[1]` (or `x.__code__.co_firstlineno`) compared to a literal constant anywhere under `tests/`.
 - An automation loop / CI-fix mesh keeps force-pushing a branch that "fixes" a line number and then fails the exact test it was fixing.
 - You are reviewing a new test that pins a documented `path:LINE symbol` reference against the live source line — flag it before it lands.
+- **(v1.1.0, planning-stage)** You are implementing the systemic guard itself — an AST/lint ban, a doc-ref guard, or a pre-push test gate for a CI-fix mesh — and need the design decisions that keep the guard from being vacuous, false-positive-prone, or self-deadlocking.
 
 ## Verified Workflow
 
@@ -71,7 +84,82 @@ pixi run pytest tests/unit/docs -q
 
 4. **Clean up the dependencies the test pulled in.** Remove the now-unused imports (`inspect`, `re`), any reference list (`PROMPT_REFS`), and the imported functions — otherwise ruff fails on unused imports (F401) or redefinitions.
 
-5. **Prevent recurrence systemically.** File a lint/AST guard that REJECTS any `getsourcelines(...)[1]` or `co_firstlineno` compared to a literal in `tests/`. If line refs are wanted for navigation, GENERATE them via a self-healing pre-commit hook — never ASSERT them (blocking). Assert **symbol presence / resolution** instead: that the function imports and `hasattr(module, "fn")` resolves.
+5. **Prevent recurrence systemically.** File a lint/AST guard that REJECTS any `getsourcelines(...)[1]` or `co_firstlineno` compared to a literal in `tests/`. If line refs are wanted for navigation, GENERATE them via a self-healing pre-commit hook — never ASSERT them (blocking). Assert **symbol presence / resolution** instead: that the function imports and `hasattr(module, "fn")` resolves. See the **Systemic Guard Design** section below for the reviewed design of all three guards.
+
+## Systemic Guard Design (v1.1.0 — planning-stage, unverified)
+
+The reviewed implementation plan for Hephaestus #2122 (the follow-up filed by the verified fix
+above). Three guards; each has a non-obvious design decision that a naive implementation gets
+wrong.
+
+### Guard 1 — AST ban in tests: blanket ban, not compare-only
+
+The issue asks to reject `getsourcelines(...)[1] == <literal>`. Do NOT implement that literally:
+a Compare-only check misses **variable indirection** —
+`n = inspect.getsourcelines(f)[1]; assert n == doc_line` has no banned Compare node. When a
+repo-wide grep shows zero current uses (run it first), ban ANY occurrence in `tests/` of:
+
+- an `ast.Subscript` with constant index `1` over a call to `getsourcelines` **or** `findsource`
+  (both return `(lines, lnum)` — `findsource` is the same hole under another name), and
+- any `ast.Attribute` access of `co_firstlineno`.
+
+Implementation notes that keep the guard sound:
+
+- **Self-tests can't trip the guard.** Synthetic banned patterns inside the guard's own test file
+  live in *string literals* passed to `ast.parse(...)`; string contents produce no
+  `Subscript`/`Attribute` nodes, so no self-exemption is needed.
+- **Add a synthetic-source negative test** (parse a string containing violations, assert they are
+  collected) so a broken collector cannot pass vacuously — same pattern as
+  `test_zero_io_imports.py::test_forbidden_detects_synthetic_forbidden_import`.
+- **Ship an empty `_ALLOWLIST` frozenset** for future sanctioned uses, mirroring the repo's other
+  AST guards, so an exemption is a reviewed one-line diff instead of a guard rewrite.
+- `getsourcelines(...)[0]` (the source *text*) stays legal — only the line-number element is banned.
+
+### Guard 2 — doc-ref guard: fence-aware regex over LIVING docs only
+
+Regex `\.py:\d+` over `docs/**/*.md`, with two scoping decisions:
+
+- **Skip fenced code blocks** (track ``` fence state per line). Example tool output like
+  `file.py:12: error` inside a fence is legitimate and would false-positive.
+- **Exclude point-in-time records** (`docs/adr/`, `docs/release-notes/`). ADR line refs are
+  historical citations of the code *as it was decided*, not navigable claims that must track
+  HEAD; forcing them to de-line rewrites history for zero benefit.
+
+The generator hook (self-healing line refs) stays optional — YAGNI unless someone actually wants
+line-precise navigation; `path function` refs are grep-able and stable.
+
+### Guard 3 — pre-push CI-fix test gate: exit-code-5 is PASS, param IDs are truncated
+
+The CI-fix mesh must re-run the failing tests locally before force-pushing. Parse failing pytest
+node IDs from the CI logs (`FAILED|ERROR <path>::<node>` summary lines), then run exactly those in
+the worktree and refuse the push on failure. Three decisions prevent the gate from fighting itself:
+
+- **pytest exit code 5 ("no tests ran") is a PASS.** The fix/rebase may have legitimately
+  *deleted* the failing test — that was exactly the #2056 remedy. Treating 5 as failure deadlocks
+  the gate against the very fix this skill prescribes. Also drop node IDs whose file no longer
+  exists in the worktree before invoking pytest.
+- **Truncate parametrized IDs at `[`.** Running `test_a` instead of `test_a[param-1]` is a safe
+  superset and survives param renames across the rebase; an exact stale param ID makes pytest
+  error with "unknown node id" and falsely blocks the push.
+- **Gate the agent CI-fix push path, not mechanical rebases of green PRs.** The mechanical-rebase
+  path has no CI-failure logs in scope (it runs on BEHIND/green PRs) and already defers to the
+  gated agent path on any conflict. Gate where the failure evidence exists.
+
+Coverage-contract note (Hephaestus-specific but generalizable): when the orchestrator module is on
+a coverage omit list, the log-parsing helper must be a module-level pure function with its own unit
+tests (mocked `subprocess.run` for the gate method) — the omit list excuses the live loop, never
+the helpers.
+
+### Design pitfalls avoided (near-misses from the planning review)
+
+| Naive design | Why it fails | Correct design |
+|--------------|--------------|----------------|
+| Ban only `getsourcelines(...)[1] == <literal>` Compare nodes | Variable indirection (`n = ...[1]; assert n == x`) has no banned Compare | Blanket-ban the subscript/attribute anywhere in `tests/` (safe when grep shows zero uses) |
+| Guard only `getsourcelines` | `inspect.findsource(fn)[1]` returns the same line number | Ban both functions' `[1]` subscript |
+| Regex-scan whole doc files | Fenced example output (`file.py:12: error`) false-positives | Track fence state; scan prose lines only |
+| De-line ADRs too | ADRs are point-in-time records; their line refs are historical citations | Exclude `docs/adr/` and `docs/release-notes/` from the guard |
+| Pre-push gate treats exit code 5 as failure | The fix that DELETES the churn-engine test "fails" the gate → self-deadlock | Exit code 5 (and vanished test files) = pass |
+| Run exact parametrized node IDs from CI logs | Param renamed by the rebase → pytest "unknown node id" error blocks the push | Truncate at `[`; run the whole test function |
 
 ## Failed Attempts
 


### PR DESCRIPTION
Recovered amendment from an orphaned July learn-session worktree (v1.1.0 edits were made but never committed). Main still carries v1.0.0 (2026-07-12); this delivers the newer revision. `license` frontmatter line added. Validation: Valid 778/778.