### PR TITLE
refactor: remove test-only legacy skill validator

### DIFF
--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -17,7 +17,7 @@ import re
 import sys
 import textwrap
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from mnemosyne_skill_utils import find_skill_files, parse_frontmatter  # noqa: F401  (re-exported for tests)
 
@@ -148,36 +148,6 @@ def validate_quick_reference_heading(body: str) -> List[str]:
         errors.append("Quick Reference should use ### (h3) not ## (h2)")
 
     return errors
-
-
-def validate_skill_md(plugin_dir: Path, _plugin_json: Dict) -> Tuple[List[str], List[str]]:
-    """Validate a legacy plugin-style skill directory.
-
-    Returns ``(errors, warnings)`` where orphaned top-level Quick Reference
-    headings are emitted as warnings, matching the historical test contract.
-    """
-    errors: List[str] = []
-    warnings: List[str] = []
-
-    skill_files = sorted(plugin_dir.rglob("SKILL.md"))
-    if not skill_files:
-        return ["Missing SKILL.md"], warnings
-
-    content = skill_files[0].read_text()
-    frontmatter, body, parse_errors = parse_frontmatter(content)
-    errors.extend(parse_errors)
-
-    if not frontmatter:
-        return errors, warnings
-
-    errors.extend(validate_frontmatter(frontmatter, skill_files[0].name))
-    errors.extend(validate_sections(body))
-    errors.extend(validate_failed_attempts_table(body))
-
-    if re.search(r"^## Quick Reference", body, re.MULTILINE):
-        warnings.append("Quick Reference should be a subsection (###) under Verified Workflow")
-
-    return errors, warnings
 
 
 def validate_plugin(filename: str) -> List[str]:

--- a/tests/test_quick_reference_transform.py
+++ b/tests/test_quick_reference_transform.py
@@ -35,7 +35,6 @@ from fix_remaining_warnings import (
     has_verified_workflow_section,
     merge_quick_reference_into_verified_workflow,
 )
-from validate_plugins import validate_skill_md
 
 
 def make_skill(
@@ -220,62 +219,3 @@ class TestFixSkillFileIntegration:
 
         assert modified is False
         assert fixes == []
-
-
-# ---------------------------------------------------------------------------
-# Tests for validate_plugins.py warning
-# ---------------------------------------------------------------------------
-
-
-class TestValidatePluginsQuickReferenceWarning:
-    def _make_plugin_dir(self, tmp_path: Path, skill_content: str) -> Path:
-        """Set up a minimal plugin directory structure."""
-        plugin_dir = tmp_path / "test-plugin"
-        skill_subdir = plugin_dir / "skills" / "test-plugin"
-        skill_subdir.mkdir(parents=True)
-        (skill_subdir / "SKILL.md").write_text(skill_content)
-
-        plugin_json_dir = plugin_dir / ".claude-plugin"
-        plugin_json_dir.mkdir()
-        import json
-
-        (plugin_json_dir / "plugin.json").write_text(
-            json.dumps(
-                {
-                    "name": "test-plugin",
-                    "version": "1.0.0",
-                    "description": "A test plugin for unit testing purposes.",
-                    "category": "tooling",
-                    "date": "2026-01-01",
-                }
-            )
-        )
-        return plugin_dir
-
-    def test_warns_on_orphaned_top_level_quick_reference(self, tmp_path: Path) -> None:
-        content = make_skill(has_quick_reference=True, has_verified_workflow=True)
-        plugin_dir = self._make_plugin_dir(tmp_path, content)
-
-        errors, warnings = validate_skill_md(plugin_dir, {})
-
-        warning_texts = " ".join(warnings)
-        assert "Quick Reference" in warning_texts
-        assert "subsection" in warning_texts.lower() or "###" in warning_texts
-
-    def test_no_warning_when_quick_reference_is_subsection(self, tmp_path: Path) -> None:
-        content = make_skill(qr_as_subsection=True)
-        plugin_dir = self._make_plugin_dir(tmp_path, content)
-
-        errors, warnings = validate_skill_md(plugin_dir, {})
-
-        qr_warnings = [w for w in warnings if "Quick Reference" in w and "subsection" in w.lower()]
-        assert qr_warnings == []
-
-    def test_no_warning_when_no_quick_reference(self, tmp_path: Path) -> None:
-        content = make_skill(has_quick_reference=False, has_verified_workflow=True)
-        plugin_dir = self._make_plugin_dir(tmp_path, content)
-
-        errors, warnings = validate_skill_md(plugin_dir, {})
-
-        qr_warnings = [w for w in warnings if "Quick Reference" in w]
-        assert qr_warnings == []


### PR DESCRIPTION
## Summary

Remove the test-only nested-plugin validator. The active flat validator retains its existing behavior and Quick Reference tests. This removes 90 net lines without changing the published parser.

## Related Issues

Closes #3385

This implements only the validator-helper part of #3378. The repair utility, its transformation tests, and the ecosystem importer remain unchanged.

## Changes Made

- Remove `validate_skill_md()` and its unused `Tuple` import.
- Remove its three legacy tests and their plugin fixture.
- Preserve all active flat validation and repair transformation tests.

## Test Plan

- [x] Baseline: 256 tests passed on base `612369bd5415018541c11804453d497ffa13000a`.
- [x] `uv run python -m pytest tests/ -q`: 253 tests passed after deletion.
- [x] `uv run ruff check scripts/ tests/` and `uv run mypy`: passed.
- [x] `uv run python scripts/validate_plugins.py`: 783/783 skills valid.
- [x] The pre-push hook ran the full suite on the committed head: 253 tests passed.

The package declaration exports only `mnemosyne_skill_utils`. A whole-repository reference search found only the removed tests as helper consumers. Restore the two changed files together to roll back.

## Checklist

- [x] No corpus prose or development-principles text changed.
- [x] The flat corpus and Athena ownership boundary remain unchanged.
- [x] No claim of ASD-STE100 certification or endorsement.
