### PR TITLE
docs(skills): verify parallel delivery capabilities

### DIFF
--- a/skills/parallel-pr-worktree-workflow.history
+++ b/skills/parallel-pr-worktree-workflow.history
@@ -1,5 +1,224 @@
 # parallel-pr-worktree-workflow — History
 
+## v2.1.0 (2026-09-07)
+
+- Disposition: amend the existing parallel delivery intent.
+- Change: verify required delivery capabilities before increasing a wave.
+- Evidence: a local audit distinguished published changes from incomplete reviewer validation.
+- Limit: no replacement review runner or successful recovery was verified.
+- Archive: complete prior retrievable v2.0.0 content follows.
+
+### Full snapshot of superseded v2.0.0 retrievable content
+
+````markdown
+---
+name: parallel-pr-worktree-workflow
+description: "Use when executing or rescuing multiple independent PRs concurrently: each writer needs an isolated worktree, dependency-aware batching, current-head CI triage, explicit merge-method/base handling, exact-lease rebases, contamination rescue, and bounded cleanup."
+category: ci-cd
+date: 2026-07-01
+version: "2.0.0"
+license: BSD-3-Clause
+user-invocable: false
+verification: verified-ci
+history: parallel-pr-worktree-workflow.history
+tags: [parallel-prs, git-worktree, agent-isolation, dependency-waves, current-head-ci,
+  mergeability, stacked-pr, auto-merge, contamination-rescue, force-with-lease]
+---
+
+# Parallel PR Worktree Workflow
+
+## Overview
+
+Parallelize independent PR work across isolated worktrees while preserving one writer per branch,
+explicit dependency order, and current-head evidence. Worktrees isolate `HEAD` and index state;
+waves isolate dependencies. Live PR metadata decides whether to rebase, fix CI, retarget, merge, or
+stop.
+
+Detailed examples are indexed in
+[`parallel-pr-worktree-workflow.notes.md`](parallel-pr-worktree-workflow.notes.md). The complete
+superseded source is in
+[`parallel-pr-worktree-workflow.history`](parallel-pr-worktree-workflow.history).
+
+## When to Use
+
+- Two or more agents will commit or push in the same repository.
+- Five or more independent fixes/PRs can be batched for throughput.
+- Many stale PRs need rebase, conflict resolution, checks, and conditional merge.
+- A shared prerequisite must land before a fan-out wave.
+- Branch/file contamination has already occurred and individual cleanup is becoming quadratic.
+- A stacked PR must be retargeted before auto-merge, or an earlier stacked merge was orphaned.
+- Checks are stale/missing, mergeability is DIRTY/CONFLICTING, or a branch predates a trunk CI fix.
+
+## Verified Workflow
+
+### 1. Inventory live state before editing
+
+For every PR, record number, head branch/OID, base, draft/state, mergeability, merge-state status,
+and check rollup. Query required checks and allowed merge methods once for the repository.
+
+```bash
+gh pr view <pr> --json number,state,isDraft,headRefName,headRefOid,baseRefName,\
+mergeable,mergeStateStatus,statusCheckRollup,url
+gh pr checks <pr>
+gh repo view --json squashMergeAllowed,rebaseMergeAllowed,mergeCommitAllowed
+```
+
+Do not rely on `gh pr checks` alone: it may display earlier-head results. Missing required checks can
+mean GitHub cannot synthesize a merge ref because the PR conflicts. Read the full failed job log
+before changing code.
+
+### 2. Build dependency waves and ownership maps
+
+Partition work into:
+
+- independent PRs that can start from the same trunk SHA;
+- prerequisite PRs that must land first;
+- dependents that branch from the prerequisite and target it temporarily; and
+- shared hot files that must be serialized.
+
+Use roughly three to four PRs per worker for repetitive rebase work, but one worktree and one writer
+per writable branch. Give every worker exact PRs, branch/base, worktree path, owned files, validation,
+push lease, and merge policy. Never use the primary checkout when another session may move it.
+
+### 3. Create explicit worktrees
+
+```bash
+git fetch origin
+git worktree add -b <branch> <absolute-path> origin/main
+git -C <absolute-path> status --short --branch
+```
+
+For an existing remote PR branch, create a unique detached or local-branch worktree without
+switching a possibly dirty local checkout:
+
+```bash
+git worktree add --detach <absolute-path> origin/<pr-branch>
+```
+
+Use the worktree path for all edits and commands. Verify branch and changed paths before commit.
+Unique paths are permanent isolation boundaries for the run; do not recycle a path across agents.
+
+### 4. Triage current-head CI and mergeability
+
+Connect failures to `headRefOid`. If a check is red, inspect the actual job log. If a required check
+is absent and `mergeable=CONFLICTING`/`mergeStateStatus=DIRTY`, rebase first—waiting cannot create a
+merge ref. After a push, `mergeable=UNKNOWN` usually means recomputation; poll rather than inventing
+a new defect.
+
+When stale branches fail on dependencies or workflows, inspect trunk history before editing branch
+code. If the fix is already on trunk, rebase the PR; do not duplicate it.
+
+```bash
+git fetch origin main <pr-branch>
+git rebase origin/main
+<focused-tests-and-lints>
+git push --force-with-lease=refs/heads/<pr-branch>:<observed-old-head> \
+  origin HEAD:refs/heads/<pr-branch>
+```
+
+Run focused tests for the edited surface and the repository's complete required validation. After
+each push, query checks again because one gate can mask the next. Distinguish unrelated local host
+failures from the repository's current-head CI evidence, but report both honestly.
+
+### 5. Handle shared prerequisites and stacked PRs
+
+Land a common blocker as its own PR. Branch dependents from that prerequisite and target the
+prerequisite branch only while it is genuinely expected to merge. Before arming auto-merge on a
+dependent, confirm the prerequisite content is on trunk, retarget the dependent to trunk, and rebase
+to remove redundant commits:
+
+```bash
+gh pr edit <dependent-pr> --base main
+git rebase origin/main
+git push --force-with-lease=refs/heads/<branch>:<old-head> origin HEAD:<branch>
+```
+
+Only then enable the repository-supported merge method. A dependent left based on a branch that is
+closed unmerged can merge into that dead branch and become orphaned. If already orphaned, cherry-pick
+the intended squash/commit onto a fresh trunk branch, validate, and open a new PR to trunk.
+
+### 6. Commit and publish each isolated unit
+
+For each worktree:
+
+1. Make only the assigned change.
+2. Run pre-commit on all PR-diff files and relevant/full tests.
+3. Inspect staged paths and commit under repository signing/DCO policy.
+4. Push the exact branch, create/update its PR, and verify the live head.
+5. Enable auto-merge only if authorized, the base is final, and the method is allowed.
+
+Do not assume `--rebase`; detect repository settings and use the accepted method, commonly squash.
+Do not publish generic PR bodies: summarize the actual delta, dependency, and runnable evidence.
+
+### 7. Rescue cross-contaminated branches
+
+If concurrent workers used a shared checkout and commits are tangled, stop publishing individual
+branches. Export staged/unstaged safety patches, identify every intended commit, and create one fresh
+integration worktree from trunk. Cherry-pick the worker commits in dependency order, resolve once,
+run combined validation, and open one consolidation PR referencing every issue. Close superseded
+worker PRs with a link.
+
+This rescue is preferable when per-branch disentangling is O(N²). For a single hijacked branch,
+stash/export the local delta and apply it in a fresh owned worktree; never continue after another
+session moves `HEAD`.
+
+### 8. Merge in waves and preserve cleanup state
+
+Wait for current-head required checks and mergeability. Merge or arm only authorized PRs. After all
+PRs in a wave land, fetch the new trunk and create the next wave from that head. Never branch a
+dependent wave from stale local main.
+
+Cleanup happens per PR only after merge/closure and work preservation are proven:
+
+```bash
+git worktree remove <absolute-path>
+git worktree prune
+```
+
+Dirty, locked, submodule-containing, or otherwise force-required worktrees need the repository's
+guarded cleanup policy; do not improvise destructive commands.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --- | --- | --- | --- |
+| Concurrent work in primary checkout | Concurrent work in primary checkout | Shared HEAD/index contaminates branches | One explicit worktree per writer |
+| Branch all dependents from trunk | Branch all dependents from trunk | Shared prerequisite blocks every PR | Land prerequisite, then fan out |
+| Arm auto-merge while still stacked | Arm auto-merge while still stacked | May merge into a dead intermediate base | Retarget/rebase to trunk first |
+| Trust stale check table | Trust stale check table | Results may belong to an old head | Bind checks to `headRefOid` |
+| Wait for missing validate on conflict | Wait for missing validate on conflict | No merge ref exists | Rebase when mergeability is conflicting |
+| Fix branch code before checking trunk | Fix branch code before checking trunk | Duplicates already-landed CI/dependency fixes | Inspect logs and trunk history first |
+| Bare force-with-lease | Bare force-with-lease | Does not pin the observed PR head explicitly | Lease exact branch and old OID |
+| Repair many contaminated PRs separately | Repair many contaminated PRs separately | Tangled commits create quadratic cleanup | Consolidate by cherry-pick in one fresh branch |
+| Reuse worktree paths | Reuse worktree paths | Risks stale state and ownership ambiguity | Unique path per writer/run |
+
+## Results & Parameters
+
+Worker brief:
+
+```text
+PR and issue: <identifiers>
+worktree: <absolute path>
+head branch/OID: <branch>/<oid>
+base branch/OID: <branch>/<oid>
+owned and forbidden paths: <lists>
+dependency wave: <number and prerequisites>
+focused/full validation: <commands>
+push: exact force-with-lease if rewritten
+merge: off | authorized method after final-base confirmation
+```
+
+Orchestrator acceptance requires one writer per branch, no unowned files, current-head green required
+checks, correct final base, supported merge method, and a recorded final head/merge OID.
+
+## Verified On
+
+- Verified-ci parallel PR, current-head triage, conflict rebase, endpoint/workflow drift, and stale
+  automation branch rescues through 2026-07-01.
+- Compacted for issue #3335 without changing the evidence classification.
+````
+
+
 ## v2.0.0 (2026-08-20)
 
 **Changed by:** Mnemosyne issue #3335 at immutable base `1ae0cb498e5250c341c2a4bf585f97e2a28060af`

