### PR TITLE
build: use uv build for the local package recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,7 +25,7 @@ validate:
 
 # Build the Python wheel + sdist (mnemosyne_skill_utils) into dist/
 package:
-    uv run python -m build
+    uv build
 
 # === Testing ===
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dev = [
     "ruff>=0.16.1",
     "jsonschema>=4.26",
     "types-PyYAML",
-    "build>=1.2",
     "twine>=7.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -37,20 +37,6 @@ wheels = [
 ]
 
 [[package]]
-name = "build"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -436,7 +422,6 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "build" },
     { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
@@ -457,7 +442,6 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "build", specifier = ">=1.2" },
     { name = "jsonschema", specifier = ">=4.26" },
     { name = "mypy", specifier = ">=2.2" },
     { name = "pytest", specifier = ">=9.0" },
@@ -484,15 +468,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pyproject-hooks"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Use `uv build` for `just package`, matching the canonical CI command. Remove the unused `build` frontend and its exclusive `pyproject-hooks` dependency. The recipe name, package backend, runtime dependencies, and artifact behavior remain unchanged.

## Related Issues

Closes #3386

## Changes Made

- Replace `uv run python -m build` with `uv build`.
- Remove `build` from the development group.
- Regenerate `uv.lock`; remove only `build` and `pyproject-hooks`, with no dependency upgrades.

## Test Plan

- [x] Baseline and changed full suites: 256 tests passed each.
- [x] `just package`: wheel and source distribution built.
- [x] Wheel member names and every member byte match the baseline build.
- [x] Source distribution member names match; only `pyproject.toml` differs.
- [x] `uv run twine check dist/*`: passed with existing missing-description metadata warnings.
- [x] Install the wheel into a separate Python 3.13 environment; isolated parser smoke test passed from `site-packages`.
- [x] Corpus validation: 783/783 skills valid.

Restore the recipe, manifest, and lockfile together to roll back. Validation used macOS arm64 and Python 3.13.11.

## Checklist

- [x] No corpus prose or development-principles text changed.
- [x] Package and Athena ownership boundaries remain unchanged.
- [x] No claim of ASD-STE100 certification or endorsement.
