### PR TITLE
fix(skills): keep policies active and use skills at specified boundaries

### DIFF
--- a/skills/skill-advisor-task-routing.history
+++ b/skills/skill-advisor-task-routing.history
@@ -1,0 +1,96 @@
+# skill-advisor-task-routing — History
+
+## v1.1.0 amendment (2026-09-06)
+
+- **Superseded version:** `1.0.0`
+- **Archive status:** `privacy-redacted`. The exact snapshot was intentionally
+  omitted.
+- **Generalized reason:** The prior retrievable content contains identifiers,
+  a URL, and attribution details that the current privacy rules prohibit.
+- **Privacy-safe provenance:** A reviewed workflow change showed that a
+  standing policy remains active before its boundary-specific validation
+  procedure starts.
+
+### Privacy-Cleared v1.0.0 Semantic Snapshot
+
+#### Metadata and overview
+
+- Name: `skill-advisor-task-routing`
+- License: `BSD-3-Clause`
+- Category: `tooling`
+- Date: `2026-07-16`
+- Version: `1.0.0`
+- User invocation: disabled
+- Tags: workflow, routing, process, and skills
+- Objective: Select an applicable procedural skill before work starts.
+- Outcome: Operational guidance for skill selection.
+
+#### Purpose and trigger
+
+The prior version routed a task to an applicable procedural skill before
+substantive work. It instructed the agent to check even when the probability
+that a skill applied was small. It also instructed the agent to get applicable
+prior knowledge before it selected a process skill. Failure to prepare a
+required knowledge source blocked that skill.
+
+#### Workflow
+
+The prior decision map had these branches:
+
+- A new feature or bug correction used `test-driven-development` before code.
+- An unexpected failure used `systematic-debugging` before a proposed
+  correction.
+- A completion claim used `verification-evidence-audit` before the claim.
+- Complex or ambiguous work used `brainstorm` before a plan or code.
+- Work that needed isolation used the applicable isolation skill. It did not
+  add a second isolation procedure when the orchestrator already supplied
+  isolation.
+- Verified work used `finish-branch-delivery-workflow` before delivery.
+- A major task used an independent review before merge when a reviewer was
+  available.
+- Review feedback received an evidence check before changes and an independent
+  recheck after changes.
+
+When more than one skill applied, the prior version used this order:
+
+1. Process skills selected the work method.
+2. Execution skills controlled the work.
+3. Completion skills checked the result and controlled delivery.
+
+The prior skip conditions were a bounded subagent task, an explicit request
+for one action without workflow overhead, and a truly trivial change.
+
+#### Failed approaches
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --- | --- | --- | --- |
+| Treat a question as simple | Skipped the skill check for a question | A question can become a substantive task | Check the task before substantive work |
+| Work from memory | Used a remembered workflow | Skill content can change | Read the current skill |
+| Reject a skill as excessive | Used task size instead of the skill trigger | A simple task can become complex | Use the applicable skill |
+| Explore before routing | Started discovery before the skill check | The skill can control the discovery method | Route the task first |
+
+#### Output contract
+
+The prior version required the agent to state the selected skill or the skip
+reason before substantive work.
+
+#### References and verification
+
+The prior version named three related procedural skills. The semantic snapshot
+keeps those skill names in the workflow section. The exact verification record
+and third-party notice are not in this privacy-cleared archive because they
+contain prohibited identifiers and attribution details. The original
+repository revision retains the exact legal record.
+
+### v1.1.0 Change Record
+
+- Separated policy scope from procedural-skill timing.
+- Replaced probability-based early activation with stated-trigger routing.
+- Added phase-aware routing and complete boundary input checks.
+- Permitted early skill use only when the user names the skill or a
+  higher-precedence instruction specifies an earlier boundary.
+- Required instruction-precedence checks for conflicting trigger statements.
+- Narrowed the explicit-action skip to trivial work with no applicable
+  repository workflow.
+- Rewrote the current guidance with new expression. The third-party notice for
+  the prior expression does not apply to the new text.

--- a/skills/skill-advisor-task-routing.md
+++ b/skills/skill-advisor-task-routing.md
@@ -1,12 +1,19 @@
 ---
 name: skill-advisor-task-routing
 license: BSD-3-Clause