--- a/skills/parallel-pr-worktree-workflow.md
+++ b/skills/parallel-pr-worktree-workflow.md
@@ -3,10 +3,10 @@ name: parallel-pr-worktree-workflow
 description: "Use when executing or rescuing multiple independent PRs concurrently: each writer needs an isolated worktree, dependency-aware batching, current-head CI triage, explicit merge-method/base handling, exact-lease rebases, contamination rescue, and bounded cleanup."
 category: ci-cd
 date: 2026-07-01
-version: "2.0.0"
+version: "2.1.0"
 license: BSD-3-Clause
 user-invocable: false
-verification: verified-ci
+verification: verified-local
 history: parallel-pr-worktree-workflow.history
 tags: [parallel-prs, git-worktree, agent-isolation, dependency-waves, current-head-ci,
   mergeability, stacked-pr, auto-merge, contamination-rescue, force-with-lease]
@@ -35,8 +35,36 @@ superseded source is in
 - Branch/file contamination has already occurred and individual cleanup is becoming quadratic.
 - A stacked PR must be retargeted before auto-merge, or an earlier stacked merge was orphaned.
 - Checks are stale/missing, mergeability is DIRTY/CONFLICTING, or a branch predates a trunk CI fix.
+- A required review tool is unavailable, although the changes are already in a PR.
 
 ## Verified Workflow
