### PR TITLE
Remove pytest execution from pre-commit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Test Plan
 
-- [ ] Tests pass locally
+- [ ] I ran and validated each new test before I created this pull request
 - [ ] Changes verified manually
 
 ## Checklist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: fast-tests
-        name: "run fast pytest tier"
-        description: "Run the same pytest selection as pull-request CI."
-        language: system
-        entry: "uv run python -m pytest tests/ -m 'not nightly' -q"
-        pass_filenames: false
-        always_run: true
-
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         description: >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,8 +313,8 @@ Write skills that users can apply in multiple repositories:
 7. Use this filename format:
    `<topic>-<subtopic>-<short-4-word-summary>.md`.
 8. Use lowercase kebab-case for the filename.
-9. If you add tests, run and validate each new test before you create a pull
-   request.
+9. If you add tests, use the Validation Delegation workflow to run and validate
+   each new test before you create a pull request.
 10. Before a merge, let CI validate the frontmatter, sections, and complete test
     suite. Pre-commit does not run pytest.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,7 +313,10 @@ Write skills that users can apply in multiple repositories:
 7. Use this filename format:
    `<topic>-<subtopic>-<short-4-word-summary>.md`.
 8. Use lowercase kebab-case for the filename.
-9. Before a merge, let CI validate the frontmatter and sections.
+9. If you add tests, run and validate each new test before you create a pull
+   request.
+10. Before a merge, let CI validate the frontmatter, sections, and complete test
+    suite. Pre-commit does not run pytest.
 
 ## Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ instructions.
 3. Complete the YAML frontmatter. See [Skill Structure](#skill-structure).
 4. Complete all required Markdown sections.
 5. You can create `skills/<name>.notes.md` for privacy-safe session details.
-6. Create a pull request. Follow the
+6. If you add tests, run and validate each new test.
+7. Create a pull request. Follow the
    [branch conventions](#branch-and-commit-conventions).
 
 ## Skill Structure
@@ -185,16 +186,17 @@ docs: update migration status - 100% complete
 1. Create a branch following the naming conventions above.
 2. Make the required changes.
 3. Before you push, run local validation. See [Validation](#validation).
-4. Push your branch.
-5. Create a pull request.
-6. Let CI validate these requirements:
+4. If you add tests, run and validate each new test.
+5. Push your branch.
+6. Create a pull request.
+7. Let CI validate these requirements:
    - YAML frontmatter has required fields.
    - All required markdown sections are present.
    - Failed Attempts section exists.
    - The description field is present.
    - Category is valid.
-7. Confirm that the description has specific trigger conditions.
-8. After CI passes and reviewers approve the pull request, maintainers can
+8. Confirm that the description has specific trigger conditions.
+9. After CI passes and reviewers approve the pull request, maintainers can
    merge it.
 
 ### Merge queue readiness
@@ -207,11 +209,20 @@ does not prove that a pull request entered the queue.
 
 ## Validation
 
-CI validates all pull requests. Before you submit a pull request, run local
-validation:
+CI validates all pull requests. Pre-commit does not run pytest. CI is the
+automated authority for the complete test suite.
+
+Before you submit a pull request, run local validation:
 
 ```bash
 python3 scripts/validate_plugins.py
+```
+
+If you add tests, run and validate each new test before you create the pull
+request:
+
+```bash
+uv run python -m pytest path/to/new_test.py
 ```
 
 The validator does these checks:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Athena searches the corpus and returns relevant skills.
 2. Complete the YAML frontmatter.
 3. Complete all required Markdown sections.
 4. Include the required **Failed Attempts** table.
-5. Create a pull request.
+5. If you add tests, run and validate each new test.
+6. Create a pull request.
 
 ### Required Sections in Skill Files
 
@@ -111,6 +112,13 @@ CI validates all pull requests:
 - The description field is present.
 - The category is valid.
 - Each retrievable main skill is at or below 30,000 bytes.
+
+Pre-commit does not run pytest. CI is the automated authority for the complete
+test suite. Before you create a pull request, run and validate each new test:
+
+```bash
+uv run python -m pytest path/to/new_test.py
+```
 
 Authors and reviewers must confirm that each description contains specific trigger
 conditions.

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ package:
 
 # === Testing ===
 
-# Run the fast test tier used by pre-commit and pull-request CI
+# Run the fast test tier used by pull-request CI
 test:
     uv run python -m pytest {{ test_dir }} -m 'not nightly' -q
 

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -7,7 +7,7 @@
 # Usage:
 #   ./scripts/run_ci_local.sh                 # Run all CI checks
 #   ./scripts/run_ci_local.sh validate        # Skill-file validation
-#   ./scripts/run_ci_local.sh test            # fast pytest tier (pre-commit/PR)
+#   ./scripts/run_ci_local.sh test            # fast pytest tier (pull-request CI)
 #   ./scripts/run_ci_local.sh nightly-test    # nightly pytest tier
 #   ./scripts/run_ci_local.sh lint            # yamllint + mypy + PII check
 #   ./scripts/run_ci_local.sh schema          # Workflow YAML schema validation

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -326,13 +326,13 @@ def test_release_publisher_remains_tag_only() -> None:
     assert on_block == {"push": {"tags": ["v*"]}}
 
 
-def test_precommit_and_pr_ci_use_the_same_fast_test_selection() -> None:
+def test_pytest_is_absent_from_precommit_and_pr_ci_uses_fast_selection() -> None:
     precommit = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
     workflow = _load_workflow(REQUIRED_WORKFLOW)
     test_steps = workflow["jobs"]["unit-tests"]["steps"]
     test_step = next(step for step in test_steps if step.get("name") == "Run fast test suite (in container)")
 
-    assert _fast_test_command("-q") in precommit
+    assert _fast_test_command("-q") not in precommit
     assert _fast_test_command("-q") in test_step["run"]
 
 


### PR DESCRIPTION
## Summary

- Remove the fast pytest hook from pre-commit.
- Clarify that CI owns complete test-suite validation.
- Require contributors to validate new tests before opening a pull request.
- Update related testing comments and documentation.

## Testing

Not run (not requested).