### PR TITLE
docs(skills): validate scanner inventory subjects

### DIFF
--- a/skills/vulnerability-scanner-evidence-fail-closed-validation.history
+++ b/skills/vulnerability-scanner-evidence-fail-closed-validation.history
@@ -1,0 +1,27 @@
+# vulnerability-scanner-evidence-fail-closed-validation — History
+
+## v1.1.0 (2026-09-06)
+
+**Change:** Added fail-closed subject and version validation for scanner inventories. Added the rule
+that a clean report is valid only for the component that its retained inventory identifies. Added
+current-revision gates for vulnerability-exception removal.
+
+**Provenance:** A CI remediation review found that a dependency inventory did not include the
+separately managed runtime named by the security claim. A runtime-inclusive inventory and scan
+passed the required CI gate.
+
+## v1.0.0 (2026-08-05)
+
+**Archive status:** privacy-redacted
+
+**Reason:** The prior main file contained case-specific identifiers, internal locations, and
+operational details that are not permitted in durable learning artifacts.
+
+**Generalized change summary:** The initial version added strict JSON decoding, nested evidence
+validation, fail-closed handling for incomplete records and unknown severity, command-mode parity,
+and exact reviewed exceptions.
+
+**Provenance:** The rule came from a locally verified vulnerability-scanner wrapper hardening
+session.
+
+The exact snapshot was intentionally omitted.

--- a/skills/vulnerability-scanner-evidence-fail-closed-validation.md
+++ b/skills/vulnerability-scanner-evidence-fail-closed-validation.md
@@ -1,240 +1,193 @@
 ---
 name: vulnerability-scanner-evidence-fail-closed-validation
 license: BSD-3-Clause
-description: "Validate complete machine-readable vulnerability-scanner evidence before filtering and make absent, malformed, incomplete, or unscored findings fail closed. Use when: (1) a scanner wrapper treats empty or non-JSON output as clean, (2) nested mapping defaults can erase malformed dependency records, (3) advisories without parseable CVSS scores bypass a severity threshold, or (4) human and JSON CLI modes can return different verdicts."
+description: "Validate vulnerability-scanner evidence and scan coverage before policy filtering. Use when scanner output can be absent, malformed, incomplete, unscored, or clean because the inventory omitted the component or version in the security claim."
 category: tooling
 date: 2026-08-05
-version: "1.0.0"
+version: "1.1.0"
 user-invocable: false
-verification: verified-local
-tags: [vulnerability-scanning, scanner-evidence, json-validation, fail-closed, cvss, pip-audit, cli, security-policy]
+verification: mixed
+history: vulnerability-scanner-evidence-fail-closed-validation.history
+tags:
+  - vulnerability-scanning
+  - scanner-evidence
+  - inventory-coverage
+  - sbom
+  - json-validation
+  - fail-closed
+  - security-policy
 ---
 
-# Validate Vulnerability-Scanner Evidence Before Filtering
+# Validate Vulnerability-Scanner Evidence and Coverage
 
 ## Overview
 
 | Field | Value |
 | ------- | ------- |
 | **Date** | 2026-08-05 |
-| **Objective** | Ensure a severity filter can return a clean verdict only from one complete, structurally valid scanner report. |
-| **Outcome** | A reusable boundary was validated locally: decode the whole JSON document, validate every field the classifier consumes, reject skipped/incomplete records, and block valid advisories whose score is absent or unparsable. |
-| **Verification** | verified-local — the full change and regression matrix passed in a disposable ProjectHephaestus worktree; CI validation is pending. |
+| **Objective** | Permit a clean scanner verdict only when one complete report covers the component and version in the security claim. |
+| **Outcome** | Operational. Structural evidence validation was verified locally. Subject-identity validation over a retained runtime inventory was verified in continuous integration (CI). |
+| **Verification** | Mixed. See [the notes](./vulnerability-scanner-evidence-fail-closed-validation.notes.md). |
+| **History** | [Version records](./vulnerability-scanner-evidence-fail-closed-validation.history). |
 
 ## When to Use
 