+
+### 0. Verify the delivery path before increasing a wave
+
+Before you add workers, verify that the host can perform each required delivery stage.
+Apply the repository and host policies. Do not replace a required capability with a weaker check.
+
+| Stage | Required evidence |
+| --- | --- |
+| Local work | The assigned worktree, owned paths, local commit, and applicable author checks. |
+| PR publication | The remote PR exists and its head matches the intended local commit. |
+| Source review | An independent review identifies the exact source and its findings. |
+| Review validation | The required execution boundary exists and supplies the required exact-head evidence. |
+| Merge readiness | The complete review, current-head checks, merge policy, and authority all permit the merge. |
+
+Success at one stage does not prove success at another.
+Green CI does not replace separate reviewer validation when that validation is required.
+A source review with no findings does not remove an unmet validation requirement.
+
+If a required capability is unavailable, identify the affected stage and its owner.
+Stop work that depends on that stage. Continue only authorized work with independent dependencies and adequate delivery capacity.
+Preserve completed work and existing PRs. Publish completed units when their publication gates permit it.
+Do not enlarge the wave while completed work accumulates behind the same unavailable stage.
+Do not repeat unchanged planning or source reviews to substitute for the missing capability.
+
+Report the last verified stage, exact commit, missing capability, next action, and any required authority.
+If the user pauses development, stop implementation and preserve the recorded delivery state.
+Do not claim that the missing capability or recovery has been verified.
 
 ### 1. Inventory live state before editing
 
