### PR TITLE
ci: tier test validation by runtime

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -145,10 +145,10 @@ jobs:
             podman-mnemosyne-${{ runner.os }}-
       - name: Build CI image (podman)
         run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
-      - name: Verify locked environment runs the test suite (in container)
+      - name: Verify locked environment runs the fast test tier (in container)
         run: >
           podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
-          mnemosyne-ci:local uv run python -m pytest tests/ -q
+          mnemosyne-ci:local uv run python -m pytest tests/ -m 'not nightly' -q
 
   justfile-check:
     name: justfile-check
@@ -199,13 +199,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
-      - name: Check out the pinned Athena agent-contract release
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          repository: HomericIntelligence/Athena
-          ref: agent-contract-v1.0.0
-          path: .athena-agent-contract
-          persist-credentials: false
       - name: Cache podman container storage
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
@@ -215,16 +208,10 @@ jobs:
             podman-mnemosyne-${{ runner.os }}-
       - name: Build CI image (podman)
         run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
-      - name: Run skill-file validation script (in container)
-        run: >
-          podman run --rm -v "$PWD:/workspace:Z"
-          --userns=keep-id:uid=1000,gid=1000
-          mnemosyne-ci:local uv run python scripts/validate_plugins.py
-      - name: Run test suite (in container)
+      - name: Run fast test suite (in container)
         run: >
           podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
-          --env ATHENA_AGENT_CONTRACT_ROOT=/workspace/.athena-agent-contract
-          mnemosyne-ci:local uv run pytest tests/ -v
+          mnemosyne-ci:local uv run python -m pytest tests/ -m 'not nightly' -q
 
   integration-tests:
     name: integration-tests
@@ -243,16 +230,11 @@ jobs:
             podman-mnemosyne-${{ runner.os }}-
       - name: Build CI image (podman)
         run: podman build -f ci/Containerfile -t mnemosyne-ci:local .
-      - name: Validate every skill file across the corpus (in container)
+      - name: Run fast test suite (in container)
         run: >
           podman run --rm -v "$PWD:/workspace:Z"
           --userns=keep-id:uid=1000,gid=1000
-          mnemosyne-ci:local uv run python scripts/validate_plugins.py
-      - name: Assert the skills corpus is non-empty
-        run: |
-          count=$(find skills -name "*.md" -not -name "*.notes.md" | wc -l)
-          echo "Skill files: $count"
-          [ "$count" -gt 0 ] || { echo "No skill files found"; exit 1; }
+          mnemosyne-ci:local uv run python -m pytest tests/ -m 'not nightly' -q
 
   # Canonical aggregate test gate (ci-naming-convention.md). Surfaces a single
   # `test` check-run that fails if either split suite fails. The split

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,51 @@
+name: Nightly Validation
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  nightly:
+    name: nightly
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Check out the pinned Athena agent-contract release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: HomericIntelligence/Athena
+          ref: agent-contract-v1.0.0
+          path: .athena-agent-contract
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          python-version: "3.13"
+      - name: Install dependencies (locked)
+        run: uv sync --locked --group dev
+      - name: Run nightly test tier
+        env:
+          ATHENA_AGENT_CONTRACT_ROOT: ${{ github.workspace }}/.athena-agent-contract
+        run: uv run python -m pytest tests/ -m nightly -v
+      - name: Validate the skills corpus
+        run: uv run python scripts/validate_plugins.py
+      - name: Validate the release contract
+        run: uv run python scripts/validate_release_contract.py
+      - name: Audit locked runtime dependencies
+        run: |
+          uv export --frozen --no-dev --no-emit-project --format requirements-txt > audit-requirements.txt
+          uvx pip-audit --requirement audit-requirements.txt
+      - name: Scan repository history for secrets
+        env:
+          GITLEAKS_IMAGE: >-
+            ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9
+        run: >-
+          podman run --rm -v "$PWD:/repo:ro" -w /repo "$GITLEAKS_IMAGE"
+          detect --source=. --verbose --exit-code=1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: fast-tests
+        name: "run fast pytest tier"
+        description: "Run the same pytest selection as pull-request CI."
+        language: system
+        entry: "uv run python -m pytest tests/ -m 'not nightly' -q"
+        pass_filenames: false
+        always_run: true
+
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         description: >

