### PR TITLE
docs(skill): qualify memory layout optimization boundaries

### DIFF
--- a/skills/bf16-monokernel-sol-profiling.history
+++ b/skills/bf16-monokernel-sol-profiling.history
@@ -537,3 +537,14 @@ this reusable decision procedure.
 - Compaction for issue #3335 preserved the verification boundary and did not claim NCU counters
   where host policy denied them.
 ````
+
+## v2.2.0
+
+- Prior version: `2.1.0`.
+- Prior archive status: `privacy-redacted`.
+- Reason: the prior main contained legacy campaign identifiers.
+- The exact prior snapshot was intentionally omitted. No retrieval pointer is retained here.
+- Change: add public-alignment and workspace-fit boundary checks to memory-layout optimization.
+- Provenance: generalized local source inspection and paired fixture observations.
+- Verification boundary: evidence supports the stated checks, not universal alignment or input coverage.
+- Delivery validation: repository validation is pending in an approved execution boundary.

--- a/skills/bf16-monokernel-sol-profiling.md
+++ b/skills/bf16-monokernel-sol-profiling.md
@@ -1,9 +1,9 @@
 ---
 name: bf16-monokernel-sol-profiling
-description: "Build and optimize a reproducible BF16 CUDA monokernel benchmark. Use when workload normalization may duplicate cases, semantic outputs and intermediate-state parity need separate acceptance policies, a cooperative launch needs phase attribution without external counters, GPU profiling needs provenance and isolation, tiny grids underfill the GPU, multi-position acceptance needs a minimax rule, or compiler/resource changes disagree with composed-kernel correctness and latency."
+description: "Build and optimize a reproducible BF16 CUDA monokernel benchmark. Use when workload normalization may duplicate cases, semantic outputs and intermediate-state parity need separate acceptance policies, a cooperative launch needs phase attribution without external counters, GPU profiling needs provenance and isolation, tiny grids underfill the GPU, multi-position acceptance needs a minimax rule, compiler/resource changes disagree with composed-kernel correctness and latency, or memory-layout changes affect alignment and workspace fit."
 category: optimization
 date: 2026-08-09
-version: "2.1.0"
+version: "2.2.0"
 license: BSD-3-Clause
 user-invocable: false
 verification: verified-local
@@ -25,7 +25,7 @@ runnable implementation. Keep stricter parity checks visible even when they are 
 
 Detailed campaign cases and artifact locations are indexed in
 [`bf16-monokernel-sol-profiling.notes.md`](bf16-monokernel-sol-profiling.notes.md).
-The complete prior source is in
+Prior versions and archive decisions are in
 [`bf16-monokernel-sol-profiling.history`](bf16-monokernel-sol-profiling.history).
 
 ## When to Use
@@ -44,6 +44,8 @@ The complete prior source is in
 - Fewer instructions/registers, partial unrolling, index narrowing, or shared-state movement makes
   the composed kernel slower.
 - Timing may be contaminated by another process or a different lock namespace on the same GPU.
+- A vector access requires more alignment than the public API guarantees.
+- A smaller reduction changes scratch storage, but an old fit guard still selects a slow path.
 
 ## Verified Workflow
 
@@ -167,6 +169,26 @@ Dispatch substitution is only a reachability control because it changes topology
 mechanism. For the real candidate, retain accepted dispatch and implement equivalent lowering in
 every active path where the geometry is legal.
 
