### PR TITLE
feat: add safety wrapper invocation lesson

### DIFF
--- a/skills/tooling-safety-wrapper-invocation-contract.history
+++ b/skills/tooling-safety-wrapper-invocation-contract.history
@@ -1,0 +1,13 @@
+# tooling-safety-wrapper-invocation-contract — History
+
+## v1.0.0 (2026-09-11)
+
+**Change:** Created the canonical rule for the first execution of a
+safety-sensitive pass-through wrapper.
+
+**Provenance:** A privacy-safe local automation session supplied the failure
+evidence. The initial wrapper call omitted its required positional arguments.
+The parser stopped before downstream execution.
+
+**Archive result:** Initial version. No prior version exists.
+

--- a/skills/tooling-safety-wrapper-invocation-contract.md
+++ b/skills/tooling-safety-wrapper-invocation-contract.md
@@ -118,4 +118,3 @@ A valid preflight gives these results:
 
 - [Exact argv admission at the subprocess boundary](tooling-command-admission-exact-argv-boundary-enforcement.md)
 - [Automation agent tool scopes](automation-agent-tool-scopes-least-privilege.md)
-

--- a/skills/tooling-safety-wrapper-invocation-contract.md
+++ b/skills/tooling-safety-wrapper-invocation-contract.md
@@ -1,0 +1,121 @@
+---
+name: tooling-safety-wrapper-invocation-contract
+description: "Use this skill before the first execution of a safety-sensitive wrapper that validates one dependency and forwards the remaining arguments to another command. It prevents an incomplete wrapper call and defines the stop rule after a nonzero result."
+category: tooling
+date: 2026-09-11
+version: "1.0.0"
+user-invocable: false
+tags: [wrapper, cli, argparse, remainder, preflight, retry, cleanup, fail-closed]
+---
+
+# Safety-Sensitive Wrapper Invocation Contract
+
+## Overview
+
+| Field | Value |
+| ------- | ------- |
+| **Date** | 2026-09-11 |
+| **Objective** | Construct the complete wrapper argument vector before the first call. |
+| **Outcome** | The wrapper validates its dependency, forwards the intended arguments, and stops safely after an unclassified failure. |
+
+## When to Use
+
+- A wrapper has one or more arguments for its own validation step.
+- The wrapper forwards the remaining arguments to a second command.
+- The second command can change or delete state.
+- The wrapper contract prohibits a retry after a nonzero result.
+- An operator knows the downstream command but has not inspected the wrapper interface.
+
+## Verified Workflow
+
+### Quick Reference
+
+```bash
+python3 <wrapper-path> --help
+python3 <wrapper-path> <dependency-checkout> <forwarded-argument> ...
+```
+
+If the first execution returns a nonzero status, stop. Do not add missing
+arguments and call the wrapper again until an authorized new operation starts.
+
+### Detailed Steps
+
+1. Read the applicable operation contract before you run the wrapper.
+2. Run the wrapper with `--help` if the operation contract permits this read-only call.
+3. Identify each wrapper-owned positional argument and option.
+4. Identify the boundary where the forwarded argument vector starts.
+5. Inspect the wrapper source when `--help` does not show the forwarding boundary clearly.
+6. Resolve and validate each wrapper-owned dependency before the operation.
+7. Construct the complete argument vector as a list. Do not infer it from the downstream command syntax.
+8. Keep standard input attached when the downstream command must ask the operator for a decision.
+9. Run the wrapper one time.
+10. If the result is nonzero, preserve the status and diagnostic output.
+11. Classify the failure before a new operation. Do not treat an argument error as authority to retry.
+12. Confirm the final state before you report that cleanup or another state change is complete.
+
+For a Python wrapper that uses one dependency argument and
+`argparse.REMAINDER`, use this shape:
+
+```python
+parser.add_argument("dependency_checkout")
+parser.add_argument("arguments", nargs=argparse.REMAINDER)
+```
+
+The call must put the dependency checkout before all forwarded arguments:
+
+```bash
+python3 <wrapper-path> <dependency-checkout> <downstream-option> <value>
+```
+
+Do not call the wrapper as if it were the downstream command.
+
+## Failed Attempts
+
+| Attempt | What Was Tried | Why It Failed | Lesson Learned |
+| --------- | ---------------- | --------------- | ---------------- |
+| Downstream-only call | The operator called the wrapper without its dependency-checkout argument. | The wrapper parser stopped with a missing positional-argument error before it started the downstream command. | Inspect the wrapper interface and include wrapper-owned arguments before forwarded arguments. |
+| Immediate corrected retry | The operator planned to add the missing argument and run the command again. | A no-retry contract makes the first nonzero result terminal for that operation. The initial failure does not prove that a second execution is safe. | Stop, preserve the state, and require an authorized new operation before another call. |
+| Infer syntax from the downstream command | The operator used only the downstream command documentation. | The downstream documentation does not describe dependency validation or the forwarding boundary in the wrapper. | Inspect both interfaces and construct one complete argument vector. |
+
+## Results & Parameters
+
+### Configuration
+
+Record these values before the first call:
+
+```yaml
+wrapper:
+  path: <wrapper-path>
+  own_arguments:
+    - <dependency-checkout>
+  forwarded_arguments:
+    - <downstream-option>
+    - <value>
+  stdin_attached: true
+  retry_policy: no-retry-after-nonzero
+```
+
+Use `stdin_attached: true` only when the operation contract requires an
+operator to answer prompts. Do not answer a destructive prompt automatically.
+
+### Expected Output
+
+A valid preflight gives these results:
+
+- The help output identifies each wrapper-owned argument.
+- The resolved dependency satisfies the wrapper's validation rule.
+- The first state-changing call contains the complete argument vector.
+- A nonzero result stops the operation without a hidden fallback or retry.
+- The completion report agrees with the observed final state.
+
+## Verified On
+
+| Project | Context | Details |
+| --------- | --------- | --------- |
+| Local automation session | A repository-cleanup wrapper stopped before downstream execution because its required positional arguments were absent. | The parser returned status 2. No cleanup action started. See the companion notes for privacy-safe evidence. |
+
+## References
+
+- [Exact argv admission at the subprocess boundary](tooling-command-admission-exact-argv-boundary-enforcement.md)
+- [Automation agent tool scopes](automation-agent-tool-scopes-least-privilege.md)
+