--- a/justfile
+++ b/justfile
@@ -29,9 +29,13 @@ package:
 
 # === Testing ===
 
-# Run all tests
+# Run the fast test tier used by pre-commit and pull-request CI
 test:
-    uv run python -m pytest {{ test_dir }}
+    uv run python -m pytest {{ test_dir }} -m 'not nightly' -q
+
+# Run the nightly test tier
+test-nightly:
+    uv run python -m pytest {{ test_dir }} -m nightly -v
 
 # === Composite ===
 
@@ -48,9 +52,13 @@ ci-build:
 ci-validate:
     ./scripts/run_ci_local.sh validate
 
-# Run CI tests in container
+# Run the fast CI test tier in container
 ci-test:
     ./scripts/run_ci_local.sh test
+
+# Run the nightly CI test tier in container
+ci-test-nightly:
+    ./scripts/run_ci_local.sh nightly-test
 
 # Run CI lint (yamllint, mypy, PII) in container
 ci-lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ py-modules = ["mnemosyne_skill_utils"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=scripts --cov-report=term-missing"
+markers = [
+    "nightly: expensive full-corpus or workflow-contract validation that runs in the nightly tier",
+]
 
 [tool.ruff]
 target-version = "py313"

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -7,7 +7,8 @@
 # Usage:
 #   ./scripts/run_ci_local.sh                 # Run all CI checks
 #   ./scripts/run_ci_local.sh validate        # Skill-file validation
-#   ./scripts/run_ci_local.sh test            # pytest unit tests
+#   ./scripts/run_ci_local.sh test            # fast pytest tier (pre-commit/PR)
+#   ./scripts/run_ci_local.sh nightly-test    # nightly pytest tier
 #   ./scripts/run_ci_local.sh lint            # yamllint + mypy + PII check
 #   ./scripts/run_ci_local.sh schema          # Workflow YAML schema validation
 #   ./scripts/run_ci_local.sh version         # deps/version-sync checks
@@ -122,8 +123,13 @@ run_validate() {
 }
 
 run_test() {
-    log_step "Unit tests (pytest)"
-    run_in_container uv run python -m pytest tests/ -v
+    log_step "Fast tests (pytest)"
+    run_in_container uv run python -m pytest tests/ -m 'not nightly' -q
+}
+
+run_nightly_test() {
+    log_step "Nightly tests (pytest)"
+    run_in_container uv run python -m pytest tests/ -m nightly -v
 }
 
 run_lint() {
@@ -177,6 +183,9 @@ case "${SUBSET}" in
     test)
         run_step "test" run_test
         ;;
+    nightly-test)
+        run_step "nightly-test" run_nightly_test
+        ;;
     lint)
         run_step "lint" run_lint
         ;;
@@ -199,7 +208,7 @@ case "${SUBSET}" in
         ;;
     *)
         log_error "Unknown subset: ${SUBSET}"
-        log_error "Valid values: all, validate, test, lint, schema, version, release"
+        log_error "Valid values: all, validate, test, nightly-test, lint, schema, version, release"
         exit 1
         ;;
 esac

--- a/tests/test_athena_boundary.py
+++ b/tests/test_athena_boundary.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from mnemosyne_skill_utils import find_skill_files, parse_frontmatter
+
+pytestmark = pytest.mark.nightly
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_frontmatter_contract.py
+++ b/tests/test_frontmatter_contract.py
@@ -10,6 +10,8 @@ import yaml
 from mnemosyne_skill_utils import find_skill_files
 from validate_plugins import validate_plugin
 
+pytestmark = pytest.mark.nightly
+
 ROOT = Path(__file__).resolve().parent.parent
 VALIDATOR = ROOT / "scripts" / "validate_plugins.py"
 

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -12,6 +12,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 REQUIRED_WORKFLOW = WORKFLOWS_DIR / "_required.yml"
+NIGHTLY_WORKFLOW = WORKFLOWS_DIR / "nightly.yml"
 VALIDATE_WORKFLOW = WORKFLOWS_DIR / "validate-plugins.yml"
 RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
 MERGE_QUEUE_POLICY = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