+### Memory-layout changes need contract and boundary checks
+
+Trace each vector access back to its allocation and the public API contract. Check the
+alignment of the base pointer, every offset, and every row stride. A caller-supplied workspace
+is not an internal allocation. Aligned test fixtures do not prove that every legal caller
+satisfies a wider access requirement. If the requirement is stronger than the API guarantee,
+retain an alignment-safe path inside the optimized implementation. Test the weakest legal
+alignment before production use. Do not strengthen host admission to make the candidate pass.
+
+When a reduction publishes fewer temporary values, update its offsets, allocation requirement,
+and fit predicate together. Prove that all live regions remain disjoint and in bounds. Include
+other scratch regions in the proof; compacting one region does not remove the others. Trace the
+selected path immediately below and above the new fit boundary. Then compare the full kernel
+with an adjacent baseline under the unchanged gate. Mark unavailable boundary fixtures as
+untested instead of claiming support for an entire range.
+
+A stale workspace guard can hide the main benefit of a compact reduction by retaining a slow
+fallback. Report that path-selection effect separately from arithmetic improvements. A benefit
+at a short input does not establish a benefit at the campaign's primary input.
+
 ### 7. Diagnose the composed kernel without static rejection gates
 
 Build the exact full composition. Resource metrics are diagnostic and cannot reject a runnable
@@ -271,5 +293,5 @@ this reusable decision procedure.
 - Verified-local BF16 decode evidence through 2026-08-26 qualified a target-policy fast intrinsic at
   nominal and extreme contexts plus the minimum legal grid, retained stricter parity, and confirmed a
   matched uninstrumented latency improvement without changing unaffected target policies.
-- Compaction for issue #3335 preserved the verification boundary and did not claim NCU counters
-  where host policy denied them.
+- Historical consolidation preserved the verification boundary and did not claim performance
+  counters where host policy denied them.

--- a/skills/bf16-monokernel-sol-profiling.notes.md
+++ b/skills/bf16-monokernel-sol-profiling.notes.md
@@ -96,3 +96,20 @@ diagnostics, then decide from an uninstrumented confirmation.
   `ee2dae76415650e0cd96ed95ee76dd8e0278d77c8153b1f5bd2b730f5075daa7`
 - Issue #3335 base: `1ae0cb498e5250c341c2a4bf585f97e2a28060af`
 - Old/new version: `1.25.0` → `2.0.0`
+
+## Memory-layout contract evidence
+
+A local candidate used wider stores on caller-supplied buffers. The existing fixtures passed,
+but source inspection found that the API accepted weaker alignment. The fixture results therefore
+did not establish safety for all legal calls. An implementation-level alignment guard preserved
+the contract. The revised candidate required its own measurements; the earlier result did not
+transfer automatically. No misaligned execution result is claimed.
+
+In a separate local experiment, a reduction emitted fewer temporary candidates while its original
+workspace offsets and fit predicate remained unchanged. A follow-up compacted both regions and
+recomputed the required capacity. A previously slow short input then used the parallel path and
+passed the unchanged output gate. This supports checking workspace admission after compaction. It
+does not prove unmeasured boundary inputs, universal speedups, or general production qualification.
+
+The reusable main contains the decision rules. Internal identities, source code, paths, exact
+workload dimensions, and measured timings are intentionally excluded from this evidence summary.


### PR DESCRIPTION
Memory-layout optimizations can pass aligned fixtures while exceeding the public API's alignment guarantee. A compact reduction can also retain obsolete workspace offsets and a fit guard that selects an unnecessarily slow path.

Amend the existing optimization skill with allocation, offset, stride, alignment, and workspace-boundary checks. Keep short-input benefits separate from primary-input qualification. Supporting notes retain only generalized observations; no internal source, identifiers, paths, or benchmark numbers are added.

- Canonical version: 2.2.0; main file: 20,385 bytes.
- Companions: existing history and notes files. No new or retired entries.
- Prior version 2.1.0 uses a privacy-redaction archive record because its prior main contained legacy campaign identifiers; the exact snapshot is intentionally omitted.
- Signed commit with DCO attestation. Static review covers all three changed paths.

Validation is unavailable locally: repository AGENTS.md requires a validation sub-agent in a host-enforced boundary with read-only source, isolated disposable outputs, no network or credentials, and resource limits. This session exposes no such boundary. No local tests, lint, or hooks were run, and no automated pass is claimed. Keep this PR in draft until approved validation and technical-English review are complete.