-- A scanner-to-filter pipeline can send empty text, a human status line, truncated JSON, or mixed text and JSON to the policy process.
-- The filter walks untrusted scanner output with defaults such as `data.get("dependencies", [])` or `finding.get("id", "?")`.
-- A scanner can emit incomplete or skipped dependency records that lack the evidence required to declare them clean.
-- Missing, empty, or unparsable severity data currently falls below a numeric threshold instead of becoming a blocking `UNKNOWN` finding.
-- A CLI supports both human and machine-readable output and both modes must expose the same nonzero verdict.
-- A repository already has reviewed advisory-ID exceptions and the hardening must preserve exact equality as the only bypass.
+- A scanner can receive empty text, human-readable text, truncated JSON, or mixed text and JSON.
+- A policy filter uses defaults that can convert malformed records to an empty result.
+- A scanner can emit incomplete dependency records.
+- An advisory has no usable severity score.
+- A security claim names a runtime, image, binary, package, or version that the current inventory
+  might not contain.
+- A dependency-only inventory can omit the interpreter or another managed runtime that executes the
+  dependencies.
+- A vulnerability exception will be removed because a scan is green.
+- Human-readable and machine-readable command modes must return the same verdict.
 
 ## Verified Workflow
 
-Verified locally only — CI validation pending.
-
 ### Quick Reference
 
-```python
-import json
-from typing import Any, cast
+```bash
+# Inventory the component that the claim names.
+syft scan <subject-root> -o json=<subject-inventory.json>
 
+# Fail if the retained inventory does not identify the expected component and version.
+python3 <identity-checker> <subject-inventory.json> --name <expected-name> --version <expected-version>
 