-description: "Route a task to the appropriate procedural skill before starting substantive work. Use when: (1) beginning any non-trivial task, (2) unsure whether a process, execution, or completion skill applies, (3) tempted to skip workflow checks because the task 'seems simple'"
+description: >
+  Use this skill to select procedural skills and their first workflow phases.
+  Use it when work starts.
+  Use it when a policy is applicable to all work but its related skill is for
+  a subsequent boundary.
+  Use it when instructions give different trigger times.
+  Use it when a user names a skill.
 category: tooling
 date: 2026-07-16
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
-tags: [workflow, routing, process, skills]
+verification: verified-review
+tags: [workflow, routing, process, skills, policy, boundary]
 ---
 
 # Skill Advisor: Task Routing
@@ -14,90 +21,171 @@ tags: [workflow, routing, process, skills]
 ## Overview
 
 | Field | Value |
-| ------- | ------- |
+| --- | --- |
 | **Date** | 2026-07-16 |
-| **Objective** | Decision tree for routing a task to the right procedural skill before work begins |
-| **Outcome** | Operational — migrated from the Athena `skill-advisor` skill into standard knowledge |
+| **Objective** | Select each applicable procedural skill and use it when its specified trigger occurs |
+| **Outcome** | Policies stay active for all work in their scopes. Skills start at their specified boundaries. |
+| **Verification** | verified-review |
+
+A policy gives a rule for applicable work. A procedural skill gives steps for
+a specified workflow phase. Policy scope and skill timing are different.
+
+In this skill, a current skill has a trigger in the current phase. A deferred
+skill is a skill for a subsequent phase.
 
 ## When to Use
 
-**Core principle:** check for a relevant skill BEFORE beginning any substantive work. If there is even a 1% chance a skill applies, invoke it.
-
-Knowledge first, then process: search the knowledge backend (advise) for prior lessons before routing to a procedural skill. Failure to prepare the required knowledge backend is blocking.
+- You start a task where skill selection is necessary.
+- A policy is applicable to all task work, but its validation skill is for a
+  subsequent workflow boundary.
+- Two instructions give different trigger times for one skill.
+- The user names a skill.
+- You will start a new workflow phase or make a completion claim.
 
 ## Verified Workflow
 
-### Decision Tree
+### Quick Reference
 
-```text
-What are you about to do?
-│
-├─ Implementing a new feature or fixing a bug?
-│   └─ → test-driven-development (BEFORE writing any code)
-│
-├─ Debugging an unexpected failure, bug, or error?
-│   └─ → systematic-debugging (BEFORE proposing fixes)
-│
-├─ About to claim work is "done", "passing", or "fixed"?
-│   └─ → verification evidence audit (BEFORE making any success claims)
-│
-├─ Starting a complex or ambiguous feature from scratch?
-│   └─ → brainstorm (BEFORE writing any code or plan)
-│
-├─ Needing an isolated workspace for a new branch?
-│   └─ → git-worktrees
-│       (skip if using myrmidon-swarm — it handles isolation automatically)
-│
-├─ Implementation complete, ready to merge or create PR?
-│   └─ → finish-branch delivery workflow (AFTER verification)
-│
-├─ Completed a major task and want quality assurance?
-│   └─ → code-review before merge (uses an independent reviewer when available)
-│
-└─ Received code review feedback to act on?
-    └─ → evaluate each comment with evidence, then request an independent recheck
-```
+| Condition | Action |
+| --- | --- |
+| A skill procedure is necessary in the current phase | Use the skill before the first applicable action |
+| A policy is applicable to all task work | Keep the policy active |
+| A skill has a subsequent boundary | Record the skill as deferred |
+| The user names a skill | Use the skill now |
+| Trigger statements give different boundaries | Use instruction precedence to select the controlling statement |
+| You cannot use instruction precedence to identify one controlling statement | Stop the affected work. Report the conflict. |
+| A deferred boundary starts | Use the skill for all applicable artifacts from previous phases |
 
-### Skill Priority
+### Detailed Steps
 
-When multiple skills could apply:
+1. **Find policies for the work.** Keep each policy active for all work in its
+   scope. Do not wait for a related skill to start.
 