@@ -79,6 +80,13 @@ EXPECTED_DIRECT_CALLER_WORKFLOWS = {
     "release.yml",
     "validate-plugins.yml",
 }
+
+pytestmark = pytest.mark.nightly
+
+
+def _fast_test_command(command: str) -> str:
+    """Return the command that executes the PR test tier."""
+    return f"uv run python -m pytest tests/ -m 'not nightly' {command}"
 
 
 def _load_workflow(path: Path) -> dict[Any, Any]:
@@ -230,7 +238,11 @@ def test_agent_contract_job_has_exact_read_only_call() -> None:
 
 
 def test_agent_contract_direct_caller_inventory_is_complete() -> None:
-    workflow_names = {path.name for path in WORKFLOWS_DIR.glob("*.yml")}
+    workflow_names = {
+        path.name
+        for path in WORKFLOWS_DIR.glob("*.yml")
+        if "agent-contract" in _load_workflow(path)["jobs"]
+    }
 
     assert workflow_names == EXPECTED_DIRECT_CALLER_WORKFLOWS
     for workflow_name in EXPECTED_DIRECT_CALLER_WORKFLOWS:
@@ -244,26 +256,13 @@ def test_release_writer_depends_on_the_agent_contract() -> None:
     assert jobs["release"]["needs"] == ["agent-contract"]
 
 
-def test_unit_tests_exercise_regeneration_against_the_pinned_athena_release() -> None:
+def test_unit_tests_run_only_the_fast_tier() -> None:
     jobs = _load_workflow(REQUIRED_WORKFLOW)["jobs"]
     steps = jobs["unit-tests"]["steps"]
 