-def _validate_finding(record: object, path: str) -> None:
-    if not isinstance(record, dict):
-        raise ValueError(f"{path} must be an object")
-    finding_id = record.get("id")
-    if not isinstance(finding_id, str) or not finding_id.strip():
-        raise ValueError(f"{path}.id must be a nonempty string")
-    severity = record.get("severity", [])
-    if not isinstance(severity, list):
-        raise ValueError(f"{path}.severity must be a list")
-    if any(not isinstance(entry, dict) for entry in severity):
-        raise ValueError(f"{path}.severity entries must be objects")
-
-
-def validate_scanner_result(data: object) -> dict[str, Any]:
-    if not isinstance(data, dict):
-        raise ValueError("expected a top-level object")
-    dependencies = data.get("dependencies")
-    if not isinstance(dependencies, list):
-        raise ValueError("dependencies must be a list")
-    for dependency_index, dependency in enumerate(dependencies):
-        path = f"dependencies[{dependency_index}]"
-        if not isinstance(dependency, dict):
-            raise ValueError(f"{path} must be an object")
-        for field in ("name", "version"):
-            value = dependency.get(field)
-            if not isinstance(value, str) or not value.strip():
-                raise ValueError(f"{path}.{field} must be a nonempty string")
-        findings = dependency.get("vulns")
-        if not isinstance(findings, list):
-            raise ValueError(f"{path}.vulns must be a list")
-        for finding_index, finding in enumerate(findings):
-            _validate_finding(finding, f"{path}.vulns[{finding_index}]")
-    return cast(dict[str, Any], data)
-
-
-def parse_scanner_input(raw: str) -> dict[str, Any]:
-    try:
-        parsed = json.loads(raw)  # one complete document; no prefix search
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"failed to parse JSON: {exc}") from exc
-    return validate_scanner_result(parsed)
-
-
-validated = validate_scanner_result(data)
-for dependency in validated["dependencies"]:
-    for finding in dependency["vulns"]:
-        finding_id = finding["id"]
-        if finding_id in reviewed_exception_ids:
-            continue
-        score = extract_score(finding.get("severity", []))
-        if score is None or score >= threshold:
-            blocking.append(finding_id)
+# Scan the same retained inventory. Do not rediscover a different input.
+grype sbom:<subject-inventory.json> -o json > <subject-report.json>
+python3 <policy-checker> <subject-report.json>
 ```
 
 ### Detailed Steps
 
-1. **Decode exactly one JSON document.** Pass the complete scanner stdout to `json.loads(raw)`.
-   Do not search for the first `{`, trim a human prefix, or interpret the absence of `{` as a
-   successful empty report. Empty, non-JSON, malformed, prefixed, and trailing content must all
-   enter the same input-error path.
+1. **Define the evidence subject.** Before the scan, state the component, version, and execution
+   boundary that the result must cover. Derive these values from an authoritative source.
 
-2. **Validate the complete consumed shape before policy classification.** Validate only fields the
-   filter actually uses, but validate all of them:
+2. **Inventory each necessary boundary.** A package environment and its managed runtime can be
+   separate roots. Inventory both when the security claim covers both. Do not assume that a scan of
+   installed libraries also scans the interpreter or container runtime.
 
-   ```text
-   report                         object
-   report.dependencies            list
-   dependency                     object
-   dependency.name                nonempty string
-   dependency.version             nonempty string
-   dependency.vulns               list
-   vulnerability                  object
-   vulnerability.id               nonempty string
-   vulnerability.severity         optional list of objects
-   ```
+3. **Require subject identity before policy filtering.** Parse the retained inventory. Require an
+   exact component name and version. If the subject is absent or has a different version, stop with
+   an evidence error. A report with zero findings is not clean evidence for a subject that is not
+   present.
 
-   Keep small record validators separate when the repository enforces cyclomatic-complexity
-   limits. In the verified Python case, one monolithic validator scored C901 `13 > 12`; extracting
-   `_validate_vulnerability(record, path)` retained one shared boundary while passing lint.
+4. **Scan the retained inventory.** Give the exact inventory that passed the identity check to the
+   vulnerability scanner. Do not run a second discovery operation and assume that its coverage is
+   equal.
 
-3. **Reject scanner-specific incomplete records deliberately.** For `pip-audit` 2.10.1, the JSON
-   formatter emits either a resolved `name`/`version`/`vulns` record or a skipped
-   `name`/`skip_reason` record. The skipped record is valid scanner output but incomplete policy
-   evidence, so a strict filtering gate must reject it rather than convert it to zero findings.
+5. **Decode exactly one report.** Pass the complete scanner output to the JSON decoder. Do not find
+   the first opening brace or remove a human-readable prefix. Treat empty, malformed, prefixed, and
+   trailing content as input errors.
 
-4. **Use required-field access after validation.** Traverse `validated["dependencies"]`,
-   `dependency["name"]`, `dependency["version"]`, `dependency["vulns"]`, and finding `id`
-   directly. Defaults such as `[]` and `"?"` are unsafe after the trust boundary because they can
-   turn malformed evidence into a clean or misleading result.
+6. **Validate all consumed fields before classification.** Validate the top-level object,
+   dependency list, dependency identity, finding list, finding identity, and severity container.
+   Reject each missing field that the policy needs.
 
-5. **Separate structural validity from score availability.** An absent or empty `severity` list is
-   structurally valid for an otherwise complete advisory. A list containing objects whose fields
-   do not yield a supported numeric score or vector is also structurally valid. Classify all three
-   cases as `UNKNOWN`, and make `score is None` blocking. Reject only an invalid severity container
-   or a non-object severity entry as malformed evidence.
+7. **Reject incomplete scanner records deliberately.** A skipped or partial record can be valid
+   scanner output but insufficient policy evidence. Do not convert it to zero findings.
 
-6. **Preserve the reviewed exception boundary without broadening it.** If repository policy uses
-   an advisory-ID ledger, check exact `finding_id in reviewed_exception_ids` before score
-   classification. Do not add wildcard, substring, package-wide, or `UNKNOWN`-wide bypasses.
-   Keep the ledger's version scope, expiry, review, and security-documentation requirements.
+8. **Use required-field access after validation.** Do not use empty collection or placeholder
+   defaults for fields that the policy requires. Such defaults can convert bad evidence to a clean
+   result.
 
-7. **Centralize input failures before any normal output.** Parse and validate before loading or
-   announcing the exception ledger. Catch `ValueError` once in `main()` and route it through one
-   helper that emits either a human stderr diagnostic or a JSON error object, returning the same
-   nonzero code in both modes.
+9. **Keep structure and severity meaning separate.** A complete advisory can have no usable score.
+   Accept its structure, classify its severity as unknown, and make the finding block the gate.
 
-8. **Test the exported function and the CLI boundary.** Direct-call tests must prove malformed
-   nested data raises instead of yielding empty lists. CLI tests should cross-product each invalid
-   shape with human and JSON modes, then assert identical exit codes. Add a separate parity test
-   for a valid unscored advisory and a separate exact-ID exception test.
+10. **Keep exceptions exact.** Match only the reviewed finding identity and its required scope.
+    Keep version, expiry, review, and documentation controls. Do not add wildcard or package-wide
+    exceptions.
+
+11. **Retain evidence before enforcement.** Retain the subject inventory and the complete scanner
+    report on pass and failure. Make the required aggregate gate depend on the subject scan.
+
+12. **Remove an exception only after current evidence passes.** Require subject identity, scanner
+    policy, and the aggregate gate at the same revision. Do not use an earlier green scan.
+
+13. **Test success and failure paths.** Test an absent subject, wrong subject version, malformed
+    report, incomplete dependency, unknown severity, allowed low-severity finding, blocking
+    finding, and exact reviewed exception. Test command-mode parity when more than one output mode
+    exists.
 
 ## Failed Attempts
 
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
-| --------- | ---------------- | --------------- | ---------------- |
-| Find the first `{` and parse the suffix | The wrapper tolerated scanner prose before JSON and treated output with no `{` as a clean scan. | Missing scanner evidence became indistinguishable from a successful empty report; prefixed output was silently normalized. | Parse the whole document with `json.loads(raw)` and make every decode failure nonzero. |
-| Traverse nested records with `.get(..., [])` | Missing `dependencies`, `vulns`, names, versions, or IDs defaulted to empty collections or placeholders. | Structurally incomplete evidence could produce zero findings and exit success. | Validate first, then use required-field indexing. |
-| Suppress `score is None` below the numeric threshold | Missing, empty, or unparsable severity data entered the non-blocking collection. | An advisory with unknown impact bypassed the security gate without review. | Treat `None` as blocking `UNKNOWN`; low numeric scores alone are non-blocking. |
-| Reject every advisory without `severity` as malformed | Structural validation required score-bearing severity entries. | Scanners legitimately emit complete advisories before a CVSS score exists; structure and policy meaning were conflated. | Permit absent/empty severity, then block the advisory as `UNKNOWN`. |
-| Announce exceptions before validating stdin | The CLI loaded and printed normal policy state before discovering malformed evidence. | Operators and JSON consumers could receive success-shaped output before the failure verdict. | Validate evidence first and route all failures through one output-mode-aware helper. |
-| Keep all nested checks in one validator | A correct single function triggered the repository's Ruff C901 limit at complexity 13. | Static validation failed even though the behavior tests passed. | Extract a small vulnerability-record validator; retain one public validation boundary. |
-| Run a focused file under package-wide coverage addopts | All 83 audit tests passed, but pytest exited nonzero because the focused run measured only 6.79% of the whole package against an 83% gate. | The command mixed behavioral verification with repository-wide coverage policy. | Use `pytest --no-cov <focused-test>` for the focused loop, then run the full coverage suite separately. |
+| ------- | -------------- | ------------- | -------------- |
+| Scan only the dependency environment | The gate scanned installed libraries but not the separately managed runtime named by the remediation claim. | The scanner returned a clean result without examining the claimed subject. | Inventory each claimed boundary and require the exact subject identity before policy filtering. |
+| Trust a zero-finding report | The report had no findings, but its inventory did not contain the expected component. | Zero findings described only the scanned input. It did not prove that the omitted component was safe. | Bind the verdict to the inventory subject and version. |
+| Find the first JSON object | The wrapper removed scanner text before the first opening brace. | Missing or mixed evidence became accepted input. | Decode one complete JSON document and reject extra content. |
+| Traverse records with empty defaults | Missing dependencies, findings, names, versions, or identifiers became empty collections or placeholders. | Incomplete evidence could produce a clean result. | Validate first, then use required-field access. |
+| Treat an unknown score as low severity | A finding without a usable score passed below the threshold. | The gate approved an unclassified risk. | Make unknown severity block unless an exact reviewed exception applies. |
+| Announce normal policy state before input validation | The command printed success-shaped information before it found malformed evidence. | Users and machine consumers could receive contradictory output. | Validate evidence first and route failures through one error boundary. |
+| Run only parser unit tests | The parser tests passed without a real retained inventory or scanner execution. | The tests did not prove tool, inventory, artifact, and gate integration. | Run an end-to-end CI scan and inspect the retained inventory and report. |
 
 ## Results & Parameters
 
 ### Verdict Matrix
 
-| Input | Structurally accepted? | Policy verdict |
+| Evidence state | Structurally accepted? | Policy verdict |
 | ------- | ------- | ------- |
-| Complete report with no vulnerabilities | Yes | Exit 0 |
-| Empty, prose-only, malformed, prefixed, or trailing input | No | Shared input error, exit 1 |
-| Scalar, array, or object without `dependencies: list` | No | Shared input error, exit 1 |
-| Skipped dependency with only `name` and `skip_reason` | No | Shared input error, exit 1 |
-| Vulnerability with missing/empty/unparseable severity | Yes | Blocking `UNKNOWN`, exit 1 |
-| Vulnerability with numeric score below threshold | Yes | Non-blocking finding |
-| Vulnerability with score at or above threshold | Yes | Blocking finding, exit 1 |
-| Exact reviewed advisory-ID exception | Yes | Finding skipped |
+| Expected subject and version are absent | No | Evidence error; exit nonzero |
+| Expected subject has a different version | No | Evidence error; exit nonzero |
+| Expected subject is present and has no findings | Yes | Clean |
+| Report is empty, malformed, prefixed, or has trailing content | No | Input error; exit nonzero |
+| Required dependency or finding field is absent | No | Input error; exit nonzero |
+| Complete finding has no usable severity | Yes | Blocking unknown finding |
+| Numeric severity is below the threshold | Yes | Non-blocking finding |
+| Numeric severity meets the threshold | Yes | Blocking finding |
+| Exact reviewed exception applies | Yes | Finding is excepted for its exact scope |
 
 ### Regression Matrix
 
 ```yaml
-decode_failures:
+inventory_identity:
+  - expected-subject-present
+  - expected-subject-absent
+  - wrong-version
+report_decode:
   - empty
   - non-json
   - malformed-json
-top_level_shapes:
-  - null
-  - string
-  - number
-  - boolean
-  - array
-  - missing-dependencies
-  - dependencies-not-list
-nested_shapes:
+  - prefixed-json
+  - trailing-content
+nested_shape:
   - dependency-not-object
   - missing-name-or-version
-  - missing-vulns
+  - missing-findings
   - skipped-dependency
-  - vulns-not-list
-  - vulnerability-not-object
-  - missing-vulnerability-id
-  - severity-not-list
-  - severity-entry-not-object
-score_states:
-  - missing-severity
-  - empty-severity
-  - unparseable-score
-output_modes: [human, json]
+  - finding-not-object
+  - missing-finding-id
+severity:
+  - missing
+  - empty
+  - unparseable
+  - below-threshold
+  - at-threshold
+exceptions:
+  - exact-match
+  - wrong-package
+  - wrong-version
 ```
 
-### Local Verification Commands
+### Verification Commands
 
 ```bash
-<project-python> -m pytest --no-cov <audit-test-file> -q
-<project-ruff> check <audit-module> <audit-test-file>
-<project-mypy> <audit-module> <audit-test-file>
+<project-test-command> <focused-scanner-tests>
+<project-lint-command> <scanner-code> <focused-scanner-tests>
+<project-type-command> <scanner-code> <focused-scanner-tests>
+<project-ci-command> <required-security-gate>
 ```
-
-Observed in the ProjectHephaestus disposable verification worktree:
-
-- `83 passed` for the focused audit suite.
-- Ruff: `All checks passed!`
-- mypy: `Success: no issues found in 2 source files`.
-- The same focused pytest invocation without `--no-cov` executed all 83 assertions successfully
-  but failed the repository-wide 83% coverage threshold; this was not a behavior-test failure.
 
 ## Verified On
 
 | Project | Context | Details |
-| --------- | --------- | --------- |
-| ProjectHephaestus | Disposable worktree at source commit `446b0fea`; complete implementation and regression matrix applied locally | 83 focused tests passed with `--no-cov`; Ruff and mypy passed; CI pending and no Hephaestus code was pushed by the learn workflow. |
+| ------- | ------- | ------- |
+| Generalized source | Runtime-inclusive CI vulnerability scan | The retained inventory identified the exact managed runtime. The scanner evaluated that inventory through the required policy gate. See [the notes](./vulnerability-scanner-evidence-fail-closed-validation.notes.md). |
 
 ## References
 
-- [pip-audit 2.10.1 JSON formatter](https://github.com/pypa/pip-audit/blob/v2.10.1/pip_audit/_format/json.py#L48-L77)
-- [scan-vulnerabilities](scan-vulnerabilities.md) — broader scanner, inventory, threshold, and exception-governance guidance.
-- [pip-audit-policy-file-over-inline-ignores](pip-audit-policy-file-over-inline-ignores.md) — task-runner wiring and centralized suppression-policy guidance.
+- [Scan vulnerabilities](scan-vulnerabilities.md) — inventory retention, scanner execution, and
+  exception governance.
+- [Policy-file exceptions](pip-audit-policy-file-over-inline-ignores.md) — centralized exception
+  controls.

--- a/skills/vulnerability-scanner-evidence-fail-closed-validation.notes.md
+++ b/skills/vulnerability-scanner-evidence-fail-closed-validation.notes.md
@@ -1,0 +1,22 @@
+# Vulnerability-Scanner Evidence Coverage Notes
+
+## Evidence
+
+A required vulnerability gate scanned a package environment. The runtime that executed that
+environment was in a separate managed location. The retained inventory did not identify the
+runtime. Thus, a clean report could not support a remediation claim about that runtime.
+
+The repair made a second inventory from the resolved runtime root. A fail-closed check required the
+expected runtime name and version in that inventory. The workflow retained the package and runtime
+inventories. It scanned both with the same vulnerability policy. The required aggregate gate passed
+at the repaired revision.
+
+The retained runtime inventory identified the expected binary and version. The scanner report
+contained real non-blocking findings for that runtime and did not contain the target vulnerability.
+This result showed that the scanner evaluated the runtime instead of an empty or unrelated input.
+
+## Limits
+
+The source case details are generalized for privacy. This note does not preserve repository names,
+issue identifiers, URLs, local paths, hostnames, or raw logs. The evidence supports the inventory
+identity rule. It does not define a universal scanner threshold or exception policy.


### PR DESCRIPTION
## Summary

- Require vulnerability evidence to identify the exact scanned subject and version.
- Retain structural fail-closed rules and add current-revision exception-removal gates.
- Add privacy-safe history and supporting evidence notes.

## Validation

- just check: 783 of 783 skills valid; 256 tests passed.
- just package: source and wheel packages built.
- markdownlint-cli2: zero errors in changed Markdown files.
- pre-commit: all applicable hooks passed for changed artifacts.
- privacy scan: no direct personal-information patterns found.