-1. **Process skills first** (brainstorm, systematic-debugging) — determine HOW to approach
-2. **Execution skills second** (test-driven-development, git-worktrees) — guide execution
-3. **Completion skills last** (verification, finish-branch, code-review) — gate closure
+2. **Get previous knowledge.** For work where skill selection is necessary,
+   use the necessary knowledge-retrieval procedure before planning or
+   implementation. Prepare a knowledge source before you use a skill that has
+   the source as a prerequisite. A source-preparation failure prevents use of
+   the related skill.
 
-Example: "Fix this bug" → systematic-debugging first, then test-driven-development for the fix.
+3. **Find procedural skills.** Read each skill trigger. Find its specified action,
+   condition, or workflow boundary. Do not use the skill before this boundary
+   only because the procedure can help you.
 
-Example: "Build new feature" → brainstorm first, then test-driven-development for implementation.
+4. **Find current and deferred skills.** Use a current skill before the first
+   action for which it is necessary. Record a skill for a subsequent phase and
+   its boundary. Do not use a skill at task start only because its related
+   policy is applicable to all task work.
 
-### When to Skip
+5. **Use a skill that the user names.** Use it now. Do not wait for its phase
+   boundary.
 
-- You are a subagent dispatched by an orchestrator with a specific task — follow your task prompt directly.
-- You were explicitly told "just do X" without workflow overhead.
-- The task is truly trivial (typo fix, single-line rename).
+6. **Use instruction precedence.** When statements give different boundaries,
+   use precedence to select the statement that controls the workflow. If
+   precedence cannot select one statement, stop the affected work. Report the
+   conflict.
+
+7. **Examine all routing instructions that control the workflow.** List the skill
+   description, repository instructions, workflow guides, and other trigger
+   statements. If the task permits changes to all conflicting instructions,
+   change the statements to specify the same boundary. If the task does not
+   permit these changes, stop the affected work. Report the conflict.
+
+8. **Use the boundary skill on the full input set.** When the boundary starts,
+   include all applicable artifacts from previous phases. A deferred skill
+   must not examine only metadata made at the boundary.
+
+9. **Examine routing at each phase change.** A deferred skill becomes current
+   when its boundary starts. Do not start it before this boundary only because
+   it can help you. If the user names the skill, use it now. If an instruction
+   with higher precedence gives a different boundary, use that boundary.
+
+### Common Routing Map
+
+| Task condition | Skill and time of use |
+| --- | --- |
+| You do not know how to do the work | Use `advise` before planning or implementation |
+| The task has multiple possible designs | Use `brainstorm` before the plan or implementation |
+| A failure has an unknown cause | Use `systematic-debugging` before you propose a correction |
+| A feature or correction requires a code change | Use `test-driven-development` before implementation |
+| An isolated checkout is necessary | Use the applicable isolation skill before file changes. Do not add a second isolation procedure when the orchestrator supplies one. |
+| You will make a completion claim | Use `verification-evidence-audit` before the claim |
+| The verified work is ready for delivery | Use `finish-branch-delivery-workflow` at the delivery boundary |
+| Independent quality assurance is necessary | Use an independent review before merge when a reviewer is available |
+| You receive review feedback | Examine each comment with evidence before you change the work. After the change, ask an independent reviewer to examine the changed work. |
+
+### Skill Order
+
+Use skills in this general order when their conditions occur:
+
+1. Process skills give the work method.
+2. Execution skills control implementation and investigation.
+3. Completion skills examine evidence and control delivery.
+
+The phase boundary controls the time of skill use. The list does not change a
+named trigger. The fact that a skill can help you does not change its trigger.
+
+### Skip Conditions
+
+You can skip this routing procedure when one condition is true:
+
+- An orchestrator gives a subagent one bounded task and names the necessary
+  procedure.
+- The user tells you to do one action, and no repository workflow is
+  applicable.
+- The task has no action, artifact, or completion claim.
+
+Record the cause when you skip the procedure.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
-| "Just a simple question" | Skipping the check for questions | Questions become tasks | Check anyway |
-| "I already know the approach" | Working from memory of a skill | Skills evolve | Check the current version |
-| "Skill is overkill" | Ad-hoc approach to a "simple" task | Simple things become complex | Use the skill |
-| "I'll check after exploring" | Exploring first, routing later | Skills tell you HOW to explore | Check first |
+| --- | --- | --- | --- |
+| Use all possible skills at task start | Treated a policy for all work as a skill trigger at task start | The procedure started before its input was available | Use the skill at its stated trigger while the policy stays active |
+| Change one trigger statement | Changed the skill description but did not change another instruction | The instructions gave different boundaries | For a trigger change, examine all routing instructions that the task permits you to change |
+| Start the policy with the skill | Used the policy only when the boundary skill started | Work on artifacts from previous phases did not follow the policy | Keep the policy active for all work in its scope |
+| Examine only new boundary metadata | Used the deferred skill only for metadata made at the boundary | The skill did not examine applicable artifacts from previous phases | Use the boundary skill on the full input set |
+| Move a skill because it can be useful | Used a preference instead of the stated trigger | The skill started before its stated boundary | Use the stated trigger unless the user or a higher-precedence instruction gives a different trigger |
+| Treat a question as a simple task | Skipped routing because the task did not change a file | The analysis made a procedural skill necessary | Route a question when skill selection is necessary |
+| Explore before routing | Started discovery before the skill selection | The applicable skill controlled the discovery method | Route the task before discovery |
+| Reject a skill as excessive | Used task size instead of the skill trigger | The task became complex during the work | Use the skill trigger instead of the first complexity estimate |
+| Work from memory | Used a remembered trigger instead of the current trigger | Skill triggers can change | Read the current trigger before routing |
 
 ## Results & Parameters
 