@@ -170,6 +198,7 @@ guarded cleanup policy; do not improvise destructive commands.
 | Attempt | What Was Tried | Why It Failed | Lesson Learned |
 | --- | --- | --- | --- |
 | Concurrent work in primary checkout | Concurrent work in primary checkout | Shared HEAD/index contaminates branches | One explicit worktree per writer |
+| Check delivery capabilities after implementation | Increased a wave before verifying a required review capability | Published work could not complete its review | Verify each required stage before increasing the wave |
 | Branch all dependents from trunk | Branch all dependents from trunk | Shared prerequisite blocks every PR | Land prerequisite, then fan out |
 | Arm auto-merge while still stacked | Arm auto-merge while still stacked | May merge into a dead intermediate base | Retarget/rebase to trunk first |
 | Trust stale check table | Trust stale check table | Results may belong to an old head | Bind checks to `headRefOid` |

--- a/skills/parallel-pr-worktree-workflow.notes.md
+++ b/skills/parallel-pr-worktree-workflow.notes.md
@@ -37,7 +37,23 @@ in CI. Detached temporary worktrees were rebased rather than editing branch code
 reported 82 and 24 passing tests, signatures/trailers were checked, exact old-head leases protected
 the pushes, and GitHub reported CLEAN/MERGEABLE with all checks passing.
 
-## Provenance
+## Delivery capability observation
+
+A local audit found published changes whose remote heads matched the intended commits.
+Independent source reviews had no remaining source finding, and CI had passed.
+A separate required reviewer execution capability was unavailable.
+The review therefore remained conditional.
+
+The audit verified the publication state and the missing review stage.
+It did not implement or verify a replacement runner.
+Repeated planning and source inspection did not supply the missing capability.
+Development stopped at the user's request, and the existing work was preserved.
+
+This evidence supports a delivery preflight and distinct stage reports.
+It does not prove that a proposed runner works or that the changes are merge-ready.
+No source identifiers, private paths, raw logs, or operational data are retained here.
+
+## Earlier provenance
 
 - Superseded main SHA-256:
   `bb8e4a6f8e500ac3e031fcd1422a7f37e9a0e19b88602d9652661f6375af8b5d`


### PR DESCRIPTION
## Summary

Amend the existing parallel-PR workflow to verify required delivery capabilities before increasing a worker wave.

Keep local commits, PR publication, source review, review validation, and merge readiness as separate evidence states.
An unavailable review capability must not become an unreported delivery blocker.
Green CI does not replace other required review evidence.

## Changes made

- Update `parallel-pr-worktree-workflow` to version `2.1.0`.
- Add one delivery preflight and one related failed-attempt row.
- Archive the complete prior version in the existing history file.
- Keep the generalized observation and its evidence limits in the existing notes file.
- Use `verified-local` for the current guidance. No replacement-runner recovery was verified.

The write scope contains three files. The active main file is 11,771 bytes.
Most added lines preserve the prior version in the required history archive.
No new skill, workflow helper, repository policy, or executable behavior is added.

## Verification

- `uv sync --locked --group dev`: passed.
- `uv run python scripts/validate_plugins.py`: 783 of 783 skills valid.
- `uv run python -m pytest tests/ -q`: 256 tests passed before and after the amendment.
- `uv run ruff check scripts/ tests/`: passed.
- `uv run mypy scripts/ --ignore-missing-imports`: passed for seven source files.
- `uv run python scripts/check_pii.py`: passed.
- `git diff --check`: passed.
- The retrieval selector returns the main skill once and excludes notes and history.
- Independent static inspection found no required correction.

The prior version archive is byte-identical to the base main file.
No source-specific identifiers, private infrastructure details, or raw session records were added.

## Checklist

- [x] The commit is signed and has one DCO sign-off.
- [x] New and changed prose was examined with ASD-STE100 Issue 9 and the repository writing policy.
- [x] Protected literals and technical meaning remain unchanged.
- [x] Frontmatter and the failed-attempt table are valid.
- [x] No standard, dictionary, logo, or certification claim was added.
- [x] The canonical workflow ownership boundary remains unchanged.
- [ ] A human reviewer has examined the changed technical English.

This is a scoped amendment, not a corpus-wide language change.
No issue closure or auto-merge is requested.