-    athena_checkout = next(
-        step for step in steps if step.get("name") == "Check out the pinned Athena agent-contract release"
-    )
-    assert athena_checkout == {
-        "name": "Check out the pinned Athena agent-contract release",
-        "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-        "with": {
-            "repository": "HomericIntelligence/Athena",
-            "ref": "agent-contract-v1.0.0",
-            "path": ".athena-agent-contract",
-            "persist-credentials": False,
-        },
-    }
-
-    test_step = next(step for step in steps if step.get("name") == "Run test suite (in container)")
-    assert "--env ATHENA_AGENT_CONTRACT_ROOT=/workspace/.athena-agent-contract" in test_step["run"]
+    assert all(step.get("name") != "Check out the pinned Athena agent-contract release" for step in steps)
+    test_step = next(step for step in steps if step.get("name") == "Run fast test suite (in container)")
+    assert _fast_test_command("-q") in test_step["run"]
 
 
 @pytest.mark.parametrize(
@@ -325,3 +324,37 @@ def test_release_publisher_remains_tag_only() -> None:
     on_block = _on_block(_load_workflow(RELEASE_WORKFLOW))
 
     assert on_block == {"push": {"tags": ["v*"]}}
+
+
+def test_precommit_and_pr_ci_use_the_same_fast_test_selection() -> None:
+    precommit = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    workflow = _load_workflow(REQUIRED_WORKFLOW)
+    test_steps = workflow["jobs"]["unit-tests"]["steps"]
+    test_step = next(step for step in test_steps if step.get("name") == "Run fast test suite (in container)")
+
+    assert _fast_test_command("-q") in precommit
+    assert _fast_test_command("-q") in test_step["run"]
+
+
+def test_nightly_workflow_runs_the_excluded_test_tier_and_expensive_checks() -> None:
+    workflow = _load_workflow(NIGHTLY_WORKFLOW)
+    on_block = _on_block(workflow)
+    nightly_steps = workflow["jobs"]["nightly"]["steps"]
+    commands = "\n".join(step.get("run", "") for step in nightly_steps)
+    workflow_text = NIGHTLY_WORKFLOW.read_text()
+
+    assert on_block == {"schedule": [{"cron": "0 8 * * *"}], "workflow_dispatch": None}
+    assert "uv run python -m pytest tests/ -m nightly -v" in commands
+    assert "uv run python scripts/validate_plugins.py" in commands
+    assert "uv run python scripts/validate_release_contract.py" in commands
+    assert "uvx pip-audit" in commands
+    assert "gitleaks/gitleaks" in workflow_text
+
+
+def test_subminute_validate_plugins_job_keeps_its_existing_full_suite() -> None:
+    workflow = _load_workflow(VALIDATE_WORKFLOW)
+    steps = workflow["jobs"]["validate"]["steps"]
+    commands = "\n".join(step.get("run", "") for step in steps)
+
+    assert "uv run python scripts/validate_plugins.py" in commands
+    assert "uv run pytest tests/ -v" in commands

--- a/tests/test_run_ci_local.py
+++ b/tests/test_run_ci_local.py
@@ -11,6 +11,8 @@ import pytest
 
 RUNNER = Path(__file__).resolve().parents[1] / "scripts" / "run_ci_local.sh"
 
+pytestmark = pytest.mark.nightly
+
 
 @pytest.fixture
 def run_ci(tmp_path):
@@ -97,6 +99,13 @@ def test_success_runs_every_command(run_ci, subset, count):
     if subset == "version":
         assert commands[0] == ["uv", "run", "python", "scripts/validate_plugins.py"]
         assert commands[1][:2] == ["bash", "-c"]
+
+
+def test_nightly_test_subset_runs_only_the_nightly_marker(run_ci):
+    result, commands = run_ci("nightly-test")
+
+    assert result.returncode == 0, result.stderr
+    assert commands == [["uv", "run", "python", "-m", "pytest", "tests/", "-m", "nightly", "-v"]]
 
 
 @pytest.mark.parametrize("fail_at,subset", [(3, "lint"), (4, "lint"), (5, "lint"), (7, "version"), (8, "version")])

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -12,6 +12,8 @@ from jsonschema import Draft202012Validator
 from mnemosyne_skill_utils import find_skill_files, parse_frontmatter
 from validate_plugins import validate_frontmatter
 
+pytestmark = pytest.mark.nightly
+
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = json.loads((ROOT / "schemas" / "skill-frontmatter.schema.json").read_text())
 SCHEMA_VALIDATOR = Draft202012Validator(SCHEMA)

--- a/tests/test_skill_consolidation_integrity.py
+++ b/tests/test_skill_consolidation_integrity.py
@@ -5,9 +5,13 @@ import sys
 from pathlib import Path
 from typing import NotRequired, TypedDict, cast
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from mnemosyne_skill_utils import parse_frontmatter
+
+pytestmark = pytest.mark.nightly
 
 ROOT = Path(__file__).resolve().parent.parent
 SKILLS_DIR = ROOT / "skills"

--- a/tests/test_validate_release_contract.py
+++ b/tests/test_validate_release_contract.py
@@ -17,7 +17,10 @@ contract no longer tracks any .claude-plugin/ marketplace or plugin.json version
 from pathlib import Path
 from typing import Optional
 
+import pytest
 from validate_release_contract import check_tag, find_violations, main
+
+pytestmark = pytest.mark.nightly
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 

--- a/tests/test_writing_policy.py
+++ b/tests/test_writing_policy.py
@@ -18,6 +18,8 @@ from pathlib import Path
 import pytest
 from mnemosyne_skill_utils import find_skill_files
 
+pytestmark = pytest.mark.nightly
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ASD_SITE_TARGETS = {
     "https://www.asd-ste100.org",


### PR DESCRIPTION
## Summary
- add fast and nightly pytest tiers with shared pre-commit/PR selection
- move eligible full-corpus validation to a nightly workflow
- retain sub-minute CI jobs unchanged, including Validate Plugins

## Verification
- `uv run python -m pytest tests/ -m 'not nightly' -q` (73 passed)
- `ATHENA_AGENT_CONTRACT_ROOT=/Users/mvillmow/.codex/worktrees/1d86/Athena uv run python -m pytest tests/ -m nightly -q` (184 passed)
- `ATHENA_AGENT_CONTRACT_ROOT=/Users/mvillmow/.codex/worktrees/1d86/Athena uv run python -m pytest tests/ -q` (258 passed)
- `uv run yamllint -c .yamllint.yaml .github/workflows/`
- `uv run ruff check scripts/ tests/`