+### Routing Record
+
+Use this format before work that has an action, artifact, or completion claim.
+Update it at each phase change.
+
+```text
+Applicable policies:
+- <policy and scope>
+
+Skills to use now:
+- <skill>: <first applicable action>
+
+Skills for subsequent phases:
+- <skill>: <workflow boundary>
+
+Trigger conflicts:
+- <conflict or none>
+```
+
 ### Expected Output
 
-The selected skill (or explicit skip justification) stated before substantive work begins.
+A routing decision is satisfactory when these conditions are true:
+
+- Each applicable policy is active for all work in its scope.
+- Each current skill starts before the first applicable action.
+- Each deferred skill has a named boundary.
+- Each boundary examination includes all applicable artifacts from previous
+  phases.
+- The agent uses instruction precedence to identify one controlling trigger
+  statement. If instruction precedence does not identify one controlling
+  statement, the agent stops the affected work and reports the conflict.
 
 ## Verified On
 
-| Project | Context | Details |
-| --------- | --------- | --------- |
-| Athena | Shipped as the `skill-advisor` plugin skill; exercised across HomericIntelligence repositories | Migrated 2026-07-16 |
-
-## References
-
-- Related: [advise-before-planning.md](advise-before-planning.md), [verification-evidence-audit.md](verification-evidence-audit.md), [finish-branch-delivery-workflow.md](finish-branch-delivery-workflow.md)
-- Adapted from [obra/superpowers](https://github.com/obra/superpowers) under the MIT License. Copyright (c) 2025 Jesse Vincent.
+| Context | Method | Result |
+| --- | --- | --- |
+| Repository policy change | Independent review of a boundary-specific validation workflow | The policy stayed active, and the validation skill moved to the delivery boundary |


### PR DESCRIPTION
## Summary

This change keeps each policy active for all work in its scope.
The change specifies the workflow boundary for each applicable procedural skill.
A boundary examination includes applicable artifacts from previous phases.
The agent uses instruction precedence when trigger statements specify different boundaries.

## Related Issues

None.

## Changes Made

- The change updates the canonical task-routing guidance.
- The change adds a privacy-cleared history record for the superseded version.

## Test Plan

- [x] Tests pass locally.
- [x] The author verified the changes manually.
- [x] The privacy review passed.
- [x] The controlled-English review passed.

## Checklist

- [x] Changed prose follows the current writing policy.
- [x] The author compared changed prose with the current official issue.
- [x] This change is not a corpus-wide change.
- [x] The corpus-wide inventory requirements do not apply.
- [x] The change includes only the intended changes to technical meaning.
- [x] The change did not change protected literals.
- [x] The change did not modify documented principles for style reasons.
- [x] The change did not copy a standard, rule set, dictionary, PDF, or logo.
- [x] The change makes no approval, certification, or endorsement claim.
- [x] Ownership statements remain consistent.
- [x] The skill has valid frontmatter.
- [x] The skill documents applicable failed attempts.
- [x] Paths use cross-repository placeholders.
- [x] The tested selector returns one canonical entry for this intent.