--- a/skills/tooling-safety-wrapper-invocation-contract.notes.md
+++ b/skills/tooling-safety-wrapper-invocation-contract.notes.md
@@ -1,0 +1,32 @@
+# Safety-Sensitive Wrapper Invocation Contract — Notes
+
+## Evidence
+
+A local repository-cleanup operation used a Python wrapper with this interface:
+
+```text
+wrapper dependency_checkout arguments ...
+```
+
+The first call supplied neither positional argument. The argument parser
+returned status 2 and reported both arguments as missing. The wrapper stopped
+before it validated the dependency or replaced itself with the downstream
+process. No cleanup action started.
+
+Source inspection showed this sequence:
+
+1. Parse one dependency-checkout positional argument.
+2. Collect the remaining arguments for the downstream command.
+3. Validate a required revision in the dependency checkout.
+4. Replace the wrapper process with the dependency-locked downstream command.
+
+The operation contract prohibited a retry after a nonzero result. The operator
+therefore stopped and preserved the repository state. This evidence verifies
+the missing-argument failure and the safe stop. It does not verify a complete
+cleanup operation.
+
+## Privacy Review
+
+This note omits repository names, paths, hostnames, user identifiers, issue
+identifiers, credentials, and operational data. It keeps only the reusable
+wrapper grammar and the observed failure result.


### PR DESCRIPTION
## Summary

- add one canonical rule for a safety-sensitive wrapper that validates its own dependency and forwards a second argument vector
- require interface inspection before the first call
- require a stop after an unclassified nonzero result when the operation has a no-retry policy
- record privacy-safe evidence from a parser failure that occurred before downstream execution

## Disposition

`create`

The bounded selector listed 783 retrievable main skills at base `03b050add8058048ac7d0b26d5956fed5ad8ec59`. The closest current entries cover exact subprocess admission and policy-downgrade failures. They do not cover the wrapper-owned positional arguments or the forwarding boundary. No open pull request changes this intent or these files.

## Validation

Local validation was not run. The available sandbox did not satisfy the repository isolation contract. It allowed home-directory reads and host-temporary writes, exposed a credential-bearing environment variable, and did not enforce all resource limits. The validation agent confirmed exact clean commit `d3058d6e3610cca10aeab0f95d7852c90c1e7847` and made no changes.

Repository continuous integration must run `python3 scripts/validate_plugins.py` and all required checks. Please also review the new technical prose against the repository writing policy. Automated checks cannot certify the prose.

## Privacy

The three artifacts omit repository names, paths, hostnames, user identifiers, issue identifiers, credentials, and operational data from the source session.
